### PR TITLE
feat: PMA address-based site selection (free US Census Geocoder)

### DIFF
--- a/js/market-analysis.js
+++ b/js/market-analysis.js
@@ -1596,6 +1596,99 @@
       placeSiteMarker(e.latlng.lat, e.latlng.lng);
       runAnalysis(e.latlng.lat, e.latlng.lng);
     });
+
+    // Address-based site selection via free US Census Geocoder.
+    // No API key required; rate-limit is generous (docs say "reasonable
+    // interactive use"). Restricts results to Colorado (STATE=08) because
+    // our downstream PMA analysis only has CO data loaded.
+    _wireAddressSearch();
+  }
+
+  /**
+   * Wire up the "Find a Colorado address" input/button to the free US
+   * Census Geocoder. Picks the first match, validates it's in Colorado
+   * (STATE=08), then fires the existing placeSiteMarker + runAnalysis
+   * flow — same code path as a map click.
+   */
+  function _wireAddressSearch() {
+    var input = document.getElementById('pmaAddressInput');
+    var btn   = document.getElementById('pmaAddressSearchBtn');
+    var status = document.getElementById('pmaAddressStatus');
+    if (!input || !btn || !status) return;   // page variant without search UI
+
+    function _setStatus(msg, level) {
+      status.textContent = msg || '';
+      status.style.color = level === 'error' ? 'var(--bad, #c0392b)'
+                        : level === 'ok' ? 'var(--good, #047857)'
+                        : 'var(--muted, #666)';
+    }
+
+    function _submit() {
+      var q = (input.value || '').trim();
+      if (!q) {
+        _setStatus('Enter a Colorado street address or landmark.', 'error');
+        input.focus();
+        return;
+      }
+      if (!dataLoaded) {
+        _setStatus('Data is still loading — wait a moment then try again.', 'error');
+        return;
+      }
+      btn.disabled = true;
+      _setStatus('Geocoding “' + q + '” via US Census Geocoder…', 'info');
+
+      // US Census Geocoder — free, no key. Public_AR_Current = latest
+      // address ranges. format=json returns coords in WGS84.
+      // Docs: https://geocoding.geo.census.gov/geocoder/Geocoding_Services_API.pdf
+      var url = 'https://geocoding.geo.census.gov/geocoder/locations/onelineaddress' +
+                '?address=' + encodeURIComponent(q) +
+                '&benchmark=Public_AR_Current' +
+                '&format=json';
+
+      fetch(url)
+        .then(function (r) {
+          if (!r.ok) throw new Error('Census Geocoder HTTP ' + r.status);
+          return r.json();
+        })
+        .then(function (d) {
+          var matches = (d && d.result && d.result.addressMatches) || [];
+          if (!matches.length) {
+            throw new Error('No match found. Try including the city + CO (e.g. "Main St, Pueblo CO").');
+          }
+          // First match is highest-confidence per Census API convention.
+          var m = matches[0];
+          var coords = m.coordinates || {};
+          var lon = parseFloat(coords.x);   // Census returns x=lon, y=lat
+          var lat = parseFloat(coords.y);
+          if (!isFinite(lat) || !isFinite(lon)) {
+            throw new Error('Geocoder returned invalid coordinates.');
+          }
+          // Validate it's in Colorado via STATE from addressComponents. We
+          // could also bounds-check lat/lon against CO (37-41°N, -109--102°W),
+          // but the STATE field from the geocoder is more reliable.
+          var addr = (m.addressComponents && m.addressComponents.state) || '';
+          if (addr && String(addr).toUpperCase() !== 'CO') {
+            throw new Error('Address resolved to ' + addr + ' — this site is Colorado-only. Add "CO" to your query.');
+          }
+          // Hand off to the same flow as a map click.
+          map.setView([lat, lon], 13);
+          placeSiteMarker(lat, lon);
+          runAnalysis(lat, lon);
+          _setStatus('Placed at ' + (m.matchedAddress || q) +
+                     ' (' + lat.toFixed(4) + ', ' + lon.toFixed(4) + ')', 'ok');
+        })
+        .catch(function (err) {
+          _setStatus(err.message || 'Geocoding failed. Try clicking the map instead.', 'error');
+        })
+        .then(function () {
+          btn.disabled = false;
+        });
+    }
+
+    btn.addEventListener('click', _submit);
+    input.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') { e.preventDefault(); _submit(); }
+    });
   }
 
   /* ── Overlay layer styles ────────────────────────────────────────── */

--- a/market-analysis.html
+++ b/market-analysis.html
@@ -271,8 +271,28 @@
           </label>
           <span id="pmaSiteCoords" style="font-size:var(--tiny);color:var(--text);margin-left:auto">No site selected</span>
         </div>
+        <!-- Address-based site selection — alternative to map-click.
+             Uses free Census Geocoder (no API key) + restricts to Colorado. -->
+        <div class="pma-address-search" role="search"
+             style="display:flex;align-items:center;gap:.5rem;margin:.6rem 0 .4rem;padding:.5rem .6rem;border:1px solid var(--border);border-radius:6px;background:var(--bg2);flex-wrap:wrap">
+          <label for="pmaAddressInput" style="font-size:.78rem;font-weight:600;color:var(--muted);white-space:nowrap">
+            Find a Colorado address:
+          </label>
+          <input id="pmaAddressInput" type="search"
+                 placeholder="e.g. 1437 Bannock St, Denver CO"
+                 aria-label="Colorado street address or place name"
+                 autocomplete="street-address"
+                 style="flex:1 1 240px;min-width:220px;padding:.35rem .5rem;border:1px solid var(--border);border-radius:4px;background:var(--card);color:var(--text);font-size:.85rem">
+          <button id="pmaAddressSearchBtn" type="button"
+                  style="padding:.35rem .85rem;font-size:.8rem;font-weight:700;border:1px solid var(--accent);background:var(--accent);color:#fff;border-radius:4px;cursor:pointer"
+                  aria-label="Geocode address and drop site marker">
+            Find &amp; drop pin
+          </button>
+          <span id="pmaAddressStatus" role="status" aria-live="polite"
+                style="font-size:.74rem;color:var(--muted);flex-basis:100%"></span>
+        </div>
         <div id="pmaMap" role="application" aria-label="Colorado map — click to place a site marker"></div>
-        <div class="pma-map-hint">Click anywhere on the map to place a site and run PMA scoring.</div>
+        <div class="pma-map-hint">Click anywhere on the map to place a site — or type an address above. Uses the free US Census Geocoder (no API key required).</div>
 
         <!-- ── Boundary overlays ── -->
         <details class="map-layer-details map-layer-section" open>


### PR DESCRIPTION
Addresses the \"PMA select by address\" request. Placing a site on the PMA map previously required clicking — fine for a known spot, friction-heavy for address-first workflows (developer research, phone screening, CSV paste).

## UI

New search row above the map:
\`\`\`
[ Find a Colorado address:  ] [input                         ] [Find & drop pin]
[ aria-live status                                                             ]
\`\`\`

Placeholder: \"1437 Bannock St, Denver CO\". Style matches the existing buffer-control row.

## Geocoder — free, no API key

US Census Geocoder (\`geocoding.geo.census.gov\`):
- \`benchmark=Public_AR_Current\` — latest address ranges
- \`format=json\`, \`onelineaddress\` endpoint
- Returns WGS84 coords (\`x\`=lon, \`y\`=lat)

Validates state via \`addressComponents.state\` — rejects non-CO matches before firing PMA scoring. First match (highest confidence) is used.

## Why Census (not Mapbox / Google)

- Free, no key, generous interactive rate limits
- Colorado coverage is complete (Census owns the authoritative address ranges)
- No privacy / referrer concerns (government source, no tracking)
- Aligns with repo's \"everything from public data\" philosophy
- Graceful degradation: if endpoint is down, map-click still works

## Error-handling (surfaced via aria-live status)

| Condition | Message |
|---|---|
| Empty query | \"Enter a Colorado street address or landmark.\" |
| Data still loading | \"Data is still loading — wait a moment…\" |
| No match | \"Try including city + CO…\" |
| Non-CO match | \"Resolved to \\<state\\> — add CO to your query.\" |
| HTTP failure | Error message surfaced verbatim |

## Verification

- Live probe: \`1437 Bannock St Denver CO\` → (39.7390, -104.9903) ✓
- \`npm run test:hna\` → 688/688 passing
- \`npm run audit:a11y\` → 0 critical / 0 serious (aria-label, aria-live, autocomplete all set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)