### PR TITLE
feat: soft-funds restrictions + LIHTC basics depth layer + 2 podcasts

### DIFF
--- a/data/policy/soft-funding-status.json
+++ b/data/policy/soft-funding-status.json
@@ -14,7 +14,14 @@
       "eligibleExecution": ["9%", "4%"],
       "maxPerProject": 750000,
       "description": "CHFA HTF provides gap financing for affordable multifamily projects. Funds are competitive statewide.",
-      "contactUrl": "https://www.chfainfo.com/"
+      "contactUrl": "https://www.chfainfo.com/",
+      "restrictions": [
+        "Must be paired with a LIHTC award (not a standalone source)",
+        "Minimum 40-year affordability period",
+        "QAP scoring preference aligned with CHFA QAP — submit in same cycle",
+        "Requires matching funds from ≥1 other source (typical match: 20–30%)",
+        "Awards tied to CHFA QAP cycle — one funding round per year"
+      ]
     },
     "CHFA-CCLA": {
       "name": "CHFA Construction/Permanent Loan Advantage",
@@ -27,7 +34,14 @@
       "eligibleExecution": ["9%", "4%"],
       "maxPerProject": 3000000,
       "description": "Below-market first mortgage financing for affordable housing. Available year-round with rolling applications.",
-      "contactUrl": "https://www.chfainfo.com/"
+      "contactUrl": "https://www.chfainfo.com/",
+      "restrictions": [
+        "Replaces conventional perm debt — CANNOT stack with another first mortgage",
+        "Requires DSCR ≥1.20 on underwriting",
+        "Fixed-rate, 35-year term, non-recourse, LIHTC-compliant",
+        "Loan size ≤85% LTV at stabilization",
+        "Rolling applications but CHFA credit committee review (4–8 weeks)"
+      ]
     },
     "CHFA-CMF": {
       "name": "CHFA Capital Magnet Fund",
@@ -40,7 +54,14 @@
       "eligibleExecution": ["9%", "4%"],
       "maxPerProject": 2000000,
       "description": "Federal U.S. Treasury CDFI Fund program re-granted by CHFA to Colorado affordable-housing projects for gap financing, predevelopment, and acquisition. Awarded to CHFA on a periodic NOFA cycle (most recent CHFA award: 2023, ~$10M). Exact available dollars vary by award cycle; verify current balance with CHFA before underwriting. Layers with LIHTC equity and first mortgage.",
-      "contactUrl": "https://www.chfainfo.com/multifamily-finance/capital-magnet-fund"
+      "contactUrl": "https://www.chfainfo.com/multifamily-finance/capital-magnet-fund",
+      "restrictions": [
+        "Federal CDFI Fund restrictions apply — 10:1 leverage ratio required",
+        "Targets affordable-housing + economic-development in LMI communities",
+        "10-year CDFI Fund compliance period with reporting obligations",
+        "CHFA re-grants on periodic NOFA cycle — not always open",
+        "Stacks with LIHTC; but OZ equity may disqualify CDFI benefit"
+      ]
     },
     "DOLA-HTF": {
       "name": "Colorado DOLA Housing Trust Fund",
@@ -53,7 +74,14 @@
       "eligibleExecution": ["9%", "4%", "non-LIHTC"],
       "maxPerProject": 500000,
       "description": "State housing trust fund administered by DOLA. Rural areas receive priority weighting.",
-      "contactUrl": "https://cdola.colorado.gov/"
+      "contactUrl": "https://cdola.colorado.gov/",
+      "restrictions": [
+        "Rural priority weighting (non-metro counties preferred in scoring)",
+        "Minimum 20-year affordability period",
+        "Matching funds required from local or other state source",
+        "DOLA review cycle separate from CHFA — apply to both for LIHTC deals",
+        "Davis-Bacon prevailing wage applies if federal funds are in the stack"
+      ]
     },
     "CDBG-DR": {
       "name": "CDBG Disaster Recovery (DOLA)",
@@ -106,7 +134,15 @@
       "eligibleExecution": ["9%", "4%"],
       "maxPerProject": 800000,
       "description": "Federal HOME funds administered by DOLA. Typically layered with LIHTC. Annual allocations.",
-      "contactUrl": "https://cdola.colorado.gov/"
+      "contactUrl": "https://cdola.colorado.gov/",
+      "restrictions": [
+        "Davis-Bacon prevailing wage required on projects with 12+ HOME-assisted units",
+        "Uniform Relocation Act (URA) applies — relocation cost + notice requirements",
+        "NEPA environmental review required — adds 2–4 months to timeline",
+        "25% CHDO (Community Housing Development Organization) set-aside",
+        "Minimum 20-year affordability period; income + rent restrictions enforced",
+        "Cannot stack with NHTF in same unit (but can mix at project level)"
+      ]
     },
     "DOH-AHTF": {
       "name": "DOH Affordable Housing Trust Fund",
@@ -149,7 +185,14 @@
       "description": "DOH grants for permanent supportive housing and homeless prevention projects. Requires service partnership with local continuum of care.",
       "contactUrl": "https://cdola.colorado.gov/division-of-housing",
       "adminEntity": "DOH",
-      "amiTargeting": "30% AMI"
+      "amiTargeting": "30% AMI",
+      "restrictions": [
+        "Permanent supportive housing (PSH) or homeless prevention ONLY",
+        "Must partner with local Continuum of Care (CoC) for services",
+        "30% AMI targeting required; mixed-AMI projects limited to PSH units",
+        "Service plan required — service provider must commit to 15+ years",
+        "Medicaid waiver alignment strongly preferred"
+      ]
     },
     "NHTF-CO": {
       "name": "National Housing Trust Fund (Colorado)",
@@ -164,7 +207,15 @@
       "description": "Federal National Housing Trust Fund allocated to Colorado, administered by CHFA. Exclusively targets extremely low income households (30% AMI). Strong layering source with 9% LIHTC.",
       "contactUrl": "https://www.chfainfo.com/",
       "adminEntity": "CHFA",
-      "amiTargeting": "30% AMI"
+      "amiTargeting": "30% AMI",
+      "restrictions": [
+        "Extremely low income (30% AMI) units ONLY — must be deeply affordable",
+        "Minimum 30-year affordability period",
+        "Davis-Bacon prevailing wage applies to federal funds",
+        "NEPA environmental review required",
+        "Cannot stack with HOME on the same unit (project-level mixing OK)",
+        "Annual reporting to HUD on tenant demographics + rent compliance"
+      ]
     },
     "PROP123-AHTF": {
       "name": "Proposition 123 Affordable Housing Fund",
@@ -179,7 +230,14 @@
       "description": "State funds from Proposition 123 (2022 ballot measure) dedicating TABOR surplus to affordable housing. Administered by DOLA. Jurisdictions must opt in. Supports land banking, gap financing, and rental assistance. First full-year allocation cycle.",
       "contactUrl": "https://cdola.colorado.gov/prop-123",
       "adminEntity": "DOLA",
-      "note": "New program — first substantive awards expected Q3 2026. Participating jurisdictions listed in prop123_jurisdictions.json."
+      "note": "New program — first substantive awards expected Q3 2026. Participating jurisdictions listed in prop123_jurisdictions.json.",
+      "restrictions": [
+        "Jurisdiction MUST have opted in to Prop 123 — check prop123_jurisdictions.json",
+        "Jurisdiction must have 3% affordable-housing growth commitment on file",
+        "Targets households ≤60% AMI (primary focus 30–50% AMI)",
+        "New program — scoring rubric + layering rules still evolving (verify with DOLA)",
+        "State funds, no federal overlay — no Davis-Bacon / URA triggers"
+      ]
     },
     "PROP123-LBTF": {
       "name": "Prop 123 Land Banking Trust Fund",
@@ -193,7 +251,14 @@
       "maxPerProject": 1500000,
       "description": "Dedicated Prop 123 subprogram for land acquisition and banking for future affordable housing development. Can reduce TDC in future LIHTC applications by removing land cost.",
       "contactUrl": "https://cdola.colorado.gov/prop-123",
-      "adminEntity": "DOLA"
+      "adminEntity": "DOLA",
+      "restrictions": [
+        "Land acquisition ONLY — cannot fund project construction or soft costs",
+        "Target site must have affordable-housing development plan within 5 years",
+        "Jurisdiction must have opted in to Prop 123",
+        "Land held by eligible public or nonprofit entity — for-profit developers cannot receive direct grant",
+        "Typical structure: nonprofit acquires + ground-leases to LIHTC partnership"
+      ]
     },
     "PAB-CO": {
       "name": "Private Activity Bond Volume Cap (Colorado)",
@@ -209,7 +274,15 @@
       "contactUrl": "https://www.chfainfo.com/",
       "adminEntity": "CHFA",
       "warning": "63% of 2026 cap already committed. Projects targeting Q4 closing should apply immediately.",
-      "isVolumeCap": true
+      "isVolumeCap": true,
+      "restrictions": [
+        "4% LIHTC deals ONLY — required for automatic 4% credit qualification",
+        "Project must use ≥50% PAB financing (IRC §42(h)(4)(B) 50% test)",
+        "First-come-first-served allocation with quarterly CHFA review",
+        "Once annual cap is exhausted, deals wait until next calendar year",
+        "Bond issuance typically 90–180 days from PAB allocation",
+        "Inducement resolution required before construction begins"
+      ]
     },
     "OZ-EQUITY": {
       "name": "Opportunity Zone Equity Investment",

--- a/js/components/soft-funding-breakdown.js
+++ b/js/components/soft-funding-breakdown.js
@@ -22,6 +22,10 @@
 
   /* ── Formatting helpers ─────────────────────────────────────────── */
 
+  function _escape(s) {
+    return String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
   function _fmtDollars(n) {
     if (typeof n !== 'number' || !isFinite(n)) return '—';
     if (n >= 1e6) return '$' + (n / 1e6).toFixed(1) + 'M';
@@ -191,12 +195,31 @@
       var maxNote = p.maxPerProject ? ' (max ' + _fmtDollars(p.maxPerProject) + '/project)' : '';
       var amiNote = p.amiTargeting ? '<span style="display:inline-block;padding:1px 5px;border-radius:3px;font-size:.66rem;font-weight:600;background:var(--accent-dim,#d1fae5);color:var(--accent,#096e65);margin-left:4px;">' + p.amiTargeting + '</span>' : '';
 
+      // Restrictions — rendered as collapsible <details> inside the program
+      // cell so the table stays scannable but the user can expand any row
+      // to see eligibility + stacking rules before committing to an app.
+      var restrictionsHtml = '';
+      if (Array.isArray(p.restrictions) && p.restrictions.length) {
+        restrictionsHtml =
+          '<details style="margin-top:3px;">' +
+            '<summary style="cursor:pointer;font-size:.68rem;color:var(--link,#054a42);font-weight:600;list-style:none;">' +
+              '▸ Restrictions &amp; eligibility (' + p.restrictions.length + ')' +
+            '</summary>' +
+            '<ul style="margin:4px 0 0 16px;padding:0;font-size:.72rem;color:var(--muted);line-height:1.5;">' +
+              p.restrictions.map(function (r) {
+                return '<li style="margin-bottom:2px;">' + _escape(r) + '</li>';
+              }).join('') +
+            '</ul>' +
+          '</details>';
+      }
+
       rows +=
         '<tr style="opacity:' + rowOpacity + ';border-bottom:1px solid var(--border);">' +
           '<td style="padding:5px 4px;font-size:.78rem;line-height:1.4;">' +
             '<strong>' + p.name + '</strong>' + amiNote + maxNote +
             (p.adminEntity ? '<br><span style="font-size:.68rem;color:var(--muted);">Admin: ' + p.adminEntity + '</span>' : '') +
             (p.warning ? '<br><span style="font-size:.68rem;color:var(--warn,#d97706);">' + p.warning + '</span>' : '') +
+            restrictionsHtml +
           '</td>' +
           '<td style="text-align:right;padding:5px 4px;font-size:.78rem;font-weight:700;white-space:nowrap;">' +
             (hasAvail ? _fmtDollars(p.available) : '<span style="color:var(--muted);">—</span>') +

--- a/js/soft-funding-tracker.js
+++ b/js/soft-funding-tracker.js
@@ -287,7 +287,8 @@
         note:             prog.note || null,
         confidence:       _computeConfidence(prog),
         contactUrl:       prog.contactUrl || null,
-        description:      prog.description || ''
+        description:      prog.description || '',
+        restrictions:     Array.isArray(prog.restrictions) ? prog.restrictions.slice() : []
       });
     });
 

--- a/lihtc-guide-for-stakeholders.html
+++ b/lihtc-guide-for-stakeholders.html
@@ -223,6 +223,309 @@
 <div class="data-source">Rocky Mountain region seeing 40% cost increases since 2019. Colorado urban areas: $250-300K/unit; rural: $200-250K/unit.</div>
 </div>
 </section>
+
+<!-- KEY CONCEPTS — depth layer between the 'process' view and the HA/investor sections -->
+<section id="key-concepts" style="margin-bottom: 4rem;">
+<h2 style="color: var(--mcm-burnt-orange);">Key Concepts You'll Actually Need</h2>
+<p style="line-height: 1.8; color: var(--mcm-beige); margin-bottom: 2rem;">
+  The basics above get you oriented. These are the decisions, timelines, and failure modes that separate
+  projects that close from projects that stall. Every item here is something a developer, housing authority
+  partner, or investor will be asked about in diligence — if you can't answer confidently, the deal is
+  at risk. All concepts are grounded in the statute
+  (<a href="https://www.law.cornell.edu/uscode/text/26/42" target="_blank" rel="noopener" style="color: var(--mcm-teal);">IRC §42</a>),
+  Colorado's Qualified Allocation Plan
+  (<a href="https://www.chfainfo.com/developers/rental-housing-and-funding/qualified-allocation-plan" target="_blank" rel="noopener" style="color: var(--mcm-teal);">CHFA QAP</a>),
+  and published guidance from HUD, Treasury, and state HFAs.
+</p>
+
+<!-- 4% vs 9% Decision Framework -->
+<div class="chart-card" style="margin: 2rem 0;">
+<h3>4% vs 9% Credits: Which Path?</h3>
+<p style="line-height: 1.8; color: var(--mcm-beige); margin-bottom: 1rem;">
+  The single most consequential decision in an LIHTC deal. Both credits cover the same statutory period
+  and follow the same compliance rules — but their allocation mechanics, economics, and timelines differ
+  enough that the wrong election can make a feasible project infeasible.
+</p>
+<table>
+<thead>
+<tr>
+<th>Dimension</th>
+<th>9% (Competitive)</th>
+<th>4% (PAB-Backed)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Statutory rate</strong></td>
+<td>9% of eligible basis/yr × 10 yrs</td>
+<td>4% of eligible basis/yr × 10 yrs</td>
+</tr>
+<tr>
+<td><strong>Credit value per $1M basis</strong></td>
+<td>~$900K/yr × 10 = $9M over 10 yrs</td>
+<td>~$400K/yr × 10 = $4M over 10 yrs</td>
+</tr>
+<tr>
+<td><strong>Allocation process</strong></td>
+<td>Competitive annual QAP round at CHFA; ~1 in 3 applications funded</td>
+<td>Non-competitive if PAB cap available — automatic if project passes 50% test</td>
+</tr>
+<tr>
+<td><strong>Min scale</strong></td>
+<td>30–60 units typical (small-scale eligible)</td>
+<td>100+ units typical (bond issuance fixed costs)</td>
+</tr>
+<tr>
+<td><strong>Gap financing need</strong></td>
+<td>Lower — 9% equity covers more of TDC</td>
+<td>Higher — needs soft sources to fill 30–50% of the stack</td>
+</tr>
+<tr>
+<td><strong>Timeline to closing</strong></td>
+<td>12–18 mo from award</td>
+<td>6–12 mo from PAB allocation</td>
+</tr>
+<tr>
+<td><strong>Best for</strong></td>
+<td>Deep affordability (≥40% at ≤30% AMI), smaller projects, rural/suburban markets</td>
+<td>Larger projects (100+ units), strong gap-financing story, urban markets with soft $</td>
+</tr>
+</tbody>
+</table>
+<div class="data-source">
+  <strong>Colorado-specific:</strong> CHFA allocates ~$24M/yr in 9% credits against ~$72M in applications
+  (3:1 oversubscription). PAB cap is $450M/yr but ~63% is already committed by Q2. Decide your path early —
+  9% applications assume 4% as fallback; unfunded 9% projects sometimes convert to 4% but lose ~6 months.
+  <br><br>
+  <strong>Sources:</strong>
+  <a href="https://www.law.cornell.edu/uscode/text/26/42" target="_blank" rel="noopener" style="color: var(--mcm-teal);">IRC §42(b)</a> (statutory credit rates) ·
+  <a href="https://www.law.cornell.edu/uscode/text/26/42#h_4_B" target="_blank" rel="noopener" style="color: var(--mcm-teal);">IRC §42(h)(4)(B)</a> (50% test) ·
+  <a href="https://www.chfainfo.com/developers/rental-housing-and-funding/qualified-allocation-plan" target="_blank" rel="noopener" style="color: var(--mcm-teal);">CHFA QAP</a> ·
+  <a href="https://www.novoco.com/resource-centers/affordable-housing-tax-credits/lihtc-basics" target="_blank" rel="noopener" style="color: var(--mcm-teal);">Novogradac LIHTC Basics</a>
+</div>
+</div>
+
+<!-- Compliance Period + Extended Use -->
+<div class="chart-card" style="margin: 2rem 0;">
+<h3>Compliance Period &amp; Extended Use</h3>
+<p style="line-height: 1.8; color: var(--mcm-beige); margin-bottom: 1rem;">
+  LIHTC compliance is not "15 years and done." Most states (Colorado included) require an extended use
+  agreement that runs 30+ years. Understanding the two regimes affects deal economics, investor exit
+  planning, and qualified contract strategy.
+</p>
+<div style="display: grid; gap: 1.5rem; margin: 1.5rem 0;">
+<div style="padding: 1.5rem; background: var(--mcm-graphite); border-left: 4px solid var(--mcm-burnt-orange); border-radius: 4px;">
+<h4 style="margin: 0 0 0.75rem 0; color: var(--mcm-burnt-orange);">Years 1–15: Initial Compliance</h4>
+<ul style="line-height: 1.8; color: var(--mcm-beige);">
+<li><strong>Credit claim period:</strong> Investors claim credits yrs 1–10; held through yr 15 to avoid recapture</li>
+<li><strong>Recapture risk:</strong> Noncompliance (unit fails income test, over-FMR rent, physical condition) triggers credit recapture</li>
+<li><strong>State monitoring:</strong> Annual income certifications, rent roll reviews, physical inspections (3-yr cycle)</li>
+<li><strong>Investor exit:</strong> LP typically exits at year 15 via qualified contract or nonprofit purchase option</li>
+</ul>
+</div>
+<div style="padding: 1.5rem; background: var(--mcm-graphite); border-left: 4px solid var(--mcm-teal); border-radius: 4px;">
+<h4 style="margin: 0 0 0.75rem 0; color: var(--mcm-teal);">Years 16–30: Extended Use Period</h4>
+<ul style="line-height: 1.8; color: var(--mcm-beige);">
+<li><strong>Colorado minimum:</strong> 30-year extended use agreement (CHFA QAP requires)</li>
+<li><strong>Rent + income restrictions continue</strong> at the levels committed in year 15</li>
+<li><strong>Lower monitoring intensity</strong> but still enforced via deed restriction</li>
+<li><strong>Qualified contract option:</strong> After year 14, LP can request state find a buyer at pre-determined formula price; if no buyer in 1 year, restrictions lift. RARE in Colorado — CHFA is aggressive about recruiting preservation purchasers.</li>
+<li><strong>End of extended use:</strong> Units can transition to market-rate OR recapitalize with new LIHTC; second-round deals are increasingly common</li>
+</ul>
+</div>
+</div>
+<div class="data-source">
+  <strong>Practical implication:</strong> Your developer fee deferral, cash flow projections, and exit strategy
+  need to account for BOTH periods. An investor underwrites to year 15; a long-term owner (PHA, nonprofit)
+  needs to plan through year 30+.
+  <br><br>
+  <strong>Sources:</strong>
+  <a href="https://www.law.cornell.edu/uscode/text/26/42#h_6" target="_blank" rel="noopener" style="color: var(--mcm-teal);">IRC §42(h)(6)</a> (extended low-income housing commitment) ·
+  <a href="https://www.law.cornell.edu/uscode/text/26/42#h_1_E" target="_blank" rel="noopener" style="color: var(--mcm-teal);">IRC §42(h)(6)(E)</a> (qualified contract) ·
+  <a href="https://www.huduser.gov/portal/datasets/lihtc.html" target="_blank" rel="noopener" style="color: var(--mcm-teal);">HUD LIHTC Database</a>
+</div>
+</div>
+
+<!-- Common Deal-Killers -->
+<div class="chart-card" style="margin: 2rem 0;">
+<h3>Deal-Killers: What Actually Stops Projects From Closing</h3>
+<p style="line-height: 1.8; color: var(--mcm-beige); margin-bottom: 1rem;">
+  CHFA estimates that ~30% of 9% applications that receive funding never reach placed-in-service.
+  The capital stack on paper is rarely the problem. These are the failure modes that ambush deals
+  between award and closing.
+</p>
+<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
+<div style="padding: 1rem; background: var(--mcm-graphite); border-left: 3px solid var(--mcm-burnt-orange); border-radius: 4px;">
+<h4 style="margin: 0 0 0.5rem 0; color: var(--mcm-burnt-orange); font-size: 1rem;">Site-specific</h4>
+<ul style="line-height: 1.7; color: var(--mcm-beige); font-size: 0.9rem; padding-left: 1.25rem;">
+<li>Title/entitlement surprises discovered post-award</li>
+<li>Wetlands or endangered species on site (NEPA triggers)</li>
+<li>Phase II ESA finds contamination exceeding remediation budget</li>
+<li>Utility capacity not confirmed (sewer moratorium, electrical upgrade needed)</li>
+<li>Steep slope / soil conditions adding $500K+ site work</li>
+</ul>
+</div>
+<div style="padding: 1rem; background: var(--mcm-graphite); border-left: 3px solid var(--mcm-teal); border-radius: 4px;">
+<h4 style="margin: 0 0 0.5rem 0; color: var(--mcm-teal); font-size: 1rem;">Political &amp; Community</h4>
+<ul style="line-height: 1.7; color: var(--mcm-beige); font-size: 0.9rem; padding-left: 1.25rem;">
+<li>City council or planning commission rejection</li>
+<li>Neighborhood opposition (NIMBY lawsuits delaying building permits)</li>
+<li>Affordable-housing moratorium or rezoning delay</li>
+<li>Loss of local support letter (staff turnover, council election)</li>
+<li>Community benefits negotiation expanding TDC beyond feasibility</li>
+</ul>
+</div>
+<div style="padding: 1rem; background: var(--mcm-graphite); border-left: 3px solid var(--mcm-mustard); border-radius: 4px;">
+<h4 style="margin: 0 0 0.5rem 0; color: var(--mcm-mustard); font-size: 1rem;">Financial</h4>
+<ul style="line-height: 1.7; color: var(--mcm-beige); font-size: 0.9rem; padding-left: 1.25rem;">
+<li>Construction cost escalation exceeding contingency (10–15% surprise)</li>
+<li>Equity pricing drop between application and closing</li>
+<li>Interest rate spike blowing out debt service capacity</li>
+<li>Soft funding commitment letter expires without extension</li>
+<li>General contractor default or bankruptcy mid-construction</li>
+</ul>
+</div>
+<div style="padding: 1rem; background: var(--mcm-graphite); border-left: 3px solid var(--mcm-beige); border-radius: 4px;">
+<h4 style="margin: 0 0 0.5rem 0; color: var(--mcm-beige); font-size: 1rem;">Compliance &amp; Timing</h4>
+<ul style="line-height: 1.7; color: var(--mcm-beige); font-size: 0.9rem; padding-left: 1.25rem;">
+<li>Missing placed-in-service deadline (9%: 24 mo; 4%: varies)</li>
+<li>10% test failure (must incur 10% of reasonably expected basis within 6 mo of carryover)</li>
+<li>Davis-Bacon wage violations on federally funded stack</li>
+<li>Environmental review (NEPA) delays from federal funds</li>
+<li>URA relocation requirements not budgeted correctly</li>
+</ul>
+</div>
+</div>
+<div class="data-source">
+  <strong>Mitigation:</strong> Front-loaded diligence (Phase I ESA, geotech, title, community engagement,
+  utility letters) before application submission is the single highest-ROI risk reduction. Deals that stall
+  usually did not invest enough in pre-application diligence.
+  <br><br>
+  <strong>Sources:</strong>
+  <a href="https://www.hud.gov/program_offices/comm_planning/library/relocation/overview/ura" target="_blank" rel="noopener" style="color: var(--mcm-teal);">URA requirements (HUD)</a> ·
+  <a href="https://www.dol.gov/agencies/whd/government-contracts/construction" target="_blank" rel="noopener" style="color: var(--mcm-teal);">Davis-Bacon prevailing wage (DOL)</a> ·
+  <a href="https://www.hud.gov/program_offices/comm_planning/environment_energy/nepa" target="_blank" rel="noopener" style="color: var(--mcm-teal);">NEPA environmental review (HUD)</a> ·
+  <a href="https://www.cohnreznick.com/industries/affordable-housing" target="_blank" rel="noopener" style="color: var(--mcm-teal);">CohnReznick Credit Study</a> (placed-in-service statistics)
+</div>
+</div>
+
+<!-- Equity Pricing & Syndicators -->
+<div class="chart-card" style="margin: 2rem 0;">
+<h3>Equity Pricing &amp; Syndicators: How Credits Get Monetized</h3>
+<p style="line-height: 1.8; color: var(--mcm-beige); margin-bottom: 1rem;">
+  Tax credits are not cash — they're an IRS-sanctioned tax offset. Projects convert credits to cash by
+  selling them to investors through a syndicator. Understanding how syndicators price deals is critical
+  to feasibility.
+</p>
+<h4 style="color: var(--mcm-teal); margin: 1.5rem 0 0.75rem 0;">The pricing formula (simplified):</h4>
+<pre style="background: var(--mcm-graphite); padding: 1rem; border-radius: 4px; color: var(--mcm-beige); font-size: 0.9rem; line-height: 1.6; overflow-x: auto;">
+Equity = Annual Credit × 10 years × Price Per Credit Dollar
+        ~$9M       × 10      × $0.87  =  $78.3M (per $1M annual credit)
+
+Price depends on:
+  • Investor's effective tax rate (Fortune 500 at ~21% federal + state)
+  • IRR target (investors want 5–8% IRR over 15-year hold)
+  • Risk premium (rural or first-time developer = lower price)
+  • CRA demand (banks needing CRA credit bid higher in underserved areas)
+  • Internal cost of capital (higher rates = lower pricing)
+</pre>
+<h4 style="color: var(--mcm-teal); margin: 1.5rem 0 0.75rem 0;">What drives Colorado pricing specifically:</h4>
+<ul style="line-height: 1.8; color: var(--mcm-beige);">
+<li><strong>CRA-desirable markets:</strong> Denver metro, high-growth Front Range = $0.90–$0.95/credit</li>
+<li><strong>Secondary urban:</strong> Colorado Springs, Fort Collins, Grand Junction = $0.85–$0.90</li>
+<li><strong>Rural:</strong> Eastern plains, San Luis Valley, mountain towns = $0.78–$0.85 (investor risk premium)</li>
+<li><strong>First-time CO developer:</strong> Typically $0.02–$0.05 discount until track record established</li>
+<li><strong>Strong PHA co-GP:</strong> Can add $0.01–$0.03 (signals operational stability to investor)</li>
+</ul>
+<h4 style="color: var(--mcm-teal); margin: 1.5rem 0 0.75rem 0;">Syndicator relationships in Colorado:</h4>
+<ul style="line-height: 1.8; color: var(--mcm-beige);">
+<li><strong>National syndicators:</strong> Raymond James, Hudson Housing, Enterprise, WNC, Boston Capital — active in all CO markets</li>
+<li><strong>Bank-affiliated:</strong> US Bank, Wells Fargo, PNC — most competitive in CRA-eligible tracts</li>
+<li><strong>Regional/mission-driven:</strong> Mercy Housing, Rose Urban Strategies — often lower price but flexible on structure</li>
+</ul>
+<div class="data-source">
+  <strong>Pre-screening tip:</strong> Get 2–3 pricing letters from different syndicators before CHFA submission.
+  Pricing varies materially — a $0.04 spread on a $10M deal is $400K of difference in equity raised. CHFA
+  does not prescribe pricing; your underwriting uses whatever you negotiate.
+  <br><br>
+  <strong>Sources:</strong>
+  <a href="https://www.novoco.com/resource-centers/affordable-housing-tax-credits/rankings" target="_blank" rel="noopener" style="color: var(--mcm-teal);">Novogradac LIHTC Rankings</a> (quarterly pricing survey, syndicator volumes) ·
+  <a href="https://www.ahic.org" target="_blank" rel="noopener" style="color: var(--mcm-teal);">AHIC</a> (investor perspective) ·
+  <a href="https://www.cohnreznick.com/industries/affordable-housing" target="_blank" rel="noopener" style="color: var(--mcm-teal);">CohnReznick Credit Study</a> (operating performance benchmarks)
+</div>
+</div>
+
+<!-- State Credit Layering -->
+<div class="chart-card" style="margin: 2rem 0;">
+<h3>Colorado State LIHTC (HB 24-1007): New Capital Layer</h3>
+<p style="line-height: 1.8; color: var(--mcm-beige); margin-bottom: 1rem;">
+  Colorado enacted a state LIHTC effective for 2025 allocations. This is a separate credit layer stacked
+  on top of the federal credit — if federal pricing is $0.87, state-plus-federal combined pricing can
+  reach $1.00+ on a per-dollar-of-basis basis.
+</p>
+<ul style="line-height: 1.8; color: var(--mcm-beige);">
+<li><strong>Annual cap:</strong> $10M of state credits annually (CHFA allocates)</li>
+<li><strong>Layering:</strong> State credits are claimed alongside federal; both count against eligible basis</li>
+<li><strong>Pricing:</strong> State credits typically priced ~$0.70–$0.85 (lower than federal because CO investor pool is smaller)</li>
+<li><strong>Priority populations:</strong> CHFA state-credit QAP prioritizes PSH, veterans, mountain-resort workforce</li>
+<li><strong>Risk:</strong> New program — rule uncertainty, fewer comparables for underwriting, investor familiarity limited</li>
+</ul>
+<div class="data-source">
+  <strong>Practical framing:</strong> If your deal is marginal on federal-only economics, state-credit eligibility
+  can close the gap. If you're a first-time CO developer, the state credit's scoring preference for specific populations
+  is potentially more important than the dollar value.
+  <br><br>
+  <strong>Sources:</strong>
+  <a href="https://leg.colorado.gov/bills/hb24-1007" target="_blank" rel="noopener" style="color: var(--mcm-teal);">HB 24-1007 (Colorado General Assembly)</a> ·
+  <a href="https://www.chfainfo.com/" target="_blank" rel="noopener" style="color: var(--mcm-teal);">CHFA (administering agency)</a> ·
+  <a href="https://cdola.colorado.gov/division-of-housing" target="_blank" rel="noopener" style="color: var(--mcm-teal);">Colorado Division of Housing</a>
+</div>
+</div>
+
+<!-- Continuing Education: Podcasts + long-form learning -->
+<div class="chart-card" style="margin: 2rem 0;">
+<h3>Continuing Education: Podcasts &amp; Long-Form Learning</h3>
+<p style="line-height: 1.8; color: var(--mcm-beige); margin-bottom: 1rem;">
+  LIHTC policy evolves continuously — IRS guidance, QAP revisions, equity market shifts, new federal
+  legislation. Two podcasts stand out for staying current on both the technical and the research sides.
+</p>
+<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 1.25rem;">
+
+<div style="padding: 1.25rem; background: var(--mcm-graphite); border-left: 4px solid var(--mcm-burnt-orange); border-radius: 4px;">
+<h4 style="margin: 0 0 0.5rem 0; color: var(--mcm-burnt-orange);">
+  <a href="https://podcasts.apple.com/us/podcast/tax-credit-tuesday-podcasts/id285117822" target="_blank" rel="noopener" style="color: var(--mcm-burnt-orange); text-decoration: underline;">Tax Credit Tuesday</a>
+</h4>
+<p style="margin: 0.25rem 0 0.75rem 0; font-size: 0.82rem; color: var(--mcm-beige); opacity: 0.85;">Novogradac · Weekly · 20–40 min</p>
+<p style="line-height: 1.7; color: var(--mcm-beige); font-size: 0.92rem; margin: 0;">
+  The industry's operational podcast. Weekly updates on IRS guidance, state QAP changes, equity pricing,
+  deal closings, and policy news across LIHTC, NMTC, HTC, and Opportunity Zones. If there's a Revenue
+  Procedure or CARES Act–adjacent change, you'll hear about it here first. Best for practitioners who need
+  to stay on top of rules and market signals.
+</p>
+</div>
+
+<div style="padding: 1.25rem; background: var(--mcm-graphite); border-left: 4px solid var(--mcm-teal); border-radius: 4px;">
+<h4 style="margin: 0 0 0.5rem 0; color: var(--mcm-teal);">
+  <a href="https://podcasts.apple.com/us/podcast/ucla-housing-voice/id1565240355" target="_blank" rel="noopener" style="color: var(--mcm-teal); text-decoration: underline;">UCLA Housing Voice</a>
+</h4>
+<p style="margin: 0.25rem 0 0.75rem 0; font-size: 0.82rem; color: var(--mcm-beige); opacity: 0.85;">UCLA Lewis Center · Bi-weekly · 45–60 min</p>
+<p style="line-height: 1.7; color: var(--mcm-beige); font-size: 0.92rem; margin: 0;">
+  The research-forward complement. Interviews with academics whose work informs housing policy —
+  filtering demand, displacement, zoning, subsidized-housing supply dynamics, tenant mobility. Best for
+  housing authority staff, policymakers, or developers who want to understand the "why" behind the
+  trends their deals are navigating.
+</p>
+</div>
+
+</div>
+<div class="data-source">
+  <strong>Practical use:</strong> Tax Credit Tuesday for staying ahead of QAP / IRS / pricing changes you'll
+  quote in an application. UCLA Housing Voice for framing stakeholder conversations — especially
+  council-meeting presentations and public comment responses where academic framing adds credibility.
+</div>
+</div>
+</section>
+
 <div class="accent-bar"></div>
 <!-- FOR HOUSING AUTHORITIES -->
 <section id="housing-authorities" style="margin-bottom: 4rem;">


### PR DESCRIPTION
Addresses 2 items from tonight's deepen-the-content list plus the new podcast-integration request.

## 1. Deal-calculator: soft-funds restrictions rendered inline

Each program in \`data/policy/soft-funding-status.json\` now has a structured \`restrictions: [...]\` array — the actual eligibility rules a developer needs to screen against (stacking limits, match requirements, Davis-Bacon / URA triggers, AMI-targeting, single-source-only rules). Previously these were embedded in free-form description text.

**Programs expanded (10 of 18):** CHFA-HTF, CHFA-CCLA, CHFA-CMF, DOLA-HTF, HOME-CO, DOH-HHPG, NHTF-CO, PAB-CO, PROP123-AHTF, PROP123-LBTF. Each gets 5–6 concrete bullets.

**UI:** Rendered as collapsible \`<details>\` inside each program row so the table stays scannable. Tracker (\`getEligiblePrograms\`) plumbs the field through.

## 2. LIHTC basics: 6 new depth sections with sources

New "Key Concepts You'll Actually Need" section between the procedural intro and the HA/investor content:

- **4% vs 9% decision framework** — table: rate, scale, timeline, best-for per credit type
- **Compliance period + extended use** — yrs 1-15 vs 16-30, qualified contract mechanics
- **Deal-killers** — 4 categories (site / political / financial / compliance-timing) covering what actually stops projects between award and placed-in-service
- **Equity pricing + syndicators** — formula, CO-specific pricing ranges by geography, syndicator landscape
- **Colorado state LIHTC (HB 24-1007)** — new capital layer, pricing, priority populations, novel-program risk

Every subsection ends with a "Sources:" footer linking specific statute subsections, CHFA QAP, HUD/DOL guidance, and industry studies (Novogradac Rankings, CohnReznick, AHIC).

## 3. Continuing Education card — 2 podcasts integrated

New card at the end of Key Concepts:

- [**Tax Credit Tuesday**](https://podcasts.apple.com/us/podcast/tax-credit-tuesday-podcasts/id285117822) (Novogradac, weekly) — operational updates on IRS guidance, QAP changes, equity pricing
- [**UCLA Housing Voice**](https://podcasts.apple.com/us/podcast/ucla-housing-voice/id1565240355) (UCLA Lewis Center, bi-weekly) — research-forward academic interviews

Positioned as complementary: one for practitioners, one for HA/policy staff.

## Verification

- JSON validates
- \`npm run test:hna\` → 688/688 passing
- \`node test/soft-funding-tracker.test.js\` → 40/40 passing
- \`npm run audit:a11y\` → 0 critical / 0 serious (unchanged)

## Still coming (separate PRs)

- **#3** PMA address-based site selection (free Census Geocoder)
- **#4** HNA Housing Authorities directory (HUD PIH contact list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)