### PR TITLE
fix: missing vacancy no longer silently inflates projected need + drop dead forecastColorado

### DIFF
--- a/js/forecasting.js
+++ b/js/forecasting.js
@@ -190,68 +190,24 @@ class EconometricForecaster {
         return forecast;
     }
 
-    // Colorado-specific forecast
-    forecastColorado(historicalData, periods = 8) {
-        const forecast = {
-            allocation: [],
-            pricing: [],
-            starts: [],
-            demand: []
-        };
-        
-        // Allocation forecast (trend + demographic growth)
-        const allocationTrend = this.calculateTrend(
-            historicalData.allocation || [250, 265, 272, 280, 287]
-        );
-        
-        for (let i = 1; i <= periods; i++) {
-            // Allocation grows with population and policy emphasis
-            const growthRate = 0.035; // 3.5% annually
-            const base = 287000000;
-            const allocated = base * Math.pow(1 + growthRate, i / 4);
-            
-            forecast.allocation.push({
-                quarter: i,
-                amount: allocated,
-                perCapita: allocated / 5850000 // Projected CO population
-            });
-            
-            // Pricing follows national trends with regional adjustment
-            const nationalBase = 0.84;
-            const regionalPremium = 0.00; // Colorado at par
-            const price = nationalBase + regionalPremium + (Math.random() - 0.5) * 0.02;
-            
-            forecast.pricing.push({
-                quarter: i,
-                price: Math.max(0.78, Math.min(0.90, price))
-            });
-            
-            // Housing starts with seasonal adjustment
-            const startsBase = 3340;
-            const seasonal = [0.95, 1.05, 1.08, 1.02][((i - 1) % 4)];
-            const starts = startsBase * seasonal * (1 + 0.02 * i / 4);
-            
-            forecast.starts.push({
-                quarter: i,
-                units: Math.round(starts)
-            });
-            
-            // Demand index (composite indicator)
-            const demandIndex = this.calculateDemandIndex({
-                rentalVacancy: 0.05,
-                medianRent: 1650,
-                medianIncome: 82000,
-                population: 5850000
-            });
-            
-            forecast.demand.push({
-                quarter: i,
-                index: demandIndex * (1 + 0.01 * i / 4)
-            });
-        }
-        
-        return forecast;
-    }
+    // (Removed `forecastColorado`.)
+    //
+    // The prior `forecastColorado(historicalData, periods)` generated
+    // "Colorado-specific" pricing/allocation/starts/demand forecasts but
+    // ignored the `historicalData` argument for every series except
+    // allocation, and even that fell back to a hardcoded [250, 265, 272,
+    // 280, 287] array if missing. The demand index was fed literal
+    // constants (rentalVacancy: 0.05, medianRent: $1650, medianIncome:
+    // $82000, population: 5.85M) and the pricing series was
+    // `nationalBase + (Math.random() - 0.5) * 0.02` — a random walk, not
+    // a forecast. Callers would receive plausible-looking quarterly
+    // output with no relationship to input data.
+    //
+    // No module in the repo actually called `forecastColorado` (verified
+    // via grep). The pricing forecast used by the UI
+    // (js/components/equity-forecast-panel.js) calls `forecastPricing`
+    // separately. Deletion removes the silent-fallback risk without
+    // breaking any feature.
 
     // Helper methods
     calculateDifferences(series) {

--- a/js/housing-need-projector.js
+++ b/js/housing-need-projector.js
@@ -74,9 +74,17 @@
   /**
    * Derive vacancy-deficit factor from vacancy_rate (%).
    * vacancy_deficit_factor = max(0, 0.05 - vacancy_rate/100) * 10
+   *
+   * IMPORTANT: returns null when vacancyRate is null/undefined. Callers
+   * must treat null as "no adjustment available" — NOT as 0. A null
+   * (missing) rate previously silently became 0 here, which then produced
+   * the MAXIMUM deficit factor (0.5) and inflated projected need by 50%.
+   * Missing vacancy data must not be indistinguishable from "critical
+   * shortage."
    */
   function _vacancyDeficitFactor(vacancyRate) {
-    var rate = (vacancyRate || 0) / 100;
+    if (vacancyRate == null) return null;   // missing → no adjustment
+    var rate = vacancyRate / 100;
     return Math.max(0, 0.05 - rate) * 10;
   }
 
@@ -143,7 +151,10 @@
     var cd = countyData || {};
     var countyName = options.countyName || cd.name || fips;
     var households = cd.households || 0;
-    var vacancyRate = cd.vacancy_rate || 0;
+    // Preserve null/undefined distinction — `|| 0` previously collapsed
+    // missing vacancy into "0% vacancy", which then triggered the MAXIMUM
+    // _vacancyDeficitFactor (0.5) and inflated projected need by 50%.
+    var vacancyRate = (cd.vacancy_rate == null) ? null : cd.vacancy_rate;
     var costBurdenedPct = cd.cost_burdened_pct || 0;
     var severelyBurdenedPct = cd.severely_burdened_pct || 0;
 
@@ -152,8 +163,12 @@
     var baselineRate = (dolaRate !== null) ? dolaRate : 0.008; // 0.8%/yr fallback
 
     /* --- Vacancy deficit factor --- */
+    // When vacancy is unknown, skip the deficit adjustment rather than
+    // defaulting to 0% vacancy (= max deficit). Projection proceeds at
+    // the natural household growth rate, flagged as uncertain.
     var vdf = _vacancyDeficitFactor(vacancyRate);
-    var vacancyMultiplier = 1 + vdf;
+    var vacancyAdjustmentApplied = (vdf !== null);
+    var vacancyMultiplier = vacancyAdjustmentApplied ? (1 + vdf) : 1;
 
     /* --- Current gap (30% AMI severely cost-burdened) --- */
     // Severely burdened households are the primary proxy for deep affordability gap
@@ -216,6 +231,14 @@
       'Annual gap = max(currentGap / 15, baseline 20-yr need / 20) = ' + _fmt(annualGap) + ' units/yr.'
     );
 
+    // Surface missing vacancy data so callers/UI can flag projection uncertainty
+    if (!vacancyAdjustmentApplied) {
+      methodology.push(
+        'Vacancy rate unavailable for this geography; deficit adjustment skipped. ' +
+        'Projection reflects baseline household growth only — consider this a floor for projected need.'
+      );
+    }
+
     return {
       fips: fips,
       countyName: countyName,
@@ -227,7 +250,8 @@
       },
       annualGap: annualGap,
       currentGap: currentGap,
-      methodology: methodology
+      methodology: methodology,
+      vacancyAdjustmentApplied: vacancyAdjustmentApplied
     };
   }
 


### PR DESCRIPTION
Two more silent-fallback fixes in the same bug class as [#693](https://github.com/pggLLC/Housing-Analytics/pull/693).

## 1. housing-need-projector.js — vacancy=0 was triggering MAX deficit

\`project()\` read vacancy via \`cd.vacancy_rate || 0\`, collapsing missing data into "0% vacancy." Then \`_vacancyDeficitFactor(0)\` returned **0.5** (the max deficit factor) which inflated projected need by **50%**. A county with no vacancy data looked identical to a county in critical housing shortage.

**Fix:** preserve the null/undefined distinction.
- \`_vacancyDeficitFactor\` returns null (not 0) when vacancy missing
- \`project()\` skips the vacancy multiplier entirely (uses 1.0)
- Methodology note records the skip
- Returned object now includes \`vacancyAdjustmentApplied: boolean\`

## 2. forecasting.js — deleted dead \`forecastColorado\`

Function ignored all inputs and generated synthetic "Colorado-specific" forecasts from hardcoded constants:
- \`rentalVacancy: 0.05\` (all quarters)
- \`medianRent: $1,650\`, \`medianIncome: $82,000\`
- \`allocationTrend\` fell back to \`[250, 265, 272, 280, 287]\`
- Pricing = \`nationalBase + (Math.random() - 0.5) * 0.02\` — a **random walk**, not a forecast

**No module in the repo called it** (verified via exhaustive grep). The real forecast used by \`equity-forecast-panel.js\` calls \`forecastPricing\`. Deletion removes ~60 lines of dead code AND the silent-fallback risk in one shot.

## Still remaining from the survey

- **#6** \`js/market-analysis/site-selection-score.js\` — \`scoreDemand/scoreAccess/scoreLandSupply\` return hardcoded \`50\` (neutral) when data missing. Fix requires updating 3 functions + ~10 test assertions enforcing the \`=== 50\` behavior. Size: 30-45 min refactor, not included here.
- **#7** \`pma-competitive-set.js\` AMI-percent default 60
- **#8** \`chfa-award-predictor.js\` fabricated thresholds
- **#10** \`workflow-state-core.js\` hardcoded equity price

## Verification

- \`npm run test:hna\` → 688/688 passing
- \`node test/lihtc-deal-predictor.test.js\` → 31/31 passing
- \`forecastColorado\` deletion verified via grep: no callers anywhere in repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)