### PR TITLE
fix(nav): make persona toggle discoverable — 'View as:' label + per-button tooltips

### DIFF
--- a/css/navigation.css
+++ b/css/navigation.css
@@ -389,6 +389,23 @@ main {
   align-items: center;
 }
 
+/* Inline "View as:" label so users can see at a glance what the
+   persona buttons control. Hidden on narrow viewports — the buttons
+   themselves carry per-persona title tooltips. */
+.audience-toggle__label {
+  font-size: .65rem;
+  color: var(--muted);
+  font-weight: 700;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+  margin-right: 6px;
+  user-select: none;
+}
+
+@media (max-width: 900px) {
+  .audience-toggle__label { display: none; }
+}
+
 .audience-toggle__btn {
   padding: 4px 9px;
   font-size: .72rem;

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -175,10 +175,16 @@
         <div class="jurisdiction-pill-wrap" id="jurisdictionPillWrap">
           <!-- populated by _updateJurisdictionPill() after DOM is ready -->
         </div>
-        <div class="audience-toggle" id="audienceToggleWrap" aria-label="Audience view">
-          <button class="audience-toggle__btn" type="button" data-audience="elected" aria-pressed="false">Elected</button>
-          <button class="audience-toggle__btn" type="button" data-audience="developer" aria-pressed="true">Developer</button>
-          <button class="audience-toggle__btn" type="button" data-audience="financier" aria-pressed="false">Financier</button>
+        <div class="audience-toggle" id="audienceToggleWrap"
+             role="group"
+             aria-label="Choose audience view to personalize tips, callouts, and starting-point CTA">
+          <span class="audience-toggle__label" aria-hidden="true">View as:</span>
+          <button class="audience-toggle__btn" type="button" data-audience="elected" aria-pressed="false"
+                  title="Elected officials &amp; staff: simplified summaries, policy framing, jurisdiction-level metrics">Elected</button>
+          <button class="audience-toggle__btn" type="button" data-audience="developer" aria-pressed="true"
+                  title="Developers &amp; project sponsors: technical detail, site selection, project pro-forma framing">Developer</button>
+          <button class="audience-toggle__btn" type="button" data-audience="financier" aria-pressed="false"
+                  title="Financiers, lenders &amp; investors: capital stack sizing, debt service coverage, deal economics">Financier</button>
         </div>
         <nav class="site-nav" aria-label="Primary">
           ${GROUPS.map(g => `


### PR DESCRIPTION
## Summary

Phase 7 of the original remediation plan. The persona buttons aren't inert — Copilot has fully wired them. What they lack is **discoverability**: new users have no way to know what the buttons control or what each persona means.

## What the toggle already does (pre-existing, not this PR)

- Persists choice to \`localStorage.coho_audience\`
- Calls \`EduCallout.setAudience()\` and \`LihtcTips.setAudience()\` → re-renders callouts/tips on 5 workflow pages (\`housing-needs-assessment\`, \`deal-calculator\`, \`market-analysis\`, \`select-jurisdiction\`, \`hna-scenario-builder\`)
- Shows a per-persona starting-point banner under the header via \`showAudienceBanner()\` — auto-hides after 8s, dismissable, includes direct CTA:
  - Elected → Open HNA
  - Developer → Select Jurisdiction
  - Financier → Open Deal Calculator

## What this PR fixes

Small, high-leverage UX polish so the toggle tells the user what it does:

**\`js/navigation.js\`**
- \`role="group"\` + descriptive \`aria-label\` on the toggle wrap: *"Choose audience view to personalize tips, callouts, and starting-point CTA"*
- Inline **"View as:"** label before the buttons
- \`title=\` tooltip on each button with the persona's framing:
  - Elected: "Elected officials & staff: simplified summaries, policy framing, jurisdiction-level metrics"
  - Developer: "Developers & project sponsors: technical detail, site selection, project pro-forma framing"
  - Financier: "Financiers, lenders & investors: capital stack sizing, debt service coverage, deal economics"

**\`css/navigation.css\`**
- \`.audience-toggle__label\` rule (uppercase, muted, small) — matches existing nav typography
- Hidden on viewports ≤900px (buttons retain tooltips for small-screen context)

## What this PR deliberately does NOT do

- **Per-persona content gating beyond callouts/tips** — e.g., hiding sections on the home page per persona. That requires a product/UX decision on which sections gate per persona, and can't be made unilaterally. Easy follow-up if you want it — just say which content should change per persona and I'll add \`data-audience\` attributes + a gating helper.

## Verification
- \`node --check js/navigation.js\` clean
- \`npm run test:validate\` — 28 passed / 0 failed
- Visual inspection only; no behavioral change to the existing toggle / banner / persistence logic

## Test plan
- [ ] Load any page → "View as: Elected | Developer | Financier" visible in nav (desktop)
- [ ] Hover any button → tooltip appears with per-persona description
- [ ] Screen reader announces toggle as a group with the full descriptive aria-label
- [ ] Resize to ≤900px → label hides, buttons remain with tooltips
- [ ] No behavioral regression: clicking still persists to localStorage, still triggers banner + EduCallout/LihtcTips re-render

🤖 Generated with [Claude Code](https://claude.com/claude-code)