### PR TITLE
fix: map double-init guard, DOMContentLoaded consolidation, chart-fix on HNA

### DIFF
--- a/colorado-deep-dive.html
+++ b/colorado-deep-dive.html
@@ -1888,7 +1888,8 @@ h3 { font-size: 1.05rem; font-weight: 700; }
   <script src="js/trend-analysis.js"></script>
   <script src="js/policy-simulator.js"></script>
   <script>
-    document.addEventListener("DOMContentLoaded", function() {
+  (function () {
+    function initModules() {
       if (window.TrendAnalysis) TrendAnalysis.init();
       if (window.PolicySimulator) PolicySimulator.init();
       // Load CAR market data
@@ -1924,7 +1925,14 @@ h3 { font-size: 1.05rem; font-weight: 700; }
           if (error)  { error.textContent = "Failed to load CAR market data."; error.style.display = "block"; }
         });
       }
-    });
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', initModules);
+    } else {
+      initModules();
+    }
+  }());
   </script>
   <script src="js/map-overlay.js"></script>
   <script src="js/ui-interactions.js"></script>

--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -30,6 +30,8 @@
   <!-- Vendor scripts -->
   <script src="js/vendor/leaflet.js"></script>
   <script defer src="js/vendor/chart.umd.min.js"></script>
+  <!-- chart-fix: re-renders charts when <details> sections open or containers become visible -->
+  <script defer src="js/chart-fix.js"></script>
   <!-- PDF export (client-side) -->
   <script defer src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>

--- a/js/co-lihtc-map.js
+++ b/js/co-lihtc-map.js
@@ -965,6 +965,12 @@
 
   // ── Map initialization ───────────────────────────────────────────────────────
   function initMap() {
+    if (window.__coLihtcMapInit) {
+      console.warn('[co-lihtc-map] initMap() called more than once — skipping duplicate initialization.');
+      return window.coLihtcMap || null;
+    }
+    window.__coLihtcMapInit = true;
+
     if (typeof L === 'undefined') {
       console.error('[co-lihtc-map] Leaflet (L) is not defined. Ensure js/vendor/leaflet.js loads before this script.');
       updateStatus('Map unavailable — Leaflet failed to load.');


### PR DESCRIPTION
Three targeted stability fixes — no logic or feature changes.

## Changes

**`js/co-lihtc-map.js`** — Add `window.__coLihtcMapInit` guard at the top of `initMap()`. Prevents the "Map container is already initialized" Leaflet error if the function is triggered more than once. This bug was fixed and re-introduced twice in PR history — the guard makes it permanent.

**`colorado-deep-dive.html`** — Wrap the bare `DOMContentLoaded` listener (line 1891) in an IIFE + `readyState` check, matching the pattern already used by all four other init blocks on the same page. Zero behavior change — eliminates the only raw listener that could race on fast loads.

**`housing-needs-assessment.html`** — Add `chart-fix.js` after `chart.umd.min.js`. 20 canvases sit inside `<details>` elements (collapsed by default). Without `chart-fix.js`, Chart.js renders into zero-size containers and charts are permanently blank when a section is first opened. `chart-fix.js` already handles this via IntersectionObserver + details toggle listeners — it just was not loaded on this page.

## Test plan
- [ ] Open `colorado-deep-dive.html` — map renders, no console errors about double init
- [ ] Reload `colorado-deep-dive.html` rapidly — no "Map container already initialized" error
- [ ] Open `housing-needs-assessment.html`, expand any `<details>` section containing a chart — chart renders correctly
- [ ] Confirm no regressions on `housing-needs-assessment.html` PDF/CSV export

🤖 Generated with [Claude Code](https://claude.com/claude-code)