### PR TITLE
chore(honesty): strip 4 unverified claims I added this session

### DIFF
--- a/historical-trends.html
+++ b/historical-trends.html
@@ -110,10 +110,13 @@
       <section class="ht-panel" aria-labelledby="htCHFAHeading">
         <h2 id="htCHFAHeading">CHFA Annual Award History</h2>
         <p class="ht-intro">
-          How many 9% competitive vs. 4% PAB-backed awards CHFA has made each year, with aggregate
-          scoring statistics. Use this to calibrate your QAP submission \u2014 a 78-point score was
-          the 2015\u20132025 average; median was 80. Colorado awards ~10 projects/year against ~27
-          applications (37% overall win rate).
+          Annual 9% competitive vs. 4% PAB-backed award counts with aggregate scoring statistics.
+          <strong>Important:</strong> the underlying dataset is a <em>synthesized sample</em> assembled from CHFA's
+          public award announcements (see <code>data/policy/chfa-awards-historical.json</code> \u2014
+          <code>meta.note</code> field). Use the CHFA-sourced panels only for directional calibration;
+          verify specific numbers against
+          <a href="https://www.chfainfo.com/developers/rental-housing-and-funding" target="_blank" rel="noopener">CHFA's current award history</a>
+          before citing them in an application.
         </p>
         <div class="ht-chart-wrap">
           <canvas id="chfaTimelineChart" role="img" aria-label="CHFA annual awards by credit type, 2015\u20132025"></canvas>

--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -1914,7 +1914,17 @@
         '</strong> local + <strong>' + stateCount + '</strong> statewide contacts for this geography.</p>'
       : '<p style="margin:0 0 6px;font-size:.78rem;color:var(--warn,#d97706)">No dedicated local PHA listed — this area is typically served by statewide programs + regional nonprofits listed below. For the authoritative federal directory, use the HUD PHA Finder link.</p>';
 
-    resultsEl.innerHTML = header +
+    // Verify banner — phone numbers + URLs in this directory were not
+    // programmatically refreshed against HUD PIH at page-render time.
+    // They are curated from the HUD Contact List but may drift as
+    // executives / websites change. Force the user to verify before
+    // cold-calling.
+    var verifyBanner =
+      '<div role="note" style="margin-bottom:8px;padding:6px 10px;background:var(--warn-dim,rgba(168,70,8,.1));border-left:3px solid var(--warn,#a84608);border-radius:0 4px 4px 0;font-size:.74rem;color:var(--text);line-height:1.4">' +
+        '\u26a0 <strong>Verify before contacting:</strong> phone numbers, URLs, and roles below are curated from HUD PIH\u2019s Contact List but are NOT live-refreshed. Confirm each entry via the current <a href="https://www.hud.gov/program_offices/public_indian_housing/pha/contacts" target="_blank" rel="noopener">HUD PHA Finder</a> before calling.' +
+      '</div>';
+
+    resultsEl.innerHTML = header + verifyBanner +
       '<ul style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px">' +
       all.map(function (a) {
         var nameCell = a.url
@@ -1931,7 +1941,7 @@
         '</li>';
       }).join('') +
     '</ul>' +
-    '<p style="margin-top:8px;font-size:.72rem;color:var(--faint)">Directory curated from HUD PIH Contact List + CHFA partners. <a href="https://www.hud.gov/program_offices/public_indian_housing/pha/contacts" target="_blank" rel="noopener" style="color:var(--accent)">Full HUD PHA Finder ↗</a></p>';
+    '<p style="margin-top:8px;font-size:.72rem;color:var(--faint)">Directory curated from HUD PIH Contact List + CHFA partners. Last curated 2026-04. <a href="https://www.hud.gov/program_offices/public_indian_housing/pha/contacts" target="_blank" rel="noopener" style="color:var(--accent)">Full HUD PHA Finder ↗</a></p>';
   }
 
   function getSelectedFips() {

--- a/js/components/development-realism.js
+++ b/js/components/development-realism.js
@@ -107,7 +107,7 @@
       '<h4 class="devr-subhead">CHFA Competitiveness</h4>' +
       _checklist([
         { text: 'Review current year CHFA Qualified Allocation Plan (QAP) priorities', flag: 'verify', note: 'QAP changes annually. 2025-2026 priorities may differ from historical patterns used in this tool.' },
-        { text: 'Check CHFA geographic distribution preferences (rural vs. urban set-asides)', note: 'CHFA typically reserves 25-30% of 9% credits for non-metro areas.' },
+        { text: 'Check CHFA geographic distribution preferences (rural vs. urban set-asides)', note: 'CHFA\u2019s current QAP specifies any non-metro set-aside percentages and geographic-distribution scoring weights. Pull the figure from the current QAP rather than relying on prior-year memory \u2014 the split changes.' },
         { text: 'Confirm project type aligns with CHFA priority populations (seniors, families, PSH)', note: 'Serving priority populations adds QAP points. Check current QAP for specific point values.' },
         { text: 'Assess readiness-to-proceed factors (site control, zoning, financing commitments)', note: 'CHFA increasingly weights projects that can close quickly after award.' },
       ]) +

--- a/lihtc-guide-for-stakeholders.html
+++ b/lihtc-guide-for-stakeholders.html
@@ -293,9 +293,9 @@
 </tbody>
 </table>
 <div class="data-source">
-  <strong>Colorado-specific:</strong> CHFA allocates ~$24M/yr in 9% credits against ~$72M in applications
-  (3:1 oversubscription). PAB cap is $450M/yr but ~63% is already committed by Q2. Decide your path early —
-  9% applications assume 4% as fallback; unfunded 9% projects sometimes convert to 4% but lose ~6 months.
+  <strong>Colorado-specific:</strong> Annual 9% allocation totals, application counts, and PAB cap utilization change each year — pull the current numbers directly from
+  <a href="https://www.chfainfo.com/developers/rental-housing-and-funding/qualified-allocation-plan" target="_blank" rel="noopener" style="color: var(--mcm-teal);">CHFA's QAP and allocation disclosures</a>
+  before using any figure in an application or investor deck. As a planning rule of thumb: 9% applications should assume 4% as a fallback path; unfunded 9% projects can sometimes convert to 4% but typically lose ~6 months.
   <br><br>
   <strong>Sources:</strong>
   <a href="https://www.law.cornell.edu/uscode/text/26/42" target="_blank" rel="noopener" style="color: var(--mcm-teal);">IRC §42(b)</a> (statutory credit rates) ·
@@ -431,12 +431,16 @@ Price depends on:
 </pre>
 <h4 style="color: var(--mcm-teal); margin: 1.5rem 0 0.75rem 0;">What drives Colorado pricing specifically:</h4>
 <ul style="line-height: 1.8; color: var(--mcm-beige);">
-<li><strong>CRA-desirable markets:</strong> Denver metro, high-growth Front Range = $0.90–$0.95/credit</li>
-<li><strong>Secondary urban:</strong> Colorado Springs, Fort Collins, Grand Junction = $0.85–$0.90</li>
-<li><strong>Rural:</strong> Eastern plains, San Luis Valley, mountain towns = $0.78–$0.85 (investor risk premium)</li>
-<li><strong>First-time CO developer:</strong> Typically $0.02–$0.05 discount until track record established</li>
-<li><strong>Strong PHA co-GP:</strong> Can add $0.01–$0.03 (signals operational stability to investor)</li>
+<li><strong>CRA demand</strong> — lenders with CRA obligations in your market bid higher; banks with deposits concentrated in the project's census tract have the strongest incentive</li>
+<li><strong>Geographic risk premium</strong> — pricing spreads from metro to rural reflect investor appetite for property-management and exit-liquidity risk, not the credit itself</li>
+<li><strong>Sponsor track record</strong> — first-time LIHTC developers typically see a pricing discount vs. repeat sponsors; nonprofit + PHA co-GP structures can partially offset</li>
+<li><strong>Deal size + structure</strong> — larger deals (100+ units, clean capital stack) price better per-credit; complex soft-funding stacks or acquisition-rehab compress pricing</li>
 </ul>
+<p style="font-size:.82rem;color:var(--mcm-beige);opacity:.85;margin:.4rem 0 0;">
+  Specific basis-point ranges by geography change every quarter and vary by syndicator — consult the current
+  <a href="https://www.novoco.com/resource-centers/affordable-housing-tax-credits/rankings" target="_blank" rel="noopener" style="color: var(--mcm-teal);">Novogradac quarterly pricing survey</a>
+  and get at least two pricing letters before making economics decisions.
+</p>
 <h4 style="color: var(--mcm-teal); margin: 1.5rem 0 0.75rem 0;">Syndicator relationships in Colorado:</h4>
 <ul style="line-height: 1.8; color: var(--mcm-beige);">
 <li><strong>National syndicators:</strong> Raymond James, Hudson Housing, Enterprise, WNC, Boston Capital — active in all CO markets</li>


### PR DESCRIPTION
**Step 1 of the hallucination-cleanup plan.** Following the origin audit, I'm cleaning my own session contributions first before touching pre-existing scaffold data (Steps 2+3 separately).

All 4 items were added by me in earlier PRs tonight (#702, #704, #706); none had citations that supported the specific numbers I gave.

## What got stripped

| Location | Before | After |
|---|---|---|
| LIHTC Guide — CO allocation figures | "\$24M/yr vs \$72M, 3:1 oversubscription, 63% of PAB cap committed by Q2" | Plain pointer to current CHFA QAP + allocation disclosures |
| LIHTC Guide — equity pricing bands | "Denver \$0.90-\$0.95, Secondary \$0.85-\$0.90, Rural \$0.78-\$0.85", developer-track discounts | Qualitative list of what DRIVES pricing differences + "get 2 pricing letters" |
| Historical Trends panel intro | Implied CHFA stats were authoritative | Labels the data as synthesized sample (matches `meta.note` in source JSON) |
| `development-realism.js` | "CHFA typically reserves 25-30% of 9% credits for non-metro" | "Pull the figure from current QAP — the split changes" |
| HA roster (#704) | Plain list of names/phones/URLs | Adds prominent warn-color *"Verify before contacting"* banner + "Last curated 2026-04" footer |

## What this does NOT do

- Does NOT remove the LIHTC Guide content itself — only the claims I couldn't support. Structural framing (4% vs 9% decision factors, compliance period, deal-killers, equity formula) stands.
- Does NOT touch pre-existing scaffold content (`trend-analysis.js`, `chfa-awards-historical.json`, PMA fallback defaults) — that's Step 2 / Step 3.

## Why this order

The origin audit showed 41% of commits are from the Copilot bot, with hallucinations overwhelmingly from three bulk scaffold commits that never got backfilled. Fixing my own additions first is the smallest, most honest first step and avoids the exact failure mode we just diagnosed: big sweep-it-all commits that don't get reviewed carefully.

## Verification

- `npm run test:hna` → 688/688 passing
- `npm run audit:a11y` → 0 critical / 0 serious (unchanged)

## What's next

- **Step 2** (separate PR): strip or loud-banner `js/trend-analysis.js` (100% fabricated 12-state peer dataset, 589 lines, never replaced)
- **Step 3** (separate tracking issue): per-file decisions for the remaining 7 scaffold files — not a heroic single-session sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)