### PR TITLE
ci: data-freshness check with per-file SLAs

### DIFF
--- a/.github/workflows/data-freshness-check.yml
+++ b/.github/workflows/data-freshness-check.yml
@@ -1,0 +1,44 @@
+name: Data Freshness Check
+
+# Verify critical data files haven't gone stale. Catches silent
+# refresh-pipeline breakage (today's HNA flake on 2026-04-20 was exactly
+# this class of incident — a scheduled workflow failed mid-morning, no
+# alert, nobody would have noticed without an explicit check).
+#
+# Partial closeout of issue #656 from epic #447. Currently checks
+# 9 data files against SLAs defined in scripts/audit/data-freshness-check.mjs.
+# Issue-auto-open on failure + Slack hook remain open sub-tasks under #656.
+
+on:
+  schedule:
+    # Daily at 16:00 UTC = 10:00 America/Denver in daylight time. Offset
+    # from the other weekly scans (Dependabot Mon 09:00, source-URL-sweep
+    # Mon 08:00) so a bad morning doesn't cascade into the same run window.
+    - cron: '0 16 * * *'
+  push:
+    branches: ['main']
+    paths:
+      - 'data/**'
+      - 'scripts/audit/data-freshness-check.mjs'
+      - '.github/workflows/data-freshness-check.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write  # reserved for the follow-up auto-open-on-failure step
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Run freshness check
+        run: node scripts/audit/data-freshness-check.mjs

--- a/scripts/audit/data-freshness-check.mjs
+++ b/scripts/audit/data-freshness-check.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * data-freshness-check.mjs — verify critical data files haven't gone stale.
+ * Partial closeout of issue #656 (data-freshness monitoring + alerting)
+ * from the #447 epic decomposition.
+ *
+ * What it does:
+ *   1. Checks each file in SLA_CONFIG.
+ *   2. For each file: prefer an in-file `updated` / `generated` /
+ *      `metadata.generated` timestamp (many of our pipelines stamp one);
+ *      fall back to the file's mtime if none is present.
+ *   3. Fails non-zero if any file is older than its SLA.
+ *
+ * Exit codes:
+ *   0  — every file within its SLA (or warn-only)
+ *   1  — at least one file past its SLA (hard stale)
+ *   2  — internal script error (e.g. missing required file)
+ *
+ * Usage:
+ *   node scripts/audit/data-freshness-check.mjs
+ *   node scripts/audit/data-freshness-check.mjs --json      (machine output)
+ *   node scripts/audit/data-freshness-check.mjs --quiet     (only print failures)
+ *
+ * To add a new file, append a row to SLA_CONFIG with a reasonable SLA in days.
+ * The SLA should be comfortably longer than the pipeline's refresh cadence —
+ * fortnightly pipeline → ~18-day SLA, weekly → 9-day, annual → ~400-day.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT      = path.resolve(__dirname, '..', '..');
+
+// SLA configuration — keyed by repo-relative path. Add new entries as
+// new data files arrive. Avoid setting SLAs aggressively tight: the check
+// is a *backstop* for silent staleness, not the primary refresh cadence.
+const SLA_CONFIG = [
+  { file: 'data/hna/ranking-index.json',                    slaDays: 9,   cadence: 'weekly (build-hna-data.yml)' },
+  { file: 'data/fred-data.json',                            slaDays: 10,  cadence: 'weekly (fetch-fred-data.yml)' },
+  { file: 'data/market/acs_tract_metrics_co.json',          slaDays: 32,  cadence: 'monthly (market-data workflow)' },
+  { file: 'data/co-county-economic-indicators.json',        slaDays: 16,  cadence: 'fortnightly (BLS LAUS refresh)' },
+  { file: 'data/hud-fmr-income-limits.json',                slaDays: 400, cadence: 'annual (HUD FMR release)' },
+  { file: 'data/hna/chas_affordability_gap.json',           slaDays: 400, cadence: 'annual (HUD CHAS release)' },
+  { file: 'data/market/hud_lihtc_co.geojson',               slaDays: 95,  cadence: 'quarterly (HUD LIHTC DB)' },
+  { file: 'data/market/nhpd_co.geojson',                    slaDays: 95,  cadence: 'quarterly (NHPD export)' },
+  { file: 'data/co_ami_gap_by_county.json',                 slaDays: 95,  cadence: 'quarterly (AMI gap build)' },
+];
+
+// Fields to probe for an in-file "updated" timestamp, in priority order.
+// Many of our JSON outputs stamp one of these; we prefer them over mtime
+// because mtime can be reset by a git checkout or backup restore. Names
+// cover the variants we've seen in this repo — ranking-index uses
+// generatedAt, HNA summary uses updated, CHAS uses meta.generated, etc.
+const TIMESTAMP_FIELDS = [
+  'updated',
+  'generated',
+  'generatedAt',
+  'last_updated',
+  'lastUpdated',
+  'timestamp',
+];
+const TIMESTAMP_PARENTS = ['metadata', 'meta'];
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  return {
+    quiet: args.includes('--quiet'),
+    json:  args.includes('--json'),
+  };
+}
+
+/** Walk an object one level deep looking for a known timestamp field. */
+function findTimestamp(obj) {
+  if (!obj || typeof obj !== 'object') return null;
+  for (const key of TIMESTAMP_FIELDS) {
+    if (typeof obj[key] === 'string' && Date.parse(obj[key])) {
+      return { source: key, value: obj[key] };
+    }
+  }
+  for (const parent of TIMESTAMP_PARENTS) {
+    const sub = obj[parent];
+    if (sub && typeof sub === 'object') {
+      for (const key of TIMESTAMP_FIELDS) {
+        if (typeof sub[key] === 'string' && Date.parse(sub[key])) {
+          return { source: `${parent}.${key}`, value: sub[key] };
+        }
+      }
+    }
+  }
+  return null;
+}
+
+async function readJsonSafe(relPath) {
+  try {
+    const txt = await fs.readFile(path.join(ROOT, relPath), 'utf8');
+    return JSON.parse(txt);
+  } catch {
+    return null;
+  }
+}
+
+async function checkOne(entry) {
+  const full = path.join(ROOT, entry.file);
+  let stat;
+  try {
+    stat = await fs.stat(full);
+  } catch {
+    return { ...entry, present: false };
+  }
+
+  // Prefer an in-file timestamp when available.
+  let recordedTs = null;
+  let source     = 'mtime';
+  if (entry.file.endsWith('.json')) {
+    const data = await readJsonSafe(entry.file);
+    const found = findTimestamp(data);
+    if (found) {
+      recordedTs = new Date(found.value);
+      source = found.source;
+    }
+  }
+  const asOf = recordedTs || new Date(stat.mtime);
+  const ageMs = Date.now() - asOf.getTime();
+  const ageDays = ageMs / 86_400_000;
+  return {
+    ...entry,
+    present: true,
+    asOf:    asOf.toISOString(),
+    source,
+    ageDays: Math.round(ageDays * 10) / 10,
+    stale:   ageDays > entry.slaDays,
+  };
+}
+
+function format(result) {
+  if (!result.present) return `MISSING       ${result.file}  (SLA ${result.slaDays}d)`;
+  const badge = result.stale ? 'STALE   ' : '  OK    ';
+  const age   = `${String(result.ageDays).padStart(5)}d`;
+  const sla   = `SLA ${result.slaDays}d`;
+  const src   = result.source === 'mtime' ? 'mtime' : `field:${result.source}`;
+  return `${badge}  ${age}  ${sla.padEnd(10)}  ${src.padEnd(22)}  ${result.file}`;
+}
+
+async function main() {
+  const { quiet, json } = parseArgs();
+  const results = [];
+  for (const entry of SLA_CONFIG) {
+    results.push(await checkOne(entry));
+  }
+
+  const missing = results.filter(r => !r.present);
+  const stale   = results.filter(r => r.present && r.stale);
+  const ok      = results.filter(r => r.present && !r.stale);
+
+  if (json) {
+    console.log(JSON.stringify({
+      checkedAt:   new Date().toISOString(),
+      total:       results.length,
+      ok:          ok.length,
+      stale:       stale.length,
+      missing:     missing.length,
+      results,
+    }, null, 2));
+  } else {
+    if (!quiet) {
+      for (const r of results) console.log(format(r));
+      console.log('');
+    }
+    console.log(`Summary: ${ok.length} ok, ${stale.length} stale, ${missing.length} missing (of ${results.length})`);
+
+    if (stale.length) {
+      console.log('\nStale files (past SLA):');
+      for (const r of stale) {
+        console.log(`  [${r.ageDays}d past SLA of ${r.slaDays}d]  ${r.file}  (cadence: ${r.cadence})`);
+      }
+    }
+    if (missing.length) {
+      console.log('\nMissing files:');
+      for (const r of missing) console.log(`  ${r.file}`);
+    }
+  }
+
+  // Missing = internal-config error (file was in SLA list but isn't on disk).
+  if (missing.length) process.exit(2);
+  // Stale = operational failure; CI should fail.
+  if (stale.length) process.exit(1);
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error('data-freshness-check crashed:', err);
+  process.exit(2);
+});


### PR DESCRIPTION
Partial closeout of [#656](https://github.com/pggLLC/Housing-Analytics/issues/656) (data-freshness monitoring + workflow-failure alerting) from epic [#447](https://github.com/pggLLC/Housing-Analytics/issues/447).

## Motivation
Today's flaked HNA build ([run 24656528796](https://github.com/pggLLC/Housing-Analytics/actions/runs/24656528796)) was exactly the class of silent staleness this catches: a scheduled workflow failed mid-morning, nothing alerted, the next day's users would have seen week-old data without any surface-level signal. This PR turns that class of failure into a visible CI error every day.

## What ships

### `scripts/audit/data-freshness-check.mjs`
Per-file SLA config, keyed by repo-relative path:

| File | SLA | Upstream cadence |
|---|---|---|
| `data/hna/ranking-index.json` | 9 d | weekly (`build-hna-data.yml`) |
| `data/fred-data.json` | 10 d | weekly (`fetch-fred-data.yml`) |
| `data/market/acs_tract_metrics_co.json` | 32 d | monthly |
| `data/co-county-economic-indicators.json` | 16 d | fortnightly (BLS LAUS) |
| `data/hud-fmr-income-limits.json` | 400 d | annual (HUD) |
| `data/hna/chas_affordability_gap.json` | 400 d | annual (HUD) |
| `data/market/hud_lihtc_co.geojson` | 95 d | quarterly (HUD) |
| `data/market/nhpd_co.geojson` | 95 d | quarterly (NHPD) |
| `data/co_ami_gap_by_county.json` | 95 d | quarterly (AMI build) |

Per file the script:
1. **Prefers an in-file timestamp** (`updated`, `generated`, `generatedAt`, `metadata.generated`, `meta.generated`, etc.) — covers every shape our JSON pipelines emit today.
2. Falls back to **file mtime** when no in-file timestamp exists (geojson, AMI-gap raw).
3. Exits **1 on stale**, **2 on missing**, **0 on ok**.

Output modes: default table, `--quiet` (only failures), `--json` (machine-readable).

### `.github/workflows/data-freshness-check.yml`
Runs:
- **Daily at 16:00 UTC** (10:00 America/Denver daylight) — offset from Dependabot (Mon 09:00) and source-URL-sweep (Mon 08:00) so a bad morning doesn't cascade
- **On push to main** when anything under `data/` or the checker itself changes — regressions land instantly rather than waiting for tomorrow's cron
- **`workflow_dispatch`** for ad-hoc runs

`permissions: issues: write` declared in preparation for the follow-up auto-open-on-failure step (tracked in #656).

## Current state — first run
```
Summary: 9 ok, 0 stale, 0 missing (of 9)
exit=0
```

Every tracked pipeline is within its SLA right now.

## Test plan
- [ ] CI green (this PR's push-trigger runs the check against the current state)
- [ ] Verify the daily cron runs tomorrow (16:00 UTC) shows in the Actions tab
- [ ] To test the failure path manually: locally `touch -d '2024-01-01' data/fred-data.json && node scripts/audit/data-freshness-check.mjs` — should report STALE and exit 1 (revert the mtime after)

## Remaining sub-tasks still open under #656
- Auto-open GitHub issue on failure + auto-close on recovery
- Optional Slack webhook wiring
- Per-workflow failure alerting on each fetch-* workflow itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)