### PR TITLE
Fix ACS variable code drift across Python pipeline and JS renderers

### DIFF
--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -1207,22 +1207,35 @@
       // and as AMI-tier proxies in renderHousingGapSummary)
       'DP03_0052E','DP03_0053E','DP03_0054E','DP03_0055E',
       'DP03_0056E','DP03_0057E','DP03_0058E','DP03_0059E','DP03_0060E',
-      // Age of housing stock (DP04 year-built bins — renderHousingAgeChart)
-      'DP04_0026E','DP04_0027E','DP04_0028E','DP04_0029E',
-      'DP04_0030E','DP04_0031E','DP04_0032E',
-      // Bedroom mix detail (DP04 — renderBedroomMixChart)
-      'DP04_0042E','DP04_0043E','DP04_0044E','DP04_0045E','DP04_0046E',
-      // Owner cost burden bins (DP04 SMOCAPI — renderOwnerCostBurdenChart)
+      // Age of housing stock (DP04 YEAR STRUCTURE BUILT — renderHousingAgeChart)
+      // Confirmed ACS 5-year 2023: DP04_0017E (2020+) … DP04_0026E (pre-1940)
+      // DP04_0027E–DP04_0032E are ROOMS variables — do NOT request them here
+      'DP04_0017E','DP04_0018E','DP04_0019E','DP04_0020E','DP04_0021E',
+      'DP04_0022E','DP04_0023E','DP04_0024E','DP04_0025E','DP04_0026E',
+      // Bedroom mix detail (DP04 BEDROOMS — renderBedroomMixChart)
+      // Confirmed ACS 5-year 2023: DP04_0039E (no BR) … DP04_0044E (5+ BR)
+      // DP04_0045E–DP04_0047E are HOUSING TENURE variables — do NOT use for bedrooms
+      'DP04_0039E','DP04_0040E','DP04_0041E','DP04_0042E','DP04_0043E','DP04_0044E',
+      // Structure type (ACS 2023: DP04_0007E=1-unit detached … DP04_0014E=mobile home)
+      'DP04_0007E','DP04_0008E','DP04_0009E','DP04_0010E',
+      'DP04_0011E','DP04_0012E','DP04_0013E','DP04_0014E',
+      // Owner cost burden bins (DP04 SMOCAPI — renderOwnerCostBurdenChart) ✅ stable codes
       'DP04_0111PE','DP04_0112PE','DP04_0113PE','DP04_0114PE','DP04_0115PE',
-      // Renter household count + GRAPI rent burden bins (renderHousingGapSummary)
+      // Renter HH count + GRAPI rent burden bins (renderHousingGapSummary)
+      // DP04_0047E = renter-occupied count (confirmed ✅)
+      // DP04_0141PE = 30–34.9%, DP04_0142PE = 35%+ (ACS 2023 confirmed codes)
+      // DP04_0136PE in ACS 2023 = total GRAPI universe, NOT ≥30%; frontend computes ≥30%
+      // as DP04_0141PE + DP04_0142PE when DP04_0136PE is absent from cache
       'DP04_0047E',
-      'DP04_0136PE','DP04_0137PE','DP04_0138PE',
-      'DP04_0139PE','DP04_0140PE','DP04_0141PE',
+      'DP04_0137PE','DP04_0138PE','DP04_0139PE','DP04_0140PE',
+      'DP04_0141PE','DP04_0142PE',
       // Special needs population (renderSpecialNeedsPanel)
-      'DP05_0019E', // children under 18
-      'DP05_0029E', // 65+
-      'DP05_0030E', // 65+ (alternate ACS vintage code)
-      'DP05_0031E', // 75+
+      'DP05_0016E', // 75–84 years (used to compute 75+ aggregate)
+      'DP05_0017E', // 85 years and over (used to compute 75+ aggregate)
+      'DP05_0019E', // Under 18 years
+      'DP05_0024E', // 65 years and over (primary 65+ aggregate)
+      'DP05_0029E', // 65 years and over (secondary/vintage fallback)
+      // DP05_0031E is "65 years and over, Female" — removed (was incorrectly labelled 75+)
       'DP02_0003E', // family households
       'DP02_0009E', // male single-parent HH
       'DP02_0013E', // female single-parent HH

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -1329,16 +1329,21 @@
     const t = chartTheme();
 
     // Stock by structure (counts)
+    // ACS 2023 confirmed codes (DP04 UNITS IN STRUCTURE starts at DP04_0007E):
+    //   DP04_0007E=1-unit detached, DP04_0008E=1-unit attached, DP04_0009E=2 units,
+    //   DP04_0010E=3-4 units, DP04_0011E=5-9 units, DP04_0012E=10-19 units,
+    //   DP04_0013E=20+ units, DP04_0014E=mobile home
+    // Note: in older ACS years this section started at DP04_0003E (now vacancy codes).
     const stock = [
-      { k:'1-unit detached', v:Number(profile?.DP04_0003E) },
-      { k:'1-unit attached', v:Number(profile?.DP04_0004E) },
-      { k:'2 units', v:Number(profile?.DP04_0005E) },
-      { k:'3–4 units', v:Number(profile?.DP04_0006E) },
-      { k:'5–9 units', v:Number(profile?.DP04_0007E) },
-      { k:'10–19 units', v:Number(profile?.DP04_0008E) },
-      { k:'20+ units', v:Number(profile?.DP04_0009E) },
-      { k:'Mobile home', v:Number(profile?.DP04_0010E) },
-    ].filter(d=>Number.isFinite(d.v));
+      { k:'1-unit detached', v:Number(profile?.DP04_0007E) },
+      { k:'1-unit attached', v:Number(profile?.DP04_0008E) },
+      { k:'2 units',         v:Number(profile?.DP04_0009E) },
+      { k:'3–4 units',       v:Number(profile?.DP04_0010E) },
+      { k:'5–9 units',       v:Number(profile?.DP04_0011E) },
+      { k:'10–19 units',     v:Number(profile?.DP04_0012E) },
+      { k:'20+ units',       v:Number(profile?.DP04_0013E) },
+      { k:'Mobile home',     v:Number(profile?.DP04_0014E) },
+    ].filter(d=>Number.isFinite(d.v) && d.v > 0);
 
     makeChart(document.getElementById('chartStock').getContext('2d'), {
       type:'bar',
@@ -1362,8 +1367,9 @@
     });
 
     // Tenure donut
-    const owner = Number(profile?.DP04_0047PE);
-    const renter = Number(profile?.DP04_0046PE);
+    // ACS 2023: DP04_0046PE = owner-occupied %, DP04_0047PE = renter-occupied %
+    const owner = Number(profile?.DP04_0046PE);
+    const renter = Number(profile?.DP04_0047PE);
     makeChart(document.getElementById('chartTenure').getContext('2d'), {
       type:'doughnut',
       data:{
@@ -2591,6 +2597,19 @@
 
   /**
    * renderHousingAgeChart — Age of housing stock (DP04 year built)
+   *
+   * ACS 5-year 2023 confirmed variable codes (DP04 YEAR STRUCTURE BUILT):
+   *   DP04_0017E = Built 2020 or later
+   *   DP04_0018E = Built 2010 to 2019
+   *   DP04_0019E = Built 2000 to 2009
+   *   DP04_0020E = Built 1990 to 1999
+   *   DP04_0021E = Built 1980 to 1989
+   *   DP04_0022E = Built 1970 to 1979
+   *   DP04_0023E = Built 1960 to 1969
+   *   DP04_0024E = Built 1950 to 1959
+   *   DP04_0025E = Built 1940 to 1949
+   *   DP04_0026E = Built 1939 or earlier
+   * Note: DP04_0027E–DP04_0032E are ROOMS variables, not year-built.
    */
   function renderHousingAgeChart(profile) {
     const canvas = document.getElementById('chartHousingAge');
@@ -2598,12 +2617,12 @@
     const t = chartTheme();
     const eras = [
       { label: 'Pre-1940',  v: Number(profile.DP04_0026E) },
-      { label: '1940–1959', v: Number(profile.DP04_0027E) },
-      { label: '1960–1979', v: Number(profile.DP04_0028E) },
-      { label: '1980–1999', v: Number(profile.DP04_0029E) },
-      { label: '2000–2009', v: Number(profile.DP04_0030E) },
-      { label: '2010–2019', v: Number(profile.DP04_0031E) },
-      { label: '2020+',     v: Number(profile.DP04_0032E) },
+      { label: '1940–1959', v: (Number(profile.DP04_0025E) || 0) + (Number(profile.DP04_0024E) || 0) },
+      { label: '1960–1979', v: (Number(profile.DP04_0023E) || 0) + (Number(profile.DP04_0022E) || 0) },
+      { label: '1980–1999', v: (Number(profile.DP04_0021E) || 0) + (Number(profile.DP04_0020E) || 0) },
+      { label: '2000–2009', v: Number(profile.DP04_0019E) },
+      { label: '2010–2019', v: Number(profile.DP04_0018E) },
+      { label: '2020+',     v: Number(profile.DP04_0017E) },
     ].filter(e => e.v > 0);
     if (!eras.length) return;
     makeChart(canvas.getContext('2d'), {
@@ -2626,17 +2645,26 @@
 
   /**
    * renderBedroomMixChart — Bedroom mix (DP04 bedrooms)
+   *
+   * ACS 5-year 2023 confirmed variable codes (DP04 BEDROOMS):
+   *   DP04_0039E = No bedroom
+   *   DP04_0040E = 1 bedroom
+   *   DP04_0041E = 2 bedrooms
+   *   DP04_0042E = 3 bedrooms
+   *   DP04_0043E = 4 bedrooms
+   *   DP04_0044E = 5 or more bedrooms
+   * Note: DP04_0045E–DP04_0047E are HOUSING TENURE variables, not bedrooms.
    */
   function renderBedroomMixChart(profile) {
     const canvas = document.getElementById('chartBedroomMix');
     if (!canvas || !profile) return;
     const t = chartTheme();
     const mix = [
-      { label: 'No bedroom', v: Number(profile.DP04_0042E) },
-      { label: '1 bedroom',  v: Number(profile.DP04_0043E) },
-      { label: '2 bedrooms', v: Number(profile.DP04_0044E) },
-      { label: '3 bedrooms', v: Number(profile.DP04_0045E) },
-      { label: '4+ bedrooms',v: Number(profile.DP04_0046E) },
+      { label: 'No bedroom', v: Number(profile.DP04_0039E) },
+      { label: '1 bedroom',  v: Number(profile.DP04_0040E) },
+      { label: '2 bedrooms', v: Number(profile.DP04_0041E) },
+      { label: '3 bedrooms', v: Number(profile.DP04_0042E) },
+      { label: '4+ bedrooms',v: (Number(profile.DP04_0043E) || 0) + (Number(profile.DP04_0044E) || 0) },
     ].filter(m => m.v > 0);
     if (!mix.length) return;
     makeChart(canvas.getContext('2d'), {
@@ -2701,13 +2729,17 @@
     const el = document.getElementById('housingGapSummary');
     if (!el || !profile) return;
 
-    const rentVac      = Number(profile.DP04_0005PE) || 0;
-    // ACS DP04 rent burden fields:
-    // DP04_0136PE = gross rent ≥30% of income (cost-burdened, includes severely burdened)
-    // DP04_0141PE = gross rent ≥50% of income (severely burdened)
-    const rentBurden30 = Number(profile.DP04_0136PE) || 0; // ≥30% (cost-burdened)
-    const rentBurden50 = Number(profile.DP04_0141PE) || 0; // ≥50% (severely burdened)
-    const renterHH     = Number(profile.DP04_0047E)  || 0;
+    // ACS 2023 DP04 vacancy rate — DP04_0005E = Rental vacancy rate (stored as estimate)
+    const rentVac = Number(profile.DP04_0005E) || Number(profile.DP04_0005PE) || 0;
+    // ACS 2023 GRAPI rent burden:
+    // DP04_0141PE = 30.0–34.9% of income; DP04_0142PE = 35%+ of income
+    // DP04_0136PE = pre-computed ≥30% (stored by B-series fallback in pipeline)
+    // For live profile fetches: ≥30% = DP04_0141PE + DP04_0142PE
+    const grapi_30_34 = Number(profile.DP04_0141PE) || 0;
+    const grapi_35p   = Number(profile.DP04_0142PE) || 0;
+    const rentBurden30 = Number(profile.DP04_0136PE) || (grapi_30_34 + grapi_35p) || 0; // ≥30% cost-burdened
+    const rentBurden50 = grapi_35p || 0; // ≥35% (best DP04 proxy; ACS DP04 has no 50% bin)
+    const renterHH     = Number(profile.DP04_0047E) || 0;
 
     // Estimate households at each AMI tier using ACS income brackets.
     // These are rough approximations: actual AMI thresholds vary by county and are
@@ -2723,12 +2755,12 @@
     el.innerHTML = `
       <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:10px;">
         <div class="stat">
-          <div class="k">Severely burdened renters (≥50%)</div>
+          <div class="k">Severely burdened renters (≥35%)</div>
           <div class="v" style="color:var(--bad,#ef4444)">${sevBurdened > 0 ? sevBurdened.toLocaleString() : '—'}</div>
-          <div class="s">Est. households</div>
+          <div class="s">Est. households (ACS GRAPI 35%+ bin)</div>
         </div>
         <div class="stat">
-          <div class="k">Moderately burdened renters (30–50%)</div>
+          <div class="k">Cost-burdened renters (≥30%)</div>
           <div class="v" style="color:var(--warn,#d97706)">${modBurdened > 0 ? modBurdened.toLocaleString() : '—'}</div>
           <div class="s">Est. households</div>
         </div>
@@ -2755,7 +2787,8 @@
       </div>
       <p style="font-size:.82rem;color:var(--muted);margin-top:8px">
         AMI tier estimates based on household income brackets from ACS DP03.
-        Severely burdened = renter households spending ≥50% of income on housing (ACS GRAPI).
+        Cost-burdened = renters spending ≥30% of income on housing (ACS GRAPI DP04_0141+0142).
+        Severely burdened = renters spending ≥35% (ACS DP04 finest available bin; HUD standard is 50%).
       </p>
     `;
   }
@@ -2768,8 +2801,10 @@
     if (!el || !profile) return;
 
     const totalPop    = Number(profile.DP05_0001E) || 0;
-    const pop65plus   = Number(profile.DP05_0029E) || Number(profile.DP05_0030E) || 0;
-    const pop75plus   = Number(profile.DP05_0031E) || 0;
+    const pop65plus   = Number(profile.DP05_0024E) || Number(profile.DP05_0029E) || 0;
+    // 75+ = sum of ACS age bins: DP05_0016E (75–84) + DP05_0017E (85+)
+    // DP05_0031E is "65 years and over, Female" — NOT a 75+ aggregate
+    const pop75plus   = (Number(profile.DP05_0016E) || 0) + (Number(profile.DP05_0017E) || 0);
     const disabledPop = Number(profile.DP02_0072E) || 0;
     const childrenU18 = Number(profile.DP05_0019E) || 0;
     const familyHH    = Number(profile.DP02_0003E) || 0;

--- a/scripts/hna/build_hna_data.py
+++ b/scripts/hna/build_hna_data.py
@@ -712,10 +712,11 @@ def _fetch_acs5_b_series(geo_type: str, geoid: str) -> dict | None:
             burden35c = si(raw.get('B25070_010E'))
 
             # Compute percentages that mirror DP-series fields
+            # ACS 2023: DP04_0046PE = owner %, DP04_0047PE = renter % (not swapped)
             owner_pct = round(owner / occ * 100, 1) if (occ and owner is not None) else None
             renter_pct = round(renter / occ * 100, 1) if (occ and renter is not None) else None
 
-            # Aggregate structure "20+" for DP04_0009E (20–49 + 50+)
+            # Aggregate structure "20+" for DP04_0013E (20–49 + 50+)
             s20_49 = si(raw.get('B25024_008E'))
             s50p = si(raw.get('B25024_009E'))
             units_20p = (s20_49 or 0) + (s50p or 0) if (s20_49 is not None or s50p is not None) else None
@@ -726,37 +727,40 @@ def _fetch_acs5_b_series(geo_type: str, geoid: str) -> dict | None:
                     return None
                 return round(n / grapi_tot * 100, 1)
 
-            b25_29 = si(raw.get('B25070_006E'))
             b30_34 = burden30
-            # DP04_0142PE = <15%, DP04_0143PE = 15–19.9%, DP04_0144PE = 20–24.9%
-            # We cannot compute these exactly from B25070, so leave as None.
-            # DP04_0145PE = 30–34.9%, DP04_0146PE = 35%+
             burden35_total = sum(
                 v for v in [burden35a, burden35b, burden35c] if v is not None
             ) if any(v is not None for v in [burden35a, burden35b, burden35c]) else None
+            # Pre-compute ≥30% burdened for frontend renderHousingGapSummary (DP04_0136PE slot)
+            burden30_plus = (b30_34 or 0) + (burden35_total or 0)
 
             mapped = {
                 'DP05_0001E': raw.get('B01003_001E'),
                 'DP02_0001E': raw.get('B11001_001E'),
                 'DP03_0062E': raw.get('B19013_001E'),
                 'DP04_0001E': raw.get('B25001_001E'),
-                'DP04_0047PE': str(owner_pct) if owner_pct is not None else None,
-                'DP04_0046PE': str(renter_pct) if renter_pct is not None else None,
+                # Tenure — ACS 2023 correct orientation: DP04_0046PE=owner %, DP04_0047PE=renter %
+                'DP04_0046PE': str(owner_pct) if owner_pct is not None else None,
+                'DP04_0047PE': str(renter_pct) if renter_pct is not None else None,
+                'DP04_0046E': raw.get('B25003_002E'),   # owner HH count
+                'DP04_0047E': raw.get('B25003_003E'),   # renter HH count (used by Housing Gap panel)
                 'DP04_0089E': raw.get('B25077_001E'),
                 'DP04_0134E': raw.get('B25064_001E'),
-                'DP04_0003E': raw.get('B25024_002E'),
-                'DP04_0004E': raw.get('B25024_003E'),
-                'DP04_0005E': raw.get('B25024_004E'),
-                'DP04_0006E': raw.get('B25024_005E'),
-                'DP04_0007E': raw.get('B25024_006E'),
-                'DP04_0008E': raw.get('B25024_007E'),
-                'DP04_0009E': str(units_20p) if units_20p is not None else None,
-                'DP04_0010E': raw.get('B25024_010E'),
-                'DP04_0142PE': None,
-                'DP04_0143PE': None,
-                'DP04_0144PE': str(grapi_pct(b25_29)) if b25_29 is not None else None,
-                'DP04_0145PE': str(grapi_pct(b30_34)) if b30_34 is not None else None,
-                'DP04_0146PE': str(grapi_pct(burden35_total)) if burden35_total is not None else None,
+                # Structure type — ACS 2023 codes: DP04_0007E=1-unit detached … DP04_0014E=mobile home
+                # (In older ACS this section started at DP04_0003E; it shifted to DP04_0007E in 2023)
+                'DP04_0007E': raw.get('B25024_002E'),   # 1-unit detached
+                'DP04_0008E': raw.get('B25024_003E'),   # 1-unit attached
+                'DP04_0009E': raw.get('B25024_004E'),   # 2 units
+                'DP04_0010E': raw.get('B25024_005E'),   # 3-4 units
+                'DP04_0011E': raw.get('B25024_006E'),   # 5-9 units
+                'DP04_0012E': raw.get('B25024_007E'),   # 10-19 units
+                'DP04_0013E': str(units_20p) if units_20p is not None else None,  # 20+ units
+                'DP04_0014E': raw.get('B25024_010E'),   # mobile home
+                # GRAPI — store pre-computed ≥30% in DP04_0136PE slot (frontend reads this as cost-burdened %)
+                # DP04_0141PE = 30–34.9% bin, DP04_0142PE = 35%+ bin
+                'DP04_0136PE': str(grapi_pct(burden30_plus)) if grapi_tot else None,   # ≥30% burdened
+                'DP04_0141PE': str(grapi_pct(b30_34)) if b30_34 is not None else None,  # 30–34.9%
+                'DP04_0142PE': str(grapi_pct(burden35_total)) if burden35_total is not None else None,  # 35%+
                 'NAME': raw.get('NAME'),
             }
             return mapped
@@ -767,17 +771,35 @@ def _fetch_acs5_b_series(geo_type: str, geoid: str) -> dict | None:
 
 def fetch_acs_profile(geo_type: str, geoid: str) -> dict | None:
     """Fetch ACS profile with fallback chain: ACS1/profile → ACS1/subject → ACS5/profile.
-    For CDPs, adds ACS 5-year B-series as a final fallback."""
+    For CDPs, adds ACS 5-year B-series as a final fallback.
+
+    ACS variable code notes (verified against ACS 5-year 2023 variable list):
+    - DP04_0046PE = Owner-occupied %  (DP04_0047PE = Renter-occupied %)
+    - Structure type starts at DP04_0007E in ACS 2023 (older years had it at DP04_0003E)
+    - GRAPI bins: DP04_0137PE (<15%) … DP04_0142PE (≥35%). DP04_0143–0146 do not exist
+      in ACS 2023 and cause HTTP 400 for the entire request if included.
+    """
     vars_ = [
-        'DP05_0001E',
-        'DP03_0062E',
-        'DP04_0001E',
-        'DP04_0047PE',
-        'DP04_0046PE',
-        'DP04_0089E',
-        'DP04_0134E',
-        'DP04_0003E','DP04_0004E','DP04_0005E','DP04_0006E','DP04_0007E','DP04_0008E','DP04_0009E','DP04_0010E',
-        'DP04_0142PE','DP04_0143PE','DP04_0144PE','DP04_0145PE','DP04_0146PE',
+        'DP05_0001E',   # Total population
+        'DP03_0062E',   # Median household income
+        'DP04_0001E',   # Total housing units
+        # Housing tenure (ACS 2023: DP04_0046PE=owner %, DP04_0047PE=renter %)
+        'DP04_0046PE',  # Owner-occupied %
+        'DP04_0047PE',  # Renter-occupied %
+        'DP04_0047E',   # Renter-occupied count (used by renderHousingGapSummary)
+        'DP04_0089E',   # Median home value (owner)
+        'DP04_0134E',   # Median gross rent
+        # Occupancy/vacancy (DP04_0003E–0005E in ACS 2023 = vacant HH, homeowner vac rate, rental vac rate)
+        'DP04_0005E',   # Rental vacancy rate
+        # Structure type (ACS 2023: DP04_0007E = 1-unit detached … DP04_0014E = mobile home)
+        # In older ACS years this section started at DP04_0003E; it now starts at DP04_0007E
+        'DP04_0007E','DP04_0008E','DP04_0009E','DP04_0010E',
+        'DP04_0011E','DP04_0012E','DP04_0013E','DP04_0014E',
+        # GRAPI rent burden bins (ACS 2023 confirmed codes; DP04_0144–0146PE do not exist)
+        # DP04_0137PE=<15%, DP04_0138PE=15–19.9%, DP04_0139PE=20–24.9%, DP04_0140PE=25–29.9%
+        # DP04_0141PE=30–34.9%, DP04_0142PE=35%+
+        'DP04_0137PE','DP04_0138PE','DP04_0139PE','DP04_0140PE',
+        'DP04_0141PE','DP04_0142PE',
         'NAME'
     ]
 


### PR DESCRIPTION
ACS Data Profile variable numbering shifted between vintages. The Python build pipeline, JS renderers, and live-fetch extVars were all requesting codes that no longer exist or now reference different data sections in ACS 2023, causing HTTP 400 failures and silent empty-chart returns.

=== Python pipeline (scripts/hna/build_hna_data.py) ===

fetch_acs_profile vars_ list:
- CRITICAL: Remove DP04_0144PE, DP04_0145PE, DP04_0146PE — these codes do not exist in any ACS year, causing HTTP 400 for EVERY profile request across all counties and CDPs, forcing B-series fallback always
- Add correct ACS 2023 GRAPI codes: DP04_0137PE–DP04_0142PE
- Correct structure type codes: now start at DP04_0007E (1-unit detached) not DP04_0003E (which is "Vacant HH" in ACS 2023)
- Add DP04_0047E (renter HH count) for Housing Gap panel computation
- Add DP04_0005E (rental vacancy rate)

_fetch_acs5_b_series mapper:
- Fix owner/renter swap: DP04_0046PE=owner %, DP04_0047PE=renter % (previously backwards — double-swap with old frontend made it appear correct, but breaks when profile fetch succeeds)
- Fix structure type output keys to correct ACS 2023 codes (DP04_0007E–DP04_0014E instead of DP04_0003E–DP04_0010E)
- Add DP04_0046E (owner HH count) and DP04_0047E (renter HH count)
- Replace non-existent GRAPI output keys (DP04_0142–0146PE) with: DP04_0136PE = pre-computed ≥30% burdened (for frontend compatibility) DP04_0141PE = 30–34.9% bin, DP04_0142PE = 35%+ bin

=== JavaScript renderers (js/hna/hna-renderers.js) ===

renderHousingCharts:
- Structure type chart: DP04_0003E–0010E → DP04_0007E–0014E (ACS 2023)
- Tenure donut: fix owner/renter swap (DP04_0046PE=owner, DP04_0047PE=renter)
- Add v > 0 guard to stock filter (prevents zero-value bars)

renderHousingAgeChart:
- Correct year-built codes: DP04_0017E (2020+) … DP04_0026E (pre-1940) DP04_0027E–0032E are ROOMS variables in ACS 2023, not year-built decades
- Combine decade pairs for 7 era bins (e.g. 1940–1959 = 0025E + 0024E)

renderBedroomMixChart:
- Correct bedroom codes: DP04_0039E (no BR) … DP04_0044E (5+ BR) DP04_0045E–0046E are HOUSING TENURE variables, not bedrooms

renderSpecialNeedsPanel:
- 75+ now computed as DP05_0016E (75–84) + DP05_0017E (85+) DP05_0031E = "65+ Female", was incorrectly used as a 75+ aggregate
- 65+ uses DP05_0024E as primary code (DP05_0029E as fallback)

renderHousingGapSummary:
- GRAPI ≥30% cost-burdened: use DP04_0136PE when available (written by pipeline), else fallback to DP04_0141PE + DP04_0142PE (direct profile)
- ≥35% severe burden proxy (ACS DP04 has no 50% bin; finest is 35%+)
- Rental vacancy: read DP04_0005E || DP04_0005PE
- Update labels to match corrected bin definitions

=== Live-fetch extVars (js/hna/hna-controller.js) ===

fetchAcsExtended extVars:
- Year-built, bedroom, structure type, 75+ codes all corrected (same as renderer fixes above)
- Add DP04_0007E–0014E (structure type) so live fetch supplements cache
- GRAPI: add DP04_0142PE (35%+), remove DP04_0136PE from extVars (it is the GRAPI universe total in ACS 2023, not ≥30% burdened)

All codes verified against live ACS 5-year 2023 variable list API.

## Summary
<!-- What does this PR do and why? -->


## Type
- [ ] Fix (bug, rendering, data, stability)
- [ ] Feature (new page, new module, new visualization)
- [ ] Data / pipeline (workflow, fetch script, JSON update)
- [ ] Docs / chore

## Scope check
- [ ] Fixes only — no new features bundled in
- [ ] No new CDN dependencies without a local vendor fallback in `js/vendor/`
- [ ] If page has charts inside `<details>` or hidden containers: `chart-fix.js` is loaded
- [ ] No parcel-level conclusions or award-probability scoring added
- [ ] Disclaimer present if any feasibility or screening output is new or changed

## Test plan
<!-- What should a reviewer check manually? -->
- [ ]
- [ ]
