### PR TITLE
chore(ci): add pro-forma + QAP simulator tests to test:ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "monitor:report:json": "node scripts/monitoring/generate-report.js --json",
     "monitor:check": "python3 scripts/monitoring/data-quality-check.py",
     "docs:sync": "node scripts/sync-docs.mjs",
-    "_comment_test_ci": "CI entry point: runs asset validation (31 HTML pages), data threshold checks, fetch-helper tests (19/19), HNA functionality (647/651 pass), and site validation.",
-    "test:ci": "npm run validate && npm run validate:data && npm run test:fetch-helper && npm run test:hna && npm run test:validate",
+    "_comment_test_ci": "CI entry point: runs asset validation (31 HTML pages), data threshold checks, fetch-helper tests (19/19), HNA functionality (647/651 pass), site validation, pro-forma (24 assertions), and QAP simulator (64 assertions).",
+    "test:ci": "npm run validate && npm run validate:data && npm run test:fetch-helper && npm run test:hna && npm run test:validate && npm run test:pro-forma && npm run test:qap-simulator",
     "test:pro-forma": "node test/pro-forma.test.js",
     "test:qap-simulator": "node test/qap-simulator.test.js",
     "test:all": "npm run test:ci && node test/smoke.test.js && node test/smoke-fmr.test.js && node test/data-quality-check.test.js && node test/pro-forma.test.js && node test/qap-simulator.test.js && python3 -m pytest tests/ -v --tb=short"


### PR DESCRIPTION
Partial closeout of audit item #24 (CI must exercise new feature modules) from the 2026-04-20 outstanding-items review.

## Problem
`test/pro-forma.test.js` and `test/qap-simulator.test.js` were already running in GitHub Actions (inline step in `.github/workflows/ci-checks.yml`), but weren't part of the `npm run test:ci` alias. So:
- Local developers running the documented CI entrypoint silently skipped **88 assertions** covering the deal calculator's 15-year pro-forma and the CHFA QAP scoring logic
- The `_comment_test_ci` hint in `package.json` didn't reflect the full coverage

## Fix
- Append `test:pro-forma` + `test:qap-simulator` to the `test:ci` chain
- Update the `_comment_test_ci` hint to mention the new assertion counts

## Verification
Full `npm run test:ci` passes locally (exit 0). Assertion deltas:
- Pro-forma: **24** passed, 0 failed
- QAP simulator: **64** passed, 0 failed

The inline "Run JS smoke tests" block in ci-checks.yml remains unchanged — it already invokes these scripts directly, so no duplication concern.

## Test plan
- [ ] CI green (the new steps should run as part of the existing `npm run test:ci` invocation in ci-checks.yml, plus continue to run inline via the smoke-tests step)
- [ ] Developers running `npm run test:ci` locally see the two new suites execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)