### PR TITLE
ci(freshness): auto-open / auto-close tracking issue on stale failure

### DIFF
--- a/.github/workflows/data-freshness-check.yml
+++ b/.github/workflows/data-freshness-check.yml
@@ -1,19 +1,21 @@
 name: Data Freshness Check
 
 # Verify critical data files haven't gone stale. Catches silent
-# refresh-pipeline breakage (today's HNA flake on 2026-04-20 was exactly
+# refresh-pipeline breakage (the HNA flake on 2026-04-20 was exactly
 # this class of incident — a scheduled workflow failed mid-morning, no
 # alert, nobody would have noticed without an explicit check).
 #
-# Partial closeout of issue #656 from epic #447. Currently checks
-# 9 data files against SLAs defined in scripts/audit/data-freshness-check.mjs.
-# Issue-auto-open on failure + Slack hook remain open sub-tasks under #656.
+# When stale, this workflow opens (or updates) a tracking issue tagged
+# with a fixed title marker. When everything is fresh again, it closes
+# any open stale-tracker issues with a recovery comment. Find-or-update
+# keeps the issue count bounded — a multi-day outage produces one issue
+# with repeated updates, not one issue per run.
+#
+# Partial closeout of issue #656 from epic #447.
 
 on:
   schedule:
-    # Daily at 16:00 UTC = 10:00 America/Denver in daylight time. Offset
-    # from the other weekly scans (Dependabot Mon 09:00, source-URL-sweep
-    # Mon 08:00) so a bad morning doesn't cascade into the same run window.
+    # Daily at 16:00 UTC = 10:00 America/Denver in daylight time.
     - cron: '0 16 * * *'
   push:
     branches: ['main']
@@ -25,7 +27,10 @@ on:
 
 permissions:
   contents: read
-  issues: write  # reserved for the follow-up auto-open-on-failure step
+  issues: write
+
+env:
+  ISSUE_TITLE_MARKER: '[data-freshness-alert]'
 
 jobs:
   check:
@@ -41,4 +46,91 @@ jobs:
           node-version: '20'
 
       - name: Run freshness check
-        run: node scripts/audit/data-freshness-check.mjs
+        id: check
+        # Continue so downstream steps can read the JSON output and file
+        # or close the tracking issue. The final step below re-raises
+        # failure as a non-zero exit so the workflow status is correct.
+        continue-on-error: true
+        run: |
+          node scripts/audit/data-freshness-check.mjs --json > /tmp/freshness.json
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          {
+            echo "json<<EOF"
+            cat /tmp/freshness.json
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Find existing open tracking issue
+        id: find_issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Grep the 100 most recent open issues for the title marker.
+          # Client-side jq filter keeps this robust to special chars in
+          # the marker (e.g. square brackets) that can trip gh's search.
+          # Tracking issues should be rare, so this scan is cheap.
+          MARKER="${ISSUE_TITLE_MARKER}" \
+          number=$(gh issue list --state open --limit 100 --json number,title \
+            --jq '[.[] | select(.title | contains(env.MARKER)) | .number] | first // empty' \
+            || true)
+          if [ -z "${number}" ]; then number=0; fi
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update tracking issue on stale failure
+        if: steps.check.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # Build a Markdown body from the JSON output.
+          body=$(python3 - <<'PY'
+          import json, os
+          with open('/tmp/freshness.json') as f:
+              d = json.load(f)
+          lines = []
+          lines.append(f"**Checked at**: {d.get('checkedAt')}")
+          lines.append(f"**Summary**: {d.get('ok', 0)} ok · **{d.get('stale', 0)} stale** · {d.get('missing', 0)} missing")
+          lines.append("")
+          lines.append("| File | Age (days) | SLA | Source | Status |")
+          lines.append("|---|---|---|---|---|")
+          for r in d.get('results', []):
+              status = 'MISSING' if not r.get('present') else ('STALE' if r.get('stale') else 'ok')
+              if status == 'ok':
+                  continue
+              lines.append(f"| `{r['file']}` | {r.get('ageDays','—')} | {r['slaDays']}d | {r.get('source','mtime')} | **{status}** |")
+          lines.append("")
+          lines.append(f"**Workflow run**: {os.environ.get('RUN_URL','?')}")
+          lines.append("")
+          lines.append("This issue was opened automatically by `.github/workflows/data-freshness-check.yml`. It will be closed automatically on the next green run (see issue #656).")
+          print("\n".join(lines))
+          PY
+          )
+
+          existing=${{ steps.find_issue.outputs.number }}
+          title="⚠️ ${{ env.ISSUE_TITLE_MARKER }} Data freshness alert"
+
+          if [ "${existing}" != "0" ]; then
+            echo "Updating existing issue #${existing}"
+            gh issue comment "${existing}" --body "$body"
+          else
+            echo "Opening new issue"
+            gh issue create --title "${title}" --body "$body"
+          fi
+
+      - name: Close tracking issue on recovery
+        if: steps.check.outcome == 'success' && steps.find_issue.outputs.number != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          number=${{ steps.find_issue.outputs.number }}
+          comment="✅ All tracked data files are within their SLAs again ([workflow run](${RUN_URL})). Auto-closing."
+          gh issue close "${number}" --comment "$comment"
+
+      - name: Re-raise failure as workflow status
+        if: steps.check.outcome == 'failure'
+        run: |
+          echo "::error::One or more tracked data files are past their freshness SLA. See the open tracking issue for details."
+          exit 1


### PR DESCRIPTION
Further closeout of [#656](https://github.com/pggLLC/Housing-Analytics/issues/656) (data-freshness monitoring + alerting), building on [#663](https://github.com/pggLLC/Housing-Analytics/pull/663).

## Motivation
The freshness-check workflow shipped in #663 surfaces stale files via workflow-failure status only — you'd have to check the Actions tab to know anything is wrong. That's the same silent-failure pattern #656 was filed to fix. This PR adds the missing active alerting.

## New workflow logic (4 steps added, 1 modified)

The existing check step now runs with `continue-on-error: true` so downstream steps can read its output. A final re-raise step restores the non-zero workflow status, keeping the Actions badge and branch-protection correct.

### 1. Find existing open tracking issue
Scans up to 100 open issues for the title marker `[data-freshness-alert]`. Client-side `jq` filter using `env.MARKER` indirection — robust to special characters in the marker. Writes `number=<id>` or `number=0` to the step output.

### 2. Open or update on failure (`check.outcome == failure`)
Builds a Markdown body from the freshness JSON — a table of every stale file with age, SLA, and detection source — and either:
- **Comments on the existing tracking issue** if one's already open (find-or-update)
- **Opens a new one** otherwise

A multi-day outage produces **one issue with repeated daily updates**, not one issue per run.

### 3. Close on recovery (`check.outcome == success && existing issue`)
Closes the open tracking issue with a "recovered" comment and a link to the green run.

### 4. Re-raise failure as workflow status (`check.outcome == failure`)
Emits a `::error::` annotation and `exit 1` so the workflow ends red. Branch-protection rules that depend on this workflow behave correctly — the tracking issue is additive, not a substitute for failure signal.

## Why a title marker, not a label
Labels need to exist before `gh issue create --label <x>` works, which would couple the workflow to a repo-setup step. A title marker (`[data-freshness-alert]`) is self-documenting and needs no provisioning. If a label is desired later, it's a one-line addition.

## Verified locally
- **YAML parses** cleanly (7 steps now vs 3 before)
- **Body-builder python** tested against the current freshness JSON with a synthetic stale entry — renders a clean Markdown table
- **jq expression** uses `env.MARKER` indirection so square brackets in the marker don't break the shell quoting

Example body (with fixture stale):
\`\`\`
**Checked at**: 2026-04-21T03:31:52.388Z
**Summary**: 9 ok · **1 stale** · 0 missing

| File | Age (days) | SLA | Source | Status |
|---|---|---|---|---|
| `data/hna/ranking-index.json` | 0.2 | 9d | metadata.generatedAt | **STALE** |

**Workflow run**: https://github.com/pggLLC/Housing-Analytics/actions/runs/...
\`\`\`

## Still open under #656 after this PR
- Optional Slack webhook wiring (value depends on whether the repo has a Slack channel wired in at all)
- Per-workflow failure alerting on individual `fetch-*` workflows (this PR covers aggregate freshness; per-workflow alerts would surface the specific upstream source when a single fetcher breaks)

## Test plan
- [ ] CI green
- [ ] When this merges, the push-trigger fires against current (healthy) state — expect 0 tracking issues opened, 0 closed, workflow green
- [ ] To exercise the alert path: temporarily `touch -d '2024-01-01' data/fred-data.json` on a test branch, push, and verify a tracking issue opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)