### PR TITLE
chore(tests,ci): consolidate Python tests + extend endpoint audit (Phase 8)

### DIFF
--- a/.github/workflows/audit-endpoints.yml
+++ b/.github/workflows/audit-endpoints.yml
@@ -152,18 +152,200 @@ jobs:
           JS
 
       # ------------------------------------------------------------------ #
+      # Probe BLS LAUS (Local Area Unemployment Statistics) reachability    #
+      # Uses BLS Public API v2 with a known-good Colorado Adams County      #
+      # series (LAUCN080010000000003). Series ID format catches regression  #
+      # of the bug fixed in PR #621 (was sending 23-char IDs vs. correct    #
+      # 20-char). HTTP 200 + `REQUEST_SUCCEEDED` JSON status = up.          #
+      # ------------------------------------------------------------------ #
+      - name: Probe BLS LAUS endpoint
+        env:
+          BLS_API_KEY: ${{ secrets.BLS_API_KEY }}
+        run: |
+          node - <<'JS'
+          const https = require('https');
+          const apiKey = (process.env.BLS_API_KEY || '').trim();
+          const payload = JSON.stringify({
+            seriesid: ['LAUCN080010000000003'],
+            startyear: '2024',
+            endyear: '2024',
+            annualaverage: true,
+            ...(apiKey ? { registrationkey: apiKey } : {})
+          });
+
+          function probe() {
+            return new Promise(function(resolve, reject) {
+              const req = https.request({
+                hostname: 'api.bls.gov',
+                path: '/publicAPI/v2/timeseries/data/',
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Content-Length': payload.length },
+                timeout: 20000
+              }, function(res) {
+                let body = '';
+                res.setEncoding('utf8');
+                res.on('data', function(c){ body += c; });
+                res.on('end', function(){
+                  try {
+                    const json = JSON.parse(body);
+                    resolve({ status: res.statusCode, jsonStatus: json.status, hasData: (json.Results && json.Results.series && json.Results.series.length > 0) });
+                  } catch(e) {
+                    resolve({ status: res.statusCode, jsonStatus: 'PARSE_ERROR', hasData: false });
+                  }
+                });
+              });
+              req.on('error', reject);
+              req.on('timeout', function(){ req.destroy(); reject(new Error('timeout')); });
+              req.write(payload);
+              req.end();
+            });
+          }
+
+          (async function() {
+            try {
+              const r = await probe();
+              if (r.status === 200 && r.jsonStatus === 'REQUEST_SUCCEEDED' && r.hasData) {
+                console.log('✓ BLS LAUS reachable (HTTP 200, REQUEST_SUCCEEDED, series returned)');
+              } else {
+                console.warn('::warning::BLS LAUS responded HTTP ' + r.status + ', jsonStatus=' + r.jsonStatus + ', hasData=' + r.hasData);
+              }
+            } catch(e) {
+              console.warn('::warning::BLS LAUS unreachable: ' + e.message);
+            }
+          })();
+          JS
+
+      # ------------------------------------------------------------------ #
+      # Probe LEHD LODES (workplace + commuter flow) reachability           #
+      # LODES is published by the Census Bureau as static gz files.         #
+      # We probe the index page rather than a specific year/state to avoid  #
+      # tying the audit to a particular vintage.                            #
+      # ------------------------------------------------------------------ #
+      - name: Probe LEHD LODES endpoint
+        run: |
+          node - <<'JS'
+          const https = require('https');
+          const url = 'https://lehd.ces.census.gov/data/lodes/LODES8/co/';
+
+          function probe(u) {
+            return new Promise(function(resolve, reject) {
+              const req = https.get(u, { timeout: 15000 }, function(res) {
+                res.resume();
+                resolve({ status: res.statusCode, ok: res.statusCode < 500 });
+              });
+              req.on('error', reject);
+              req.on('timeout', function(){ req.destroy(); reject(new Error('timeout')); });
+            });
+          }
+
+          (async function() {
+            try {
+              const r = await probe(url);
+              if (r.ok) {
+                console.log('✓ LEHD LODES reachable (HTTP ' + r.status + ')');
+              } else {
+                console.warn('::warning::LEHD LODES returned HTTP ' + r.status);
+              }
+            } catch(e) {
+              console.warn('::warning::LEHD LODES unreachable: ' + e.message);
+            }
+          })();
+          JS
+
+      # ------------------------------------------------------------------ #
+      # Probe HUD CHAS (Comprehensive Housing Affordability Strategy) data  #
+      # CHAS is published by HUD as zipped CSVs by year. Probe the data     #
+      # directory landing page.                                              #
+      # ------------------------------------------------------------------ #
+      - name: Probe HUD CHAS endpoint
+        run: |
+          node - <<'JS'
+          const https = require('https');
+          const url = 'https://www.huduser.gov/portal/datasets/cp.html';
+
+          function probe(u) {
+            return new Promise(function(resolve, reject) {
+              const req = https.get(u, { timeout: 15000, headers: { 'User-Agent': 'HousingAnalytics-EndpointAudit/1.0' } }, function(res) {
+                res.resume();
+                resolve({ status: res.statusCode, ok: res.statusCode < 500 });
+              });
+              req.on('error', reject);
+              req.on('timeout', function(){ req.destroy(); reject(new Error('timeout')); });
+            });
+          }
+
+          (async function() {
+            try {
+              const r = await probe(url);
+              if (r.ok) {
+                console.log('✓ HUD CHAS reachable (HTTP ' + r.status + ')');
+              } else {
+                console.warn('::warning::HUD CHAS returned HTTP ' + r.status);
+              }
+            } catch(e) {
+              console.warn('::warning::HUD CHAS unreachable: ' + e.message);
+            }
+          })();
+          JS
+
+      # ------------------------------------------------------------------ #
+      # Probe BLS QCEW (Quarterly Census of Employment and Wages)           #
+      # KNOWN ISSUE: BLS appears to have deprecated the public CEW data API #
+      # (data.bls.gov/cew/data/api/.../area/.../json — every URL pattern    #
+      # tested returns HTTP 404, see PR #621 commit notes). This probe will #
+      # fail until the endpoint is restored or we migrate to FRED's         #
+      # COBPPRIVSAUS series. Kept here as a watchdog so we notice the day   #
+      # BLS brings the endpoint back.                                       #
+      # ------------------------------------------------------------------ #
+      - name: Probe BLS QCEW endpoint (known broken — watchdog)
+        continue-on-error: true
+        run: |
+          node - <<'JS'
+          const https = require('https');
+          const url = 'https://data.bls.gov/cew/data/api/2024/a/area/08001.json';
+
+          function probe(u) {
+            return new Promise(function(resolve, reject) {
+              const req = https.get(u, { timeout: 15000 }, function(res) {
+                res.resume();
+                resolve({ status: res.statusCode, ok: res.statusCode < 500 });
+              });
+              req.on('error', reject);
+              req.on('timeout', function(){ req.destroy(); reject(new Error('timeout')); });
+            });
+          }
+
+          (async function() {
+            try {
+              const r = await probe(url);
+              if (r.ok) {
+                console.log('::notice::BLS QCEW endpoint is BACK UP (HTTP ' + r.status + '). Time to revert FRED fallback.');
+              } else {
+                console.log('BLS QCEW still broken (HTTP ' + r.status + ') — using FRED fallback.');
+              }
+            } catch(e) {
+              console.log('BLS QCEW unreachable (' + e.message + ') — using FRED fallback.');
+            }
+          })();
+          JS
+
+      # ------------------------------------------------------------------ #
       # Summary                                                             #
       # ------------------------------------------------------------------ #
       - name: Audit summary
         env:
           CENSUS_API_KEY: ${{ secrets.CENSUS_API_KEY }}
           FRED_API_KEY:   ${{ secrets.FRED_API_KEY }}
+          BLS_API_KEY:    ${{ secrets.BLS_API_KEY }}
         run: |
           node - <<'JS'
           const censusKey = (process.env.CENSUS_API_KEY || '').trim();
           const fredKey   = (process.env.FRED_API_KEY   || '').trim();
+          const blsKey    = (process.env.BLS_API_KEY    || '').trim();
           console.log('=== Endpoint Audit Summary ===');
           console.log('CENSUS_API_KEY :', censusKey ? `configured (${censusKey.length} chars)` : '⚠ NOT SET');
           console.log('FRED_API_KEY   :', fredKey   ? `configured (${fredKey.length} chars)`   : '⚠ NOT SET');
+          console.log('BLS_API_KEY    :', blsKey    ? `configured (${blsKey.length} chars)`    : 'unset (BLS LAUS still works without a key but is rate-limited)');
+          console.log('Probed: Census ACS · FRED · HUD GIS · BLS LAUS · LEHD LODES · HUD CHAS · BLS QCEW (known broken).');
           console.log('Audit complete.');
           JS

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -206,8 +206,10 @@ jobs:
 
       - name: Run pytest suite
         run: pytest tests/ -v --tb=short
-
-      - name: Run standalone Python tests
-        run: |
-          python test/economic_indicators_test.py
-          python test/build_counties_co_test.py
+        # Note: previously a separate "Run standalone Python tests" step
+        # invoked test/economic_indicators_test.py and
+        # test/build_counties_co_test.py. Those files have been moved into
+        # tests/ (see Phase 8 consolidation PR) so pytest now discovers
+        # and runs them as part of the suite above. demographic_projections_test.py
+        # has also been moved and is now exercised — it was orphaned before
+        # (existed in test/ but never invoked by any workflow).

--- a/TESTING.md
+++ b/TESTING.md
@@ -4,23 +4,42 @@ This document describes the test infrastructure for the COHO Housing Analytics p
 
 ## Test Directory Structure
 
+> **Convention (post-Phase-8 consolidation):**
+> - **`tests/`** — *all* Python tests (pytest-discovered).
+> - **`test/`**  — JavaScript test suites only (Node.js).
+>
+> Three Python test files (`build_counties_co_test.py`, `demographic_projections_test.py`,
+> `economic_indicators_test.py`) previously lived under `test/`. They have been moved
+> to `tests/` so `pytest tests/` exercises them automatically — no more standalone
+> `python test/foo.py` invocations in CI. (Bonus: `demographic_projections_test.py`
+> existed in `test/` but was never invoked by any workflow; pytest now picks it up.)
+
 ```
 tests/                          # Python pytest test suite
-  conftest.py                   # Shared fixtures and configuration
-  test_governance_stress.py     # Pre-commit governance rule validation (12 probes)
-  test_hna_geography_coverage.py  # HNA geography coverage consistency
-  test_ranking_index_sentinels.py # Sentinel/leak value detection in ranking data
-  test_pma_provenance.py        # PMA confidence module and data-quality API
-  test_stage2_temporal.py       # FRED temporal continuity checks
-  test_stage3_accessibility.py  # WCAG 2.1 AA contrast and landmark checks
-  test_stage3_visualization.py  # Chart color tokens, canvas aria, aria-live regions
+  conftest.py                          # Shared fixtures and configuration
+  test_governance_stress.py            # Pre-commit governance rule validation (12 probes)
+  test_hna_geography_coverage.py       # HNA geography coverage consistency
+  test_hna_ranking_integrity.py        # Ranking-index naming/LODES/pct_renters invariants
+  test_ranking_index_sentinels.py      # Sentinel/leak value detection in ranking data
+  test_pma_provenance.py               # PMA confidence module and data-quality API
+  test_sentinel_normalization.py       # Production JSON sentinel scan
+  test_stage2_temporal.py              # FRED temporal continuity checks
+  test_stage3_accessibility.py         # WCAG 2.1 AA contrast and landmark checks
+  test_stage3_visualization.py         # Chart color tokens, canvas aria, aria-live regions
+  build_counties_co_test.py            # Resilience tests for build_counties_co.py (moved from test/)
+  demographic_projections_test.py      # CohortComponentModel + headship + housing demand (moved from test/)
+  economic_indicators_test.py          # Employment, wage, industry concentration, J:W (moved from test/)
 
-test/                           # Legacy JavaScript test suites
-  hna-functionality-check.js    # HNA module smoke tests (Node.js, no pytest)
+test/                           # JavaScript test suites (Node.js, no pytest)
+  hna-functionality-check.js    # HNA module smoke tests
   smoke-market-analysis.js      # Market analysis smoke tests (sections 1–18)
   unit/                         # Unit tests for individual modules
   integration/                  # Integration tests for multi-module flows
 ```
+
+**Adding a new test:**
+- Python → drop into `tests/` with filename matching `test_*.py` or `*_test.py`. pytest will discover it automatically.
+- JavaScript → drop into `test/` and wire into the relevant `npm run test:*` script in `package.json`.
 
 ## Running Tests
 

--- a/tests/build_counties_co_test.py
+++ b/tests/build_counties_co_test.py
@@ -8,7 +8,8 @@ Tests the resilience improvements:
 
 Usage
 -----
-    python test/build_counties_co_test.py
+    pytest tests/build_counties_co_test.py -v
+    # (or, standalone) python tests/build_counties_co_test.py
 """
 
 from __future__ import annotations

--- a/tests/demographic_projections_test.py
+++ b/tests/demographic_projections_test.py
@@ -12,7 +12,8 @@ Also tests HeadshipRateModel and HousingDemandProjector.
 
 Usage
 -----
-    python test/demographic_projections_test.py
+    pytest tests/demographic_projections_test.py -v
+    # (or, standalone) python tests/demographic_projections_test.py
 """
 
 import sys

--- a/tests/economic_indicators_test.py
+++ b/tests/economic_indicators_test.py
@@ -10,7 +10,8 @@ Tests:
 
 Usage
 -----
-    python test/economic_indicators_test.py
+    pytest tests/economic_indicators_test.py -v
+    # (or, standalone) python tests/economic_indicators_test.py
 """
 
 import sys


### PR DESCRIPTION
## Summary

Phase 8 of the original remediation plan. Three small, safe changes bundled because they're cheap to review together:

1. **Python tests now all live in \`tests/\`** — three stray files moved from \`test/\` so \`pytest tests/\` discovers them.
2. **Endpoint audit covers BLS LAUS, LEHD LODES, HUD CHAS** (was: only Census, FRED, HUD GIS).
3. **\`TESTING.md\` documents the convention** so future contributors don't recreate the split.

## 8a — Python test consolidation

| Was | Now |
|---|---|
| \`test/build_counties_co_test.py\` | \`tests/build_counties_co_test.py\` |
| \`test/demographic_projections_test.py\` | \`tests/demographic_projections_test.py\` |
| \`test/economic_indicators_test.py\` | \`tests/economic_indicators_test.py\` |

All three already use \`def test_*\` naming and path-resolution helpers that work from any cwd — no code changes inside the files, just updated their usage-example docstrings.

**Bonus:** \`demographic_projections_test.py\` was orphaned — it lived in \`test/\` but no workflow ever invoked it. Pytest now picks it up.

\`.github/workflows/ci-checks.yml\` — dropped the "Run standalone Python tests" step entirely; pytest \`tests/\` covers all three. Left a comment explaining the change.

## 8b — Endpoint audit coverage

\`audit-endpoints.yml\` extended from 3 → 6 (+1 watchdog) endpoints:

| Endpoint | Probe |
|---|---|
| Census ACS | (existing) |
| FRED | (existing) |
| HUD GIS | (existing) |
| **BLS LAUS** | NEW — POST to \`api.bls.gov/publicAPI/v2/timeseries/data/\` with the exact known-good series \`LAUCN080010000000003\` from PR #621. Catches regression of the series-ID bug. |
| **LEHD LODES** | NEW — GET \`lehd.ces.census.gov/data/lodes/LODES8/co/\` index. |
| **HUD CHAS** | NEW — GET portal landing page. |
| **BLS QCEW (watchdog)** | NEW (continue-on-error) — known broken since #621; emits GitHub \`::notice\` if the endpoint ever returns 200, signaling time to unwind the FRED fallback. |

Audit summary step now also reports \`BLS_API_KEY\` status.

## 8c — TESTING.md

Updated the directory-structure section with an explicit convention callout:

> - **\`tests/\`** — *all* Python tests (pytest-discovered).
> - **\`test/\`**  — JavaScript test suites only (Node.js).

Added an "Adding a new test" cheatsheet so future devs land their files in the right place.

## Verification
- All 3 moved Python files compile clean (\`python3 -m py_compile\`).
- \`npm run test:validate\`: 28 passed / 0 failed.
- No behavior change for already-green tests; the only net-new behavior is pytest discovering the 3 moved files (which it should — they're standard \`def test_*\` functions).

## Risk
- **Low.** The Python files use \`os.path.dirname(__file__)\` for path resolution and don't import each other, so the move is safe.
- The CI step that previously ran them as \`python test/foo.py\` is replaced by pytest discovery — same code, same Python interpreter, same fixtures, just better invocation.
- Test-script renames are an audit-able single-commit change (git \`R\` rename detection should make the diff easy to review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)