### PR TITLE
ci + docs: surface schema validation; establish fetch_errors convention

### DIFF
--- a/.github/actions/notify-workflow-outcome/action.yml
+++ b/.github/actions/notify-workflow-outcome/action.yml
@@ -1,0 +1,131 @@
+name: 'Notify Workflow Outcome'
+description: >
+  On failure, open (or update) a tracking issue with a per-workflow title
+  marker and optionally POST to a Slack webhook. On success, close any
+  open tracking issue for the same workflow. Idempotent — multi-day
+  outages produce one issue with repeated comments, not one per run.
+
+inputs:
+  workflow_id:
+    description: >
+      Stable identifier for the calling workflow (e.g. 'build-hna-data').
+      Used as the issue-title marker so multiple workflows can coexist.
+    required: true
+  outcome:
+    description: >
+      Overall job/workflow outcome to react to. Pass `${{ job.status }}`
+      or `${{ needs.<id>.result }}`. The action only acts on 'success'
+      and 'failure'; other values (cancelled, skipped) are no-ops.
+    required: true
+  slack_webhook:
+    description: >
+      Optional Slack incoming-webhook URL. If empty, Slack notification
+      is skipped silently. Pass `${{ secrets.SLACK_WEBHOOK_URL }}` —
+      action treats an unset secret as empty.
+    required: false
+    default: ''
+  github_token:
+    description: >
+      Token for issue open/update/close. Defaults to `${{ github.token }}`;
+      override if you need a PAT with broader repo access.
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Find existing tracking issue
+      id: find
+      shell: bash
+      env:
+        GH_TOKEN:   ${{ inputs.github_token }}
+        MARKER:     '[workflow-fail:${{ inputs.workflow_id }}]'
+      run: |
+        # Scan up to 100 open issues for the marker. Client-side jq
+        # filter via env.MARKER handles the square brackets cleanly.
+        number=$(gh issue list --state open --limit 100 --json number,title \
+          --jq '[.[] | select(.title | contains(env.MARKER)) | .number] | first // empty' \
+          2>/dev/null || true)
+        if [ -z "${number}" ]; then number=0; fi
+        echo "number=${number}" >> "$GITHUB_OUTPUT"
+        echo "marker=${MARKER}" >> "$GITHUB_OUTPUT"
+
+    - name: Open or update tracking issue on failure
+      if: inputs.outcome == 'failure'
+      shell: bash
+      env:
+        GH_TOKEN:    ${{ inputs.github_token }}
+        RUN_URL:     ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        WORKFLOW_ID: ${{ inputs.workflow_id }}
+      run: |
+        set -euo pipefail
+        existing="${{ steps.find.outputs.number }}"
+        marker="${{ steps.find.outputs.marker }}"
+        title="⚠️ ${marker} ${WORKFLOW_ID} workflow failing"
+        body=$(cat <<EOF
+        **Workflow**: \`${WORKFLOW_ID}\`
+        **Failed run**: ${RUN_URL}
+        **Triggered by**: ${{ github.event_name }} on \`${{ github.ref_name }}\`
+
+        This issue was opened automatically by the \`notify-workflow-outcome\`
+        composite action. It will be commented on each time the workflow fails,
+        and closed automatically on the next green run.
+
+        **What to do**
+        1. Open the failed run (link above), inspect the failing step
+        2. Common causes: upstream API key expired, rate-limited request,
+           schema change, or partial-write interrupted by timeout
+        3. If the fix requires a code change, open a PR referencing this issue
+        4. If the failure is transient, a manual re-run will close this issue
+           on success
+
+        See \`docs/WORKFLOW_TROUBLESHOOTING.md\` for per-workflow runbooks
+        (where available).
+        EOF
+        )
+        if [ "${existing}" != "0" ]; then
+          echo "Commenting on existing issue #${existing}"
+          gh issue comment "${existing}" --body "$body"
+        else
+          echo "Opening new tracking issue"
+          gh issue create --title "${title}" --body "$body"
+        fi
+
+    - name: Close tracking issue on recovery
+      if: inputs.outcome == 'success' && steps.find.outputs.number != '0'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        RUN_URL:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        number="${{ steps.find.outputs.number }}"
+        comment="✅ \`${{ inputs.workflow_id }}\` workflow recovered ([run](${RUN_URL})). Auto-closing."
+        gh issue close "${number}" --comment "$comment"
+
+    - name: Post to Slack (optional)
+      if: inputs.outcome == 'failure' && inputs.slack_webhook != ''
+      shell: bash
+      env:
+        WEBHOOK:     ${{ inputs.slack_webhook }}
+        RUN_URL:     ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        WORKFLOW_ID: ${{ inputs.workflow_id }}
+      run: |
+        # Minimal Slack Block Kit payload — keeps the webhook lightweight
+        # and avoids pulling in a full SDK. If the webhook POST fails
+        # (e.g. Slack's endpoint rate-limits us), we print a warning and
+        # do NOT fail the workflow further — the GitHub tracking issue
+        # is the primary signal path; Slack is additive.
+        payload=$(jq -n \
+          --arg wf "${WORKFLOW_ID}" \
+          --arg url "${RUN_URL}" \
+          '{
+            text: ("⚠️ Workflow failed: " + $wf),
+            blocks: [
+              { type: "section", text: { type: "mrkdwn",
+                text: ("*⚠️ Workflow failed:* `" + $wf + "`\n<" + $url + "|View run>") } }
+            ]
+          }')
+        if ! curl -fsS -X POST -H 'Content-Type: application/json' \
+               --data "$payload" "$WEBHOOK" > /dev/null 2>&1; then
+          echo "::warning::Slack webhook POST failed — tracking issue is the primary signal; not re-raising."
+        fi

--- a/.github/workflows/build-hna-data.yml
+++ b/.github/workflows/build-hna-data.yml
@@ -144,3 +144,11 @@ jobs:
           git diff --cached --quiet || git commit -m "chore: build HNA cache + scenarios data $(date -u +'%Y-%m-%d')"
           git pull --rebase --autostash origin main
           git push
+
+      - name: Notify on failure / close tracker on recovery
+        if: always()
+        uses: ./.github/actions/notify-workflow-outcome
+        with:
+          workflow_id: build-hna-data
+          outcome: ${{ job.status }}
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -176,8 +176,56 @@ jobs:
           echo "✅  No fragile fetch paths found."
 
       - name: Validate JSON schemas for critical artifacts
-        run: node scripts/validate-schemas.js
+        id: schema_validate
+        # Keep continue-on-error: true so schema drift doesn't block PRs
+        # while the schema contract is still maturing. The next step
+        # promotes the output into the job summary so failures are
+        # visible on the run page without manual log-reading (see #657).
         continue-on-error: true
+        run: |
+          set +e
+          node scripts/validate-schemas.js | tee /tmp/schema-validate.log
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Surface schema validation into job summary
+        if: always()
+        shell: bash
+        run: |
+          if [ ! -s /tmp/schema-validate.log ]; then
+            echo "::warning::validate-schemas produced no output"
+            exit 0
+          fi
+          # Parse the tail line: "Results: N passed, M failed"
+          summary=$(grep -E '^Results: [0-9]+ passed, [0-9]+ failed' /tmp/schema-validate.log | tail -n1 || true)
+          failed=$(echo "$summary" | sed -n 's/.* \([0-9]\+\) failed.*/\1/p')
+          failed=${failed:-0}
+          {
+            echo '## Schema validation'
+            echo ""
+            if [ -n "$summary" ]; then
+              echo "**$summary**"
+            else
+              echo "_Schema validator produced no summary line — check raw log._"
+            fi
+            echo ""
+            if [ "$failed" -gt 0 ] 2>/dev/null; then
+              echo "### Failures"
+              echo '```'
+              grep -E '^\s*❌|^\s*FAIL' /tmp/schema-validate.log | head -40 || true
+              echo '```'
+            fi
+            echo ""
+            echo "<details><summary>Raw validator output (last 100 lines)</summary>"
+            echo ""
+            echo '```'
+            tail -n 100 /tmp/schema-validate.log
+            echo '```'
+            echo ""
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$failed" -gt 0 ] 2>/dev/null; then
+            echo "::warning::Schema validation reported $failed failure(s). See the Summary tab for details. (Non-blocking per the current continue-on-error posture — see #657 to flip.)"
+          fi
 
       # ── JavaScript smoke tests ──
       - name: Install Node.js dependencies

--- a/docs/DATA_QUALITY.md
+++ b/docs/DATA_QUALITY.md
@@ -1,0 +1,123 @@
+# Data Quality
+
+How this repo signals and handles data-quality problems in its ETL pipelines. Partial closeout of [#657](https://github.com/pggLLC/Housing-Analytics/issues/657).
+
+Three complementary signals are in place today; this document defines the conventions each follows so new pipelines can plug in consistently.
+
+---
+
+## 1. Staleness — `scripts/audit/data-freshness-check.mjs`
+
+**What it catches:** files whose last refresh is past their SLA threshold.
+
+**Signal:** non-zero exit from the check script; daily scheduled workflow ([`data-freshness-check.yml`](../.github/workflows/data-freshness-check.yml)) runs the check and auto-opens a tracking issue with marker `[data-freshness-alert]` on the first failure. The same issue gets commented on each subsequent failure (bounded). The tracker auto-closes on the next green run.
+
+**Configuration:** edit `SLA_CONFIG` in the check script. Set the SLA comfortably longer than the pipeline's refresh cadence (weekly → 9–10 days, monthly → 32 days, quarterly → 95 days, annual → 400 days). The check prefers an in-file `updated` / `generated` / `metadata.generatedAt` timestamp; falls back to file mtime when no in-file timestamp exists.
+
+## 2. Corruption — `scripts/audit/data-sentinels-check.mjs`
+
+**What it catches:** files that regenerate fresh but with silently-truncated content — a full file with 50 of an expected 500 entries passes the freshness gate but is still broken.
+
+**Signal:** non-zero exit from the check script; daily scheduled workflow ([`data-sentinels-check.yml`](../.github/workflows/data-sentinels-check.yml)) runs the check and auto-opens a tracking issue with marker `[data-sentinels-alert]`. Same auto-close-on-recovery pattern as freshness.
+
+**Configuration:** edit `SENTINELS` in the check script. Each sentinel specifies `path`, `minRows`, a `count` extractor function, and whether it's a `file` or `directory` kind. Set `minRows` comfortably below the current row count so the sentinel triggers on **cratering**, not normal drift.
+
+## 3. Schema drift — `scripts/validate-schemas.js`
+
+**What it catches:** files that structurally violate their declared JSON Schema (missing required keys, wrong types, sentinel-value leakage, row-count invariants like \"AMI gap must cover 64 counties\").
+
+**Signal:** `ci-checks.yml` runs the validator on every push / PR. Currently `continue-on-error: true` — validation failures are surfaced in the **job summary tab** (introduced alongside this document) but do not block PRs while the schema contract is still maturing.
+
+**Posture:** the `continue-on-error` is intentionally a policy lever. Flipping it to `false` would make schema violations hard-blocking for every PR. Revisit when:
+  - Schema definitions are stable enough that cross-repo PRs rarely touch them
+  - Every pipeline writing to a schema-owned path has been audited for sentinel-value leakage
+  - A run of `main` has shown zero schema failures for ≥2 weeks
+
+See [#657](https://github.com/pggLLC/Housing-Analytics/issues/657) for the flip-it checklist.
+
+## 4. Arbitrary workflow failure — `.github/actions/notify-workflow-outcome`
+
+**What it catches:** a scheduled workflow fails for *any* reason — upstream API outage, rate-limit, auth failure, step timeout, partial write.
+
+**Signal:** each workflow wired to the composite action calls it with `if: always()` and passes `${{ job.status }}`. On failure, the composite finds-or-opens a tracking issue with marker `[workflow-fail:<workflow_id>]` and optionally POSTs to Slack if `SLACK_WEBHOOK_URL` is set. On success (with an open tracker), the composite auto-closes it.
+
+---
+
+## The `fetch_errors` manifest convention
+
+ETL scripts that iterate over many items (counties, places, tracts) should **not silently skip** failed items. Accumulate per-item failures and emit them alongside the primary output so downstream visibility is preserved.
+
+### Shape
+
+Any ETL script that produces a JSON output SHOULD include a top-level `fetch_errors` key alongside its data. Empty array when all items fetched cleanly:
+
+```json
+{
+  "updated": "2026-04-21T03:45:00Z",
+  "counties": { "08001": { ... }, "08013": { ... } },
+  "fetch_errors": [
+    {
+      "geoid": "08043",
+      "error": "HTTP 429: rate limited by api.census.gov",
+      "retries": 3,
+      "timestamp": "2026-04-21T03:43:12Z"
+    }
+  ]
+}
+```
+
+### Required per-error fields
+
+| Field | Purpose |
+|---|---|
+| `geoid` or `item_id` | The specific item that failed (county FIPS, tract GEOID, program ID, etc.) |
+| `error` | Short one-line description of the failure class + proximate cause |
+| `timestamp` | ISO-8601 UTC timestamp when the failure was recorded |
+
+### Optional per-error fields
+
+| Field | Purpose |
+|---|---|
+| `retries` | Number of retry attempts exhausted before giving up |
+| `http_status` | HTTP response code, if the failure was network-layer |
+| `suggested_action` | Free-form hint for an operator (\"verify CENSUS_API_KEY\", \"retry after API recovery\") |
+
+### Why alongside the data, not in logs
+
+Logs rot and are hard to grep across a backfill. A `fetch_errors` array inside the output manifest stays with the data through any downstream pipeline step or human inspection. A CI step can also diff `fetch_errors.length` across runs to flag regressions.
+
+### When to fail the script vs. record an error
+
+- **Record + continue**: partial failure is acceptable for the output's intended use (e.g. missing one county's data still leaves 63 usable records).
+- **Fail fast**: failure affects the output's structural integrity (primary upstream gone; auth broken for ALL items; required shared lookup missing).
+
+A good rule of thumb: if the output would still be *useful* with the missing items clearly flagged, record and continue. If the output would silently mislead, fail.
+
+### Proposed migration order (tracked in #657)
+
+1. `scripts/fetch-county-demographics.js` — iterates 64 counties, well-scoped
+2. `scripts/hna/build_hna_data.py` — iterates 547 geographies
+3. `scripts/market/fetch_*.py` (each)
+4. Eventually: all multi-item ETL scripts
+
+---
+
+## Sentinel values
+
+ACS variables return `-666666666` for \"data unavailable\" and a handful of related sentinels for \"suppressed\", \"not applicable\", etc. These must not leak through as literal values in outputs — they trash any downstream sort or aggregation that doesn't filter them.
+
+**Current coverage:**
+- `scripts/hna/build_ranking_index.py::safe_float` explicitly filters any value ≤ `-1_000_000` as \"missing\"
+- `scripts/hna/acs_validator.py` has a sentinel-detection pass that's run on raw ACS responses
+
+**Gap (tracked in #657):** every other fetch script handling ACS data has its own `safe_float`-equivalent — some handle sentinels, some don't. An audit is needed to confirm coverage.
+
+**Rule for new code:** if your fetch script calls `api.census.gov` or consumes any output that originated there, **route every numeric value through a sentinel-aware coercer** before writing it. Don't rely on downstream consumers to filter.
+
+---
+
+## Related issues
+
+- [#656](https://github.com/pggLLC/Housing-Analytics/issues/656) — freshness monitoring + alerting (substantially closed)
+- [#657](https://github.com/pggLLC/Housing-Analytics/issues/657) — this page's parent; row-count sentinels + schema surface + fetch_errors + sentinel-value audit
+- [#447](https://github.com/pggLLC/Housing-Analytics/issues/447) — parent epic for data quality / monitoring / a11y


### PR DESCRIPTION
Further closeout of [#657](https://github.com/pggLLC/Housing-Analytics/issues/657). Sibling to [#663](https://github.com/pggLLC/Housing-Analytics/pull/663)/[#664](https://github.com/pggLLC/Housing-Analytics/pull/664) (freshness) and [#665](https://github.com/pggLLC/Housing-Analytics/pull/665)/[#666](https://github.com/pggLLC/Housing-Analytics/pull/666) (sentinels). Stacks on [#672](https://github.com/pggLLC/Housing-Analytics/pull/672).

## 1. Schema validation no longer silent

`scripts/validate-schemas.js` has been running with `continue-on-error: true` since Phase 3 — failures invisible unless you hand-dig the run log. This PR tees the validator output to a temp file and adds a follow-up `if: always()` step that posts structured results to `$GITHUB_STEP_SUMMARY`:

- Tail summary line (`Results: N passed, M failed`)
- First 40 failure lines (grep for `❌` / `FAIL`)
- Collapsible raw-output block (last 100 lines)
- `::warning::` annotation when `failures > 0`

**`continue-on-error` is preserved deliberately.** Flipping it to hard-blocking is a repo-owner policy decision with its own pre-flip checklist (documented in the new `docs/DATA_QUALITY.md`). This PR only makes the existing signal visible; doesn't change the PR-gating behavior.

## 2. New: `docs/DATA_QUALITY.md`

Unifies the four data-quality signals shipped this session plus defines the `fetch_errors` manifest convention for multi-item ETL scripts.

**The four signals:**

| Signal | Catches | Mechanism | Alert |
|---|---|---|---|
| Staleness | past-SLA files | `data-freshness-check.mjs` | `[data-freshness-alert]` issue |
| Corruption | below-floor row counts | `data-sentinels-check.mjs` | `[data-sentinels-alert]` issue |
| Schema drift | structural violations | `validate-schemas.js` | `$GITHUB_STEP_SUMMARY` + warning (this PR) |
| Workflow failure | arbitrary step failure | `notify-workflow-outcome` | `[workflow-fail:<id>]` issue + optional Slack |

**The `fetch_errors` convention:**

ETL scripts that iterate over many items (counties, places, tracts) should **not silently skip** failures. Accumulate per-item failures and emit alongside the primary output:

```json
{
  \"updated\": \"2026-04-21T03:45:00Z\",
  \"counties\": { \"08001\": { ... } },
  \"fetch_errors\": [
    {
      \"geoid\": \"08043\",
      \"error\": \"HTTP 429: rate limited by api.census.gov\",
      \"retries\": 3,
      \"timestamp\": \"2026-04-21T03:43:12Z\"
    }
  ]
}
```

Required fields: `item_id` / `error` / `timestamp`. Optional: `retries`, `http_status`, `suggested_action`.

Rule for when to fail vs. record: **record + continue** if the output is still useful with items clearly flagged; **fail fast** if the failure would silently mislead. Migration order for existing scripts proposed in the doc (county-demographics → build_hna_data → fetch_* → rest).

**Also documents the sentinel-value gap:** `safe_float` in `build_ranking_index.py` filters ACS's `-666666666`, but other fetch scripts have their own coercers with inconsistent coverage. Flags the audit as open work under #657 — not attempted in this PR (cross-cutting cleanup wants a dedicated session).

## Still open under #657 after this

| Work | Rough scope |
|---|---|
| Each ETL script adopts the `fetch_errors` convention | 1–2 hr per script (migration order in doc) |
| Sentinel-value audit across fetch scripts | Day-scale, touches many files |
| Flip schema validation to hard-blocking | Repo policy decision — checklist in doc |

## Test plan
- [ ] CI green on this PR
- [ ] On a PR that breaks a schema: run is still green (continue-on-error), but Summary tab shows the failure table + the workflow run emits a `::warning::`
- [ ] On a PR with clean schemas: Summary tab shows `Results: N passed, 0 failed` and the collapsible raw-output section

🤖 Generated with [Claude Code](https://claude.com/claude-code)