### PR TITLE
bug: STATEFP→STATE sweep (TIGERweb broke silently in 4 more call sites)

### DIFF
--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -210,10 +210,13 @@
 
 
   async function fetchCoCountiesList(){
-    // TIGERweb county layer (State_County MapServer/1)
+    // TIGERweb county layer (State_County MapServer/1) exposes the FIPS
+    // field as STATE, not STATEFP. Querying STATEFP returns HTTP 400 —
+    // the code path was silently erroring and the UI fell back to
+    // a static county list.
     const base = 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County/MapServer/1/query';
     const params = new URLSearchParams({
-      where: `STATEFP='${window.HNAUtils.STATE_FIPS_CO}'`,
+      where: `STATE='${window.HNAUtils.STATE_FIPS_CO}'`,
       outFields: 'NAME,GEOID',
       f: 'json',
       returnGeometry: 'false',

--- a/js/prop123-map.js
+++ b/js/prop123-map.js
@@ -167,15 +167,18 @@
     const { muni, county } = buildIndex(payload);
 
     // Fetch Colorado geometries
-    // For Places, TIGERweb uses STATEFP='08' field; for Counties, STATEFP='08' is the correct field.
+    // TIGERweb Places (layer 4) and State_County (layer 1) both expose
+    // the FIPS field as STATE, not STATEFP. Querying STATEFP returns
+    // HTTP 400 "Failed to execute query" — this was silently failing
+    // and falling back to empty geometry.
     let placesGeo, countiesGeo;
     try {
-      placesGeo = await arcgisQueryGeoJSON(TIGER_PLACES, "STATEFP='08'");
+      placesGeo = await arcgisQueryGeoJSON(TIGER_PLACES, "STATE='08'");
     } catch (e) {
       console.warn('Places geometry fetch failed', e);
     }
     try {
-      countiesGeo = await arcgisQueryGeoJSON(TIGER_COUNTIES, "STATEFP='08'");
+      countiesGeo = await arcgisQueryGeoJSON(TIGER_COUNTIES, "STATE='08'");
     } catch (e) {
       console.warn('Counties geometry fetch failed', e);
     }

--- a/scripts/hna/build_hna_data.py
+++ b/scripts/hna/build_hna_data.py
@@ -432,9 +432,12 @@ def fetch_acs5_profile_year(year: int, geo_type: str, geoid: str, vars_: list[st
 def fetch_counties() -> list[dict]:
     base = 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County/MapServer/1/query'
     params = urllib.parse.urlencode({
-        # STATEFP is the correct TIGERweb field for the state FIPS code.
-        # STATE= was the old alias; use STATEFP= to match the JS fetch logic.
-        'where': f"STATEFP='{STATE_FIPS_CO}'",
+        # TIGERweb State_County/MapServer/1 exposes the FIPS field as
+        # STATE (not STATEFP). Querying STATEFP returns HTTP 400 "Failed
+        # to execute query" and this function was falling through to the
+        # empty-list bailout, silently producing builds with no county
+        # metadata. Verified via the ArcGIS layer metadata endpoint.
+        'where': f"STATE='{STATE_FIPS_CO}'",
         'outFields': 'NAME,GEOID',
         'returnGeometry': 'false',
         'orderByFields': 'NAME',

--- a/test/hna-functionality-check.js
+++ b/test/hna-functionality-check.js
@@ -788,33 +788,34 @@ test('census-stats.js: each SERIES entry has a table code for source links', () 
 
 
 // ---------------------------------------------------------------------------
-// TIGERweb field-name consistency: STATEFP vs STATE
-// Both the JS county-list fetch and the Python build-script fetch_counties()
-// must use STATEFP='08' — the authoritative TIGERweb field for the state FIPS
-// code on the State_County/MapServer/1 layer.  Using the old alias STATE='08'
-// returns an empty result set on newer TIGERweb vintages.
+// TIGERweb field-name consistency: STATE (not STATEFP)
+// TIGERweb's State_County/MapServer/1 and Places_CouSub.../MapServer/4 layers
+// expose the FIPS field as STATE. Using STATEFP returns HTTP 400 "Failed to
+// execute query" — verified against the live metadata endpoint as of
+// 2026-04-22. Prior iteration of these tests enforced STATEFP which was
+// wrong; both JS and Python county fetches were silently failing.
 // ---------------------------------------------------------------------------
-test('JS: fetchCoCountiesList uses STATEFP (not STATE) for TIGERweb county query', () => {
+test('JS: fetchCoCountiesList uses STATE (not STATEFP) for TIGERweb county query', () => {
     assert(
-        js.includes("STATEFP='${STATE_FIPS_CO}'") || js.includes("STATEFP='08'") ||
-        js.includes("STATEFP='${window.HNAUtils.STATE_FIPS_CO}'"),
-        'fetchCoCountiesList queries TIGERweb with STATEFP field'
+        js.includes("STATE='${STATE_FIPS_CO}'") || js.includes("STATE='08'") ||
+        js.includes("STATE='${window.HNAUtils.STATE_FIPS_CO}'"),
+        'fetchCoCountiesList queries TIGERweb with STATE field'
     );
     assert(
-        !js.includes("where: `STATE='${STATE_FIPS_CO}'`") && !js.includes("where: \"STATE='08'\""),
-        'fetchCoCountiesList does NOT use the deprecated STATE= alias'
+        !js.match(/where:\s*`STATEFP='/) && !js.match(/where:\s*"STATEFP='08'"/),
+        'fetchCoCountiesList does NOT use STATEFP (returns HTTP 400 on TIGERweb)'
     );
 });
 
-test('Python build_hna_data.py: fetch_counties uses STATEFP (not STATE) for TIGERweb query', () => {
+test('Python build_hna_data.py: fetch_counties uses STATE (not STATEFP) for TIGERweb query', () => {
     const py = fs.readFileSync(path.join(ROOT, 'scripts', 'hna', 'build_hna_data.py'), 'utf8');
     assert(
-        py.includes("STATEFP='{STATE_FIPS_CO}'") || py.includes("STATEFP='08'"),
-        'fetch_counties queries TIGERweb with STATEFP field'
+        py.includes("STATE='{STATE_FIPS_CO}'") || py.includes("STATE='08'"),
+        'fetch_counties queries TIGERweb with STATE field'
     );
     assert(
-        !py.includes("STATE='{STATE_FIPS_CO}'") && !py.includes("STATE='08'"),
-        'fetch_counties does NOT use the deprecated STATE= alias'
+        !py.includes("STATEFP='{STATE_FIPS_CO}'") && !py.includes("STATEFP='08'"),
+        'fetch_counties does NOT use STATEFP (returns HTTP 400 on TIGERweb)'
     );
 });
 


### PR DESCRIPTION
Follow-up to [#689](https://github.com/pggLLC/Housing-Analytics/pull/689). A grep for the same \`STATEFP\` pattern I fixed there surfaced **4 more call sites** making the same broken TIGERweb request across 3 files — all silently falling through to empty data or static fallbacks.

## Empirical verification

TIGERweb's metadata endpoints show the actual field schema:

| Service | Field for FIPS |
|---|---|
| \`State_County/MapServer/1\` | **STATE** (not STATEFP) |
| \`Places_CouSub_ConCity_SubMCD/MapServer/4\` | **STATE** (not STATEFP) |

Querying with STATEFP returns HTTP 400 \"Failed to execute query\"; querying with STATE works.

## Sites fixed

1. **\`js/prop123-map.js\`** — 2 queries (Places + Counties). Source comment claimed "STATEFP is correct" which was wrong.
2. **\`js/hna/hna-controller.js fetchCoCountiesList\`** — JS county list. UI fell back to a static list when this errored.
3. **\`scripts/hna/build_hna_data.py fetch_counties\`** — Python county list in the build pipeline. \`except\` block bailed to empty list, possibly cause of occasional empty HNA summary files.
4. **\`test/hna-functionality-check.js\`** — the test was *enforcing* STATEFP and *forbidding* STATE. Flipped both assertions. **688/688 tests still pass** after the flip.

## Intentionally NOT changed

- **\`js/market-analysis.js:1559\`** — \`arcgisWhere: \"STATEFP='08'\"\` against \`services.arcgis.com/.../Opportunity_Zones_2/FeatureServer/0\`. That FeatureServer's metadata DOES expose STATEFP. Different service; not a TIGERweb bug.

## Verification

- Fetch with \`STATE='08'\` returns 64 Colorado counties (verified via browser \`fetch()\`) 
- \`npm run test:hna\` → 688/688 passing
- Hidden silent-failure paths are now real data paths

## Test plan

- [x] Probe both TIGERweb endpoints with STATE vs STATEFP (empirical)
- [x] Run HNA test suite after test-assertion flip
- [x] Verify browser fetch returns 64 counties
- [x] Check no other STATEFP sites in codebase (market-analysis.js confirmed to be a valid different-service use)

🤖 Generated with [Claude Code](https://claude.com/claude-code)