### PR TITLE
bug: close all 6 console-audit errors (closes #608)

### DIFF
--- a/construction-commodities.html
+++ b/construction-commodities.html
@@ -204,7 +204,8 @@
                     .map(key => createPriceCard(key, data[key]))
                     .join('');
                 
-                window.__announceUpdate && window.__announceUpdate(\'Commodity price data loaded\'); document.getElementById('price-cards-container').innerHTML = cardsHTML;
+                window.__announceUpdate && window.__announceUpdate('Commodity price data loaded');
+                document.getElementById('price-cards-container').innerHTML = cardsHTML;
                 
                 // Create charts
                 // Steel & Metal

--- a/dashboard.html
+++ b/dashboard.html
@@ -244,8 +244,14 @@
                     .on('mousemove', moveTooltip)
                     .on('mouseleave', hideTooltip);
                 
+                // Filter features where centroid is undefined (outside projection
+                // bounds or degenerate geometry) — otherwise d3 writes
+                // `translate(NaN,NaN)` and Chrome logs a SVGAttributeException.
                 svg.selectAll('text.state-label')
-                    .data(states.features)
+                    .data(states.features.filter(d => {
+                        const c = path.centroid(d);
+                        return Number.isFinite(c[0]) && Number.isFinite(c[1]);
+                    }))
                     .enter()
                     .append('text')
                     .attr('class', 'state-label')

--- a/js/hna/hna-utils.js
+++ b/js/hna/hna-utils.js
@@ -12,7 +12,13 @@
   // fetchWithTimeout is provided globally by js/fetch-helper.js (window.fetchWithTimeout).
   // Alias it locally so in-file calls work without modification.
 
-  const ACS_VINTAGES = [2025, 2024, 2023, 2022, 2021];
+  // ACS 5-year release cadence: vintage Y is released ~December of year Y+1.
+  // As of 2026-04 Census has published through 2024; 2025 (covering 2021-2025)
+  // typically ships in Dec 2026. Probing 2025 first generates a 404 on every
+  // page load that's visible in Chrome's network panel even when downstream
+  // fallback succeeds — kept 2024 as primary and slowly accept 2025 back
+  // in once Census publishes it.
+  const ACS_VINTAGES = [2024, 2023, 2022, 2021];
   // Keep named constants so existing checks and references still work.
   const ACS_YEAR_PRIMARY  = ACS_VINTAGES[0];
   const ACS_YEAR_FALLBACK = ACS_VINTAGES[1];

--- a/js/regional.js
+++ b/js/regional.js
@@ -1,6 +1,12 @@
 // Regional Analysis Page JavaScript
 
 document.addEventListener('DOMContentLoaded', function() {
+    // The regional page migrated from a Leaflet tile map to a D3 SVG choropleth
+    // (#us-map). This module is kept for its chart/table bindings but the
+    // Leaflet init needs a guard — when regional.html doesn't define #map,
+    // L.map('map') throws "Map container not found" to the console.
+    if (!document.getElementById('map')) return;
+
     const colors = {
         primary: '#1a3a52',
         primaryLight: '#2d5573',
@@ -8,7 +14,7 @@ document.addEventListener('DOMContentLoaded', function() {
         success: '#27ae60',
         info: '#3498db'
     };
-    
+
     // Initialize Leaflet map
     const map = L.map('map').setView([39.8283, -98.5795], 4);
     if (window.addMapHomeButton) { addMapHomeButton(map, { center: [39.8283, -98.5795], zoom: 4 }); }

--- a/regional.html
+++ b/regional.html
@@ -291,7 +291,13 @@
                     .on('mouseleave', hideTooltip);
                 
                 svg.selectAll('text.state-label')
-                    .data(states.features)
+                    // Filter features with non-finite centroids (outside the
+                    // Albers USA projection) — otherwise Chrome logs a SVG
+                    // attribute exception for each NaN translate.
+                    .data(states.features.filter(d => {
+                        const c = path.centroid(d);
+                        return Number.isFinite(c[0]) && Number.isFinite(c[1]);
+                    }))
                     .enter()
                     .append('text')
                     .attr('class', 'state-label')


### PR DESCRIPTION
Reproduces [#608](https://github.com/pggLLC/Housing-Analytics/issues/608) locally and fixes each root cause. Ends at **0 errors / 4 benign warnings** (was 6 errors / 4 warnings).

## Fixes

| Page | Errors | Root cause | Fix |
|---|---|---|---|
| housing-needs-assessment | 2 × ACS 2025 404 | `ACS_VINTAGES` listed 2025 first; Census ships ACS5 2025 ~Dec 2026 | Remove 2025 from the probe list; 2024 is now primary (verified via Census API) |
| construction-commodities | 1 × SyntaxError | `\'Commodity price data loaded\'` — backslash-escaped single quotes outside a string literal | Unescape |
| regional | 1 × "Map container not found" | `js/regional.js` calls `L.map('map')` but page migrated to a D3 SVG choropleth (`#us-map`) | Guard with element-exists check |
| dashboard + regional | 1 + 1 × `translate(NaN,NaN)` | `path.centroid()` returns `[NaN, NaN]` for features outside the Albers USA projection; d3 writes that directly to SVG | Filter features with non-finite centroids |

## Verification

Ran `scripts/audit/console-error-reporter.mjs` before + after. All 35 pages now clean of errors.

Remaining 4 warnings are pre-existing hidden/graceful-degradation states:
- `economic-dashboard`: 2 FRED series return no observations (\`PCU236200236200\`, \`LAUST080000000000003\`); indicator is hidden from the UI
- `colorado-deep-dive`, `colorado-market`: places overlay treats "got 0 features" as unavailable, not fatal

These are behavior-correct (data sourcing edge cases with graceful fallback) and don't break pages. Can be filed as a separate data-sourcing issue if prioritized.

## Test plan

- [x] Reproduce all 6 errors on main via `scripts/audit/console-error-reporter.mjs`
- [x] Fix each root cause
- [x] Re-run audit → 0 errors
- [x] Verified fixes via `curl` against Census API (404 on 2025; 200 on 2024)
- [x] Verified construction-commodities no longer SyntaxErrors (pageerror listener returns empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)