### PR TITLE
feat: Land Value & Negotiation — dedicated page (closes deployment guide Phase F)

### DIFF
--- a/data/reports/a11y-baseline.json
+++ b/data/reports/a11y-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-22T19:06:01.808Z",
+  "generatedAt": "2026-04-23T13:57:46.133Z",
   "summary": {
     "byImpact": {
       "critical": 0,
@@ -9,7 +9,7 @@
     },
     "byRule": {},
     "totalNodes": 0,
-    "pageCount": 14
+    "pageCount": 15
   },
   "results": [
     {
@@ -43,9 +43,9 @@
     {
       "page": "lihtc-allocations.html",
       "violations": [],
-      "passCount": 30,
-      "incompleteCount": 2,
-      "inapplicable": 31
+      "passCount": 28,
+      "incompleteCount": 3,
+      "inapplicable": 32
     },
     {
       "page": "colorado-deep-dive.html",
@@ -78,9 +78,9 @@
     {
       "page": "market-analysis.html",
       "violations": [],
-      "passCount": 38,
+      "passCount": 39,
       "incompleteCount": 2,
-      "inapplicable": 23
+      "inapplicable": 22
     },
     {
       "page": "deal-calculator.html",
@@ -88,6 +88,13 @@
       "passCount": 33,
       "incompleteCount": 1,
       "inapplicable": 28
+    },
+    {
+      "page": "land-value.html",
+      "violations": [],
+      "passCount": 28,
+      "incompleteCount": 1,
+      "inapplicable": 33
     },
     {
       "page": "housing-legislation-2026.html",

--- a/docs/reports/a11y-baseline-2026.md
+++ b/docs/reports/a11y-baseline-2026.md
@@ -1,8 +1,8 @@
 # WCAG 2.1 AA accessibility baseline — 2026
 
-_Generated: 2026-04-22T19:06:01.809Z_
+_Generated: 2026-04-23T13:57:46.134Z_
 
-Audited 14 page(s) via axe-core. Any regression from this baseline will appear in the diff of this file on the next weekly run.
+Audited 15 page(s) via axe-core. Any regression from this baseline will appear in the diff of this file on the next weekly run.
 
 ## Summary by impact
 
@@ -47,8 +47,8 @@ Audited 14 page(s) via axe-core. Any regression from this baseline will appear i
 
 ### lihtc-allocations.html
 
-- Passing rules: **30**
-- Incomplete (needs manual check): **2**
+- Passing rules: **28**
+- Incomplete (needs manual check): **3**
 - Violations: **0** (0 element(s))
 
 ### colorado-deep-dive.html
@@ -77,13 +77,19 @@ Audited 14 page(s) via axe-core. Any regression from this baseline will appear i
 
 ### market-analysis.html
 
-- Passing rules: **38**
+- Passing rules: **39**
 - Incomplete (needs manual check): **2**
 - Violations: **0** (0 element(s))
 
 ### deal-calculator.html
 
 - Passing rules: **33**
+- Incomplete (needs manual check): **1**
+- Violations: **0** (0 element(s))
+
+### land-value.html
+
+- Passing rules: **28**
 - Incomplete (needs manual check): **1**
 - Violations: **0** (0 element(s))
 

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -41,6 +41,7 @@
         { label: "Colorado Deep Dive",    href: "colorado-deep-dive.html",        desc: "County-level LIHTC & market overview" },
         { label: "CHFA Portfolio",        href: "chfa-portfolio.html",            desc: "Browse CHFA LIHTC projects" },
         { label: "Economic Dashboard",    href: "economic-dashboard.html",        desc: "FRED indicators for deal timing" },
+        { label: "Land Value & Negotiation", href: "land-value.html",            desc: "Market comps + residual bid for site negotiation" },
         { label: "LIHTC Allocations",     href: "lihtc-allocations.html",         desc: "National per-capita allocation data" },
         { label: "Preservation Tracking", href: "preservation.html",              desc: "NHPD subsidy expiry risk" },
       ]

--- a/land-value.html
+++ b/land-value.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="theme-color" content="#096e65" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#0fd4cf" media="(prefers-color-scheme: dark)">
+  <title>Land Value &amp; Negotiation | COHO Analytics</title>
+  <meta name="description" content="Educational land value estimation and negotiation-support tool for early-stage LIHTC development in Colorado. Comparable sales analysis + residual land value + negotiation band." />
+  <meta property="og:title" content="Land Value &amp; Negotiation | COHO Analytics">
+  <meta property="og:description" content="Educational land valuation tool for early-stage LIHTC development. Not a formal appraisal.">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="assets/og-image.png">
+  <link rel="stylesheet" href="css/site-theme.css">
+  <link rel="stylesheet" href="css/layout.css">
+  <link rel="stylesheet" href="css/pages.css">
+  <link rel="stylesheet" href="css/responsive.css">
+  <!-- Sync: required before deferred modules -->
+  <script src="js/path-resolver.js"></script>
+  <script src="js/config.js"></script>
+  <script src="js/workflow-state-core.js"></script>
+  <script src="js/workflow-state-api.js"></script>
+  <script defer src="js/components/page-context.js"></script>
+  <script src="js/fetch-helper.js"></script>
+  <script src="js/site-state.js"></script>
+  <!-- Deferred: navigation and UI -->
+  <script defer src="js/navigation.js"></script>
+  <script defer src="js/dark-mode-toggle.js"></script>
+  <script defer src="js/mobile-menu.js"></script>
+  <!-- Toast notifications (must load before component scripts) -->
+  <script defer src="js/components/toast.js"></script>
+  <!-- Source + data-quality UI utilities -->
+  <script defer src="js/components/source-badge.js"></script>
+  <script defer src="js/components/data-quality-summary.js"></script>
+  <!-- Deferred: land value tool (renders into #landValueMount) -->
+  <script defer src="js/components/land-value-tool.js"></script>
+</head>
+<body data-page-last-updated="2026-04-23"
+      data-page-source="User-entered comparables + residual valuation">
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+
+  <header class="site-header">
+    <!-- Injected by navigation.js -->
+  </header>
+
+  <main id="main-content">
+
+    <!-- ── Jurisdiction context banner ───────────────────────────────── -->
+    <div id="lvJurisdictionBanner" class="hna-jurisdiction-banner" hidden>
+      <div class="hna-jurisdiction-banner__inner">
+        <div class="hna-jurisdiction-banner__info">
+          <span class="hna-jurisdiction-banner__label">Analyzing</span>
+          <strong id="lvJurisdictionName">—</strong>
+          <span id="lvJurisdictionSub" class="hna-jurisdiction-banner__sub"></span>
+        </div>
+        <div class="hna-jurisdiction-banner__actions">
+          <a href="select-jurisdiction.html" class="hna-jurisdiction-banner__change">Change</a>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── Editorial header ───────────────────────────────────────────── -->
+    <div class="dc-hero">
+      <div class="kicker">Land Value &amp; Negotiation</div>
+      <h1>What is a site worth to a LIHTC developer?</h1>
+      <p class="dc-lead">
+        Two valuation approaches, one tool. Enter your comparable sales to estimate market land value,
+        and model a residual bid based on your project's feasibility envelope. The negotiation band
+        between seller ask and developer max tells you where a deal actually has room to close.
+      </p>
+      <p style="font-size:.82rem;color:var(--muted);margin-top:.25rem;" role="note">
+        <strong>Educational + negotiation-support only.</strong> This tool is not a formal appraisal.
+        Market value estimates depend on comp quality and user adjustments; residual estimates depend
+        on your project assumptions. For offer letters, refinancing, or capital-stack commitments,
+        always engage an MAI or state-certified appraiser.
+      </p>
+    </div>
+
+    <div id="pageContext" style="max-width:1200px;margin:0 auto;padding:0 18px;"></div>
+    <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      if (window.PageContext) PageContext.render('pageContext', {
+        what: 'Two valuation paths in one place: (1) Market value from comparable sales you enter — you\u2019re the local knowledge source, the tool does the math; (2) Residual value from development feasibility — what your pro-forma can actually support. Outputs: market range, developer max bid, negotiation band, and a confidence score based on input completeness.',
+        why: 'Land is the single most negotiable line in a LIHTC pro forma. Sellers anchor on highest-and-best-use market value; developers anchor on what the deal can support given AMI-restricted rents. Knowing both gives you room to structure the offer — and to walk away from sites where the gap is unbridgeable.',
+        not: 'This does NOT replace a professional appraisal (MAI or state-certified). It does NOT access real-time MLS / assessor / CoStar data. It does NOT account for entitlement risk, environmental remediation, or off-site improvement costs unless you enter them. It does NOT model a ground-lease structure — that requires different inputs.',
+        nextSteps: [
+          { label: 'Market Analysis &amp; PMA', href: 'market-analysis.html', desc: 'Run PMA + site scoring for your chosen location' },
+          { label: 'Deal Calculator', href: 'deal-calculator.html', desc: 'Model the capital stack with land cost included' },
+          { label: 'LIHTC Guide', href: 'lihtc-guide-for-stakeholders.html', desc: 'Review how residual valuation fits in the LIHTC workflow' }
+        ]
+      });
+    });
+    </script>
+
+    <!-- ── Data Quality Summary ──────────────────────────────────────── -->
+    <div id="lvDataQuality" style="max-width:1200px;margin:1rem auto;padding:0 18px;"></div>
+    <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      if (window.DataQualitySummary) {
+        window.DataQualitySummary.render('lvDataQuality', {
+          sources: [
+            { name: 'Comparable sales', status: 'user-entered', vintage: 'varies', coverage: 'Depends on your comp research (county assessor, CoStar, LoopNet, MLS closed sales)', note: 'You are the data source. Enter 3+ comps for usable results.' },
+            { name: 'Residual valuation inputs', status: 'user-entered', vintage: 'N/A', coverage: 'Your project feasibility assumptions', note: 'TDC, equity + debt capacity, soft sources, deferred fee, offsite/remediation costs' },
+            { name: 'Confidence scoring', status: 'derived', vintage: 'live', coverage: 'Based on input completeness + comp count', note: 'Moderate ≥70, Low 40\u201369, Very Low <40' }
+          ],
+          limitations: 'Educational and negotiation-support tool. No live market data feed — accuracy depends entirely on the quality of comps and assumptions you enter. Use for screening and structuring; do not use for offer letters or refinancing appraisals.'
+        });
+      }
+    });
+    </script>
+
+    <!-- ── Land Value Tool mount ─────────────────────────────────────── -->
+    <div style="max-width:1200px;margin:1.5rem auto;padding:0 18px;">
+      <div id="landValueMount"></div>
+      <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        if (window.LandValueTool) LandValueTool.render('landValueMount');
+      });
+      </script>
+    </div>
+
+    <!-- ── Educational context section ───────────────────────────────── -->
+    <section style="max-width:1200px;margin:2rem auto;padding:0 18px;">
+      <div class="chart-card">
+        <h2 style="margin-top:0;">How this tool is used in practice</h2>
+
+        <h3 style="color:var(--accent);margin-top:1rem;">Market value from comparables</h3>
+        <p style="line-height:1.7;">
+          The first valuation approach mirrors how an appraiser would size up a site — by comparing
+          recent sales of similar land nearby. The tool asks you to enter at least 3 comparable sales
+          with acreage, sale price, and a date. It computes a median <code>$/acre</code> and applies
+          that to your site's acreage. The range between lowest and highest comp is your <em>market
+          range</em>; the median is your <em>market estimate</em>.
+        </p>
+        <p style="line-height:1.7;">
+          <strong>Where to find comps:</strong>
+        </p>
+        <ul style="line-height:1.8;">
+          <li><strong>County assessor:</strong> public record of sales, usually free via the assessor's web portal (e.g., <a href="https://www.denvergov.org/Government/Agencies-Departments-Offices/Agencies-Departments-Offices-Directory/Assessor" target="_blank" rel="noopener">Denver</a>, <a href="https://www.bouldercounty.org/property-and-land/assessor/" target="_blank" rel="noopener">Boulder County</a>)</li>
+          <li><strong>CoStar / LoopNet / Crexi:</strong> commercial platforms with filtering by land use, zoning, transaction date — paid subscription</li>
+          <li><strong>MLS:</strong> land category; REALTOR access required for closed sales data</li>
+          <li><strong>LIHTC + affordable-housing peers:</strong> talk to other developers. Comparable <em>multifamily-entitled</em> land in your market is often sold off-market and doesn't appear in public databases</li>
+          <li><strong>CHFA historical awards:</strong> prior LIHTC deals publicly disclose site acquisition costs — the
+            <a href="chfa-portfolio.html">CHFA Portfolio</a> page on this site shows project-level data for Colorado deals</li>
+        </ul>
+        <p style="line-height:1.7;">
+          <strong>Adjustment judgment:</strong> Raw $/acre across heterogeneous parcels can mislead. A 2-acre infill
+          parcel in Denver isn't directly comparable to a 20-acre greenfield in Weld County even if both recently sold.
+          Best practice: limit comps to the same zoning class, similar entitlement status, and within 12-24 months.
+          Apply qualitative adjustments (better transit, lower flood risk, utility availability) as confidence
+          context, not as a dollar-amount fudge.
+        </p>
+
+        <h3 style="color:var(--accent);margin-top:1.5rem;">Residual land value</h3>
+        <p style="line-height:1.7;">
+          The second valuation approach starts from the other end of the deal: what's the <em>maximum a
+          developer can afford to pay</em> for this land given the project's feasibility envelope?
+        </p>
+        <pre style="background:var(--bg2);padding:1rem;border-radius:6px;font-size:.9rem;line-height:1.6;overflow-x:auto;">
+Residual = (Equity + Debt + Soft Sources + Deferred Fee)
+           − (Total Development Cost excluding land)
+
+Where:
+  Equity        = 9% or 4% credit × 10 years × syndicator price
+  Debt          = NOI ÷ DSCR ÷ mortgage constant
+  Soft Sources  = CHFA HTF, HOME, DOLA HTF, local trust fund, etc.
+  Deferred Fee  = ~50% of developer fee, paid from cash flow yrs 8-15
+  TDC           = Hard + soft + developer fee (ex-land)
+</pre>
+        <p style="line-height:1.7;">
+          If the seller's asking price is below your residual value, the deal has <strong>margin</strong> — room
+          to negotiate and still close. If asking price is above residual, you need a public-land contribution,
+          a seller carry-note, or to walk away. The tool surfaces these outcomes explicitly via the negotiation
+          band chart.
+        </p>
+        <p style="line-height:1.7;">
+          <strong>When residual is lower than market:</strong> common in resort/high-cost markets where land pricing
+          is driven by luxury demand, not LIHTC economics. Solutions: PHA land donation, ground lease (typically
+          99-year for LIHTC compliance), Prop 123 Land Banking Fund, or community benefits negotiation with
+          the seller to bridge the gap.
+        </p>
+
+        <h3 style="color:var(--accent);margin-top:1.5rem;">Negotiation band interpretation</h3>
+        <p style="line-height:1.7;">
+          The tool outputs four price points — Seller's ask (high comp), Market (median comp), Public-partner
+          price (if a discount is entered), and Developer max (residual). The visual bars show the <em>spread
+          where a deal has room</em>:
+        </p>
+        <ul style="line-height:1.8;">
+          <li><strong>Developer max ≥ Market:</strong> project can afford market-rate land. Negotiate from strength.</li>
+          <li><strong>Developer max ≥ Public partner, &lt; Market:</strong> project needs a below-market deal, but a PHA / Prop 123 Land Banking contribution can close the gap.</li>
+          <li><strong>Developer max &gt; $0, &lt; Public partner:</strong> substantial gap. Ground lease, donated land, or seller carry-note likely required.</li>
+          <li><strong>Developer max = $0 or negative:</strong> deal cannot support any land acquisition cost. Don't pursue unless a land donation is on the table.</li>
+        </ul>
+
+        <h3 style="color:var(--accent);margin-top:1.5rem;">Further reading</h3>
+        <ul style="line-height:1.8;">
+          <li><a href="https://www.appraisalinstitute.org" target="_blank" rel="noopener">Appraisal Institute</a> — MAI certification directory; <em>The Appraisal of Real Estate</em> (14th ed.) covers residual and sales-comparison methods formally</li>
+          <li><a href="https://www.novoco.com/resource-centers/affordable-housing-tax-credits" target="_blank" rel="noopener">Novogradac LIHTC Resource Center</a> — developer-perspective writeups on land valuation in LIHTC deals</li>
+          <li><a href="https://www.cohnreznick.com/industries/affordable-housing" target="_blank" rel="noopener">CohnReznick Affordable Housing Credit Study</a> — operating-performance benchmarks that inform residual assumptions</li>
+          <li><a href="https://cdola.colorado.gov/prop-123" target="_blank" rel="noopener">DOLA Prop 123 Land Banking Fund</a> — Colorado-specific land-acquisition subsidy for future affordable-housing development</li>
+        </ul>
+      </div>
+    </section>
+
+  </main>
+  <script defer src="js/scroll-fix.js"></script>
+</body>
+</html>

--- a/scripts/audit/a11y-audit.mjs
+++ b/scripts/audit/a11y-audit.mjs
@@ -49,6 +49,7 @@ const AUDIT_PAGES = [
   'regional.html',
   'market-analysis.html',
   'deal-calculator.html',
+  'land-value.html',
   'housing-legislation-2026.html',
   'about.html',
   'insights.html',


### PR DESCRIPTION
Closes the last Phase F item from the original deployment guide. The \`LandValueTool\` component (\`js/components/land-value-tool.js\`, 397 lines, production-ready) has been built for a while but was only mounted inside the Deal Calculator — no direct link, no discoverability, no standalone context.

## New page: \`land-value.html\`

- **Editorial hero** — \"What is a site worth to a LIHTC developer?\" with educational-not-appraisal positioning up front
- **PageContext** — what / why / not / nextSteps (same pattern as HNA / PMA / Deal Calc)
- **DataQualitySummary** — explicit that comps + residual inputs are USER-ENTERED, no live data feed
- **LandValueTool mount** — renders the existing 397-line component
- **Educational context section** below the tool:
  - How to find comparable sales (assessor, CoStar, MLS, CHFA portfolio peers)
  - Residual valuation formula
  - Negotiation band interpretation — 4 outcomes: deal has margin / needs public-partner discount / needs donated land / infeasible
  - Further reading (Appraisal Institute, Novogradac, CohnReznick, DOLA Prop 123 Land Banking)

## Navigation

Added \"Land Value & Negotiation\" to the \"Explore\" menu group between Economic Dashboard and LIHTC Allocations. Description: *\"Market comps + residual bid for site negotiation.\"*

## Audit wiring

Added to \`AUDIT_PAGES\` in \`scripts/audit/a11y-audit.mjs\`. Fresh audit: **0 critical / 0 serious** on the new page.

## Why this matters

A LIHTC developer's toughest negotiation is almost always land acquisition. Knowing BOTH the market-derived value AND the residual-derived max before making an offer determines whether the deal closes. This tool has the math; the page gives developers context for HOW to use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)