### PR TITLE
fix(market): NHPD competitive-set properties use correct field mapping

### DIFF
--- a/js/pma-competitive-set.js
+++ b/js/pma-competitive-set.js
@@ -60,12 +60,31 @@
   function _propName(f) {
     if (!f) return 'Unknown Property';
     var p = f.properties || f;
-    return p.PROJECT_NAME || p.projectName || p.name || p.PROPERTY_NAME || 'Unknown Property';
+    // Handles HUD LIHTC (PROJECT_NAME), NHPD (property_name), and internal shapes
+    return p.PROJECT_NAME || p.projectName || p.name
+        || p.PROPERTY_NAME || p.property_name || 'Unknown Property';
   }
 
   function _propUnits(f) {
     var p = (f && f.properties) ? f.properties : f;
-    return toNum(p && (p.LI_UNITS || p.N_UNITS || p.totalUnits || p.units) || 0);
+    // LI_UNITS/N_UNITS = HUD LIHTC; total_units/assisted_units = NHPD
+    return toNum(p && (p.LI_UNITS || p.N_UNITS || p.totalUnits || p.units
+                    || p.total_units || p.assisted_units) || 0);
+  }
+
+  // Extract expiry year from LIHTC numeric fields or NHPD date strings
+  function _propExpiryYear(f) {
+    var p = (f && f.properties) ? f.properties : f;
+    if (!p) return null;
+    var direct = toNum(p.expiryYear || p.EXPIRY_YEAR || 0);
+    if (direct) return direct;
+    // NHPD subsidy_expiration is a date string like "2027-09-30"
+    var iso = p.subsidy_expiration || p.subsidyExpiration;
+    if (iso) {
+      var y = parseInt(String(iso).slice(0, 4), 10);
+      if (y >= 1900 && y <= 2100) return y;
+    }
+    return null;
   }
 
   /* ── Core API ────────────────────────────────────────────────────── */
@@ -115,8 +134,7 @@
       var props   = f.properties || f;
       var expiryYear = null;
       if (nhpdMatch) {
-        var nhpdProps = nhpdMatch.properties || nhpdMatch;
-        expiryYear = toNum(nhpdProps.expiryYear || nhpdProps.EXPIRY_YEAR || 0) || null;
+        expiryYear = _propExpiryYear(nhpdMatch);
       }
       return {
         id:              props.HUDID || props.id || ('lihtc-' + Math.random().toString(36).slice(2)),
@@ -145,15 +163,15 @@
       if (!alreadyMerged) {
         var dist = haversine(siteLat, siteLon, _propLat(f), _propLon(f));
         var props = f.properties || f;
-        var expYear = toNum(props.expiryYear || props.EXPIRY_YEAR || 0) || null;
+        var expYear = _propExpiryYear(f);
         merged.push({
-          id:              props.id || ('nhpd-' + Math.random().toString(36).slice(2)),
+          id:              props.id || props.nhpd_id || ('nhpd-' + Math.random().toString(36).slice(2)),
           name:            _propName(f),
           lat:             _propLat(f),
           lon:             _propLon(f),
           distanceMiles:   Math.round(dist * 10) / 10,
           units:           _propUnits(f),
-          programType:     props.program || props.PROGRAM || 'Section 8',
+          programType:     props.program || props.PROGRAM || props.subsidy_type || 'Section 8',
           amiPercent:      toNum(props.amiPercent || 60),
           yearPlaced:      toNum(props.yearPlaced || 0),
           hasNhpd:         true,
@@ -182,8 +200,7 @@
 
     lastExpiryRisk = nhpdFeatures
       .map(function (f) {
-        var props = f.properties || f;
-        var expiry = toNum(props.expiryYear || props.EXPIRY_YEAR || 0);
+        var expiry = _propExpiryYear(f) || 0;
         return {
           property:    _propName(f),
           lat:         _propLat(f),


### PR DESCRIPTION
Closes #629.

## Problem
Every NHPD entry returned from `PMACompetitiveSet.buildCompetitiveSet()` surfaced as:

\`\`\`json
{ "name": "Unknown Property", "units": 0, "programType": "Section 8",
  "subsidyExpiryYear": null, "atExpiryRisk": null }
\`\`\`

`flagSubsidyExpiryRisk()` consistently returned zero at-risk properties despite 20 NHPD features in the dataset.

## Root cause
Field-name mismatch. The NHPD source (`data/market/nhpd_co.geojson`) uses snake_case:

\`\`\`
property_name, total_units, assisted_units, subsidy_expiration, subsidy_type
\`\`\`

But the `_prop*` helpers in `js/pma-competitive-set.js` only looked for LIHTC-style names (`PROJECT_NAME`, `LI_UNITS`, `expiryYear` numeric). None of those exist on an NHPD feature, so every lookup fell through to defaults.

## Fix
- `_propName`: also read `property_name`
- `_propUnits`: also read `total_units` / `assisted_units`
- New `_propExpiryYear(f)` that extracts a year from either the numeric `expiryYear` / `EXPIRY_YEAR` (LIHTC path, preserved) or a `"YYYY-MM-DD"` `subsidy_expiration` date string (NHPD path)
- Replace 3 inline expiry-year lookups with `_propExpiryYear()`
- NHPD-only branch now also reads `subsidy_type` for `programType` and `nhpd_id` for a stable id

## Verification
Browser-tested on Denver City Hall coords (39.7392, -104.9903) + 5mi buffer:

| Field | Before | After |
|---|---|---|
| NHPD entry name | "Unknown Property" | "Mariposa Apartments" / "Aurora Gateway Residences" |
| units | 0 | 210 / 200 |
| programType | "Section 8" (default) | "HUD Section 8 PBRA" (from subsidy_type) |
| subsidyExpiryYear | null | 2027 / 2028 |
| atExpiryRisk | null | true |
| flagSubsidyExpiryRisk() count (statewide) | 0 | 14 |

Zero console errors.

## Test plan
- [ ] CI green
- [ ] Load `market-analysis.html`, confirm no regression to LIHTC (non-NHPD) entries
- [ ] Smoke-check the subsidy-expiry panel renders at-risk properties with names + years
- [ ] Confirm the 14 at-risk properties look sensible (range of expiry years, realistic unit counts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)