### PR TITLE
feat: data-vintage badges + place-approximation hint on HNA

### DIFF
--- a/.github/workflows/a11y-audit.yml
+++ b/.github/workflows/a11y-audit.yml
@@ -1,0 +1,96 @@
+name: A11y Audit (axe-core)
+
+# WCAG 2.1 AA audit via axe-core. Complements accessibility.yml
+# (CSS contrast-token linting) with runtime DOM inspection — different
+# coverage, same epic (#447 / #658).
+#
+# Design posture: the audit runs, commits any drift to the baseline
+# report, and surfaces summary counts in the job summary. It does NOT
+# hard-fail on finding violations today — the audit is a reporter
+# until the baseline is driven to zero. Regressions show up as diffs
+# on docs/reports/a11y-baseline-2026.md in subsequent PR runs.
+
+on:
+  schedule:
+    # Weekly on Tuesday 15:00 UTC = 09:00 America/Denver DST. Offset
+    # from the daily freshness/sentinels checks so the a11y run's
+    # longer runtime (Playwright launch + 14 pages) doesn't overlap.
+    - cron: '0 15 * * 2'
+  pull_request:
+    paths:
+      - 'css/**'
+      - '*.html'
+      - 'js/**'
+      - 'scripts/audit/a11y-audit.mjs'
+      - '.github/workflows/a11y-audit.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  axe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run axe-core audit
+        id: audit
+        run: node scripts/audit/a11y-audit.mjs
+
+      - name: Post summary
+        if: always()
+        run: |
+          if [ -f data/reports/a11y-baseline.json ]; then
+            summary=$(node -e '
+              const d = require(process.cwd() + "/data/reports/a11y-baseline.json");
+              const s = d.summary || {};
+              const bi = s.byImpact || {};
+              console.log("pages=" + (s.pageCount||0));
+              console.log("total=" + (s.totalNodes||0));
+              console.log("critical=" + (bi.critical||0));
+              console.log("serious="  + (bi.serious ||0));
+              console.log("moderate=" + (bi.moderate||0));
+              console.log("minor="    + (bi.minor   ||0));
+            ')
+            eval "$summary"
+            {
+              echo "## A11y audit summary"
+              echo ""
+              echo "| Impact | Elements |"
+              echo "|---|---:|"
+              echo "| critical | $critical |"
+              echo "| serious  | $serious  |"
+              echo "| moderate | $moderate |"
+              echo "| minor    | $minor    |"
+              echo "| **Total** | **$total** |"
+              echo ""
+              echo "Audited **$pages page(s)**. Full report: \`docs/reports/a11y-baseline-2026.md\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            if [ "$critical" -gt 0 ] 2>/dev/null; then
+              echo "::warning::$critical critical a11y violation element(s) found. See baseline report."
+            fi
+          fi
+
+      - name: Upload baseline artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: a11y-baseline-${{ github.run_id }}
+          path: |
+            data/reports/a11y-baseline.json
+            docs/reports/a11y-baseline-2026.md
+          retention-days: 30

--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -400,6 +400,54 @@ footer.site-footer { margin-top: var(--sp6); border-top: 1px solid var(--border)
 .chart-source a { color: var(--faint); text-decoration: none; }
 .chart-source a:hover { text-decoration: underline; }
 
+/* Data vintage badge — renders age + optional stale-data warning.
+   Auto-attached by js/components/data-vintage-badge.js to any element
+   marked with data-vintage-source="path/to/file.json". Signal agrees
+   with the CI freshness check (same timestamp-probe order). */
+.data-vintage-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.32rem 0.65rem;
+  margin: 0.35rem 0;
+  font-size: 0.78rem;
+  line-height: 1.35;
+  color: var(--muted, #64748b);
+  background: var(--bg2, #f8fafc);
+  border: 1px solid var(--border, #cbd5e1);
+  border-radius: 999px;
+  white-space: nowrap;
+}
+.data-vintage-badge .data-vintage-icon { font-size: 0.65rem; opacity: 0.75; }
+.data-vintage-badge .data-vintage-age { color: var(--faint, #94a3b8); }
+.data-vintage-badge--stale {
+  color: #92400e;
+  background: rgba(217, 119, 6, 0.08);
+  border-color: rgba(217, 119, 6, 0.5);
+  white-space: normal;
+}
+.data-vintage-badge--stale .data-vintage-icon { opacity: 1; color: #d97706; }
+.data-vintage-badge--stale .data-vintage-age { color: #92400e; }
+
+/* Place-approximation hint on HNA stats — a compact pill that sits next
+   to a stat header to warn that the number is downscaled from a county
+   source. Twin of the comparative-analysis panel disclaimer shipped in
+   #647; applied to housing-needs-assessment.html's CHAS / AMI tier
+   stats when a place/CDP is selected. */
+.data-approx-hint {
+  display: inline-block;
+  margin-left: 0.5rem;
+  padding: 0.1rem 0.45rem;
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: #92400e;
+  background: rgba(217, 119, 6, 0.1);
+  border: 1px solid rgba(217, 119, 6, 0.35);
+  border-radius: 999px;
+  vertical-align: middle;
+  cursor: help;
+}
+
 /* Explainer tooltip — zero-JS inline methodology popover.
    Used for stat cards where a one-line label can't fully describe the
    methodology, data scope, or limitations. Built on native <details>

--- a/data/reports/a11y-baseline.json
+++ b/data/reports/a11y-baseline.json
@@ -1,0 +1,929 @@
+{
+  "generatedAt": "2026-04-22T03:21:09.553Z",
+  "summary": {
+    "byImpact": {
+      "critical": 21,
+      "serious": 19,
+      "moderate": 0,
+      "minor": 0
+    },
+    "byRule": {
+      "button-name": {
+        "impact": "critical",
+        "help": "Buttons must have discernible text",
+        "nodeCount": 14,
+        "pages": [
+          "index.html",
+          "housing-needs-assessment.html",
+          "hna-comparative-analysis.html",
+          "economic-dashboard.html",
+          "lihtc-allocations.html",
+          "colorado-deep-dive.html",
+          "lihtc-guide-for-stakeholders.html",
+          "dashboard.html",
+          "regional.html",
+          "market-analysis.html",
+          "deal-calculator.html",
+          "housing-legislation-2026.html",
+          "about.html",
+          "insights.html"
+        ]
+      },
+      "aria-prohibited-attr": {
+        "impact": "serious",
+        "help": "Elements must only use permitted ARIA attributes",
+        "nodeCount": 1,
+        "pages": [
+          "housing-needs-assessment.html"
+        ]
+      },
+      "color-contrast": {
+        "impact": "serious",
+        "help": "Elements must meet minimum color contrast ratio thresholds",
+        "nodeCount": 15,
+        "pages": [
+          "housing-needs-assessment.html",
+          "hna-comparative-analysis.html",
+          "economic-dashboard.html",
+          "market-analysis.html",
+          "deal-calculator.html",
+          "about.html",
+          "insights.html"
+        ]
+      },
+      "link-in-text-block": {
+        "impact": "serious",
+        "help": "Links must be distinguishable without relying on color",
+        "nodeCount": 3,
+        "pages": [
+          "hna-comparative-analysis.html",
+          "colorado-deep-dive.html"
+        ]
+      },
+      "select-name": {
+        "impact": "critical",
+        "help": "Select element must have an accessible name",
+        "nodeCount": 4,
+        "pages": [
+          "dashboard.html",
+          "regional.html"
+        ]
+      },
+      "label": {
+        "impact": "critical",
+        "help": "Form elements must have labels",
+        "nodeCount": 3,
+        "pages": [
+          "deal-calculator.html"
+        ]
+      }
+    },
+    "totalNodes": 40,
+    "pageCount": 14
+  },
+  "results": [
+    {
+      "page": "index.html",
+      "violations": [
+        {
+          "id": "button-name",
+          "impact": "critical",
+          "description": "Ensure buttons have discernible text",
+          "help": "Buttons must have discernible text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/button-name?application=axeAPI",
+          "tags": [
+            "cat.name-role-value",
+            "wcag2a",
+            "wcag412",
+            "section508",
+            "section508.22.a",
+            "TTv5",
+            "TT6.a",
+            "EN-301-549",
+            "EN-9.4.1.2",
+            "ACT",
+            "RGAAv4",
+            "RGAA-11.9.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              ".dark-mode-toggle"
+            ],
+            "html": "<button class=\"dark-mode-toggle\" type=\"button\" aria-live=\"polite\"></button>"
+          }
+        }
+      ],
+      "passCount": 26,
+      "incompleteCount": 2,
+      "inapplicable": 35
+    },
+    {
+      "page": "housing-needs-assessment.html",
+      "violations": [
+        {
+          "id": "aria-prohibited-attr",
+          "impact": "serious",
+          "description": "Ensure ARIA attributes are not prohibited for an element's role",
+          "help": "Elements must only use permitted ARIA attributes",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/aria-prohibited-attr?application=axeAPI",
+          "tags": [
+            "cat.aria",
+            "wcag2a",
+            "wcag412",
+            "EN-301-549",
+            "EN-9.4.1.2",
+            "RGAAv4",
+            "RGAA-7.1.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              "#hnaMap"
+            ],
+            "html": "<div id=\"hnaMap\" aria-label=\"Boundary map\"></div>"
+          }
+        },
+        {
+          "id": "button-name",
+          "impact": "critical",
+          "description": "Ensure buttons have discernible text",
+          "help": "Buttons must have discernible text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/button-name?application=axeAPI",
+          "tags": [
+            "cat.name-role-value",
+            "wcag2a",
+            "wcag412",
+            "section508",
+            "section508.22.a",
+            "TTv5",
+            "TT6.a",
+            "EN-301-549",
+            "EN-9.4.1.2",
+            "ACT",
+            "RGAAv4",
+            "RGAA-11.9.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              ".dark-mode-toggle"
+            ],
+            "html": "<button class=\"dark-mode-toggle\" type=\"button\" aria-live=\"polite\"></button>"
+          }
+        },
+        {
+          "id": "color-contrast",
+          "impact": "serious",
+          "description": "Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds",
+          "help": "Elements must meet minimum color contrast ratio thresholds",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/color-contrast?application=axeAPI",
+          "tags": [
+            "cat.color",
+            "wcag2aa",
+            "wcag143",
+            "TTv5",
+            "TT13.c",
+            "EN-301-549",
+            "EN-9.1.4.3",
+            "ACT",
+            "RGAAv4",
+            "RGAA-3.2.1"
+          ],
+          "nodeCount": 4,
+          "sampleNode": {
+            "target": [
+              ".hna-waiting-dashes"
+            ],
+            "html": "<div class=\"hna-waiting-dashes\" aria-hidden=\"true\">— — — — —</div>"
+          }
+        }
+      ],
+      "passCount": 29,
+      "incompleteCount": 2,
+      "inapplicable": 32
+    },
+    {
+      "page": "hna-comparative-analysis.html",
+      "violations": [
+        {
+          "id": "button-name",
+          "impact": "critical",
+          "description": "Ensure buttons have discernible text",
+          "help": "Buttons must have discernible text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/button-name?application=axeAPI",
+          "tags": [
+            "cat.name-role-value",
+            "wcag2a",
+            "wcag412",
+            "section508",
+            "section508.22.a",
+            "TTv5",
+            "TT6.a",
+            "EN-301-549",
+            "EN-9.4.1.2",
+            "ACT",
+            "RGAAv4",
+            "RGAA-11.9.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              ".dark-mode-toggle"
+            ],
+            "html": "<button class=\"dark-mode-toggle\" type=\"button\" aria-live=\"polite\"></button>"
+          }
+        },
+        {
+          "id": "color-contrast",
+          "impact": "serious",
+          "description": "Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds",
+          "help": "Elements must meet minimum color contrast ratio thresholds",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/color-contrast?application=axeAPI",
+          "tags": [
+            "cat.color",
+            "wcag2aa",
+            "wcag143",
+            "TTv5",
+            "TT13.c",
+            "EN-301-549",
+            "EN-9.1.4.3",
+            "ACT",
+            "RGAAv4",
+            "RGAA-3.2.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              ".hca-explore-banner__link"
+            ],
+            "html": "<a href=\"select-jurisdiction.html\" class=\"hca-explore-banner__link\">I already know my jurisdiction →</a>"
+          }
+        },
+        {
+          "id": "link-in-text-block",
+          "impact": "serious",
+          "description": "Ensure links are distinguished from surrounding text in a way that does not rely on color",
+          "help": "Links must be distinguishable without relying on color",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/link-in-text-block?application=axeAPI",
+          "tags": [
+            "cat.color",
+            "wcag2a",
+            "wcag141",
+            "TTv5",
+            "TT13.a",
+            "EN-301-549",
+            "EN-9.1.4.1",
+            "RGAAv4",
+            "RGAA-10.6.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              ".hca-hero-sub > a[href=\"housing-needs-assessment.html\"]"
+            ],
+            "html": "<a href=\"housing-needs-assessment.html\">Housing Needs Assessment</a>"
+          }
+        }
+      ],
+      "passCount": 32,
+      "incompleteCount": 2,
+      "inapplicable": 29
+    },
+    {
+      "page": "economic-dashboard.html",
+      "violations": [
+        {
+          "id": "button-name",
+          "impact": "critical",
+          "description": "Ensure buttons have discernible text",
+          "help": "Buttons must have discernible text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/button-name?application=axeAPI",
+          "tags": [
+            "cat.name-role-value",
+            "wcag2a",
+            "wcag412",
+            "section508",
+            "section508.22.a",
+            "TTv5",
+            "TT6.a",
+            "EN-301-549",
+            "EN-9.4.1.2",
+            "ACT",
+            "RGAAv4",
+            "RGAA-11.9.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              ".dark-mode-toggle"
+            ],
+            "html": "<button class=\"dark-mode-toggle\" type=\"button\" aria-live=\"polite\"></button>"
+          }
+        },
+        {
+          "id": "color-contrast",
+          "impact": "serious",
+          "description": "Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds",
+          "help": "Elements must meet minimum color contrast ratio thresholds",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/color-contrast?application=axeAPI",
+          "tags": [
+            "cat.color",
+            "wcag2aa",
+            "wcag143",
+            "TTv5",
+            "TT13.c",
+            "EN-301-549",
+            "EN-9.1.4.3",
+            "ACT",
+            "RGAAv4",
+            "RGAA-3.2.1"
+          ],
+          "nodeCount": 5,
+          "sampleNode": {
+            "target": [
+              ".census-construction-card.card:nth-child(1) > .census-src > a[target=\"_blank\"][rel=\"noopener\"]"
+            ],
+            "html": "<a href=\"https://fred.stlouisfed.org/series/HOUST5F\" target=\"_blank\" rel=\"noopener\">FRED ↗</a>"
+          }
+        }
+      ],
+      "passCount": 25,
+      "incompleteCount": 2,
+      "inapplicable": 36
+    },
+    {
+      "page": "lihtc-allocations.html",
+      "violations": [
+        {
+          "id": "button-name",
+          "impact": "critical",
+          "description": "Ensure buttons have discernible text",
+          "help": "Buttons must have discernible text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/button-name?application=axeAPI",
+          "tags": [
+            "cat.name-role-value",
+            "wcag2a",
+            "wcag412",
+            "section508",
+            "section508.22.a",
+            "TTv5",
+            "TT6.a",
+            "EN-301-549",
+            "EN-9.4.1.2",
+            "ACT",
+            "RGAAv4",
+            "RGAA-11.9.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              ".dark-mode-toggle"
+            ],
+            "html": "<button class=\"dark-mode-toggle\" type=\"button\" aria-live=\"polite\"></button>"
+          }
+        }
+      ],
+      "passCount": 30,
+      "incompleteCount": 2,
+      "inapplicable": 31
+    },
+    {
+      "page": "colorado-deep-dive.html",
+      "violations": [
+        {
+          "id": "button-name",
+          "impact": "critical",
+          "description": "Ensure buttons have discernible text",
+          "help": "Buttons must have discernible text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/button-name?application=axeAPI",
+          "tags": [
+            "cat.name-role-value",
+            "wcag2a",
+            "wcag412",
+            "section508",
+            "section508.22.a",
+            "TTv5",
+            "TT6.a",
+            "EN-301-549",
+            "EN-9.4.1.2",
+            "ACT",
+            "RGAAv4",
+            "RGAA-11.9.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              ".dark-mode-toggle"
+            ],
+            "html": "<button class=\"dark-mode-toggle\" type=\"button\" aria-live=\"polite\"></button>"
+          }
+        },
+        {
+          "id": "link-in-text-block",
+          "impact": "serious",
+          "description": "Ensure links are distinguished from surrounding text in a way that does not rely on color",
+          "help": "Links must be distinguishable without relying on color",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/link-in-text-block?application=axeAPI",
+          "tags": [
+            "cat.color",
+            "wcag2a",
+            "wcag141",
+            "TTv5",
+            "TT13.a",
+            "EN-301-549",
+            "EN-9.1.4.1",
+            "RGAAv4",
+            "RGAA-10.6.1"
+          ],
+          "nodeCount": 2,
+          "sampleNode": {
+            "target": [
+              ".chart-card[data-hover-init=\"1\"]:nth-child(2) > .chart-source > a[target=\"_blank\"][rel=\"noopener\"]:nth-child(1)"
+            ],
+            "html": "<a href=\"https://www.huduser.gov/portal/datasets/il.html\" target=\"_blank\" rel=\"noopener\">HUD FY2025 Income Limits</a>"
+          }
+        }
+      ],
+      "passCount": 31,
+      "incompleteCount": 3,
+      "inapplicable": 29
+    },
+    {
+      "page": "lihtc-guide-for-stakeholders.html",
+      "violations": [
+        {
+          "id": "button-name",
+          "impact": "critical",
+          "description": "Ensure buttons have discernible text",
+          "help": "Buttons must have discernible text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/button-name?application=axeAPI",
+          "tags": [
+            "cat.name-role-value",
+            "wcag2a",
+            "wcag412",
+            "section508",
+            "section508.22.a",
+            "TTv5",
+            "TT6.a",
+            "EN-301-549",
+            "EN-9.4.1.2",
+            "ACT",
+            "RGAAv4",
+            "RGAA-11.9.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              ".dark-mode-toggle"
+            ],
+            "html": "<button class=\"dark-mode-toggle\" type=\"button\" aria-live=\"polite\"></button>"
+          }
+        }
+      ],
+      "passCount": 26,
+      "incompleteCount": 1,
+      "inapplicable": 35
+    },
+    {
+      "page": "dashboard.html",
+      "violations": [
+        {
+          "id": "button-name",
+          "impact": "critical",
+          "description": "Ensure buttons have discernible text",
+          "help": "Buttons must have discernible text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/button-name?application=axeAPI",
+          "tags": [
+            "cat.name-role-value",
+            "wcag2a",
+            "wcag412",
+            "section508",
+            "section508.22.a",
+            "TTv5",
+            "TT6.a",
+            "EN-301-549",
+            "EN-9.4.1.2",
+            "ACT",
+            "RGAAv4",
+            "RGAA-11.9.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              ".dark-mode-toggle"
+            ],
+            "html": "<button class=\"dark-mode-toggle\" type=\"button\" aria-live=\"polite\"></button>"
+          }
+        },
+        {
+          "id": "select-name",
+          "impact": "critical",
+          "description": "Ensure select element has an accessible name",
+          "help": "Select element must have an accessible name",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/select-name?application=axeAPI",
+          "tags": [
+            "cat.forms",
+            "wcag2a",
+            "wcag412",
+            "section508",
+            "section508.22.n",
+            "TTv5",
+            "TT5.c",
+            "EN-301-549",
+            "EN-9.4.1.2",
+            "ACT",
+            "RGAAv4",
+            "RGAA-11.1.1"
+          ],
+          "nodeCount": 2,
+          "sampleNode": {
+            "target": [
+              "#year-select"
+            ],
+            "html": "<select class=\"control-select\" id=\"year-select\">\n<option selected=\"\" value=\"2026\">2026</option>\n<option value=\"2025\">2025</option>\n<option value=\"2024\">2024</option>\n</select>"
+          }
+        }
+      ],
+      "passCount": 26,
+      "incompleteCount": 1,
+      "inapplicable": 34
+    },
+    {
+      "page": "regional.html",
+      "violations": [
+        {
+          "id": "button-name",
+          "impact": "critical",
+          "description": "Ensure buttons have discernible text",
+          "help": "Buttons must have discernible text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/button-name?application=axeAPI",
+          "tags": [
+            "cat.name-role-value",
+            "wcag2a",
+            "wcag412",
+            "section508",
+            "section508.22.a",
+            "TTv5",
+            "TT6.a",
+            "EN-301-549",
+            "EN-9.4.1.2",
+            "ACT",
+            "RGAAv4",
+            "RGAA-11.9.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              ".dark-mode-toggle"
+            ],
+            "html": "<button class=\"dark-mode-toggle\" type=\"button\" aria-live=\"polite\"></button>"
+          }
+        },
+        {
+          "id": "select-name",
+          "impact": "critical",
+          "description": "Ensure select element has an accessible name",
+          "help": "Select element must have an accessible name",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/select-name?application=axeAPI",
+          "tags": [
+            "cat.forms",
+            "wcag2a",
+            "wcag412",
+            "section508",
+            "section508.22.n",
+            "TTv5",
+            "TT5.c",
+            "EN-301-549",
+            "EN-9.4.1.2",
+            "ACT",
+            "RGAAv4",
+            "RGAA-11.1.1"
+          ],
+          "nodeCount": 2,
+          "sampleNode": {
+            "target": [
+              "#map-mode-select"
+            ],
+            "html": "<select class=\"filter-select\" id=\"map-mode-select\">\n<option value=\"allocation\">Allocation Amount</option>\n<option value=\"region\">Geographic Region</option>\n</select>"
+          }
+        }
+      ],
+      "passCount": 26,
+      "incompleteCount": 1,
+      "inapplicable": 34
+    },
+    {
+      "page": "market-analysis.html",
+      "violations": [
+        {
+          "id": "button-name",
+          "impact": "critical",
+          "description": "Ensure buttons have discernible text",
+          "help": "Buttons must have discernible text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/button-name?application=axeAPI",
+          "tags": [
+            "cat.name-role-value",
+            "wcag2a",
+            "wcag412",
+            "section508",
+            "section508.22.a",
+            "TTv5",
+            "TT6.a",
+            "EN-301-549",
+            "EN-9.4.1.2",
+            "ACT",
+            "RGAAv4",
+            "RGAA-11.9.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              ".dark-mode-toggle"
+            ],
+            "html": "<button class=\"dark-mode-toggle\" type=\"button\" aria-live=\"polite\"></button>"
+          }
+        },
+        {
+          "id": "color-contrast",
+          "impact": "serious",
+          "description": "Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds",
+          "help": "Elements must meet minimum color contrast ratio thresholds",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/color-contrast?application=axeAPI",
+          "tags": [
+            "cat.color",
+            "wcag2aa",
+            "wcag143",
+            "TTv5",
+            "TT13.c",
+            "EN-301-549",
+            "EN-9.1.4.3",
+            "ACT",
+            "RGAAv4",
+            "RGAA-3.2.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              "#pmaMethodTabBuffer > span"
+            ],
+            "html": "<span style=\"font-size:.75em;opacity:.65;\">(legacy)</span>"
+          }
+        }
+      ],
+      "passCount": 38,
+      "incompleteCount": 2,
+      "inapplicable": 23
+    },
+    {
+      "page": "deal-calculator.html",
+      "violations": [
+        {
+          "id": "button-name",
+          "impact": "critical",
+          "description": "Ensure buttons have discernible text",
+          "help": "Buttons must have discernible text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/button-name?application=axeAPI",
+          "tags": [
+            "cat.name-role-value",
+            "wcag2a",
+            "wcag412",
+            "section508",
+            "section508.22.a",
+            "TTv5",
+            "TT6.a",
+            "EN-301-549",
+            "EN-9.4.1.2",
+            "ACT",
+            "RGAAv4",
+            "RGAA-11.9.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              ".dark-mode-toggle"
+            ],
+            "html": "<button class=\"dark-mode-toggle\" type=\"button\" aria-live=\"polite\"></button>"
+          }
+        },
+        {
+          "id": "color-contrast",
+          "impact": "serious",
+          "description": "Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds",
+          "help": "Elements must meet minimum color contrast ratio thresholds",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/color-contrast?application=axeAPI",
+          "tags": [
+            "cat.color",
+            "wcag2aa",
+            "wcag143",
+            "TTv5",
+            "TT13.c",
+            "EN-301-549",
+            "EN-9.1.4.3",
+            "ACT",
+            "RGAAv4",
+            "RGAA-3.2.1"
+          ],
+          "nodeCount": 2,
+          "sampleNode": {
+            "target": [
+              "#dcSaveBtn"
+            ],
+            "html": "<button class=\"btn hna-save-btn\" id=\"dcSaveBtn\" type=\"button\">Save to Project</button>"
+          }
+        },
+        {
+          "id": "label",
+          "impact": "critical",
+          "description": "Ensure every form element has a label",
+          "help": "Form elements must have labels",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/label?application=axeAPI",
+          "tags": [
+            "cat.forms",
+            "wcag2a",
+            "wcag412",
+            "section508",
+            "section508.22.n",
+            "TTv5",
+            "TT5.c",
+            "EN-301-549",
+            "EN-9.4.1.2",
+            "ACT",
+            "RGAAv4",
+            "RGAA-11.1.1"
+          ],
+          "nodeCount": 3,
+          "sampleNode": {
+            "target": [
+              "#qsim_devScore"
+            ],
+            "html": "<input type=\"range\" id=\"qsim_devScore\" name=\"devScore\" min=\"0\" max=\"15\" step=\"0.5\" value=\"11.4\">"
+          }
+        }
+      ],
+      "passCount": 33,
+      "incompleteCount": 1,
+      "inapplicable": 28
+    },
+    {
+      "page": "housing-legislation-2026.html",
+      "violations": [
+        {
+          "id": "button-name",
+          "impact": "critical",
+          "description": "Ensure buttons have discernible text",
+          "help": "Buttons must have discernible text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/button-name?application=axeAPI",
+          "tags": [
+            "cat.name-role-value",
+            "wcag2a",
+            "wcag412",
+            "section508",
+            "section508.22.a",
+            "TTv5",
+            "TT6.a",
+            "EN-301-549",
+            "EN-9.4.1.2",
+            "ACT",
+            "RGAAv4",
+            "RGAA-11.9.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              ".dark-mode-toggle"
+            ],
+            "html": "<button class=\"dark-mode-toggle\" type=\"button\" aria-live=\"polite\"></button>"
+          }
+        }
+      ],
+      "passCount": 27,
+      "incompleteCount": 1,
+      "inapplicable": 34
+    },
+    {
+      "page": "about.html",
+      "violations": [
+        {
+          "id": "button-name",
+          "impact": "critical",
+          "description": "Ensure buttons have discernible text",
+          "help": "Buttons must have discernible text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/button-name?application=axeAPI",
+          "tags": [
+            "cat.name-role-value",
+            "wcag2a",
+            "wcag412",
+            "section508",
+            "section508.22.a",
+            "TTv5",
+            "TT6.a",
+            "EN-301-549",
+            "EN-9.4.1.2",
+            "ACT",
+            "RGAAv4",
+            "RGAA-11.9.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              ".dark-mode-toggle"
+            ],
+            "html": "<button class=\"dark-mode-toggle\" type=\"button\" aria-live=\"polite\"></button>"
+          }
+        },
+        {
+          "id": "color-contrast",
+          "impact": "serious",
+          "description": "Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds",
+          "help": "Elements must meet minimum color contrast ratio thresholds",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/color-contrast?application=axeAPI",
+          "tags": [
+            "cat.color",
+            "wcag2aa",
+            "wcag143",
+            "TTv5",
+            "TT13.c",
+            "EN-301-549",
+            "EN-9.1.4.3",
+            "ACT",
+            "RGAAv4",
+            "RGAA-3.2.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              ".kicker"
+            ],
+            "html": "<span class=\"kicker contrast-guard-fixed\" style=\"color: var(--text-d, #e5e7eb);\">Platform</span>"
+          }
+        }
+      ],
+      "passCount": 24,
+      "incompleteCount": 1,
+      "inapplicable": 37
+    },
+    {
+      "page": "insights.html",
+      "violations": [
+        {
+          "id": "button-name",
+          "impact": "critical",
+          "description": "Ensure buttons have discernible text",
+          "help": "Buttons must have discernible text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/button-name?application=axeAPI",
+          "tags": [
+            "cat.name-role-value",
+            "wcag2a",
+            "wcag412",
+            "section508",
+            "section508.22.a",
+            "TTv5",
+            "TT6.a",
+            "EN-301-549",
+            "EN-9.4.1.2",
+            "ACT",
+            "RGAAv4",
+            "RGAA-11.9.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              ".dark-mode-toggle"
+            ],
+            "html": "<button class=\"dark-mode-toggle\" type=\"button\" aria-live=\"polite\"></button>"
+          }
+        },
+        {
+          "id": "color-contrast",
+          "impact": "serious",
+          "description": "Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds",
+          "help": "Elements must meet minimum color contrast ratio thresholds",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/color-contrast?application=axeAPI",
+          "tags": [
+            "cat.color",
+            "wcag2aa",
+            "wcag143",
+            "TTv5",
+            "TT13.c",
+            "EN-301-549",
+            "EN-9.1.4.3",
+            "ACT",
+            "RGAAv4",
+            "RGAA-3.2.1"
+          ],
+          "nodeCount": 1,
+          "sampleNode": {
+            "target": [
+              ".kicker"
+            ],
+            "html": "<span class=\"kicker contrast-guard-fixed\" style=\"color: var(--text-d, #e5e7eb);\">Analysis &amp; Reports</span>"
+          }
+        }
+      ],
+      "passCount": 26,
+      "incompleteCount": 1,
+      "inapplicable": 35
+    }
+  ]
+}

--- a/docs/reports/a11y-baseline-2026.md
+++ b/docs/reports/a11y-baseline-2026.md
@@ -1,0 +1,182 @@
+# WCAG 2.1 AA accessibility baseline — 2026
+
+_Generated: 2026-04-22T03:21:09.558Z_
+
+Audited 14 page(s) via axe-core. Any regression from this baseline will appear in the diff of this file on the next weekly run.
+
+## Summary by impact
+
+| Impact | Affected element count |
+|---|---:|
+| critical | 21 |
+| serious | 19 |
+| moderate | 0 |
+| minor | 0 |
+| **Total** | **40** |
+
+## Summary by rule
+
+| Rule | Impact | Elements | Pages | Help |
+|---|---|---:|---:|---|
+| `color-contrast` | serious | 15 | 7 | Elements must meet minimum color contrast ratio thresholds |
+| `button-name` | critical | 14 | 14 | Buttons must have discernible text |
+| `select-name` | critical | 4 | 2 | Select element must have an accessible name |
+| `link-in-text-block` | serious | 3 | 2 | Links must be distinguishable without relying on color |
+| `label` | critical | 3 | 1 | Form elements must have labels |
+| `aria-prohibited-attr` | serious | 1 | 1 | Elements must only use permitted ARIA attributes |
+
+## Per-page detail
+
+### index.html
+
+- Passing rules: **26**
+- Incomplete (needs manual check): **2**
+- Violations: **1** (1 element(s))
+
+| Rule | Impact | Elements | Help |
+|---|---|---:|---|
+| `button-name` | critical | 1 | Buttons must have discernible text |
+
+### housing-needs-assessment.html
+
+- Passing rules: **29**
+- Incomplete (needs manual check): **2**
+- Violations: **3** (6 element(s))
+
+| Rule | Impact | Elements | Help |
+|---|---|---:|---|
+| `color-contrast` | serious | 4 | Elements must meet minimum color contrast ratio thresholds |
+| `aria-prohibited-attr` | serious | 1 | Elements must only use permitted ARIA attributes |
+| `button-name` | critical | 1 | Buttons must have discernible text |
+
+### hna-comparative-analysis.html
+
+- Passing rules: **32**
+- Incomplete (needs manual check): **2**
+- Violations: **3** (3 element(s))
+
+| Rule | Impact | Elements | Help |
+|---|---|---:|---|
+| `button-name` | critical | 1 | Buttons must have discernible text |
+| `color-contrast` | serious | 1 | Elements must meet minimum color contrast ratio thresholds |
+| `link-in-text-block` | serious | 1 | Links must be distinguishable without relying on color |
+
+### economic-dashboard.html
+
+- Passing rules: **25**
+- Incomplete (needs manual check): **2**
+- Violations: **2** (6 element(s))
+
+| Rule | Impact | Elements | Help |
+|---|---|---:|---|
+| `color-contrast` | serious | 5 | Elements must meet minimum color contrast ratio thresholds |
+| `button-name` | critical | 1 | Buttons must have discernible text |
+
+### lihtc-allocations.html
+
+- Passing rules: **30**
+- Incomplete (needs manual check): **2**
+- Violations: **1** (1 element(s))
+
+| Rule | Impact | Elements | Help |
+|---|---|---:|---|
+| `button-name` | critical | 1 | Buttons must have discernible text |
+
+### colorado-deep-dive.html
+
+- Passing rules: **31**
+- Incomplete (needs manual check): **3**
+- Violations: **2** (3 element(s))
+
+| Rule | Impact | Elements | Help |
+|---|---|---:|---|
+| `link-in-text-block` | serious | 2 | Links must be distinguishable without relying on color |
+| `button-name` | critical | 1 | Buttons must have discernible text |
+
+### lihtc-guide-for-stakeholders.html
+
+- Passing rules: **26**
+- Incomplete (needs manual check): **1**
+- Violations: **1** (1 element(s))
+
+| Rule | Impact | Elements | Help |
+|---|---|---:|---|
+| `button-name` | critical | 1 | Buttons must have discernible text |
+
+### dashboard.html
+
+- Passing rules: **26**
+- Incomplete (needs manual check): **1**
+- Violations: **2** (3 element(s))
+
+| Rule | Impact | Elements | Help |
+|---|---|---:|---|
+| `select-name` | critical | 2 | Select element must have an accessible name |
+| `button-name` | critical | 1 | Buttons must have discernible text |
+
+### regional.html
+
+- Passing rules: **26**
+- Incomplete (needs manual check): **1**
+- Violations: **2** (3 element(s))
+
+| Rule | Impact | Elements | Help |
+|---|---|---:|---|
+| `select-name` | critical | 2 | Select element must have an accessible name |
+| `button-name` | critical | 1 | Buttons must have discernible text |
+
+### market-analysis.html
+
+- Passing rules: **38**
+- Incomplete (needs manual check): **2**
+- Violations: **2** (2 element(s))
+
+| Rule | Impact | Elements | Help |
+|---|---|---:|---|
+| `button-name` | critical | 1 | Buttons must have discernible text |
+| `color-contrast` | serious | 1 | Elements must meet minimum color contrast ratio thresholds |
+
+### deal-calculator.html
+
+- Passing rules: **33**
+- Incomplete (needs manual check): **1**
+- Violations: **3** (6 element(s))
+
+| Rule | Impact | Elements | Help |
+|---|---|---:|---|
+| `label` | critical | 3 | Form elements must have labels |
+| `color-contrast` | serious | 2 | Elements must meet minimum color contrast ratio thresholds |
+| `button-name` | critical | 1 | Buttons must have discernible text |
+
+### housing-legislation-2026.html
+
+- Passing rules: **27**
+- Incomplete (needs manual check): **1**
+- Violations: **1** (1 element(s))
+
+| Rule | Impact | Elements | Help |
+|---|---|---:|---|
+| `button-name` | critical | 1 | Buttons must have discernible text |
+
+### about.html
+
+- Passing rules: **24**
+- Incomplete (needs manual check): **1**
+- Violations: **2** (2 element(s))
+
+| Rule | Impact | Elements | Help |
+|---|---|---:|---|
+| `button-name` | critical | 1 | Buttons must have discernible text |
+| `color-contrast` | serious | 1 | Elements must meet minimum color contrast ratio thresholds |
+
+### insights.html
+
+- Passing rules: **26**
+- Incomplete (needs manual check): **1**
+- Violations: **2** (2 element(s))
+
+| Rule | Impact | Elements | Help |
+|---|---|---:|---|
+| `button-name` | critical | 1 | Buttons must have discernible text |
+| `color-contrast` | serious | 1 | Elements must meet minimum color contrast ratio thresholds |
+

--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -26,6 +26,7 @@
   <script src="js/workflow-state-api.js"></script>
   <script src="js/components/workflow-progress.js" defer></script>
   <script src="js/components/lihtc-tips.js" defer></script>
+  <script src="js/components/data-vintage-badge.js" defer></script>
   <script src="js/components/analytics.js" data-step="2" data-step-label="housing_needs_assessment"></script>
   <script defer src="js/components/page-context.js"></script>
   <script src="js/fetch-helper.js"></script>
@@ -136,6 +137,10 @@
         <div id="hnaBanner" class="banner"></div>
         <div id="hnaLiveRegion" aria-live="polite" aria-atomic="true" class="sr-only"></div>
         <small id="hnaDataTimestamp" class="data-timestamp"></small>
+        <!-- Data vintage badge — auto-attached by js/components/data-vintage-badge.js.
+             Reads metadata.generatedAt from the ranking-index (HNA's primary
+             data artifact) and switches to a stale banner past the 10-day SLA. -->
+        <div data-vintage-source="data/hna/ranking-index.json" data-vintage-sla-days="10"></div>
         <div class="hna-controls" style="margin-top:var(--sp3);">
           <label style="color:var(--muted);font-weight:700" for="geoType">Geography type</label>
           <select id="geoType">
@@ -372,7 +377,7 @@
       </div>
 
       <div class="chart-card span-6">
-        <h2>Cost burden by AMI tier (HUD CHAS)</h2>
+        <h2>Cost burden by AMI tier (HUD CHAS)<span id="chasApproxHint" class="data-approx-hint" hidden title="When a place or CDP is selected, CHAS tiers are scaled from the containing county — the selected geography may not have its own CHAS breakdown. See comparative-analysis detail panel for full disclaimer.">(county-approx)</span></h2>
         <p>Renter households by income tier (% of Area Median Income) showing not-burdened, moderately burdened (30–50% of income), and severely burdened (&gt;50%) households. Source: HUD Comprehensive Housing Affordability Strategy (CHAS).</p>
         <div class="chart-box" data-source="HUD CHAS 2017-2021" data-source-url="https://www.huduser.gov/portal/datasets/cp.html"><canvas id="chartChasGap" role="img" aria-label="Renter cost burden by AMI income tier chart (HUD CHAS)"></canvas></div>
         <p class="sr-only">Stacked bar chart showing renter households at each AMI income tier (≤30%, 31–50%, 51–80%, 81–100%) broken down by housing cost burden status.</p>
@@ -2260,6 +2265,25 @@
         { heading: 'HNA Concepts' });
     }
   });
+}());
+</script>
+
+<!-- Place-level CHAS approximation hint — toggle the "(county-approx)"
+     pill next to the CHAS AMI tier header when a place or CDP is selected.
+     CHAS data only exists at county granularity; place selections show
+     their containing county's breakdown. Twin of the detail-panel
+     disclaimer shipped in #647 for hna-comparative-analysis.html. -->
+<script>
+(function () {
+  var hint   = document.getElementById('chasApproxHint');
+  var geoSel = document.getElementById('geoType');
+  if (!hint || !geoSel) return;
+  function sync() {
+    var v = geoSel.value;
+    hint.hidden = !(v === 'place' || v === 'cdp');
+  }
+  geoSel.addEventListener('change', sync);
+  sync();
 }());
 </script>
 

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
   <script src="js/scroll-fix.js"></script>
   <script defer src="js/navigation.js"></script>
   <script defer src="js/dark-mode-toggle.js"></script>
+  <script defer src="js/components/data-vintage-badge.js"></script>
   <script defer src="js/mobile-menu.js"></script>
 </head>
 <body>
@@ -56,6 +57,13 @@
             Not sure where to start? Explore all Colorado jurisdictions →
           </a>
         </div>
+        <!-- Data vintage badge — shows when the statewide ranking data was last
+             rebuilt. Switches to a stale-warning pill once past the 10-day SLA
+             (matches build-hna-data.yml cadence + data-freshness-check.yml). -->
+        <div data-vintage-source="data/hna/ranking-index.json"
+             data-vintage-sla-days="10"
+             data-vintage-label="Colorado housing data as of"
+             style="margin-top:var(--sp3);"></div>
       </div>
     </section>
 

--- a/js/components/data-vintage-badge.js
+++ b/js/components/data-vintage-badge.js
@@ -1,0 +1,156 @@
+/**
+ * js/components/data-vintage-badge.js
+ *
+ * Auto-renders a "Data as of …" vintage badge on any element marked with
+ *   data-vintage-source="relative/path/to/file.json"
+ *   [data-vintage-sla-days="16"]   (optional; default 30)
+ *   [data-vintage-label="custom prefix"]  (optional; default "Data as of")
+ *
+ * Pulls the in-file timestamp field the freshness-check script uses
+ * (updated / generated / generatedAt / metadata.generated / meta.generated)
+ * so the UI signal and the CI signal agree on what "fresh" means.
+ *
+ * Switches to a stale-data warning banner appearance when the file's age
+ * exceeds the declared SLA — mirrors the condition under which
+ * data-freshness-check.yml would open a tracking issue. Complements #663
+ * (detector) + #664 (alert issue) with a user-facing signal.
+ *
+ * Closes a slice of #659.
+ *
+ * Exposes window.DataVintageBadge for imperative use.
+ */
+(function () {
+  'use strict';
+
+  var DEFAULT_SLA_DAYS = 30;
+  var SELECTOR = '[data-vintage-source]';
+
+  // Same field-probe order as scripts/audit/data-freshness-check.mjs
+  var TIMESTAMP_FIELDS  = ['updated', 'generated', 'generatedAt', 'last_updated', 'lastUpdated', 'timestamp'];
+  var TIMESTAMP_PARENTS = ['metadata', 'meta'];
+
+  function findTimestamp(obj) {
+    if (!obj || typeof obj !== 'object') return null;
+    for (var i = 0; i < TIMESTAMP_FIELDS.length; i++) {
+      var k = TIMESTAMP_FIELDS[i];
+      if (typeof obj[k] === 'string' && !isNaN(Date.parse(obj[k]))) {
+        return { source: k, value: obj[k] };
+      }
+    }
+    for (var j = 0; j < TIMESTAMP_PARENTS.length; j++) {
+      var p = obj[TIMESTAMP_PARENTS[j]];
+      if (p && typeof p === 'object') {
+        for (var m = 0; m < TIMESTAMP_FIELDS.length; m++) {
+          var kk = TIMESTAMP_FIELDS[m];
+          if (typeof p[kk] === 'string' && !isNaN(Date.parse(p[kk]))) {
+            return { source: TIMESTAMP_PARENTS[j] + '.' + kk, value: p[kk] };
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  function formatAge(days) {
+    if (days < 1)   return 'today';
+    if (days < 2)   return 'yesterday';
+    if (days < 14)  return Math.floor(days) + ' days ago';
+    if (days < 60)  return Math.floor(days / 7) + ' weeks ago';
+    return Math.floor(days / 30) + ' months ago';
+  }
+
+  function formatIsoDate(iso) {
+    // Accept YYYY-MM-DD or full ISO; return just the date portion.
+    return String(iso || '').slice(0, 10);
+  }
+
+  /**
+   * Render the badge into `target`. If `target` already has one, replace it.
+   * @param {HTMLElement} target
+   * @param {{ updated: string, sla: number, source: string, label: string }} info
+   */
+  function renderBadge(target, info) {
+    var existing = target.querySelector('.data-vintage-badge');
+    if (existing) existing.remove();
+
+    var ts = new Date(info.updated);
+    var ageDays = (Date.now() - ts.getTime()) / 86_400_000;
+    var isStale = info.sla > 0 && ageDays > info.sla;
+
+    var badge = document.createElement('div');
+    badge.className = 'data-vintage-badge' + (isStale ? ' data-vintage-badge--stale' : '');
+    badge.setAttribute('role', isStale ? 'status' : 'note');
+    badge.setAttribute('aria-live', isStale ? 'polite' : 'off');
+
+    var icon = isStale ? '\u26A0' : '\u25CF';  // warning triangle vs filled circle
+    var prefix = isStale ? 'Stale data &mdash; ' : (info.label || 'Data as of') + ' ';
+    var dateText = formatIsoDate(info.updated);
+    var ageText  = formatAge(ageDays);
+
+    badge.innerHTML =
+      '<span class="data-vintage-icon" aria-hidden="true">' + icon + '</span>' +
+      '<span class="data-vintage-text">' +
+        prefix + '<strong>' + dateText + '</strong> <span class="data-vintage-age">(' + ageText + ')</span>' +
+      '</span>' +
+      '<span class="data-vintage-source" title="Source field: ' + info.source + '">' +
+        (isStale ? ' &middot; refresh cadence exceeded' : '') +
+      '</span>';
+
+    // If the target itself is a flow element (heading, hero, section),
+    // append the badge. If it's a chart-card or stat container, prepend so
+    // the badge reads above the numbers.
+    if (target.classList && (target.classList.contains('chart-card') || target.classList.contains('stat-card'))) {
+      target.insertBefore(badge, target.firstChild);
+    } else {
+      target.appendChild(badge);
+    }
+  }
+
+  /**
+   * Scan the document for [data-vintage-source] and attach a badge to each.
+   * Safe to call multiple times; each call replaces the existing badge.
+   */
+  function scan() {
+    var els = document.querySelectorAll(SELECTOR);
+    els.forEach(function (el) {
+      var src = el.getAttribute('data-vintage-source');
+      if (!src) return;
+      var sla   = parseInt(el.getAttribute('data-vintage-sla-days'), 10);
+      if (!isFinite(sla) || sla <= 0) sla = DEFAULT_SLA_DAYS;
+      var label = el.getAttribute('data-vintage-label') || 'Data as of';
+
+      var fetcher = (typeof window.safeFetchJSON === 'function')
+        ? window.safeFetchJSON
+        : function (u) { return fetch(u).then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); }); };
+
+      fetcher(src).then(function (data) {
+        var ts = findTimestamp(data);
+        if (!ts) {
+          // No in-file timestamp — skip rather than render a misleading badge.
+          return;
+        }
+        renderBadge(el, {
+          updated: ts.value,
+          source:  ts.source,
+          sla:     sla,
+          label:   label,
+        });
+      }).catch(function () {
+        // Silent on fetch failure — we don't want a blocked resource to
+        // mask a functional page with a scary-looking error badge.
+      });
+    });
+  }
+
+  function init() {
+    scan();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  window.DataVintageBadge = { scan: scan, renderBadge: renderBadge };
+})();

--- a/market-analysis.html
+++ b/market-analysis.html
@@ -16,6 +16,7 @@
   <script src="js/workflow-state-api.js"></script>
   <script src="js/components/workflow-progress.js" defer></script>
   <script src="js/components/lihtc-tips.js" defer></script>
+  <script src="js/components/data-vintage-badge.js" defer></script>
   <script src="js/components/export-panel.js" defer></script>
   <script src="js/components/analytics.js" data-step="3" data-step-label="market_analysis"></script>
   <script defer src="js/components/page-context.js"></script>
@@ -113,6 +114,13 @@
       <p class="pma-intro-note" role="note"><strong>Screening tool only.</strong> Scores are for early-stage site identification using public data. They are not a substitute for a formal CHFA-required PMA, independent market study, or professional underwriting.</p>
       <small id="pmaDataStatus" style="color:var(--faint)">Loading data…</small>
       <small id="pmaDataTimestamp" class="data-timestamp"></small>
+      <!-- Data vintage badge — ACS tract metrics drive the PMA composite;
+           their monthly-refresh cadence sets the SLA. Switches to stale
+           past 32 days (matches data-freshness-check.mjs SLA_CONFIG). -->
+      <div data-vintage-source="data/market/acs_tract_metrics_co.json"
+           data-vintage-sla-days="32"
+           data-vintage-label="ACS metrics as of"
+           style="margin-top:var(--sp2);"></div>
     </div>
 
     <!-- ── Data Quality Banner ── -->

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint:html": "npx htmlhint '*.html'",
     "lint:css": "npx stylelint 'css/*.css'",
     "audit:contrast": "node scripts/contrast-audit/run.js",
+    "audit:a11y": "node scripts/audit/a11y-audit.mjs",
     "audit:data": "node scripts/audit/data-inventory.mjs",
     "audit:data:manifest": "node scripts/audit/data-inventory.mjs --json",
     "audit:site": "node scripts/audit/site-audit.mjs",

--- a/scripts/audit/a11y-audit.mjs
+++ b/scripts/audit/a11y-audit.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+/**
+ * scripts/audit/a11y-audit.mjs — WCAG 2.1 AA accessibility audit via axe-core.
+ *
+ * Partial closeout of #658 (WCAG audit + axe-core configured and runnable
+ * as `npm run audit:a11y`).
+ *
+ * Design:
+ *   - Uses Playwright to open each configured HTML page via file:// URLs.
+ *     file:// is fine for this first pass — axe inspects the rendered DOM,
+ *     and dynamic-data issues show up on pages whose static markup is
+ *     already WCAG-clean (so file:// is a strict subset of what a live
+ *     audit would surface).
+ *   - Loads axe-core via page.addScriptTag from node_modules. axe-core is
+ *     already a transitive devDep via lighthouse — no new package needed.
+ *   - Emits:
+ *       data/reports/a11y-baseline.json  — raw axe output per page
+ *       docs/reports/a11y-baseline-2026.md — human-readable baseline
+ *     The baseline file is committed so a PR-time diff shows regressions.
+ *
+ * Exit codes:
+ *   0  — audit ran to completion (violations OK; this is a reporter)
+ *   1  — script-level error (Playwright failed to launch, page 404, etc.)
+ *
+ * Usage:
+ *   npm run audit:a11y             # default: all pages in AUDIT_PAGES
+ *   node scripts/audit/a11y-audit.mjs --page index.html
+ *   node scripts/audit/a11y-audit.mjs --json-only
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT      = path.resolve(__dirname, '..', '..');
+
+// Pages covered by the audit. Keep in sync with test/pages-availability-check.js
+// HTML_PAGES list — this is the user-facing entry-point set.
+const AUDIT_PAGES = [
+  'index.html',
+  'housing-needs-assessment.html',
+  'hna-comparative-analysis.html',
+  'economic-dashboard.html',
+  'lihtc-allocations.html',
+  'colorado-deep-dive.html',
+  'lihtc-guide-for-stakeholders.html',
+  'dashboard.html',
+  'regional.html',
+  'market-analysis.html',
+  'deal-calculator.html',
+  'housing-legislation-2026.html',
+  'about.html',
+  'insights.html',
+];
+
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const pageArgIdx = args.indexOf('--page');
+  return {
+    pages:    pageArgIdx !== -1 && args[pageArgIdx + 1] ? [args[pageArgIdx + 1]] : AUDIT_PAGES,
+    jsonOnly: args.includes('--json-only'),
+    quiet:    args.includes('--quiet'),
+  };
+}
+
+async function locateAxeScript() {
+  // axe-core is bundled inside node_modules/axe-core/axe.js after lighthouse
+  // pulls it in transitively. The resolve-on-disk approach avoids a new
+  // @axe-core/playwright devDep.
+  const candidate = path.join(ROOT, 'node_modules', 'axe-core', 'axe.js');
+  await fs.access(candidate);
+  return candidate;
+}
+
+async function auditPage(browser, pagePath, axeScript) {
+  const context = await browser.newContext();
+  const page    = await context.newPage();
+
+  // Silence page console errors during audit — many of our pages fetch data
+  // from relative paths that 404 under file://, which is not an a11y issue.
+  page.on('pageerror', () => {});
+  page.on('console',   () => {});
+
+  const fileUrl = pathToFileURL(path.join(ROOT, pagePath)).href;
+  try {
+    await page.goto(fileUrl, { waitUntil: 'load', timeout: 15_000 });
+  } catch (err) {
+    await context.close();
+    return { page: pagePath, error: `goto failed: ${err.message}`, violations: [] };
+  }
+
+  // Inject axe-core then run it.
+  await page.addScriptTag({ path: axeScript });
+
+  const result = await page.evaluate(async (wcagTags) => {
+    // eslint-disable-next-line no-undef
+    const r = await window.axe.run(document, { runOnly: { type: 'tag', values: wcagTags } });
+    // Trim the raw result to the fields we surface in the baseline.
+    return {
+      violations: r.violations.map(v => ({
+        id:          v.id,
+        impact:      v.impact,
+        description: v.description,
+        help:        v.help,
+        helpUrl:     v.helpUrl,
+        tags:        v.tags,
+        nodeCount:   v.nodes.length,
+        sampleNode:  v.nodes[0] && {
+          target: v.nodes[0].target,
+          html:   (v.nodes[0].html || '').slice(0, 200),
+        },
+      })),
+      passCount:       r.passes.length,
+      incompleteCount: r.incomplete.length,
+      inapplicable:    r.inapplicable.length,
+    };
+  }, WCAG_TAGS);
+
+  await context.close();
+  return { page: pagePath, ...result };
+}
+
+function summarize(results) {
+  const byImpact = { critical: 0, serious: 0, moderate: 0, minor: 0 };
+  const byRule   = {};
+  let totalNodes = 0;
+
+  for (const r of results) {
+    if (r.error) continue;
+    for (const v of r.violations) {
+      const impact = v.impact || 'moderate';
+      byImpact[impact] = (byImpact[impact] || 0) + v.nodeCount;
+      byRule[v.id] = byRule[v.id] || { impact, help: v.help, nodeCount: 0, pages: [] };
+      byRule[v.id].nodeCount += v.nodeCount;
+      byRule[v.id].pages.push(r.page);
+      totalNodes += v.nodeCount;
+    }
+  }
+
+  return { byImpact, byRule, totalNodes, pageCount: results.length };
+}
+
+function toMarkdown(results, summary) {
+  const lines = [];
+  lines.push('# WCAG 2.1 AA accessibility baseline — 2026');
+  lines.push('');
+  lines.push(`_Generated: ${new Date().toISOString()}_`);
+  lines.push('');
+  lines.push(`Audited ${summary.pageCount} page(s) via axe-core. Any regression from this baseline will appear in the diff of this file on the next weekly run.`);
+  lines.push('');
+  lines.push('## Summary by impact');
+  lines.push('');
+  lines.push('| Impact | Affected element count |');
+  lines.push('|---|---:|');
+  for (const impact of ['critical', 'serious', 'moderate', 'minor']) {
+    lines.push(`| ${impact} | ${summary.byImpact[impact] || 0} |`);
+  }
+  lines.push(`| **Total** | **${summary.totalNodes}** |`);
+  lines.push('');
+  lines.push('## Summary by rule');
+  lines.push('');
+  lines.push('| Rule | Impact | Elements | Pages | Help |');
+  lines.push('|---|---|---:|---:|---|');
+  const rules = Object.entries(summary.byRule)
+    .sort((a, b) => b[1].nodeCount - a[1].nodeCount);
+  for (const [id, info] of rules) {
+    lines.push(`| \`${id}\` | ${info.impact} | ${info.nodeCount} | ${info.pages.length} | ${info.help} |`);
+  }
+  lines.push('');
+  lines.push('## Per-page detail');
+  lines.push('');
+  for (const r of results) {
+    lines.push(`### ${r.page}`);
+    lines.push('');
+    if (r.error) {
+      lines.push(`_Audit failed: ${r.error}_`);
+      lines.push('');
+      continue;
+    }
+    lines.push(`- Passing rules: **${r.passCount}**`);
+    lines.push(`- Incomplete (needs manual check): **${r.incompleteCount}**`);
+    lines.push(`- Violations: **${r.violations.length}** (${r.violations.reduce((s, v) => s + v.nodeCount, 0)} element(s))`);
+    if (r.violations.length) {
+      lines.push('');
+      lines.push('| Rule | Impact | Elements | Help |');
+      lines.push('|---|---|---:|---|');
+      for (const v of r.violations.sort((a, b) => (b.nodeCount - a.nodeCount))) {
+        lines.push(`| \`${v.id}\` | ${v.impact || '—'} | ${v.nodeCount} | ${v.help} |`);
+      }
+    }
+    lines.push('');
+  }
+  return lines.join('\n') + '\n';
+}
+
+async function main() {
+  const { pages, jsonOnly, quiet } = parseArgs();
+
+  let playwright;
+  try { playwright = await import('playwright'); }
+  catch {
+    console.error('Playwright not installed. Run `npm ci` and `npx playwright install chromium`.');
+    process.exit(1);
+  }
+
+  const axeScript = await locateAxeScript().catch(() => null);
+  if (!axeScript) {
+    console.error('axe-core not found in node_modules. Run `npm ci`.');
+    process.exit(1);
+  }
+
+  if (!quiet) console.log(`[a11y-audit] auditing ${pages.length} page(s) via axe-core`);
+
+  const browser = await playwright.chromium.launch();
+  const results = [];
+  for (const p of pages) {
+    if (!quiet) process.stdout.write(`[a11y-audit] ${p} ... `);
+    const r = await auditPage(browser, p, axeScript);
+    results.push(r);
+    if (!quiet) {
+      if (r.error) console.log(`error: ${r.error}`);
+      else        console.log(`${r.violations.length} violation(s), ${r.violations.reduce((s, v) => s + v.nodeCount, 0)} element(s)`);
+    }
+  }
+  await browser.close();
+
+  const summary = summarize(results);
+
+  // Write outputs
+  const jsonOut = path.join(ROOT, 'data', 'reports', 'a11y-baseline.json');
+  const mdOut   = path.join(ROOT, 'docs', 'reports', 'a11y-baseline-2026.md');
+  await fs.mkdir(path.dirname(jsonOut), { recursive: true });
+  await fs.mkdir(path.dirname(mdOut),   { recursive: true });
+  await fs.writeFile(jsonOut, JSON.stringify({ generatedAt: new Date().toISOString(), summary, results }, null, 2));
+  if (!jsonOnly) {
+    await fs.writeFile(mdOut, toMarkdown(results, summary));
+  }
+
+  if (!quiet) {
+    console.log('');
+    console.log(`Summary: ${summary.totalNodes} total violation element(s)`);
+    console.log(`  critical: ${summary.byImpact.critical || 0}`);
+    console.log(`  serious:  ${summary.byImpact.serious  || 0}`);
+    console.log(`  moderate: ${summary.byImpact.moderate || 0}`);
+    console.log(`  minor:    ${summary.byImpact.minor    || 0}`);
+    console.log(`Raw JSON:   ${path.relative(ROOT, jsonOut)}`);
+    if (!jsonOnly) console.log(`Report:     ${path.relative(ROOT, mdOut)}`);
+  }
+}
+
+main().catch(err => {
+  console.error('a11y-audit crashed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes [#659](https://github.com/pggLLC/Housing-Analytics/issues/659) (real-time data-quality indicators in dashboards). Stacks on [#677](https://github.com/pggLLC/Housing-Analytics/pull/677).

## What ships

### Reusable component: `js/components/data-vintage-badge.js`

One-line markup, no framework:

\`\`\`html
<div data-vintage-source=\"data/hna/ranking-index.json\"
     data-vintage-sla-days=\"10\"
     data-vintage-label=\"Data as of\"></div>
\`\`\`

The component auto-attaches a pill that reads **\"Data as of 2026-04-20 (yesterday)\"** on page load. When the file's age exceeds the declared SLA, the badge switches to an **amber stale-data warning** with a warning-triangle icon and a \"· refresh cadence exceeded\" suffix.

**Key invariant:** the component probes the same timestamp fields as `scripts/audit/data-freshness-check.mjs` (`updated`, `generated`, `generatedAt`, `metadata.generated`, `meta.generated`) — so the **UI signal agrees with the CI signal** on what \"fresh\" means. Users see the same state as ops; no duplicated config.

Loads via `window.safeFetchJSON` when available (stale-while-revalidate localStorage cache) so it doesn't hammer the network. Silent on fetch failure — never blocks a functional page with a scary-looking error badge.

### HNA place-approximation hint

`housing-needs-assessment.html` now shows a compact **\"(county-approx)\"** pill next to the \"Cost burden by AMI tier (HUD CHAS)\" section header — visible only when a place or CDP is selected. CHAS data only exists at county granularity; place selections show their containing county's breakdown. This pill is the twin of the detail-panel disclaimer shipped in #647 for `hna-comparative-analysis.html`, so users see the **same signal** when inspecting a place's HNA page directly.

### Wired into 3 primary dashboards

| Page | Source file | SLA |
|---|---|---|
| `index.html` | `data/hna/ranking-index.json` | 10 d |
| `housing-needs-assessment.html` | same | 10 d |
| `market-analysis.html` | `data/market/acs_tract_metrics_co.json` | 32 d |

SLAs match the corresponding entries in `data-freshness-check.mjs::SLA_CONFIG`.

## Browser-verified

| Page | Badge text | Stale? |
|---|---|---|
| `index.html` | \"Colorado housing data as of 2026-04-20 (yesterday)\" | no |
| `housing-needs-assessment.html` | \"Data as of 2026-04-20 (yesterday)\" | no |
| `market-analysis.html` | \"ACS metrics as of 2026-04-13 (8 days ago)\" | no |

**HNA hint toggling:** `geoType=state` → hidden. `geoType=place` → visible. `geoType=county` → hidden. Correct per the CHAS-only-at-county rationale.

**Stale path** (tested with `data-vintage-sla-days=1` on an 8-day-old file): amber background `rgba(217,119,6,0.08)`, warning-triangle icon, **\"Stale data — 2026-04-13 (8 days ago) · refresh cadence exceeded\"**.

Zero console errors across all 3 pages.

## Why a separate badge rather than extending `data-freshness-monitor.js`
The existing `js/data-freshness-monitor.js` is a dashboard-specific module (`dashboard-data-quality.html`) that hard-codes its data source and display location. This component is **generic** — drops into any page with a single markup attribute — and sidesteps coupling to the dashboard's internal state. Worth keeping them separate.

## Follow-ups (tracked in #659 comment)
- Extend badge coverage to `deal-calculator.html` and `hna-comparative-analysis.html` (same one-line markup)
- Optional cache-hit indicator (low priority per the issue)
- Vintage-badge scan() could hook into MutationObserver for dynamically-rendered dashboards (pattern from #651)

## Test plan
- [ ] CI green
- [ ] Deployed preview: confirm badge renders on all 3 pages with correct dates
- [ ] HNA: change geoType dropdown between state/county/place — \"(county-approx)\" hint visibility tracks
- [ ] On a test branch: `touch -d '2024-01-01' data/hna/ranking-index.json` → stale badge styling on index + HNA

🤖 Generated with [Claude Code](https://claude.com/claude-code)