### PR TITLE
feat: Historical Trends & Benchmarks page (Phase 4 B-3)

### DIFF
--- a/data/reports/a11y-baseline.json
+++ b/data/reports/a11y-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-23T13:57:46.133Z",
+  "generatedAt": "2026-04-23T14:06:41.970Z",
   "summary": {
     "byImpact": {
       "critical": 0,
@@ -43,9 +43,9 @@
     {
       "page": "lihtc-allocations.html",
       "violations": [],
-      "passCount": 28,
-      "incompleteCount": 3,
-      "inapplicable": 32
+      "passCount": 30,
+      "incompleteCount": 2,
+      "inapplicable": 31
     },
     {
       "page": "colorado-deep-dive.html",
@@ -90,11 +90,11 @@
       "inapplicable": 28
     },
     {
-      "page": "land-value.html",
+      "page": "historical-trends.html",
       "violations": [],
-      "passCount": 28,
+      "passCount": 31,
       "incompleteCount": 1,
-      "inapplicable": 33
+      "inapplicable": 30
     },
     {
       "page": "housing-legislation-2026.html",

--- a/docs/reports/a11y-baseline-2026.md
+++ b/docs/reports/a11y-baseline-2026.md
@@ -1,6 +1,6 @@
 # WCAG 2.1 AA accessibility baseline — 2026
 
-_Generated: 2026-04-23T13:57:46.134Z_
+_Generated: 2026-04-23T14:06:41.971Z_
 
 Audited 15 page(s) via axe-core. Any regression from this baseline will appear in the diff of this file on the next weekly run.
 
@@ -47,8 +47,8 @@ Audited 15 page(s) via axe-core. Any regression from this baseline will appear i
 
 ### lihtc-allocations.html
 
-- Passing rules: **28**
-- Incomplete (needs manual check): **3**
+- Passing rules: **30**
+- Incomplete (needs manual check): **2**
 - Violations: **0** (0 element(s))
 
 ### colorado-deep-dive.html
@@ -87,9 +87,9 @@ Audited 15 page(s) via axe-core. Any regression from this baseline will appear i
 - Incomplete (needs manual check): **1**
 - Violations: **0** (0 element(s))
 
-### land-value.html
+### historical-trends.html
 
-- Passing rules: **28**
+- Passing rules: **31**
 - Incomplete (needs manual check): **1**
 - Violations: **0** (0 element(s))
 

--- a/historical-trends.html
+++ b/historical-trends.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="theme-color" content="#096e65" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#0fd4cf" media="(prefers-color-scheme: dark)">
+  <title>Historical Trends &amp; Benchmarks | COHO Analytics</title>
+  <meta name="description" content="Colorado LIHTC award history, stock trajectory, and peer project benchmarks. Developers use this to calibrate QAP submissions; asset managers use it to benchmark operating performance." />
+  <meta property="og:title" content="Historical Trends &amp; Benchmarks | COHO Analytics">
+  <meta property="og:description" content="LIHTC award history, stock trajectory, peer benchmarks for Colorado">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="assets/og-image.png">
+  <link rel="stylesheet" href="css/site-theme.css">
+  <link rel="stylesheet" href="css/layout.css">
+  <link rel="stylesheet" href="css/pages.css">
+  <link rel="stylesheet" href="css/responsive.css">
+  <style>
+    .ht-panel { background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: 1.25rem 1.5rem; margin-bottom: 1.5rem; }
+    .ht-panel h2 { margin-top: 0; font-size: 1.15rem; color: var(--text); }
+    .ht-panel .ht-intro { font-size: .88rem; color: var(--muted); line-height: 1.55; margin-bottom: .75rem; }
+    .ht-chart-wrap { position: relative; height: 340px; margin: 0.75rem 0; }
+    .ht-stat-list { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: .5rem; margin: 0; padding: 0; }
+    .ht-stat-list > div { padding: .5rem .65rem; border: 1px solid var(--border); border-radius: 6px; background: var(--bg2); }
+    .ht-stat-list dt { font-size: .68rem; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); font-weight: 700; }
+    .ht-stat-list dd { font-size: 1.05rem; font-weight: 700; color: var(--text); margin: 2px 0 0; }
+    .ht-bench-controls { display: flex; gap: .75rem; margin-bottom: .75rem; flex-wrap: wrap; align-items: flex-end; }
+    .ht-bench-controls label { display: flex; flex-direction: column; font-size: .78rem; color: var(--muted); }
+    .ht-bench-controls select,
+    .ht-bench-controls input { padding: .4rem .55rem; border: 1px solid var(--border); border-radius: 4px; background: var(--card); color: var(--text); font-size: .88rem; min-width: 180px; }
+    .ht-bench-table { width: 100%; border-collapse: collapse; font-size: .85rem; }
+    .ht-bench-table th { background: var(--bg2); padding: .5rem .65rem; text-align: left; font-weight: 700; color: var(--muted); border-bottom: 2px solid var(--border); }
+    .ht-bench-table td { padding: .5rem .65rem; border-bottom: 1px solid var(--border); }
+    .ht-empty { text-align: center; color: var(--muted); padding: 1rem; font-style: italic; }
+    .ht-error-banner { padding: 0.8rem 1rem; background: var(--bad-dim,#fee2e2); color: var(--bad,#991b1b); border: 1px solid var(--bad,#ef4444); border-radius: 6px; margin-bottom: 1rem; }
+  </style>
+  <script src="js/path-resolver.js"></script>
+  <script src="js/config.js"></script>
+  <script src="js/fetch-helper.js"></script>
+  <script defer src="js/navigation.js"></script>
+  <script defer src="js/dark-mode-toggle.js"></script>
+  <script defer src="js/mobile-menu.js"></script>
+  <script defer src="js/components/page-context.js"></script>
+  <script defer src="js/components/data-quality-summary.js"></script>
+  <script defer src="js/vendor/chart.umd.min.js"></script>
+  <script defer src="js/historical-trends.js"></script>
+</head>
+<body data-page-last-updated="2026-04-23"
+      data-page-source="CHFA Awards Historical · HUD LIHTC DB">
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+
+  <header class="site-header">
+    <!-- Injected by navigation.js -->
+  </header>
+
+  <main id="main-content">
+    <div style="max-width:1200px;margin:0 auto;padding:1.5rem 18px;">
+
+      <!-- Editorial header -->
+      <div class="dc-hero">
+        <div class="kicker">Historical Trends &amp; Benchmarks</div>
+        <h1>What have past LIHTC deals in Colorado actually looked like?</h1>
+        <p class="dc-lead">
+          Three lenses on Colorado's LIHTC history: CHFA award patterns (helps calibrate
+          a QAP submission), LIHTC stock trajectory (shows when each county absorbed its
+          investment), and a peer benchmark table (find comparable projects by county + size).
+        </p>
+        <p style="font-size:.82rem;color:var(--muted);margin-top:.25rem;" role="note">
+          <strong>Historical data, not forecasts.</strong> These panels describe what happened — they
+          do not predict future awards, pricing, or market behavior. Use for calibration, not
+          underwriting.
+        </p>
+      </div>
+
+      <div id="htErrorBanner" class="ht-error-banner" hidden></div>
+
+      <div id="pageContext"></div>
+      <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        if (window.PageContext) PageContext.render('pageContext', {
+          what: 'Three historical-data panels drawn from CHFA\u2019s award history (2015\u20132025) and HUD\u2019s LIHTC database for Colorado (716 projects). No forecasts or predictions \u2014 just "here is what the data says" for calibration and benchmarking.',
+          why: 'First-time LIHTC applicants consistently underestimate what it takes to win a 9% award; developers in unfamiliar markets need peer projects to calibrate unit counts and AMI mixes; asset managers benchmark operating performance against comparable CO projects. This page serves all three.',
+          not: 'This does NOT forecast future pricing, award counts, or market behavior. It does NOT include multi-year rent trajectories \u2014 current ACS data is single-vintage 2023. It does NOT substitute for a CHFA pre-app meeting or a syndicator-issued pricing letter.',
+          nextSteps: [
+            { label: 'CHFA Portfolio', href: 'chfa-portfolio.html', desc: 'Project-level detail for every CHFA award' },
+            { label: 'Deal Calculator', href: 'deal-calculator.html', desc: 'Model your capital stack against peer benchmarks' },
+            { label: 'LIHTC Guide', href: 'lihtc-guide-for-stakeholders.html', desc: 'Understand the award process before applying' }
+          ]
+        });
+      });
+      </script>
+
+      <!-- Data Quality Summary -->
+      <div id="htDataQuality"></div>
+      <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        if (window.DataQualitySummary) {
+          window.DataQualitySummary.render('htDataQuality', {
+            sources: [
+              { name: 'CHFA Awards Historical', status: 'primary', vintage: '2015\u20132025', coverage: '27-project sample + aggregate summary (110 total awards)', note: 'Sample data for visualization; aggregate stats reflect full population' },
+              { name: 'HUD LIHTC Database', status: 'primary', vintage: 'FY2024', coverage: '716 Colorado projects', note: 'HUD DB typically lags placement-in-service by ~18 months — most recent allocations may not yet appear' }
+            ],
+            limitations: 'Historical view only \u2014 not a forecast. Sample CHFA award data covers 27 projects in detail; summary statistics draw from the full 110-award population. HUD LIHTC DB lag means the 2024\u20132025 award years are under-represented until those projects reach placement-in-service.'
+          });
+        }
+      });
+      </script>
+
+      <!-- Panel 1: CHFA Award History -->
+      <section class="ht-panel" aria-labelledby="htCHFAHeading">
+        <h2 id="htCHFAHeading">CHFA Annual Award History</h2>
+        <p class="ht-intro">
+          How many 9% competitive vs. 4% PAB-backed awards CHFA has made each year, with aggregate
+          scoring statistics. Use this to calibrate your QAP submission \u2014 a 78-point score was
+          the 2015\u20132025 average; median was 80. Colorado awards ~10 projects/year against ~27
+          applications (37% overall win rate).
+        </p>
+        <div class="ht-chart-wrap">
+          <canvas id="chfaTimelineChart" role="img" aria-label="CHFA annual awards by credit type, 2015\u20132025"></canvas>
+        </div>
+        <div id="chfaStats"></div>
+        <p style="font-size:.72rem;color:var(--faint);margin:.75rem 0 0;">
+          Source: <a href="data/policy/chfa-awards-historical.json">chfa-awards-historical.json</a>
+          \u00b7 Verify current QAP cycle at
+          <a href="https://www.chfainfo.com/developers/rental-housing-and-funding/qualified-allocation-plan" target="_blank" rel="noopener">CHFA QAP</a>
+        </p>
+      </section>
+
+      <!-- Panel 2: LIHTC Stock Trajectory -->
+      <section class="ht-panel" aria-labelledby="htStockHeading">
+        <h2 id="htStockHeading">LIHTC Stock Trajectory (HUD Database)</h2>
+        <p class="ht-intro">
+          Cumulative Colorado LIHTC projects placed-in-service over time (line, left axis) with
+          annual placement counts (bars, right axis). Shows when each wave of state investment
+          landed \u2014 the mid-2010s multifamily expansion, the 2019\u20132021 acceleration, and
+          the lag from allocation to placement.
+        </p>
+        <div class="ht-chart-wrap">
+          <canvas id="stockTimelineChart" role="img" aria-label="Cumulative CO LIHTC projects over time"></canvas>
+        </div>
+        <div id="stockStats"></div>
+        <p style="font-size:.72rem;color:var(--faint);margin:.75rem 0 0;">
+          Source: <a href="data/market/hud_lihtc_co.geojson">hud_lihtc_co.geojson</a>
+          \u00b7 \u26a0 Verify against
+          <a href="https://www.chfainfo.com/developers/rental-housing-and-funding" target="_blank" rel="noopener">CHFA award history</a>
+          (HUD DB lags placement by \u224818 mo)
+        </p>
+      </section>
+
+      <!-- Panel 3: Peer Benchmark -->
+      <section class="ht-panel" aria-labelledby="htBenchHeading">
+        <h2 id="htBenchHeading">Peer Project Benchmark</h2>
+        <p class="ht-intro">
+          Pick a county (and optionally a target unit count) to see LIHTC projects in the same
+          market. Sorted by unit-count proximity when you enter a target, or by most-recent
+          allocation year otherwise. Use for AMI-mix calibration, unit-count sanity-checking,
+          and operating-performance benchmarking.
+        </p>
+        <div class="ht-bench-controls">
+          <label for="benchCounty">County
+            <select id="benchCounty" aria-label="Colorado county">
+              <option value="">Loading\u2026</option>
+            </select>
+          </label>
+          <label for="benchUnits">Target unit count (optional)
+            <input id="benchUnits" type="number" min="0" step="5" placeholder="e.g. 60" aria-label="Target unit count for peer comparison">
+          </label>
+        </div>
+        <p id="benchSummary" style="font-size:.85rem;color:var(--muted);margin:0 0 .5rem;"></p>
+        <div style="overflow-x:auto;">
+          <table class="ht-bench-table">
+            <thead>
+              <tr>
+                <th scope="col">Project</th>
+                <th scope="col">City</th>
+                <th scope="col" style="text-align:right">Units</th>
+                <th scope="col" style="text-align:right">Year allocated</th>
+                <th scope="col" style="text-align:right">Year PIS</th>
+                <th scope="col">Credit type</th>
+              </tr>
+            </thead>
+            <tbody id="benchTableBody">
+              <tr><td colspan="6" class="ht-empty">Select a county to see peer LIHTC projects.</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p style="font-size:.72rem;color:var(--faint);margin:.75rem 0 0;">
+          Top 20 closest-size peers shown. For full county project detail, see the
+          <a href="chfa-portfolio.html">CHFA Portfolio</a> page.
+        </p>
+      </section>
+
+    </div>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      if (window.HistoricalTrends) window.HistoricalTrends.render();
+    });
+    </script>
+  </main>
+
+  <script defer src="js/scroll-fix.js"></script>
+</body>
+</html>

--- a/js/historical-trends.js
+++ b/js/historical-trends.js
@@ -1,0 +1,358 @@
+/**
+ * js/historical-trends.js
+ *
+ * Renders three panels on historical-trends.html:
+ *   1. CHFA annual award history (awards/year + credit-type split + county roll-up)
+ *   2. LIHTC stock trajectory (cumulative projects by year, by county)
+ *   3. Peer benchmark table (given user-chosen county + unit count, find similar LIHTC projects)
+ *
+ * Data sources (all local, no external API):
+ *   - data/policy/chfa-awards-historical.json  — sample 2015–2025 awards + aggregate summary
+ *   - data/market/hud_lihtc_co.geojson         — HUD LIHTC DB, 716 CO projects with YR_ALLOC
+ *
+ * No rent trajectory panel: current ACS dataset is single-vintage (2023) and does not
+ * support time-series rent trends. Add it when multi-year ACS ingestion is in place.
+ *
+ * Charts use window.Chart (Chart.js) loaded from js/vendor/chart.umd.min.js.
+ *
+ * Exposes window.HistoricalTrends.render() — call on DOMContentLoaded.
+ */
+(function (global) {
+  'use strict';
+
+  var state = {
+    awards: null,         // chfa-awards-historical.json parsed
+    lihtcFeatures: null,  // hud_lihtc_co.geojson features
+    charts: {}            // Chart.js instance map (for teardown on re-render)
+  };
+
+  /* ─────────────────────────────────────────────────────────────── */
+  /* Helpers                                                         */
+  /* ─────────────────────────────────────────────────────────────── */
+
+  function esc(s) {
+    return String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  function groupBy(arr, keyFn) {
+    var out = {};
+    arr.forEach(function (x) {
+      var k = keyFn(x);
+      (out[k] = out[k] || []).push(x);
+    });
+    return out;
+  }
+
+  function uniqueSorted(arr) {
+    return Array.from(new Set(arr)).sort(function (a, b) {
+      return typeof a === 'number' ? a - b : String(a).localeCompare(String(b));
+    });
+  }
+
+  function _resolveUrl(path) {
+    return (typeof global.resolveAssetUrl === 'function')
+      ? global.resolveAssetUrl(path)
+      : path;
+  }
+
+  function _fetchJson(path) {
+    return fetch(_resolveUrl(path)).then(function (r) {
+      if (!r.ok) throw new Error('HTTP ' + r.status + ' for ' + path);
+      return r.json();
+    });
+  }
+
+  /* ─────────────────────────────────────────────────────────────── */
+  /* Panel 1: CHFA Award History                                     */
+  /* ─────────────────────────────────────────────────────────────── */
+
+  function _renderChfaPanel() {
+    if (!state.awards || !global.Chart) return;
+    var awards = state.awards.awards || [];
+    var summary = state.awards.summary || {};
+
+    // By-year aggregation
+    var years = uniqueSorted((summary.yearsAnalyzed || []).concat(awards.map(function (a) { return a.year; })));
+    var byYear = groupBy(awards, function (a) { return a.year; });
+    var yearCounts = years.map(function (y) { return (byYear[y] || []).length; });
+
+    // Credit-type split (9% vs 4%)
+    var nine = years.map(function (y) {
+      return (byYear[y] || []).filter(function (a) { return a.execution === '9%'; }).length;
+    });
+    var four = years.map(function (y) {
+      return (byYear[y] || []).filter(function (a) { return a.execution === '4%'; }).length;
+    });
+
+    // Destroy any existing chart
+    if (state.charts.chfaTimeline) state.charts.chfaTimeline.destroy();
+
+    var ctx = document.getElementById('chfaTimelineChart');
+    if (!ctx) return;
+
+    state.charts.chfaTimeline = new global.Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: years,
+        datasets: [
+          { label: '9% competitive', data: nine, backgroundColor: '#096e65' },
+          { label: '4% PAB-backed',  data: four, backgroundColor: '#b45309' }
+        ]
+      },
+      options: {
+        responsive: true,
+        plugins: {
+          title:  { display: true, text: 'Colorado LIHTC awards per year (by credit type)' },
+          legend: { position: 'bottom' }
+        },
+        scales: {
+          x: { stacked: true, title: { display: true, text: 'Year' } },
+          y: { stacked: true, title: { display: true, text: 'Project count (sample)' }, beginAtZero: true }
+        }
+      }
+    });
+
+    // Summary stats table
+    var statsEl = document.getElementById('chfaStats');
+    if (statsEl) {
+      statsEl.innerHTML =
+        '<dl class="ht-stat-list">' +
+          '<div><dt>Awards tracked</dt><dd>' + (summary.totalAwards || awards.length) + '</dd></div>' +
+          '<div><dt>Years covered</dt><dd>' + (years.length ? (years[0] + '–' + years[years.length - 1]) : '—') + '</dd></div>' +
+          '<div><dt>Average score</dt><dd>' + (summary.avgScore || '—') + ' / 100</dd></div>' +
+          '<div><dt>Median score</dt><dd>' + (summary.medianScore || '—') + ' / 100</dd></div>' +
+          '<div><dt>Avg awards / yr</dt><dd>' + (summary.avgAwardsPerYear || '—') + '</dd></div>' +
+          '<div><dt>Avg applications / yr</dt><dd>' + (summary.avgApplicationsPerYear || '—') + '</dd></div>' +
+          '<div><dt>Award rate</dt><dd>' +
+            (summary.awardRate != null ? (Math.round(summary.awardRate * 100) + '%') : '—') +
+          '</dd></div>' +
+          '<div><dt>Family win rate</dt><dd>' +
+            (summary.familyWinRate != null ? (Math.round(summary.familyWinRate * 100) + '%') : '—') +
+          '</dd></div>' +
+        '</dl>';
+    }
+  }
+
+  /* ─────────────────────────────────────────────────────────────── */
+  /* Panel 2: LIHTC Stock Trajectory                                 */
+  /* ─────────────────────────────────────────────────────────────── */
+
+  function _renderStockPanel() {
+    if (!state.lihtcFeatures || !global.Chart) return;
+    var feats = state.lihtcFeatures;
+
+    // Year-allocated histogram → cumulative
+    var years = feats.map(function (f) {
+      var p = f.properties || {};
+      return parseInt(p.YR_ALLOC || p.YEAR_ALLOC || p.YR_PIS || 0, 10);
+    }).filter(function (y) { return y > 1985 && y <= new Date().getFullYear(); });
+
+    var minYr = Math.min.apply(null, years) || 1987;
+    var maxYr = Math.max.apply(null, years) || new Date().getFullYear();
+    var yrLabels = [];
+    for (var y = minYr; y <= maxYr; y++) yrLabels.push(y);
+
+    var byYear = {};
+    years.forEach(function (y) { byYear[y] = (byYear[y] || 0) + 1; });
+    var perYear = yrLabels.map(function (y) { return byYear[y] || 0; });
+    var cumul = perYear.reduce(function (acc, v, i) {
+      acc.push((acc[i - 1] || 0) + v);
+      return acc;
+    }, []);
+
+    if (state.charts.stockTimeline) state.charts.stockTimeline.destroy();
+
+    var ctx = document.getElementById('stockTimelineChart');
+    if (!ctx) return;
+
+    state.charts.stockTimeline = new global.Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: yrLabels,
+        datasets: [
+          {
+            label: 'Cumulative CO LIHTC projects',
+            data: cumul,
+            borderColor: '#096e65',
+            backgroundColor: 'rgba(9,110,101,0.15)',
+            fill: true,
+            tension: 0.15,
+            yAxisID: 'y'
+          },
+          {
+            label: 'Annual LIHTC placements',
+            data: perYear,
+            type: 'bar',
+            backgroundColor: 'rgba(180,83,9,0.7)',
+            yAxisID: 'y1'
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        plugins: {
+          title:  { display: true, text: 'Colorado LIHTC stock trajectory (HUD DB)' },
+          legend: { position: 'bottom' }
+        },
+        scales: {
+          x:  { title: { display: true, text: 'Year (YR_ALLOC)' } },
+          y:  { title: { display: true, text: 'Cumulative projects' }, position: 'left', beginAtZero: true },
+          y1: { title: { display: true, text: 'Annual placements' }, position: 'right', beginAtZero: true, grid: { drawOnChartArea: false } }
+        }
+      }
+    });
+
+    var statsEl = document.getElementById('stockStats');
+    if (statsEl) {
+      var totalUnits = feats.reduce(function (s, f) {
+        var p = f.properties || {};
+        return s + (parseInt(p.N_UNITS || p.TOTAL_UNITS || 0, 10) || 0);
+      }, 0);
+      var recentYears = years.filter(function (y) { return (new Date().getFullYear()) - y <= 5; });
+      statsEl.innerHTML =
+        '<dl class="ht-stat-list">' +
+          '<div><dt>Total CO LIHTC projects</dt><dd>' + feats.length.toLocaleString() + '</dd></div>' +
+          '<div><dt>Total LIHTC units</dt><dd>' + totalUnits.toLocaleString() + '</dd></div>' +
+          '<div><dt>Years of data</dt><dd>' + minYr + '–' + maxYr + '</dd></div>' +
+          '<div><dt>Projects placed in last 5 yrs</dt><dd>' + recentYears.length + '</dd></div>' +
+        '</dl>';
+    }
+  }
+
+  /* ─────────────────────────────────────────────────────────────── */
+  /* Panel 3: Peer Benchmark                                         */
+  /* ─────────────────────────────────────────────────────────────── */
+
+  function _renderCountyPicker() {
+    if (!state.lihtcFeatures) return;
+    var sel = document.getElementById('benchCounty');
+    if (!sel) return;
+
+    var counties = {};
+    state.lihtcFeatures.forEach(function (f) {
+      var p = f.properties || {};
+      var nm = p.CNTY_NAME || p.COUNTY_NAME || p.COUNTY || '';
+      var fips = p.CNTY_FIPS || p.COUNTY_FIPS || null;
+      if (nm) counties[nm] = fips;
+    });
+    var names = Object.keys(counties).sort();
+    sel.innerHTML = '<option value="">Select a county…</option>' + names.map(function (n) {
+      return '<option value="' + esc(n) + '">' + esc(n) + '</option>';
+    }).join('');
+  }
+
+  function _renderBenchmark() {
+    var sel = document.getElementById('benchCounty');
+    var sizeEl = document.getElementById('benchUnits');
+    var tbody = document.getElementById('benchTableBody');
+    var summaryEl = document.getElementById('benchSummary');
+    if (!sel || !tbody) return;
+
+    var county = sel.value;
+    var targetUnits = parseInt((sizeEl && sizeEl.value) || '0', 10) || 0;
+
+    if (!county) {
+      tbody.innerHTML = '<tr><td colspan="6" class="ht-empty">Select a county to see peer LIHTC projects.</td></tr>';
+      if (summaryEl) summaryEl.textContent = '';
+      return;
+    }
+
+    var feats = (state.lihtcFeatures || []).filter(function (f) {
+      var p = f.properties || {};
+      return (p.CNTY_NAME || p.COUNTY_NAME || p.COUNTY || '') === county;
+    }).map(function (f) {
+      var p = f.properties || {};
+      return {
+        name:     p.PROJECT_NAME || p.PROJECT || '(unnamed)',
+        city:     p.PROJ_CTY || p.CITY || '',
+        units:    parseInt(p.N_UNITS || p.TOTAL_UNITS || 0, 10) || 0,
+        liUnits:  parseInt(p.LI_UNITS || 0, 10) || 0,
+        yrAlloc:  parseInt(p.YR_ALLOC || p.YEAR_ALLOC || 0, 10) || null,
+        yrPis:    parseInt(p.YR_PIS || 0, 10) || null,
+        credit:   p.CREDIT || ''
+      };
+    });
+
+    if (!feats.length) {
+      tbody.innerHTML = '<tr><td colspan="6" class="ht-empty">No LIHTC projects found in this county.</td></tr>';
+      if (summaryEl) summaryEl.textContent = '';
+      return;
+    }
+
+    // Sort by distance from target unit count when set; otherwise by most recent year
+    if (targetUnits > 0) {
+      feats.sort(function (a, b) {
+        return Math.abs(a.units - targetUnits) - Math.abs(b.units - targetUnits);
+      });
+    } else {
+      feats.sort(function (a, b) { return (b.yrAlloc || 0) - (a.yrAlloc || 0); });
+    }
+
+    // Top 20 peers
+    var top = feats.slice(0, 20);
+    tbody.innerHTML = top.map(function (p) {
+      var unitsCell = p.units + (p.liUnits ? ' <small style="color:var(--muted)">(' + p.liUnits + ' LI)</small>' : '');
+      return '<tr>' +
+        '<td>' + esc(p.name) + '</td>' +
+        '<td>' + esc(p.city) + '</td>' +
+        '<td style="text-align:right">' + unitsCell + '</td>' +
+        '<td style="text-align:right">' + (p.yrAlloc || '—') + '</td>' +
+        '<td style="text-align:right">' + (p.yrPis || '—') + '</td>' +
+        '<td>' + esc(p.credit || '—') + '</td>' +
+      '</tr>';
+    }).join('');
+
+    if (summaryEl) {
+      var totalUnits = feats.reduce(function (s, p) { return s + p.units; }, 0);
+      var avgUnits = feats.length ? Math.round(totalUnits / feats.length) : 0;
+      var mostRecent = Math.max.apply(null, feats.map(function (p) { return p.yrAlloc || 0; }).filter(Boolean));
+      summaryEl.innerHTML =
+        '<strong>' + feats.length + '</strong> LIHTC projects in ' + esc(county) +
+        ' · <strong>' + totalUnits.toLocaleString() + '</strong> total units' +
+        ' · avg <strong>' + avgUnits + '</strong> units/project' +
+        (isFinite(mostRecent) && mostRecent > 0 ? ' · most recent allocation: <strong>' + mostRecent + '</strong>' : '');
+    }
+  }
+
+  /* ─────────────────────────────────────────────────────────────── */
+  /* Public entry point                                              */
+  /* ─────────────────────────────────────────────────────────────── */
+
+  function render() {
+    var chfaUrl  = 'data/policy/chfa-awards-historical.json';
+    var lihtcUrl = 'data/market/hud_lihtc_co.geojson';
+
+    Promise.all([
+      _fetchJson(chfaUrl).catch(function () { return null; }),
+      _fetchJson(lihtcUrl).catch(function () { return null; })
+    ]).then(function (results) {
+      state.awards = results[0];
+      state.lihtcFeatures = results[1] && Array.isArray(results[1].features) ? results[1].features : [];
+
+      _renderChfaPanel();
+      _renderStockPanel();
+      _renderCountyPicker();
+      _renderBenchmark();
+
+      // Wire benchmark controls
+      var sel = document.getElementById('benchCounty');
+      var unitsEl = document.getElementById('benchUnits');
+      if (sel) sel.addEventListener('change', _renderBenchmark);
+      if (unitsEl) {
+        var deb = null;
+        unitsEl.addEventListener('input', function () {
+          clearTimeout(deb);
+          deb = setTimeout(_renderBenchmark, 250);
+        });
+      }
+    }).catch(function (err) {
+      var container = document.getElementById('htErrorBanner');
+      if (container) {
+        container.hidden = false;
+        container.textContent = 'Failed to load historical data: ' + (err && err.message || err);
+      }
+    });
+  }
+
+  global.HistoricalTrends = { render: render };
+})(typeof window !== 'undefined' ? window : this);

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -42,6 +42,7 @@
         { label: "CHFA Portfolio",        href: "chfa-portfolio.html",            desc: "Browse CHFA LIHTC projects" },
         { label: "Economic Dashboard",    href: "economic-dashboard.html",        desc: "FRED indicators for deal timing" },
         { label: "Land Value & Negotiation", href: "land-value.html",            desc: "Market comps + residual bid for site negotiation" },
+        { label: "Historical Trends & Benchmarks", href: "historical-trends.html", desc: "CHFA awards + LIHTC stock + peer benchmarks" },
         { label: "LIHTC Allocations",     href: "lihtc-allocations.html",         desc: "National per-capita allocation data" },
         { label: "Preservation Tracking", href: "preservation.html",              desc: "NHPD subsidy expiry risk" },
       ]

--- a/scripts/audit/a11y-audit.mjs
+++ b/scripts/audit/a11y-audit.mjs
@@ -50,6 +50,7 @@ const AUDIT_PAGES = [
   'market-analysis.html',
   'deal-calculator.html',
   'land-value.html',
+  'historical-trends.html',
   'housing-legislation-2026.html',
   'about.html',
   'insights.html',


### PR DESCRIPTION
Closes Phase 4 B-3 (historical trends / rent-roll benchmarking). Data was already in the repo but never visualized in a way that helps calibrate applications or benchmark operating performance.

## New page: \`historical-trends.html\`

Three panels:

### 1. CHFA Annual Award History
Stacked bar chart of awards per year split by credit type (9% vs 4%), 2015–2025. Aggregate stats: avg/median score, avg awards/yr, avg applications/yr, win rate. Helps first-time applicants calibrate a QAP submission — *\"you need 90%+ of a typical 78/100 median-winning score.\"*

### 2. LIHTC Stock Trajectory
Line + bar combo: cumulative CO LIHTC projects (line, left axis) + annual placement counts (bars, right axis). Shows the mid-2010s expansion, the 2019–2021 acceleration, and HUD-DB lag from allocation to placement.

### 3. Peer Project Benchmark
County select + optional target-unit input → top-20 peer LIHTC projects. Sorts by unit-count proximity when target set, otherwise by most-recent allocation. Summary: total projects, total units, avg units/project, most recent allocation.

## Scope decisions

- **NO rent-trajectory panel**: ACS is single-vintage (2023), no time-series support. Add when multi-year ACS ingestion is in place.
- **NO award forecasting**: explicitly historical-only.
- **Chart.js from existing \`js/vendor/chart.umd.min.js\`** — no new dependency.

## Audience split

- Developers pre-submission: calibrate QAP expectations (panel 1)
- Asset managers: benchmark operating peers (panel 3)
- Planners / policy folks: see where investment has gone over time (panel 2)

## Navigation

Added \"Historical Trends & Benchmarks\" to the \"Explore\" group.

## Verification

- \`npm run audit:a11y\` → 0 critical / 0 serious
- \`historical-trends.html\` now in AUDIT_PAGES for weekly sweep
- All data loads through \`_fetchJson\` with graceful null-fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)