### PR TITLE
ci: reusable notify-workflow-outcome action + wire build-hna-data

### DIFF
--- a/.github/actions/notify-workflow-outcome/action.yml
+++ b/.github/actions/notify-workflow-outcome/action.yml
@@ -1,0 +1,131 @@
+name: 'Notify Workflow Outcome'
+description: >
+  On failure, open (or update) a tracking issue with a per-workflow title
+  marker and optionally POST to a Slack webhook. On success, close any
+  open tracking issue for the same workflow. Idempotent — multi-day
+  outages produce one issue with repeated comments, not one per run.
+
+inputs:
+  workflow_id:
+    description: >
+      Stable identifier for the calling workflow (e.g. 'build-hna-data').
+      Used as the issue-title marker so multiple workflows can coexist.
+    required: true
+  outcome:
+    description: >
+      Overall job/workflow outcome to react to. Pass `${{ job.status }}`
+      or `${{ needs.<id>.result }}`. The action only acts on 'success'
+      and 'failure'; other values (cancelled, skipped) are no-ops.
+    required: true
+  slack_webhook:
+    description: >
+      Optional Slack incoming-webhook URL. If empty, Slack notification
+      is skipped silently. Pass `${{ secrets.SLACK_WEBHOOK_URL }}` —
+      action treats an unset secret as empty.
+    required: false
+    default: ''
+  github_token:
+    description: >
+      Token for issue open/update/close. Defaults to `${{ github.token }}`;
+      override if you need a PAT with broader repo access.
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Find existing tracking issue
+      id: find
+      shell: bash
+      env:
+        GH_TOKEN:   ${{ inputs.github_token }}
+        MARKER:     '[workflow-fail:${{ inputs.workflow_id }}]'
+      run: |
+        # Scan up to 100 open issues for the marker. Client-side jq
+        # filter via env.MARKER handles the square brackets cleanly.
+        number=$(gh issue list --state open --limit 100 --json number,title \
+          --jq '[.[] | select(.title | contains(env.MARKER)) | .number] | first // empty' \
+          2>/dev/null || true)
+        if [ -z "${number}" ]; then number=0; fi
+        echo "number=${number}" >> "$GITHUB_OUTPUT"
+        echo "marker=${MARKER}" >> "$GITHUB_OUTPUT"
+
+    - name: Open or update tracking issue on failure
+      if: inputs.outcome == 'failure'
+      shell: bash
+      env:
+        GH_TOKEN:    ${{ inputs.github_token }}
+        RUN_URL:     ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        WORKFLOW_ID: ${{ inputs.workflow_id }}
+      run: |
+        set -euo pipefail
+        existing="${{ steps.find.outputs.number }}"
+        marker="${{ steps.find.outputs.marker }}"
+        title="⚠️ ${marker} ${WORKFLOW_ID} workflow failing"
+        body=$(cat <<EOF
+        **Workflow**: \`${WORKFLOW_ID}\`
+        **Failed run**: ${RUN_URL}
+        **Triggered by**: ${{ github.event_name }} on \`${{ github.ref_name }}\`
+
+        This issue was opened automatically by the \`notify-workflow-outcome\`
+        composite action. It will be commented on each time the workflow fails,
+        and closed automatically on the next green run.
+
+        **What to do**
+        1. Open the failed run (link above), inspect the failing step
+        2. Common causes: upstream API key expired, rate-limited request,
+           schema change, or partial-write interrupted by timeout
+        3. If the fix requires a code change, open a PR referencing this issue
+        4. If the failure is transient, a manual re-run will close this issue
+           on success
+
+        See \`docs/WORKFLOW_TROUBLESHOOTING.md\` for per-workflow runbooks
+        (where available).
+        EOF
+        )
+        if [ "${existing}" != "0" ]; then
+          echo "Commenting on existing issue #${existing}"
+          gh issue comment "${existing}" --body "$body"
+        else
+          echo "Opening new tracking issue"
+          gh issue create --title "${title}" --body "$body"
+        fi
+
+    - name: Close tracking issue on recovery
+      if: inputs.outcome == 'success' && steps.find.outputs.number != '0'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        RUN_URL:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        number="${{ steps.find.outputs.number }}"
+        comment="✅ \`${{ inputs.workflow_id }}\` workflow recovered ([run](${RUN_URL})). Auto-closing."
+        gh issue close "${number}" --comment "$comment"
+
+    - name: Post to Slack (optional)
+      if: inputs.outcome == 'failure' && inputs.slack_webhook != ''
+      shell: bash
+      env:
+        WEBHOOK:     ${{ inputs.slack_webhook }}
+        RUN_URL:     ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        WORKFLOW_ID: ${{ inputs.workflow_id }}
+      run: |
+        # Minimal Slack Block Kit payload — keeps the webhook lightweight
+        # and avoids pulling in a full SDK. If the webhook POST fails
+        # (e.g. Slack's endpoint rate-limits us), we print a warning and
+        # do NOT fail the workflow further — the GitHub tracking issue
+        # is the primary signal path; Slack is additive.
+        payload=$(jq -n \
+          --arg wf "${WORKFLOW_ID}" \
+          --arg url "${RUN_URL}" \
+          '{
+            text: ("⚠️ Workflow failed: " + $wf),
+            blocks: [
+              { type: "section", text: { type: "mrkdwn",
+                text: ("*⚠️ Workflow failed:* `" + $wf + "`\n<" + $url + "|View run>") } }
+            ]
+          }')
+        if ! curl -fsS -X POST -H 'Content-Type: application/json' \
+               --data "$payload" "$WEBHOOK" > /dev/null 2>&1; then
+          echo "::warning::Slack webhook POST failed — tracking issue is the primary signal; not re-raising."
+        fi

--- a/.github/workflows/build-hna-data.yml
+++ b/.github/workflows/build-hna-data.yml
@@ -144,3 +144,11 @@ jobs:
           git diff --cached --quiet || git commit -m "chore: build HNA cache + scenarios data $(date -u +'%Y-%m-%d')"
           git pull --rebase --autostash origin main
           git push
+
+      - name: Notify on failure / close tracker on recovery
+        if: always()
+        uses: ./.github/actions/notify-workflow-outcome
+        with:
+          workflow_id: build-hna-data
+          outcome: ${{ job.status }}
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
**Final slice of [#656](https://github.com/pggLLC/Housing-Analytics/issues/656)** — workflow-failure alerting with optional Slack. Stacks on [#671](https://github.com/pggLLC/Housing-Analytics/pull/671).

## Motivation
#663/#664 catch stale data. #665/#666 catch truncated data. But when a **scheduled workflow fails outright** (like the 2026-04-20 HNA flake), there's no per-workflow alert unless someone opens the Actions tab. `build-hna-data.yml` in particular had **zero** post-completion notification — its existing `alert.js` path only fires on a specific \"empty output\" case, not on arbitrary step failure.

## What ships

### 1. Reusable composite action: `.github/actions/notify-workflow-outcome`

Drop-in for any workflow, one `if: always()` step:

```yaml
- name: Notify on failure / close tracker on recovery
  if: always()
  uses: ./.github/actions/notify-workflow-outcome
  with:
    workflow_id: my-workflow-id
    outcome: ${{ job.status }}
    slack_webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
```

| Input | Purpose |
|---|---|
| `workflow_id` | Stable marker (e.g. `build-hna-data`) — used in issue title so multiple workflows coexist |
| `outcome` | Pass `${{ job.status }}` — action only reacts to `success` / `failure` |
| `slack_webhook` | Optional; unset secret = Slack step silently skipped |
| `github_token` | Defaults to `${{ github.token }}` |

**Behavior:**
- **Failure** → find-or-update a tracking issue with marker `[workflow-fail:<id>]`. Same bounded-issue-count pattern as #664 / #666 — multi-day outages produce one issue with repeated comments, not N issues.
- **Success** (with open tracker) → auto-close with recovery comment + run link.
- **Slack** → additive. Env-gated (unset secret = no POST). If the POST itself fails (rate-limit, endpoint down), emits a `::warning::` and does NOT fail the workflow. GitHub tracking issue is the primary signal; Slack is nice-to-have.

### 2. Wired `build-hna-data.yml`
Added as the final step with `if: always()` and `outcome: ${{ job.status }}`. When the workflow flakes the way it did on 2026-04-20, a tracking issue auto-opens; next green run auto-closes.

## Deliberately NOT migrated in this PR

| Workflow | Existing alerting | Why deferred |
|---|---|---|
| `market_data_build.yml` | Bespoke `github-script` block with `market-data-build-failure` label | Migration = retiring the label + reshaping issue titles. Worth a focused follow-up PR. |
| `fetch-fred-data.yml` | Uses `scripts/monitoring/alert.js` with its own payload shape | Same — coordinated retirement with alert.js callers |

Both retain their existing alerting; this PR just makes the composite *available* for workflows that currently lack coverage. Future follow-up can retire the ad-hoc paths once the composite is proven.

## Rollout path
1. Merge this PR → build-hna-data.yml gets composite-based alerting
2. Wait ~1 week to confirm behavior on a real trigger (scheduled Monday runs, manual dispatches)
3. Follow-up PR to migrate market_data_build + fetch-fred + other ETL workflows still on ad-hoc paths
4. Eventually retire `scripts/monitoring/alert.js` once all callers migrated

## Validated
- YAML parses on both files
- Composite has 4 steps with correct `if:` guards:
  1. Find existing tracking issue (always)
  2. Open/update on failure
  3. Close on success when tracker open
  4. Slack POST on failure when webhook set
- `env.MARKER` jq indirection consistent with #664 / #666 patterns

## Test plan
- [ ] CI green (this PR's push doesn't trigger the workflow itself — just validates YAML via the workflow parse)
- [ ] On next scheduled `build-hna-data` run (Mondays 06:30 UTC): if successful, no new issue. If failed, a `[workflow-fail:build-hna-data]` tracking issue opens.
- [ ] Deliberately test the recovery path: after any tracking issue auto-opens, trigger `workflow_dispatch` — green run should auto-close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)