### PR TITLE
feat(market): add walking + biking isochrone rings to PMA map

### DIFF
--- a/js/market-analysis.js
+++ b/js/market-analysis.js
@@ -65,8 +65,21 @@
   var bufferCircle = null;
   var todCircle    = null;   // ½-mile TOD isochrone (CHFA 3-pt scoring)
   var todMarkers   = null;   // L.layerGroup for highlighted transit stops in ½-mile
+  var isochroneRingsLayer = null;  // L.featureGroup of walking + biking rings
   var siteLatLng   = null;
   var bufferMiles  = 5;
+
+  // Walking + biking ring radii (miles). The ½-mile walking ring is the
+  // canonical CHFA TOD-scoring ring drawn separately as `todCircle` — skipped
+  // here to avoid visual overlap. Mode is used for tooltip labels + coloring.
+  var ISOCHRONE_RINGS = [
+    { miles: 0.25, mode: 'walk', color: '#16a34a' }, // 5-min walk
+    { miles: 0.75, mode: 'walk', color: '#22c55e' }, // 15-min walk
+    { miles: 1.0,  mode: 'walk', color: '#86efac' }, // 20-min walk
+    { miles: 2.0,  mode: 'bike', color: '#2563eb' }, // 10-min bike
+    { miles: 3.0,  mode: 'bike', color: '#3b82f6' }, // 15-min bike
+    { miles: 5.0,  mode: 'bike', color: '#93c5fd' }  // 25-min bike
+  ];
   var lastResult   = null;
   var dataLoaded   = false;  // true once loadData() has settled
 
@@ -2021,7 +2034,61 @@
     // Highlight transit stops within ½ mile
     _highlightTodTransit(lat, lon, HALF_MILE_M);
 
+    // Walking + biking concentric rings (toggleable; off by default)
+    _refreshIsochroneRings(lat, lon);
+
     setText('pmaSiteCoords', lat.toFixed(5) + ', ' + lon.toFixed(5));
+  }
+
+  /**
+   * Build the walking + biking concentric-ring overlay around (lat, lon).
+   *
+   * Rings are computed as straight-line buffers (matching how CHFA QAP
+   * scoring works for transit/amenity proximity points) — not network
+   * isochrones. A future enhancement could fetch real network-aware
+   * isochrones from OSRM or Valhalla and cache per-site, but for screening
+   * the straight-line approximation is what reviewers actually use.
+   *
+   * Honors the #pmaIsochroneToggle checkbox: rings are only added to the
+   * map when checked, but the layer is built either way so toggling on/off
+   * is instant.
+   */
+  function _refreshIsochroneRings(lat, lon) {
+    var L = window.L;
+    if (!L || !map) return;
+
+    // Tear down any existing ring layer
+    if (isochroneRingsLayer) {
+      if (map.hasLayer(isochroneRingsLayer)) map.removeLayer(isochroneRingsLayer);
+      isochroneRingsLayer = null;
+    }
+
+    var rings = [];
+    for (var i = 0; i < ISOCHRONE_RINGS.length; i++) {
+      var r = ISOCHRONE_RINGS[i];
+      var radiusMeters = r.miles * 1609.34;
+      var ring = L.circle([lat, lon], {
+        radius: radiusMeters,
+        color: r.color,
+        fillColor: r.color,
+        fillOpacity: 0.0,                 // fill off — rings only, not solid disks
+        weight: 1.5,
+        dashArray: r.mode === 'walk' ? '4 4' : '6 8',
+        interactive: true
+      });
+      var label = (r.miles < 1
+        ? (r.miles * 5280).toFixed(0) + ' ft'
+        : r.miles + ' mi') +
+        ' · ' + (r.mode === 'walk' ? 'walking' : 'biking');
+      ring.bindTooltip(label, { sticky: true, className: 'pma-tooltip' });
+      rings.push(ring);
+    }
+    isochroneRingsLayer = L.featureGroup(rings);
+
+    var cb = document.getElementById('pmaIsochroneToggle');
+    if (cb && cb.checked) {
+      isochroneRingsLayer.addTo(map);
+    }
   }
 
   /**
@@ -2449,6 +2516,20 @@
     bindRunBtn();
     bindAmiInputs();
     bindExport();
+
+    // Walking + biking isochrone rings toggle. The layer is rebuilt every
+    // time the site moves; here we just show/hide the cached layer.
+    var isoCb = document.getElementById('pmaIsochroneToggle');
+    if (isoCb) {
+      isoCb.addEventListener('change', function () {
+        if (!isochroneRingsLayer) return;
+        if (isoCb.checked) {
+          if (!map.hasLayer(isochroneRingsLayer)) isochroneRingsLayer.addTo(map);
+        } else {
+          if (map.hasLayer(isochroneRingsLayer)) map.removeLayer(isochroneRingsLayer);
+        }
+      });
+    }
 
     // Validate required modules are available.
     ['DataService', 'MAState', 'MARenderers', 'SiteSelectionScore', 'MAController'].forEach(function (name) {

--- a/market-analysis.html
+++ b/market-analysis.html
@@ -255,6 +255,12 @@
             <option value="10">10 miles</option>
             <option value="15">15 miles</option>
           </select>
+          <label for="pmaIsochroneToggle" class="pma-iso-toggle"
+                 style="display:inline-flex;align-items:center;gap:.4rem;margin-left:.9rem;font-size:.78rem;color:var(--muted);cursor:pointer"
+                 title="Show concentric rings around the placed site at walking and biking radii">
+            <input type="checkbox" id="pmaIsochroneToggle" aria-label="Show walking and biking isochrone rings">
+            <span>Walking + biking rings</span>
+          </label>
           <span id="pmaSiteCoords" style="font-size:var(--tiny);color:var(--text);margin-left:auto">No site selected</span>
         </div>
         <div id="pmaMap" role="application" aria-label="Colorado map — click to place a site marker"></div>


### PR DESCRIPTION
## Summary

Phase 5 MVP. Adds a toggleable overlay of 6 concentric rings around the placed site at the radii reviewers actually score against — useful for at-a-glance proximity assessment without manually measuring distances.

## Rings

| Mode | Radius | Mins | Color |
|---|---|---|---|
| 🟢 Walking | 0.25 mi | 5 min | green |
| 🟢 Walking | **0.5 mi** | 10 min | (existing TOD ring, drawn separately) |
| 🟢 Walking | 0.75 mi | 15 min | green |
| 🟢 Walking | 1.0 mi | 20 min | green |
| 🔵 Biking | 2.0 mi | 10 min | blue |
| 🔵 Biking | 3.0 mi | 15 min | blue |
| 🔵 Biking | 5.0 mi | 25 min | blue |

The 0.5-mi TOD ring is already drawn separately as \`todCircle\` (CHFA 3-pt scoring); skipped here to avoid visual overlap.

## Why straight-line, not network isochrones

Distances are straight-line buffers, **not** network-aware isochrones. Two reasons:

1. **CHFA QAP scoring uses straight-line distance** for transit/amenity points — what reviewers actually use.
2. **No external API dependency.** Real network isochrones require OSRM or Valhalla, plus a per-site caching layer. That's worthwhile follow-up work but out of scope for this MVP.

## UX

- Checkbox in \`.pma-controls\` next to the buffer-radius selector: **"Walking + biking rings"**.
- **Off by default** to avoid initial-load clutter.
- Each ring shows a sticky tooltip on hover: \`"1320 ft · walking"\`, \`"3 mi · biking"\`, etc.
- Rings re-center automatically when the user clicks elsewhere on the map.

## Files
- \`market-analysis.html\` — new checkbox in \`.pma-controls\` (+6 lines)
- \`js/market-analysis.js\` — \`ISOCHRONE_RINGS\` config, \`_refreshIsochroneRings()\` helper, hook into \`placeSiteMarker\`, DOMContentLoaded handler (+81 lines)

**No new dependencies, no external API calls, no data files added.**

## Test plan
- [ ] Load \`market-analysis.html\` → "Walking + biking rings" checkbox appears next to "Buffer radius"
- [ ] Click anywhere on the map → site marker + 0.5-mi TOD ring appear (existing behavior)
- [ ] Tick the checkbox → 6 concentric rings appear in green/blue, with dashed strokes
- [ ] Hover any ring → tooltip shows radius + mode
- [ ] Click a different spot → rings recenter
- [ ] Untick → rings disappear, TOD ring stays
- [ ] No console errors

## Future work (not in this PR)
- Score each LIHTC project / amenity by which ring it falls in
- Real network-aware isochrones (OSRM/Valhalla, cached per site)
- Add ring-specific scoring panels (e.g. "12 transit stops within 0.5 mi", "3 grocery stores within 1 mi")

🤖 Generated with [Claude Code](https://claude.com/claude-code)