### PR TITLE
chore(ci): add Dependabot for npm + github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Denver"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Denver"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"


### PR DESCRIPTION
Partial closeout of audit item #26 (security baseline) from the 2026-04-20 outstanding-items review.

## What this adds
- `.github/dependabot.yml` — weekly npm + github-actions scans, Monday 9am MT
- Dev-dependency minor/patch bumps are grouped into a single PR to reduce noise
- Production-dependency and major bumps get individual review PRs
- `open-pull-requests-limit: 5` (npm), `3` (actions) to cap backlog size

## What this doesn't include
**Deferred:** the `node-fetch` 2.7 → 3.x upgrade.

node-fetch v3 is ESM-only. Upgrading would require migrating 5 CommonJS files to dynamic imports:
- `test/daily-audit-system.js`
- `scripts/trigger-car-workflow.js`
- `test/audit-modules/report-generator.js`
- `scripts/fetch-county-demographics.js`
- `test/website-monitor-enhanced.js`

Better to let Dependabot itself propose that PR — the ESM-conversion tradeoff gets reviewed with full context, and each file gets touched only when the upgrade is explicitly approved.

## Test plan
- [ ] CI green
- [ ] First Dependabot scan triggers within 24h of merge
- [ ] Confirm first PR from Dependabot respects the grouping config (dev deps grouped; prod deps individual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)