### PR TITLE
chore: ignore Finder "foo 2.ext" duplicate-on-copy artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,11 @@ _site/
 # (its own README admitted "It is not secured"); see SECURITY note in PR.
 # Keep local copies if you need them; host them somewhere authenticated instead.
 private/
+
+# macOS Finder "duplicate-on-copy" artifacts — when a file collides on a
+# copy/paste, Finder names the new file "foo 2.ext" (with an embedded space).
+# A batch of 163 such files accumulated across docs/api/, docs/guides/,
+# docs/reports/, test/, and js/components/ in 2026-04; deleted in cleanup.
+# Ignore the pattern so a future mis-paste doesn't silently reintroduce them.
+* 2.*
+* [3-9].*


### PR DESCRIPTION
macOS Finder, when pasting a file that would collide, names the new copy \"foo 2.ext\" (embedded space). A batch of **163 such files** accumulated across \`docs/api/\`, \`docs/guides/\`, \`docs/reports/\`, \`test/\`, and \`js/components/\` in 2026-04.

## QA/QC before cleanup

| Check | Result |
|---|---|
| Tracked by git | 0/163 — all untracked |
| Referenced in code/workflows | 0 references |
| Content match originals | 161/163 byte-identical |
| Divergent files | 2, both older auto-generated artifacts (\`scripts__sync-docs 2.md\` reflected a pre-rename code state; \`a11y-baseline-2026 2.md\` was a pre-#687 snapshot) |
| mtime pattern | All dupes 2026-04-21; originals 2026-04-22 — consistent with a one-day-old filesystem copy |

All 163 deleted locally. This PR adds the ignore rule so the next Finder mis-paste doesn't silently reintroduce them.

## The rule

\`\`\`
* 2.*
* [3-9].*
\`\`\`

Matches the exact Finder duplicate naming pattern (embedded space + digit + dot + extension). The \`[3-9]\` companion covers later Finder duplicates (\"foo 3.ext\", etc.). No real filenames in the repo use this pattern.

## Test plan

- [x] Local \`git status\` clean after deletion
- [x] Full test:ci passes (688/688 HNA + 401 pytest + 7 unit suites)
- [x] No real files match the pattern: \`find . -name '* [0-9].*' -not -path ./node_modules/*\` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)