### PR TITLE
fix(hna): scenario-panel copy reflects 10/20-year horizon toggle

### DIFF
--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -620,7 +620,7 @@
             </div>
             <div class="chart-card span-4" style="margin:0">
               <h3 style="font-size:.95rem;margin:0 0 4px">Selected scenario detail</h3>
-              <p style="font-size:.82rem;color:var(--muted);margin:0 0 8px">Single-scenario population trend over the 10-year horizon.</p>
+              <p id="scenarioDetailDesc" style="font-size:.82rem;color:var(--muted);margin:0 0 8px">Single-scenario population trend over the 10-year horizon.</p>
               <div class="chart-box tall"><canvas id="chartProjectionDetail" role="img" aria-label="Single-scenario population projection detail chart"></canvas></div>
             </div>
           </div>
@@ -639,7 +639,7 @@
         <div id="projViewDemand" hidden style="margin-top:12px">
           <div class="chart-card" style="margin:0">
             <h3 style="font-size:.95rem;margin:0 0 4px">Projected housing demand by affordability tier (renter households)</h3>
-            <p style="font-size:.82rem;color:var(--muted);margin:0 0 8px">Estimated renter households by AMI tier over the 10-year horizon. Used to identify missing AMI tiers for LIHTC applications. Based on statewide CO income distributions (ACS CHAS).</p>
+            <p id="demandTierDesc" style="font-size:.82rem;color:var(--muted);margin:0 0 8px">Estimated renter households by AMI tier over the 10-year horizon. Used to identify missing AMI tiers for LIHTC applications. Based on statewide CO income distributions (ACS CHAS).</p>
             <div class="chart-box tall"><canvas id="chartHouseholdDemand" role="img" aria-label="Housing demand by AMI affordability tier chart showing projected renter households at each income tier"></canvas></div>
           </div>
         </div>

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -1994,6 +1994,16 @@
     var horizonEl = document.querySelector('.horizon-btn--active');
     var SCENARIO_HORIZON = (horizonEl && parseInt(horizonEl.getAttribute('data-horizon'), 10)) || 10;
 
+    // Keep descriptive copy in sync with the selected horizon
+    var detailDesc = document.getElementById('scenarioDetailDesc');
+    if (detailDesc) {
+      detailDesc.textContent = 'Single-scenario population trend over the ' + SCENARIO_HORIZON + '-year horizon.';
+    }
+    var demandDesc = document.getElementById('demandTierDesc');
+    if (demandDesc) {
+      demandDesc.textContent = 'Estimated renter households by AMI tier over the ' + SCENARIO_HORIZON + '-year horizon. Used to identify missing AMI tiers for LIHTC applications. Based on statewide CO income distributions (ACS CHAS).';
+    }
+
     // Find the index of the base year in the years array
     const baseIdx = years.indexOf(baseYear);
     const basePop0 = (baseIdx >= 0 && popSel[baseIdx] !== null) ? popSel[baseIdx]


### PR DESCRIPTION
Closes #630.

## Problem
In the scenario-projections section of `housing-needs-assessment.html`, two descriptive paragraphs were hardcoded with "over the 10-year horizon":

- _"Single-scenario population trend over the 10-year horizon."_ (next to `chartProjectionDetail`)
- _"Estimated renter households by AMI tier over the 10-year horizon..."_ (next to `chartHouseholdDemand`)

The charts themselves correctly re-rendered from 10 → 20 years when the horizon button changed, but the accompanying copy stayed stuck at "10-year horizon," producing conflicting signals.

## Fix
- Give the two paragraphs stable IDs (`scenarioDetailDesc`, `demandTierDesc`)
- In `_renderScenarioSection` in `js/hna/hna-renderers.js` (called on every horizon change, per the existing `data-horizon` toggle), rewrite both paragraphs to use the active `SCENARIO_HORIZON` value

## Verification
Browser-tested on Denver County (08031). Captured copy at each step:

| Step | `scenarioDetailDesc` | `demandTierDesc` |
|---|---|---|
| Initial (10yr) | "...over the **10-year** horizon." | "...over the **10-year** horizon..." |
| Click 20-Year | "...over the **20-year** horizon." | "...over the **20-year** horizon..." |
| Back to 10-Year | "...over the **10-year** horizon." | "...over the **10-year** horizon..." |

Zero console errors.

## Test plan
- [ ] CI green
- [ ] Spot-check on one additional county (e.g. Boulder) — same behavior
- [ ] No regressions in the other two scenario charts (`chartScenarioComparison`, `chartProjectedHH`) which already had horizon-aware titles or no horizon-specific copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)