### PR TITLE
fix: harden deal-calculator scope boundary + add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+<!-- What does this PR do and why? -->
+
+
+## Type
+- [ ] Fix (bug, rendering, data, stability)
+- [ ] Feature (new page, new module, new visualization)
+- [ ] Data / pipeline (workflow, fetch script, JSON update)
+- [ ] Docs / chore
+
+## Scope check
+- [ ] Fixes only — no new features bundled in
+- [ ] No new CDN dependencies without a local vendor fallback in `js/vendor/`
+- [ ] If page has charts inside `<details>` or hidden containers: `chart-fix.js` is loaded
+- [ ] No parcel-level conclusions or award-probability scoring added
+- [ ] Disclaimer present if any feasibility or screening output is new or changed
+
+## Test plan
+<!-- What should a reviewer check manually? -->
+- [ ]
+- [ ]

--- a/js/deal-calculator.js
+++ b/js/deal-calculator.js
@@ -562,10 +562,14 @@
     note.style.display = basisBoostEligible ? 'block' : 'none';
   }
 
-  // TODO (Future PR): integrate full 4%/9% deal-predictor module
-  //   (js/lihtc-deal-predictor.js) with CHFA QAP scoring, soft-debt layering,
-  //   and investor pricing.  This calculator is intentionally scoped to
-  //   early-stage feasibility sizing only and is not a final underwriting tool.
+  // SCOPE BOUNDARY — do not expand this file into a deal predictor or scoring engine.
+  // This calculator is intentionally limited to early-stage feasibility sizing:
+  // eligible basis, annual credits, rough equity, and gap-to-subsidy estimates.
+  //
+  // A full 4%/9% deal-predictor (CHFA QAP scoring, soft-debt layering, investor
+  // pricing) is out of scope here and requires explicit product decision before
+  // implementation. Adding automated award-probability scoring or parcel-level
+  // conclusions would cross the platform's "screening, not certainty" boundary.
   window.__DealCalc = { init: init, recalculate: recalculate, setDesignationContext: setDesignationContext };
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
Two non-code governance fixes to prevent the recurring failure modes identified in the full PR history review.

## Changes

**`js/deal-calculator.js`** — Replace the open-ended `// TODO (Future PR): integrate full 4%/9% deal-predictor` comment with an explicit `SCOPE BOUNDARY` comment. The prior wording invited a future automated PR to add CHFA QAP scoring and investor pricing logic. The new comment makes clear that doing so requires an explicit product decision and would cross the platform's "screening, not certainty" boundary. No code change.

**`.github/PULL_REQUEST_TEMPLATE.md`** — Add a PR checklist covering the recurring failure modes in this repo's 481-PR history:
- Fix+feature bundling (the most common issue)
- CDN dependencies added without local vendor fallbacks
- Charts inside `<details>` or hidden containers missing `chart-fix.js`
- Parcel-level conclusions or scoring scope creep
- Missing disclaimers on feasibility/screening output

Every future PR (including Copilot-generated ones) will see this checklist automatically.

## Test plan
- [ ] Open a new PR — confirm the template appears in the description field
- [ ] Confirm `js/deal-calculator.js` has no functional change (diff is comment-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)