### PR TITLE
fix(hna): GRAPI rent-burden bin chart — use correct DP04 field codes

### DIFF
--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -1544,12 +1544,16 @@
 
   function renderRentBurdenBins(profile){
     const t = chartTheme();
+    // ACS DP04 GRAPI bins (gross rent as % of household income):
+    // DP04_0137PE = <15%, _0138PE = 15–19.9%, _0139PE = 20–24.9%,
+    // _0140PE = 25–29.9%, _0141PE = 30–34.9%, _0142PE = 35%+
     const bins = [
-      { k:'<20%', v:Number(profile?.DP04_0142PE) },
-      { k:'20–24.9%', v:Number(profile?.DP04_0143PE) },
-      { k:'25–29.9%', v:Number(profile?.DP04_0144PE) },
-      { k:'30–34.9%', v:Number(profile?.DP04_0145PE) },
-      { k:'35%+', v:Number(profile?.DP04_0146PE) },
+      { k:'<15%', v:Number(profile?.DP04_0137PE) },
+      { k:'15–19.9%', v:Number(profile?.DP04_0138PE) },
+      { k:'20–24.9%', v:Number(profile?.DP04_0139PE) },
+      { k:'25–29.9%', v:Number(profile?.DP04_0140PE) },
+      { k:'30–34.9%', v:Number(profile?.DP04_0141PE) },
+      { k:'35%+', v:Number(profile?.DP04_0142PE) },
     ].filter(d=>Number.isFinite(d.v));
 
     makeChart(document.getElementById('chartRentBurdenBins').getContext('2d'), {


### PR DESCRIPTION
Closes #628.

## Problem
On `housing-needs-assessment.html` for every county/place, `chartRentBurdenBins` rendered a single data point instead of the 6-bin GRAPI distribution. The renderer was keying on DP04 fields that don't exist in the ACS profile (`DP04_0143PE`..`DP04_0146PE`); the one field that did exist (`DP04_0142PE`, the 35%+ bin) got mis-labeled as "<20%".

## Fix
`js/hna/hna-renderers.js:1545-1568` now uses the correct GRAPI bin codes:

| Field | Bin |
|---|---|
| `DP04_0137PE` | <15% |
| `DP04_0138PE` | 15–19.9% |
| `DP04_0139PE` | 20–24.9% |
| `DP04_0140PE` | 25–29.9% |
| `DP04_0141PE` | 30–34.9% |
| `DP04_0142PE` | 35%+ |

## Verification
Browser-tested on Denver County (FIPS 08031). Chart renders all six bars; data sums to ~97% (remainder is `DP04_0143PE` "not computed"), no console errors. Screenshot captured during QA.

## Test plan
- [ ] CI green
- [ ] Spot-check 3 additional counties (Boulder, Mesa, El Paso) to confirm all render six bins
- [ ] Confirm bin ordering left-to-right matches label order (low burden → high burden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)