### PR TITLE
Revert #691 — gitignore rule too broad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,11 +43,3 @@ _site/
 # (its own README admitted "It is not secured"); see SECURITY note in PR.
 # Keep local copies if you need them; host them somewhere authenticated instead.
 private/
-
-# macOS Finder "duplicate-on-copy" artifacts — when a file collides on a
-# copy/paste, Finder names the new file "foo 2.ext" (with an embedded space).
-# A batch of 163 such files accumulated across docs/api/, docs/guides/,
-# docs/reports/, test/, and js/components/ in 2026-04; deleted in cleanup.
-# Ignore the pattern so a future mis-paste doesn't silently reintroduce them.
-* 2.*
-* [3-9].*


### PR DESCRIPTION
Reverts [#691](https://github.com/pggLLC/Housing-Analytics/pull/691).

## Why

The rule \`* 2.*\` and \`* [3-9].*\` would block legitimate future filenames:
- \`Part 2.md\`, \`Section 3.md\` (multi-part docs)
- \`Figure 1.png\`, \`Figure 2.png\` (numbered figures)

Empirical check at commit time showed zero matches in the current tree or git history, but the false-positive surface for **future** filenames isn't worth the one-time cleanup convenience.

## What stays

The 163-file manual cleanup from #691 is still in place — nothing to restore. If Finder-style duplicates recur, we can delete them again. A better preventive mechanism would be a pre-commit hook that **warns** (not blocks) on the pattern, if we want one at all.

## Test plan

- [x] Verify \`.gitignore\` is back to pre-#691 state
- [x] Verify \`git ls-files | grep -E ' [0-9]\\.'\` still returns empty (no real files match the pattern)
- [x] No other references in the repo rely on the rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)