### PR TITLE
feat(market): explainer tooltips for LIHTC Supply + Peer Benchmarking

### DIFF
--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -399,6 +399,48 @@ footer.site-footer { margin-top: var(--sp6); border-top: 1px solid var(--border)
 .chart-source { font-size: 0.72rem; color: var(--faint); margin-top: var(--sp2); padding: 0 var(--sp4) var(--sp3); }
 .chart-source a { color: var(--faint); text-decoration: none; }
 .chart-source a:hover { text-decoration: underline; }
+
+/* Explainer tooltip — zero-JS inline methodology popover.
+   Used for stat cards where a one-line label can't fully describe the
+   methodology, data scope, or limitations. Built on native <details>
+   so it's keyboard-accessible and needs no framework. */
+.info-tooltip { display: inline-block; margin-left: 0.35rem; vertical-align: middle; }
+.info-tooltip > summary {
+  list-style: none;            /* hide default disclosure triangle */
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.05rem; height: 1.05rem;
+  border-radius: 50%;
+  background: var(--bg2, #f1f5f9);
+  color: var(--muted, #64748b);
+  font-size: 0.75rem;
+  font-weight: 700;
+  border: 1px solid var(--border, #cbd5e1);
+  transition: background .15s, color .15s;
+}
+.info-tooltip > summary::-webkit-details-marker { display: none; }
+.info-tooltip > summary:hover,
+.info-tooltip > summary:focus-visible { background: var(--accent, #1e40af); color: #fff; outline: none; }
+.info-tooltip[open] > summary { background: var(--accent, #1e40af); color: #fff; }
+.info-tooltip-body {
+  display: block;
+  margin-top: 0.5rem;
+  padding: 0.7rem 0.85rem;
+  border-radius: var(--radius, 6px);
+  background: var(--bg2, #f8fafc);
+  border: 1px solid var(--border, #cbd5e1);
+  font-size: 0.82rem;
+  line-height: 1.55;
+  color: var(--text, #0f172a);
+  max-width: 42rem;
+}
+.info-tooltip-body p { margin: 0 0 0.5rem; }
+.info-tooltip-body p:last-child { margin-bottom: 0; }
+.info-tooltip-body dl { display: grid; grid-template-columns: max-content 1fr; gap: 0.25rem 0.75rem; margin: 0.25rem 0; font-size: 0.78rem; }
+.info-tooltip-body dt { color: var(--muted, #64748b); font-weight: 600; }
+.info-tooltip-body dd { margin: 0; }
 /* Leaflet map legend swatches (used by co-lihtc-map.js Leaflet legend control) */
 .map-legend .swatch-dda { width:14px;height:10px;border-radius:3px;display:inline-block;flex-shrink:0;background:rgba(255,200,90,.22);border:1px solid rgba(255,200,90,.55); }
 .map-legend .swatch-qct { width:14px;height:10px;border-radius:3px;display:inline-block;flex-shrink:0;background:rgba(120,255,170,.24);border:1px solid rgba(120,255,170,.55); }

--- a/market-analysis.html
+++ b/market-analysis.html
@@ -463,7 +463,25 @@
 
         <!-- LIHTC Supply -->
         <div class="pma-card">
-          <h2>LIHTC Supply in Buffer</h2>
+          <h2 style="display:inline-block;margin:0;">LIHTC Supply in Buffer</h2>
+          <details class="info-tooltip">
+            <summary title="What's counted in 'supply'?" aria-label="Show LIHTC supply methodology">i</summary>
+            <div class="info-tooltip-body">
+              <p><strong>What this counts.</strong> Every LIHTC property within the user-selected buffer radius of the site, including:</p>
+              <ul style="margin:0 0 0.5rem 1.1rem;padding:0">
+                <li><strong>Placed-in-service</strong> projects (completed and operating)</li>
+                <li><strong>Pipeline / under-construction</strong> projects (allocated but not yet in service)</li>
+              </ul>
+              <p>Properties whose affordability period has expired — or is at risk of expiring in the near term — are <strong>excluded</strong>, since they no longer represent active competitive supply.</p>
+              <dl>
+                <dt>Buffer radius</dt><dd>3, 5, 10, or 15 miles — selected via the control above the map</dd>
+                <dt>Primary source</dt><dd>HUD LIHTC Database (<code>data/market/hud_lihtc_co.geojson</code>)</dd>
+                <dt>Fallback source</dt><dd>CHFA portfolio (<code>data/chfa-lihtc.json</code>) when HUD data is missing</dd>
+                <dt>Capture rate</dt><dd>existing LIHTC units ÷ renter households in buffer (ACS 2024)</dd>
+                <dt>Prop 123 overlay</dt><dd>count of units in DOLA Prop 123 jurisdictions — surfaces local-commitment alignment</dd>
+              </dl>
+            </div>
+          </details>
           <div class="pma-stat-grid">
             <div class="pma-stat">
               <div class="pma-stat-value" id="pmaLihtcCount">—</div>
@@ -551,8 +569,22 @@
 
         <!-- Peer Benchmarking -->
         <div class="pma-card">
-          <h2>Peer Benchmarking</h2>
-          <p style="font-size:var(--tiny);margin-bottom:0.5rem">Compare this site to ~50 known Colorado LIHTC projects.</p>
+          <h2 style="display:inline-block;margin:0;">Peer Benchmarking</h2>
+          <details class="info-tooltip">
+            <summary title="How are peers selected?" aria-label="Show peer benchmarking methodology">i</summary>
+            <div class="info-tooltip-body">
+              <p><strong>What this compares.</strong> Your site's PMA composite score against a curated set of ~50 known Colorado LIHTC projects (the "reference set"). Lets you see where the site lands relative to deals that have already been allocated and underwritten.</p>
+              <dl>
+                <dt>Reference set</dt><dd><code>data/market/reference-projects.json</code> — ~50 CO LIHTC projects (2015–2025 vintage) with known PMA score, unit count, credit type, market type</dd>
+                <dt>Primary comparison</dt><dd>percentile rank of this site's PMA score against the full reference set</dd>
+                <dt>Comparable window</dt><dd>reference projects within ±10 PMA points of this site are surfaced as "directly comparable"</dd>
+                <dt>Breakdowns</dt><dd>market-type (urban / suburban / rural / resort), credit-type (4% PAB / 9% competitive), unit-count band</dd>
+                <dt>What this is <em>not</em></dt><dd>it's not a predictor of allocation — CHFA QAP scoring is a separate model (see QAP Simulator). This is a market-positioning benchmark, not a policy-scoring estimate.</dd>
+              </dl>
+              <p style="margin-top:0.5rem;font-size:0.76rem;color:var(--muted)">Full methodology: <a href="docs/PMA_DATA_ENHANCEMENTS.md" target="_blank" rel="noopener">docs/PMA_DATA_ENHANCEMENTS.md</a></p>
+            </div>
+          </details>
+          <p style="font-size:var(--tiny);margin-bottom:0.5rem;margin-top:0.5rem">Compare this site to ~50 known Colorado LIHTC projects.</p>
           <div id="pmaBenchmarkResult">
             <div class="pma-empty">Run analysis to see benchmarking.</div>
           </div>


### PR DESCRIPTION
Closes audit items **#4** (Peer Benchmarking methodology) and **#5** (LIHTC Supply in Buffer tooltip) from the 2026-04-20 outstanding-items review. **Completes Wave 2.**

## What this adds

### Reusable `.info-tooltip` component
New CSS in `css/site-theme.css` — a zero-JS accessible popover built on native `<details>`/`<summary>`:
- Round "i" disclosure button appears inline next to the card heading
- Click/Enter/Space expands an inline `<div class=\"info-tooltip-body\">` with structured methodology copy
- Keyboard-reachable by default (native `<details>`), screen-reader friendly, no framework
- `max-width: 42rem` caps the body so long content doesn't blow up card layout
- Hover/focus state highlights the disclosure in the accent color

Can be dropped into any future stat card that needs more than a one-line label can carry.

### Copy per the Q4 and audit decisions

**LIHTC Supply in Buffer** tooltip documents the Q4 decision on what \"supply\" means:
- Counted: placed-in-service **AND** pipeline/under-construction properties
- Excluded: expiring or preservation-at-risk properties (active affordability only)
- Definition list for: buffer radius, primary source, fallback source, capture-rate formula, Prop 123 overlay

**Peer Benchmarking** tooltip explains the methodology that was only implicit before:
- Reference set (`data/market/reference-projects.json`)
- Primary comparison (percentile rank vs the set)
- Comparable window (±10 PMA points)
- Market / credit / size breakdowns
- Explicit \"what this is *not*\" — not a CHFA allocation predictor (that's the QAP Simulator). This disambiguation alone justifies shipping.
- Link to `docs/PMA_DATA_ENHANCEMENTS.md` for full methodology

## Verification

Browser (market-analysis.html):
- Both tooltips render, closed by default
- Open on click to 405×~420 px — content flows, no overflow
- Keyboard-accessible (Tab focuses the \"i\", Enter/Space toggles)
- Zero console errors
- Screenshot captured (structured definition list renders crisply)

`npm run test:ci` still green (exit 0).

## Test plan
- [ ] CI green
- [ ] On deployed preview: click the \"i\" on LIHTC Supply — content matches source scope you (product) signed off on in Q4
- [ ] Click the \"i\" on Peer Benchmarking — content disambiguates from the QAP Simulator
- [ ] Keyboard-only: Tab to each disclosure, Enter opens/closes, focus ring visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)