### PR TITLE
a11y: fix audit cache + docs/A11Y.md integrates 3 workflow layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Reference documentation for each of the four analysis modules. Each guide covers
 
 See also:
 - [`docs/DATA_QUALITY.md`](docs/DATA_QUALITY.md) — data-pipeline freshness, corruption, schema, and workflow-failure signals
+- [`docs/A11Y.md`](docs/A11Y.md) — three-layer accessibility testing: token lint, site-wide contrast, rendered axe-core
 - [`docs/api/`](docs/api/) — auto-generated JSDoc API reference
 - [`docs/reports/test-coverage.md`](docs/reports/test-coverage.md) — weekly test-assertion coverage report
 - [`docs/reports/a11y-baseline-2026.md`](docs/reports/a11y-baseline-2026.md) — WCAG 2.1 AA baseline

--- a/data/reports/a11y-baseline.json
+++ b/data/reports/a11y-baseline.json
@@ -1,9 +1,9 @@
 {
-  "generatedAt": "2026-04-22T11:42:58.708Z",
+  "generatedAt": "2026-04-22T13:36:12.348Z",
   "summary": {
     "byImpact": {
       "critical": 0,
-      "serious": 16,
+      "serious": 19,
       "moderate": 0,
       "minor": 0
     },
@@ -11,7 +11,7 @@
       "color-contrast": {
         "impact": "serious",
         "help": "Elements must meet minimum color contrast ratio thresholds",
-        "nodeCount": 16,
+        "nodeCount": 19,
         "pages": [
           "housing-needs-assessment.html",
           "hna-comparative-analysis.html",
@@ -19,7 +19,6 @@
           "lihtc-allocations.html",
           "lihtc-guide-for-stakeholders.html",
           "dashboard.html",
-          "regional.html",
           "deal-calculator.html",
           "housing-legislation-2026.html",
           "about.html",
@@ -27,7 +26,7 @@
         ]
       }
     },
-    "totalNodes": 16,
+    "totalNodes": 19,
     "pageCount": 14
   },
   "results": [
@@ -93,12 +92,12 @@
             "RGAAv4",
             "RGAA-3.2.1"
           ],
-          "nodeCount": 1,
+          "nodeCount": 2,
           "sampleNode": {
             "target": [
-              ".hca-explore-banner__link"
+              "button[data-audience=\"developer\"]"
             ],
-            "html": "<a href=\"select-jurisdiction.html\" class=\"hca-explore-banner__link\">I already know my jurisdiction →</a>"
+            "html": "<button class=\"audience-toggle__btn\" type=\"button\" data-audience=\"developer\" aria-pressed=\"true\" title=\"Developers &amp; project sponsors: technical detail, site selection, project pro-forma framing\">"
           }
         }
       ],
@@ -127,7 +126,7 @@
             "RGAAv4",
             "RGAA-3.2.1"
           ],
-          "nodeCount": 2,
+          "nodeCount": 3,
           "sampleNode": {
             "target": [
               "button[data-audience=\"developer\"]"
@@ -136,9 +135,9 @@
           }
         }
       ],
-      "passCount": 25,
+      "passCount": 27,
       "incompleteCount": 2,
-      "inapplicable": 36
+      "inapplicable": 34
     },
     {
       "page": "lihtc-allocations.html",
@@ -161,25 +160,25 @@
             "RGAAv4",
             "RGAA-3.2.1"
           ],
-          "nodeCount": 1,
+          "nodeCount": 3,
           "sampleNode": {
             "target": [
-              "button[data-audience=\"developer\"]"
+              ":root"
             ],
-            "html": "<button class=\"audience-toggle__btn\" type=\"button\" data-audience=\"developer\" aria-pressed=\"true\" title=\"Developers &amp; project sponsors: technical detail, site selection, project pro-forma framing\">"
+            "html": "<li class=\"contrast-guard-fixed\" style=\"padding: 2px 0px; border-bottom: 1px solid rgba(255, 255, 255, 0.08); word-break: break-all; color: var(--text-d, #e5e7eb);\"><span style=\"color:#a8e6a3\">✔</span"
           }
         }
       ],
-      "passCount": 28,
+      "passCount": 30,
       "incompleteCount": 3,
-      "inapplicable": 32
+      "inapplicable": 30
     },
     {
       "page": "colorado-deep-dive.html",
       "violations": [],
-      "passCount": 31,
+      "passCount": 34,
       "incompleteCount": 3,
-      "inapplicable": 29
+      "inapplicable": 26
     },
     {
       "page": "lihtc-guide-for-stakeholders.html",
@@ -251,34 +250,7 @@
     },
     {
       "page": "regional.html",
-      "violations": [
-        {
-          "id": "color-contrast",
-          "impact": "serious",
-          "description": "Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds",
-          "help": "Elements must meet minimum color contrast ratio thresholds",
-          "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/color-contrast?application=axeAPI",
-          "tags": [
-            "cat.color",
-            "wcag2aa",
-            "wcag143",
-            "TTv5",
-            "TT13.c",
-            "EN-301-549",
-            "EN-9.1.4.3",
-            "ACT",
-            "RGAAv4",
-            "RGAA-3.2.1"
-          ],
-          "nodeCount": 1,
-          "sampleNode": {
-            "target": [
-              "button[data-audience=\"developer\"]"
-            ],
-            "html": "<button class=\"audience-toggle__btn\" type=\"button\" data-audience=\"developer\" aria-pressed=\"true\" title=\"Developers &amp; project sponsors: technical detail, site selection, project pro-forma framing\">"
-          }
-        }
-      ],
+      "violations": [],
       "passCount": 27,
       "incompleteCount": 1,
       "inapplicable": 34

--- a/docs/A11Y.md
+++ b/docs/A11Y.md
@@ -1,0 +1,93 @@
+# Accessibility
+
+How we test for WCAG 2.1 AA conformance, what each layer catches, and where to look when something's flagged. Closeout of the [#658](https://github.com/pggLLC/Housing-Analytics/issues/658) consolidation + [#675](https://github.com/pggLLC/Housing-Analytics/issues/675) tooling-reform questions.
+
+---
+
+## Three layers, one picture
+
+| Layer | Workflow | What it checks | When it runs |
+|---|---|---|---|
+| **Token contrast** | [`accessibility.yml`](../.github/workflows/accessibility.yml) | CSS token *pairs* declared in `.contrast-check-config.json` against WCAG AA ratios | On every PR that touches `css/`, `*.html`, the config, or the contrast tool |
+| **Site-wide token scan** | [`contrast-audit.yml`](../.github/workflows/contrast-audit.yml) | Same contrast-checker run across the full site (scheduled) | Weekly + on push to main |
+| **Rendered-page audit** | [`a11y-audit.yml`](../.github/workflows/a11y-audit.yml) | axe-core against 14 user-facing pages — catches what the token layer can't (inline styles, runtime DOM, full WCAG 2.1 AA ruleset) | Weekly + on PR that touches CSS/HTML/JS/the script |
+
+The layers are **complementary**, not redundant:
+
+- **Token linting** is fast and catches design-system-level regressions (a new `--accent` value that breaks existing pairs). It doesn't know about inline styles or runtime-applied colors.
+- **Rendered axe** catches everything the token layer misses — inline `style=` attributes, color composites over transparent bgs, ARIA hygiene, heading order, form labels, all 90+ rules WCAG 2.1 AA defines.
+
+Both layers **report color-contrast**. They don't always agree — because they measure different things — and that's by design. The typical follow-up when axe reports a violation the token audit missed is either:
+1. The element has inline styles overriding the token system → fix the inline OR mark the element to route through a token, or
+2. The element has an unusual bg composite (parent has `rgba()` background) → axe computes effective rendered contrast; token audit doesn't.
+
+---
+
+## Baseline report
+
+[`docs/reports/a11y-baseline-2026.md`](reports/a11y-baseline-2026.md) is the canonical axe-core state. Regenerated on every audit run. When this file diffs on a PR, that's the PR's a11y impact.
+
+Current baseline (2026-04-22, from commit `6785df68`):
+
+| Impact | Element count |
+|---|---:|
+| critical | 0 |
+| serious | 19 |
+| moderate | 0 |
+| minor | 0 |
+
+**All 19 serious are `color-contrast`**. Tracked in [#675](https://github.com/pggLLC/Housing-Analytics/issues/675) for fix-by-fix resolution. Critical bucket was cleared in [#683](https://github.com/pggLLC/Housing-Analytics/pull/683) earlier this session.
+
+---
+
+## Running locally
+
+```
+npm run audit:a11y          # full site, 14 pages, axe-core via Playwright
+npm run audit:contrast      # CSS-token scan via contrast-checker
+```
+
+Both write their outputs into the repo (`data/reports/a11y-baseline.json`, `docs/reports/a11y-baseline-2026.md` for axe; various for contrast-checker). Commit the artifacts — diffs on these files are the signal.
+
+### A note on audit reliability
+
+`scripts/audit/a11y-audit.mjs` uses Playwright's Chromium. Earlier versions of the script had **cross-page cache artifacts** — a Chromium instance shared across page audits would serve cached versions of recently-edited CSS files, producing counts that didn't match single-page runs. This was fixed by:
+
+1. Disabling the shared HTTP cache via a `context.route()` interceptor that sets `Cache-Control: no-cache, no-store` on every request
+2. Appending `?audit=<timestamp>` to the navigation URL so Chromium's internal cache can't key on the file path alone
+3. Creating a fresh `context.newContext({ serviceWorkers: 'block' })` for each page so no state bleeds across audits
+
+Watch for this pattern in future audit-tool work — anywhere Playwright is used to scan multiple pages of the same site, the same cache-busting belt-and-braces is worth applying.
+
+---
+
+## Adding a page to the audit
+
+Edit `AUDIT_PAGES` in [`scripts/audit/a11y-audit.mjs`](../scripts/audit/a11y-audit.mjs). Keep in sync with the user-facing entry-point set listed in `test/pages-availability-check.js`.
+
+## Adding a rule
+
+axe-core runs with `runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'] }`. To include best-practice rules (axe's larger catalogue), add `'best-practice'` to that array. Expect the baseline to grow by 5–10x on first enable.
+
+## Fixing a violation
+
+1. Regenerate the baseline: `npm run audit:a11y`
+2. Find the element in `docs/reports/a11y-baseline-2026.md` (per-page detail section)
+3. Inspect the source code via the `target` selector — axe gives you a specific CSS selector chain
+4. Edit, re-run, confirm the violation count drops
+5. Commit the baseline alongside the code fix so future PRs diff against reality
+
+If the fix touches `js/contrast-guard.js` or shared CSS tokens, **double-check you haven't introduced new failures elsewhere** — the contrast-guard module runs at page load on every page and can paper over (or create) contrast failures depending on its heuristics. The module was rewritten in [#685](https://github.com/pggLLC/Housing-Analytics/pull/685) to stop creating its own failures on mid-tone backgrounds.
+
+---
+
+## Related PRs + issues
+
+- [#658](https://github.com/pggLLC/Housing-Analytics/issues/658) — WCAG 2.1 AA audit epic (parent)
+- [#677](https://github.com/pggLLC/Housing-Analytics/pull/677) — axe-core baseline + workflow + `npm run audit:a11y`
+- [#683](https://github.com/pggLLC/Housing-Analytics/pull/683) — critical bucket closeout (21 → 0)
+- [#684](https://github.com/pggLLC/Housing-Analytics/pull/684) — link-in-text-block + aria-prohibited-attr closeout
+- [#685](https://github.com/pggLLC/Housing-Analytics/pull/685) — contrast-guard bug fix + partial color-contrast cleanup
+- [#674](https://github.com/pggLLC/Housing-Analytics/issues/674) — button/select/label names (closed)
+- [#675](https://github.com/pggLLC/Housing-Analytics/issues/675) — color-contrast (open)
+- [#676](https://github.com/pggLLC/Housing-Analytics/issues/676) — link distinguishability + ARIA (closed)

--- a/docs/reports/a11y-baseline-2026.md
+++ b/docs/reports/a11y-baseline-2026.md
@@ -1,6 +1,6 @@
 # WCAG 2.1 AA accessibility baseline — 2026
 
-_Generated: 2026-04-22T11:42:58.708Z_
+_Generated: 2026-04-22T13:36:12.351Z_
 
 Audited 14 page(s) via axe-core. Any regression from this baseline will appear in the diff of this file on the next weekly run.
 
@@ -9,16 +9,16 @@ Audited 14 page(s) via axe-core. Any regression from this baseline will appear i
 | Impact | Affected element count |
 |---|---:|
 | critical | 0 |
-| serious | 16 |
+| serious | 19 |
 | moderate | 0 |
 | minor | 0 |
-| **Total** | **16** |
+| **Total** | **19** |
 
 ## Summary by rule
 
 | Rule | Impact | Elements | Pages | Help |
 |---|---|---:|---:|---|
-| `color-contrast` | serious | 16 | 11 | Elements must meet minimum color contrast ratio thresholds |
+| `color-contrast` | serious | 19 | 10 | Elements must meet minimum color contrast ratio thresholds |
 
 ## Per-page detail
 
@@ -42,35 +42,35 @@ Audited 14 page(s) via axe-core. Any regression from this baseline will appear i
 
 - Passing rules: **32**
 - Incomplete (needs manual check): **2**
-- Violations: **1** (1 element(s))
-
-| Rule | Impact | Elements | Help |
-|---|---|---:|---|
-| `color-contrast` | serious | 1 | Elements must meet minimum color contrast ratio thresholds |
-
-### economic-dashboard.html
-
-- Passing rules: **25**
-- Incomplete (needs manual check): **2**
 - Violations: **1** (2 element(s))
 
 | Rule | Impact | Elements | Help |
 |---|---|---:|---|
 | `color-contrast` | serious | 2 | Elements must meet minimum color contrast ratio thresholds |
 
-### lihtc-allocations.html
+### economic-dashboard.html
 
-- Passing rules: **28**
-- Incomplete (needs manual check): **3**
-- Violations: **1** (1 element(s))
+- Passing rules: **27**
+- Incomplete (needs manual check): **2**
+- Violations: **1** (3 element(s))
 
 | Rule | Impact | Elements | Help |
 |---|---|---:|---|
-| `color-contrast` | serious | 1 | Elements must meet minimum color contrast ratio thresholds |
+| `color-contrast` | serious | 3 | Elements must meet minimum color contrast ratio thresholds |
+
+### lihtc-allocations.html
+
+- Passing rules: **30**
+- Incomplete (needs manual check): **3**
+- Violations: **1** (3 element(s))
+
+| Rule | Impact | Elements | Help |
+|---|---|---:|---|
+| `color-contrast` | serious | 3 | Elements must meet minimum color contrast ratio thresholds |
 
 ### colorado-deep-dive.html
 
-- Passing rules: **31**
+- Passing rules: **34**
 - Incomplete (needs manual check): **3**
 - Violations: **0** (0 element(s))
 
@@ -98,11 +98,7 @@ Audited 14 page(s) via axe-core. Any regression from this baseline will appear i
 
 - Passing rules: **27**
 - Incomplete (needs manual check): **1**
-- Violations: **1** (1 element(s))
-
-| Rule | Impact | Elements | Help |
-|---|---|---:|---|
-| `color-contrast` | serious | 1 | Elements must meet minimum color contrast ratio thresholds |
+- Violations: **0** (0 element(s))
 
 ### market-analysis.html
 

--- a/scripts/audit/a11y-audit.mjs
+++ b/scripts/audit/a11y-audit.mjs
@@ -76,15 +76,40 @@ async function locateAxeScript() {
 }
 
 async function auditPage(browser, pagePath, axeScript) {
-  const context = await browser.newContext();
-  const page    = await context.newPage();
+  // A fresh incognito-style context for each page — prevents any cross-page
+  // state bleed. Combined with the cache-busting query-param below, this
+  // eliminates the false-positive/false-negative drift we saw earlier
+  // (batch-run flagged elements that single-page runs showed passing).
+  const context = await browser.newContext({
+    serviceWorkers: 'block',
+    // Playwright respects browser's HTTP cache by default; the one knob
+    // we can tweak without version-specific Chromium flags is to disable
+    // the context-level cache via a request interceptor (see below).
+  });
+
+  // Intercept every request on this context and strip cache-friendly
+  // headers, then append cache-busting no-store headers. Belt + braces
+  // with the query-string busting on page.goto().
+  await context.route('**/*', route => {
+    const headers = {
+      ...route.request().headers(),
+      'Cache-Control': 'no-cache, no-store, must-revalidate',
+      'Pragma': 'no-cache',
+    };
+    route.continue({ headers });
+  });
+
+  const page = await context.newPage();
 
   // Silence page console errors during audit — many of our pages fetch data
   // from relative paths that 404 under file://, which is not an a11y issue.
   page.on('pageerror', () => {});
   page.on('console',   () => {});
 
-  const fileUrl = pathToFileURL(path.join(ROOT, pagePath)).href;
+  // Cache-bust the URL so Chromium never reuses a previously-cached response.
+  // Query strings are harmless on file:// — the renderer loads the same file
+  // but Chromium's internal cache keys on the full URL.
+  const fileUrl = pathToFileURL(path.join(ROOT, pagePath)).href + '?audit=' + Date.now();
   try {
     await page.goto(fileUrl, { waitUntil: 'load', timeout: 15_000 });
   } catch (err) {


### PR DESCRIPTION
Integrates the tooling-reform work with the rest of Wave 3. Stacks on #685 — diff will narrow to just this commit once #685 merges.

## Summary

- **Fix:** `scripts/audit/a11y-audit.mjs` was producing unstable counts on batch runs due to Chromium's shared HTTP cache across Playwright contexts. Three-layer fix (cache-control headers + `?audit=<ts>` query + `serviceWorkers:'block'`) stabilizes the count.
- **Docs:** New `docs/A11Y.md` is the single source of truth for the three a11y workflows (`accessibility.yml`, `contrast-audit.yml`, `a11y-audit.yml`), explaining what each layer checks, why they're complementary not redundant, and how to interpret disagreements.
- **Honesty gain:** Baseline shifts from 16 → 19 serious color-contrast violations. The cache had been masking 3 real ones. All 19 are tracked under #675 for fix-by-fix resolution.

## The three layers (now documented)

| Workflow | Checks | Cadence |
|---|---|---|
| accessibility.yml | Token-pair contrast via `.contrast-check-config.json` | Per PR (CSS/HTML touches) |
| contrast-audit.yml | Site-wide token scan | Weekly + push to main |
| a11y-audit.yml | axe-core against 14 rendered pages, full WCAG 2.1 AA ruleset | Weekly + per PR |

## The cache-bust pattern (reusable)

Any future Playwright-based multi-page site-scanning tool should mirror:

\`\`\`js
const context = await browser.newContext({ serviceWorkers: 'block' });
await context.route('**/*', route => route.continue({
  headers: { ...route.request().headers(),
    'Cache-Control': 'no-cache, no-store, must-revalidate',
    'Pragma': 'no-cache',
  }
}));
const url = pathToFileURL(filePath).href + '?audit=' + Date.now();
\`\`\`

Documented in `docs/A11Y.md#a-note-on-audit-reliability`.

## Not done in this PR

Deprecating `accessibility.yml` or `contrast-audit.yml`. Both remain useful fast-feedback layers. The new doc explains the relationship so a future consolidation decision can be made with context.

## Test plan

- [x] Re-ran `npm run audit:a11y` → 19 serious, 0 critical (stable across 3 consecutive runs)
- [x] Single-page audit matches full-run element count for that page (was drifting before)
- [x] `docs/A11Y.md` renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)