### PR TITLE
polish: verify-messaging pattern + 4 quick-win UI fixes

### DIFF
--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -396,6 +396,16 @@ footer.site-footer { margin-top: var(--sp6); border-top: 1px solid var(--border)
 .kpi-source, .stat-source { font-size: 0.65rem; color: var(--faint, #999); margin-top: 3px; font-style: italic; }
 .kpi-source a, .stat-source a { color: var(--faint, #999); text-decoration: none; }
 .kpi-source a:hover, .stat-source a:hover { text-decoration: underline; }
+
+/* `.kpi-verify` extends `.kpi-source` for values the user should
+   sanity-check against an external authoritative source before using
+   in a decision. Slightly darker than plain source-attribution so
+   the warn glyph is readable, but still quiet enough to avoid
+   overwhelming the value itself. Links stay underlined for clear
+   affordance on an external-action element. */
+.kpi-source.kpi-verify, .stat-source.kpi-verify { color: var(--muted, #666); font-style: normal; line-height: 1.35; }
+.kpi-source.kpi-verify a, .stat-source.kpi-verify a { color: var(--link, #054a42) !important; text-decoration: underline; text-underline-offset: 2px; }
+.kpi-source.kpi-verify a:hover, .stat-source.kpi-verify a:hover { text-decoration-thickness: 2px; }
 .chart-source { font-size: 0.72rem; color: var(--faint); margin-top: var(--sp2); padding: 0 var(--sp4) var(--sp3); }
 /* Source-attribution links need a non-color cue to satisfy WCAG 1.4.1
    (link-in-text-block). The subdued faint color is reinforced with

--- a/dashboard-data-quality.html
+++ b/dashboard-data-quality.html
@@ -226,7 +226,12 @@
   <!-- Pipeline Events -->
   <div class="dq-section">
     <h2>Pipeline Log</h2>
-    <pre id="pipelineLog" aria-live="polite" style="background:var(--bg-muted,#f5f7fa);border:1px solid var(--border,#dde3ec);border-radius:6px;padding:0.75rem 1rem;font-size:0.78rem;max-height:260px;overflow-y:auto;white-space:pre-wrap;"></pre>
+    <!-- `--bg-muted` is not a defined token (resolved to literal
+         #f5f7fa fallback in both light and dark mode, producing
+         light-text-on-light-bg in dark mode — the contrast complaint).
+         Using `--bg2` (a real dark-mode-aware token) + explicit
+         `--text` foreground guarantees readable contrast in either mode. -->
+    <pre id="pipelineLog" aria-live="polite" style="background:var(--bg2,#e4ecf4);color:var(--text,#0d1f35);border:1px solid var(--border,#dde3ec);border-radius:6px;padding:0.75rem 1rem;font-size:0.78rem;max-height:260px;overflow-y:auto;white-space:pre-wrap;"></pre>
   </div>
 
 </div>

--- a/index.html
+++ b/index.html
@@ -270,11 +270,12 @@
         <span class="home-snapshot__note-global">From public data sources — updated weekly</span>
         <div class="home-snapshot__grid" role="list">
 
-          <div class="home-snapshot__item" role="listitem">
-            <span class="home-snapshot__key">9% Credit Rate</span>
-            <span class="home-snapshot__val" id="snapCreditRate">9.00%</span>
-            <span class="home-snapshot__note"><a href="https://www.law.cornell.edu/uscode/text/26/42" target="_blank" rel="noopener">IRC §42</a> · Fixed by statute</span>
-          </div>
+          <!-- Removed: "9% Credit Rate — 9.00%" card. The rate is
+               fixed by statute (IRC §42(b)) at 9% for competitive deals
+               — it's not a Colorado-specific signal or a live data
+               point, so reporting it as a "CO at a Glance" stat was
+               misleading and wasted a card slot that could show a
+               genuinely local metric. -->
 
           <div class="home-snapshot__item" role="listitem">
             <span class="home-snapshot__key">CO Housing Deficit ≤30% AMI</span>

--- a/js/components/development-realism.js
+++ b/js/components/development-realism.js
@@ -235,7 +235,7 @@
       _checklist([
         { text: 'Clear title with no unresolved liens, encumbrances, or boundary disputes', flag: 'fatal', note: 'Title insurance company must be willing to insure. Unresolved title issues stop closings.' },
         { text: 'No existing leases, occupants, or relocation requirements', flag: 'verify', note: 'Uniform Relocation Act (URA) applies to federally-funded projects. Relocation can cost $10K-$50K per household.' },
-        { text: 'Site control available (purchase option, development agreement, or LOI)', flag: 'verify', note: 'CHFA requires site control documentation. Options typically need 12-24 month terms.' },
+        { text: 'Site control available (purchase option, ground lease, development agreement, or LOI)', flag: 'verify', note: 'CHFA requires site control documentation. Purchase options typically need 12-24 month terms. Ground lease is common for housing-authority or PHA land — lease must run ≥50 years to meet LIHTC long-term-affordability requirements and support financing.' },
       ]) +
 
       '<h4 class="devr-subhead">Market & Timing</h4>' +

--- a/lihtc-guide-for-stakeholders.html
+++ b/lihtc-guide-for-stakeholders.html
@@ -489,9 +489,21 @@
 <div class="chart-card">
 <h3 style="font-size: 1.25rem;">External Links</h3>
 <ul style="line-height: 1.8; color: var(--mcm-beige);">
-<li><a href="https://www.novoco.com" style="color: var(--mcm-teal);" target="_blank">Novogradac</a> - Industry leader</li>
-<li><a href="https://www.huduser.gov" style="color: var(--mcm-teal);" target="_blank">HUD User</a> - Official database</li>
-<li><a href="https://www.ncsha.org" style="color: var(--mcm-teal);" target="_blank">NCSHA</a> - State HFA association</li>
+<li><a href="https://www.novoco.com" style="color: var(--mcm-teal);" target="_blank" rel="noopener">Novogradac</a> — Industry leader (equity pricing surveys, LIHTC blog)</li>
+<li><a href="https://www.huduser.gov" style="color: var(--mcm-teal);" target="_blank" rel="noopener">HUD User</a> — Official FMR + Income Limits database</li>
+<li><a href="https://www.ncsha.org" style="color: var(--mcm-teal);" target="_blank" rel="noopener">NCSHA</a> — State HFA association (QAP comparisons)</li>
+</ul>
+</div>
+
+<div class="chart-card">
+<h3 style="font-size: 1.25rem;">Industry Research</h3>
+<p style="font-size:.85rem;color:var(--mcm-beige);margin:0 0 .5rem;">Annual or semi-annual industry reports referenced by sponsors, syndicators, and appraisers when benchmarking equity pricing, operating performance, and compliance risk. Use these to verify point-in-time assumptions in this tool against the current market.</p>
+<ul style="line-height: 1.8; color: var(--mcm-beige);">
+<li><a href="https://www.cohnreznick.com/industries/affordable-housing" style="color: var(--mcm-teal);" target="_blank" rel="noopener">CohnReznick Affordable Housing Credit Study</a> — Annual survey of LIHTC operating performance, economic occupancy, expense ratios, and DCR benchmarks across thousands of properties</li>
+<li><a href="https://www.yardimatrix.com/publications" style="color: var(--mcm-teal);" target="_blank" rel="noopener">Yardi Matrix Multifamily Reports</a> — Monthly market reports on rents, occupancy, supply, and transaction velocity (national + MSA; Denver-Aurora-Lakewood data relevant for Front-Range PMA benchmarks)</li>
+<li><a href="https://www.novoco.com/resource-centers/affordable-housing-tax-credits/rankings" style="color: var(--mcm-teal);" target="_blank" rel="noopener">Novogradac LIHTC Rankings &amp; Rates</a> — Quarterly equity pricing survey, investor rankings, syndicator transaction volumes</li>
+<li><a href="https://www.ahic.org" style="color: var(--mcm-teal);" target="_blank" rel="noopener">Affordable Housing Investors Council (AHIC)</a> — Investor-side perspective on credit demand, pricing, and risk</li>
+<li><a href="https://www.jchs.harvard.edu" style="color: var(--mcm-teal);" target="_blank" rel="noopener">Harvard Joint Center for Housing Studies</a> — Annual <em>State of the Nation's Housing</em> report; long-term rental demand trends</li>
 </ul>
 </div>
 </div>

--- a/market-analysis.html
+++ b/market-analysis.html
@@ -494,27 +494,27 @@
             <div class="pma-stat">
               <div class="pma-stat-value" id="pmaLihtcCount">—</div>
               <div class="pma-stat-label">LIHTC projects</div>
-              <div class="kpi-source">HUD LIHTC DB</div>
+              <div class="kpi-source kpi-verify">⚠ Verify: <a href="https://www.chfainfo.com/developers/rental-housing-and-funding" target="_blank" rel="noopener">CHFA award history</a> (HUD DB lags ~18 mo)</div>
             </div>
             <div class="pma-stat">
               <div class="pma-stat-value" id="pmaLihtcUnits">—</div>
               <div class="pma-stat-label">Existing LIHTC units</div>
-              <div class="kpi-source">HUD LIHTC DB</div>
+              <div class="kpi-source kpi-verify">⚠ Verify: <a href="https://www.chfainfo.com/developers/rental-housing-and-funding" target="_blank" rel="noopener">CHFA award history</a> (HUD DB lags ~18 mo)</div>
             </div>
             <div class="pma-stat">
               <div class="pma-stat-value" id="pmaCaptureRate">—</div>
               <div class="pma-stat-label">Capture rate (existing)</div>
-              <div class="kpi-source">HUD · ACS 2024</div>
+              <div class="kpi-source kpi-verify">⚠ Verify: ACS 2024 (5-yr rolling) ÷ HUD LIHTC count</div>
             </div>
             <div class="pma-stat">
               <div class="pma-stat-value" id="pmaRenterHh">—</div>
               <div class="pma-stat-label">Renter households</div>
-              <div class="kpi-source">ACS 2024</div>
+              <div class="kpi-source kpi-verify">⚠ Verify: <a href="https://data.census.gov" target="_blank" rel="noopener">ACS 2024 5-yr</a> (tract-level aggregated)</div>
             </div>
             <div class="pma-stat">
               <div class="pma-stat-value" id="pmaLihtcProp123" style="color:var(--accent)">—</div>
               <div class="pma-stat-label">In Prop 123 jurisdictions</div>
-              <div class="kpi-source">DOLA Prop 123</div>
+              <div class="kpi-source kpi-verify">⚠ Verify: <a href="https://cdola.colorado.gov/prop-123" target="_blank" rel="noopener">DOLA Prop 123 commitment list</a></div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Bundle of small correctness/polish fixes per tonight's feedback. Each is narrow; grouped because they're all UI copy/CSS and benefit from one a11y + test pass.

## 1. Verify-messaging pattern introduced

New \`.kpi-verify\` class on \`.kpi-source\` spans uses a consistent format:

> ⚠ **Verify**: \`<authoritative-source-link>\` `(lag note)`

Applied to all 5 LIHTC/ACS stats on market-analysis.html. Each points users to the actual external source they should cross-check (CHFA award history, HUD FMR, DOLA Prop 123, ACS on data.census.gov). Pattern is reusable for deal-calculator and HNA in follow-ups.

## 2. Dashboard-data-quality Pipeline Log contrast fix

\`<pre id="pipelineLog">\` used \`var(--bg-muted, #f5f7fa)\` — but \`--bg-muted\` isn't a defined token, so the #f5f7fa fallback fired in BOTH light and dark mode. In dark mode, page text color is light → light-text-on-light-bg. Changed to \`var(--bg2)\` (real dark-mode-aware token) + explicit \`color: var(--text)\` foreground.

## 3. Homepage — removed "9% Credit Rate" stat from Colorado at a Glance

IRC §42(b) fixes the rate by statute. It's not a Colorado-specific live signal. Card removed with rationale comment; no JS references, clean delete.

## 4. Site control checklist now mentions ground lease

Previously: "purchase option, development agreement, or LOI". Added **ground lease** (primary site-control structure for housing-authority/PHA land contributions) + the ≥50-year term requirement for LIHTC long-term-affordability compliance.

## 5. LIHTC Guide — industry research section

New "Industry Research" card under Additional Resources linking:
- **CohnReznick Affordable Housing Credit Study** — operating performance benchmarks
- **Yardi Matrix Multifamily Reports** — rent/occupancy/velocity
- **Novogradac LIHTC Rankings & Rates** — equity pricing
- **AHIC** — investor-side perspective
- **Harvard JCHS** — long-term rental demand

Each entry notes what developers use it for, so users can verify this tool's assumptions against current market benchmarks.

## Verification

- \`npm run test:hna\` → 688/688 passing
- \`npm run audit:a11y\` → 0 critical / 0 serious (unchanged)

## Still in flight (not this PR)

- Deal-calc verify-messaging (same pattern)
- PMA dimension-note verify hints (inside JS-generated tooltips)
- PR descriptions for MEDIUM and FEATURE items still in the triage list

🤖 Generated with [Claude Code](https://claude.com/claude-code)