### PR TITLE
fix: screening disclaimers (rebased) + HNA/economic-dashboard notes + workflow pin

### DIFF
--- a/.github/workflows/update-co-housing-costs.yml
+++ b/.github/workflows/update-co-housing-costs.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/colorado-deep-dive.html
+++ b/colorado-deep-dive.html
@@ -367,7 +367,7 @@ h3 { font-size: 1.05rem; font-weight: 700; }
   <a class="workflow-step" href="lihtc-allocations.html">5. LIHTC Allocations</a>
 </div>
 <div class="platform-disclaimer" role="note">
-  <strong>COHO Analytics</strong> provides data-driven research tools. Analysis represents independent research using public datasets. Not financial or legal advice.
+  <strong>COHO Analytics</strong> provides data-driven research tools. Analysis represents independent research using public datasets. Not financial or legal advice. <strong>Screening tool only</strong> — map overlays, KPI cards, and market metrics are for early-stage identification. They do not replace a formal CHFA-required PMA or independent due diligence.
 </div>
     
 <div class="page-hero">

--- a/economic-dashboard.html
+++ b/economic-dashboard.html
@@ -71,6 +71,7 @@
 <p class="sub" style="max-width:none;font-size:0.97rem;line-height:1.7;margin-bottom:var(--sp4);">
         Construction PPIs feed feasibility models, Treasury yields and mortgage spreads set permanent debt terms, SOFR for variable-rate exposure, and vacancy and homeownership rates anchor market studies. All sourced from FRED, the Federal Reserve’s public data repository, and updated on each series’ schedule. In affordable housing finance, assumptions are made months before closing, and the market rarely waits.
       </p>
+<p style="font-size:.82rem;color:var(--muted);margin-bottom:var(--sp3);" role="note"><strong>Screening tool only.</strong> Macro indicators shown here are for early-stage deal context and market orientation. They are not investment advice, underwriting inputs, or a substitute for current lender quotes, appraisals, or professional financial analysis.</p>
 <div class="toolbar">
 <div class="card control" style="flex-wrap:wrap;">
 <span class="pill">FRED connected: <strong id="conn">…</strong></span>

--- a/hna-scenario-builder.html
+++ b/hna-scenario-builder.html
@@ -58,6 +58,7 @@
         Create and compare demographic growth scenarios through 2050 using the cohort-component model.
         Adjust fertility, migration, and mortality assumptions — then save custom scenarios for later comparison.
       </p>
+      <p style="font-size:.82rem;color:var(--muted);margin-top:.5rem;" role="note"><strong>Screening tool only.</strong> Projections are illustrative planning estimates based on public DOLA and Census data. They are not certified forecasts and do not substitute for a formal housing needs study or CHFA-required analysis.</p>
     </div>
 
     <!-- Geography selector -->

--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -77,6 +77,7 @@
           A report-style, data-driven snapshot for Colorado communities: housing stock, tenure, affordability,
           commuting, and demographic change. Powered by cached public datasets with live Census API fallbacks.
         </p>
+        <p style="font-size:.82rem;color:var(--muted);margin-top:.25rem;margin-bottom:var(--sp2);" role="note"><strong>Screening tool only.</strong> Data snapshots are for early-stage community planning and site research using public Census, DOLA, and HUD datasets. They are not a certified housing needs study and do not substitute for a CHFA-required market analysis or formal due diligence.</p>
         <div id="hnaBanner" class="banner"></div>
         <div id="hnaLiveRegion" aria-live="polite" aria-atomic="true" class="sr-only"></div>
         <small id="hnaDataTimestamp" class="data-timestamp"></small>

--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -52,6 +52,7 @@
   <script defer src="js/data-connectors/hud-fmr.js"></script>
   <script defer src="js/hna/hna-controller.js"></script>
   <script defer src="js/housing-needs-assessment.js"></script>
+  <script defer src="js/site-state.js"></script>
 </head>
 <body data-page-last-updated="2026-03-22"
       data-page-source="Census ACS · HUD · DOLA · LEHD">
@@ -1288,6 +1289,34 @@
     watchGeoChange();
     var geo = getCurrentGeo();
     initActionPlan(geo.geoType, geo.geoid);
+  }
+}());
+</script>
+<script>
+// Wire HNA county selection into SiteState so Market Analysis
+// and other tools automatically inherit the selected geography.
+(function () {
+  function syncCountyToSiteState() {
+    if (!window.SiteState || !window.HNAState) return;
+    var geoType = window.HNAState.els && window.HNAState.els.geoType && window.HNAState.els.geoType.value;
+    var geoSelect = window.HNAState.els && window.HNAState.els.geoSelect;
+    if (!geoSelect) return;
+    geoSelect.addEventListener('change', function () {
+      if (geoType !== 'county') return;
+      var fips = geoSelect.value;
+      var name = geoSelect.options[geoSelect.selectedIndex] && geoSelect.options[geoSelect.selectedIndex].text;
+      if (fips) window.SiteState.setCounty(fips, name || fips);
+    });
+    // Also sync geoType changes so we always read the current type
+    var geoTypeEl = window.HNAState.els.geoType;
+    if (geoTypeEl) geoTypeEl.addEventListener('change', function () {
+      geoType = geoTypeEl.value;
+    });
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', syncCountyToSiteState);
+  } else {
+    syncCountyToSiteState();
   }
 }());
 </script>

--- a/js/deal-calculator.js
+++ b/js/deal-calculator.js
@@ -567,7 +567,7 @@
   // eligible basis, annual credits, rough equity, and gap-to-subsidy estimates.
   //
   // A full 4%/9% deal-predictor (CHFA QAP scoring, soft-debt layering, investor
-  // pricing) is out of scope here and requires explicit product decision before
+  // pricing) is out of scope here and requires an explicit product decision before
   // implementation. Adding automated award-probability scoring or parcel-level
   // conclusions would cross the platform's "screening, not certainty" boundary.
   window.__DealCalc = { init: init, recalculate: recalculate, setDesignationContext: setDesignationContext };

--- a/market-analysis.html
+++ b/market-analysis.html
@@ -55,6 +55,7 @@
       <span class="kicker">Analysis</span>
 <h1 style="margin-bottom:0.25rem">Market Analysis</h1>
       <p style="max-width:640px">Public Market Analysis (PMA) scoring engine. Click the map to place a site, choose a buffer radius, and receive a scored feasibility assessment using Census ACS, HUD LIHTC, and TIGERweb data — no API key required. Scores cover vacancy, income qualification, commuting patterns, transit access, schools, competitive supply, and development opportunity factors.</p>
+      <p style="max-width:640px;font-size:.82rem;color:var(--muted);margin-top:.25rem;" role="note"><strong>Screening tool only.</strong> Scores are for early-stage site identification using public data. They are not a substitute for a formal CHFA-required PMA, independent market study, or professional underwriting.</p>
       <small id="pmaDataStatus" style="color:var(--faint)">Loading data…</small>
       <small id="pmaDataTimestamp" class="data-timestamp"></small>
     </div>


### PR DESCRIPTION
## Summary

Rebased replacement for PR #486 (which diverged from main and could not be auto-rebased). Carries all six changes from #486 forward onto current main, plus three additional items identified in the PR 3 review.

### From PR #486 (rebased)
- `market-analysis.html` — "Screening tool only" note below PMA description
- `colorado-deep-dive.html` — screening caveat appended to existing `platform-disclaimer`
- `hna-scenario-builder.html` — screening disclaimer below hero subtitle
- `housing-needs-assessment.html` — load `js/site-state.js` + SiteState county-sync IIFE
- `js/deal-calculator.js` — SCOPE BOUNDARY comment replacing open TODO
- `.github/PULL_REQUEST_TEMPLATE.md` — already in main via #483; correctly not re-added

### New in this PR (PR 3 review findings)
- `housing-needs-assessment.html` — add visible "Screening tool only" disclaimer text (SiteState wiring was present; user-facing note was missing)
- `economic-dashboard.html` — add "Screening tool only" note below hero description
- `.github/workflows/update-co-housing-costs.yml` — fix `actions/checkout@v6` (non-existent tag, would break next scheduled run) → `actions/checkout@v4`

## Type
- [x] Fix (bug, rendering, data, stability)

## Scope check
- [x] Fixes only — no new features bundled in
- [x] No new CDN dependencies without a local vendor fallback in `js/vendor/`
- [x] No parcel-level conclusions or award-probability scoring added
- [x] Disclaimer present if any feasibility or screening output is new or changed

## Test plan
- [ ] Confirm "Screening tool only" note visible on `housing-needs-assessment.html` below hero subtitle
- [ ] Confirm "Screening tool only" note visible on `economic-dashboard.html` below hero description
- [ ] Confirm `market-analysis.html` note still present (regression check)
- [ ] Confirm `colorado-deep-dive.html` platform-disclaimer shows screening caveat
- [ ] Confirm `hna-scenario-builder.html` hero has screening note
- [ ] Trigger `update-co-housing-costs` workflow manually via Actions tab — confirm it does not fail on checkout step
- [ ] Select a county in Housing Needs Assessment — confirm Market Analysis inherits it