### PR TITLE
fix(honesty): null-propagate 3 silent fallbacks (issue #712 Category A)

### DIFF
--- a/js/chfa-award-predictor.js
+++ b/js/chfa-award-predictor.js
@@ -227,9 +227,15 @@
     var band        = _likelihoodToBand(likelihood);
     var percentile  = _computePercentile(scoreEst);
 
-    var avgApps   = _summary.avgApplicationsPerYear || 27;
-    var awardRate = _summary.awardRate || 0.37;
-    var funded    = Math.round(avgApps * awardRate);
+    // Historical summary stats — return null + visible "unavailable"
+    // rather than fabricating 27 apps / 37% rate when the summary file
+    // didn't load. Hardcoded fallbacks were flagged as hallucinations
+    // in the 2026-04-23 origin audit (issue #712).
+    var summaryLoaded = typeof _summary.avgApplicationsPerYear === 'number' &&
+                        typeof _summary.awardRate === 'number';
+    var avgApps   = summaryLoaded ? _summary.avgApplicationsPerYear : null;
+    var awardRate = summaryLoaded ? _summary.awardRate              : null;
+    var funded    = summaryLoaded ? Math.round(avgApps * awardRate) : null;
 
     var narrative = _buildNarrative(likelihood, band, scoreEst, c);
 
@@ -239,6 +245,9 @@
       'Developer track record assumed neutral — adjust if known.',
       'Contact CHFA for pre-application consultation before submission.'
     ];
+    if (!summaryLoaded) {
+      caveats.unshift('⚠ Historical summary data did not load — application-count and award-rate context unavailable; see CHFA directly for current figures.');
+    }
 
     if (ctx.isRural) {
       caveats.push('Rural markets have historically lower award rates — rural priority tiebreaker may offset.');
@@ -250,10 +259,13 @@
       scoreEstimate:    scoreEst,
       factors:          factors,
       competitiveContext: {
-        applicationsExpected: avgApps,
-        fundingAvailable:     funded,
+        applicationsExpected: avgApps,          // may be null
+        fundingAvailable:     funded,           // may be null
         percentileRank:       percentile,
-        note:                 'Based on ' + _awards.length + ' historical awards (2015–2025).'
+        summaryAvailable:     summaryLoaded,    // new flag for UI renderers
+        note: summaryLoaded
+          ? 'Based on ' + _awards.length + ' historical awards (2015–2025).'
+          : 'Historical-award summary not available — competitive context omitted.'
       },
       narrative: narrative,
       caveats:   caveats

--- a/js/components/qap-competitiveness-panel.js
+++ b/js/components/qap-competitiveness-panel.js
@@ -314,7 +314,12 @@
           '</div>' +
           '<div style="font-size:.75rem;color:var(--muted);margin-top:2px;">' +
             'Percentile: ' + Math.round(cc.percentileRank * 100) + 'th vs historical winners' +
-            ' · ~' + cc.applicationsExpected + ' applications / ~' + cc.fundingAvailable + ' funded per year' +
+            // Suppress the apps/funded-per-year figures when the summary
+            // file didn't load — the predictor returns null for both to
+            // avoid fabricating 27 apps / 37% rate (issue #712).
+            (cc.summaryAvailable !== false && cc.applicationsExpected != null && cc.fundingAvailable != null
+              ? ' · ~' + cc.applicationsExpected + ' applications / ~' + cc.fundingAvailable + ' funded per year'
+              : ' · historical application/funding context unavailable') +
           '</div>' +
         '</div>' +
       '</div>' +

--- a/js/data-service-portable.js
+++ b/js/data-service-portable.js
@@ -1187,13 +1187,21 @@
             var td = localData.tracts[tractIds[i]];
             if (!td) continue;
             if (td.hasSFHA) sfhaCount++;
+            // `floodRiskScore || 95` previously fabricated a near-perfect
+            // "safe" score (95/100) when the tract lacked the field.
+            // Flagged as a hallucination in the 2026-04-23 origin audit
+            // (issue #712). Return null so downstream composite scorers
+            // propagate "unavailable" rather than silently bumping the
+            // site's feasibility score.
+            var hasRisk = typeof td.floodRiskScore === 'number';
             floodZones.push({
               type: 'Feature',
               properties: {
                 tractId: tractIds[i],
                 FLD_ZONE: (td.zones && td.zones[0]) || 'X',
                 hasSFHA: td.hasSFHA || false,
-                floodRiskScore: td.floodRiskScore || 95,
+                floodRiskScore: hasRisk ? td.floodRiskScore : null,
+                floodRiskAvailable: hasRisk,
                 zones: td.zones || []
               },
               geometry: null

--- a/js/pma-analysis-runner.js
+++ b/js/pma-analysis-runner.js
@@ -187,15 +187,29 @@
 
       var employmentP = (pmaEmployment && results.commuting && results.commuting.residentOriginZones)
         ? Promise.resolve().then(function () {
-            var workplaces = (results.commuting.residentOriginZones || []).map(function (z) {
-              return { lat: z.lat, lon: z.lon, jobCount: z.estimatedWorkers || 100 };
-            });
+            // `estimatedWorkers || 100` previously fabricated a 100-worker
+            // zone when LODES data lacked the count — inflating
+            // employment-center density scores. Flagged as a hallucination
+            // in the 2026-04-23 origin audit (issue #712). Skip zones
+            // without a real worker count instead of manufacturing one.
+            var rawZones = results.commuting.residentOriginZones || [];
+            var workplaces = rawZones
+              .filter(function (z) { return typeof z.estimatedWorkers === 'number' && z.estimatedWorkers > 0; })
+              .map(function (z) {
+                return { lat: z.lat, lon: z.lon, jobCount: z.estimatedWorkers };
+              });
+            var skipped = rawZones.length - workplaces.length;
             var clusters  = pmaEmployment.clusterByJobDensity(workplaces);
             var corridors = pmaEmployment.identifyMajorCorridors(clusters);
             results.employmentCenters = clusters;
             results.employmentCorridors = corridors;
             results.employmentScore = pmaEmployment.scoreEmploymentAccessibility(lat, lon, clusters);
-            progress('employment', 'Identifying employment centers…');
+            results.employmentZonesSkipped = skipped;       // surfaces in UI via renderers
+            if (skipped > 0) {
+              progress('employment', 'Identifying employment centers… (' + skipped + ' zones skipped, no worker count)');
+            } else {
+              progress('employment', 'Identifying employment centers…');
+            }
           })
         : Promise.resolve().then(function () {
             results.employmentCenters = [];


### PR DESCRIPTION
**Category A from issue #712** — three mechanical null-propagation fixes, no product decisions needed. Same pattern as the AMI fallback fix that shipped in #693.

## The 3 hallucinations fixed

| File | Before | Impact |
|---|---|---|
| \`chfa-award-predictor.js\` | \`avgApps \|\| 27\`, \`awardRate \|\| 0.37\` | Silently printed \"~27 apps / 37% win rate\" as authoritative history when summary file didn't load |
| \`data-service-portable.js:1196\` | \`floodRiskScore \|\| 95\` | Fabricated near-perfect 95/100 flood-safety score when tract lacked the field — flowed into feasibility composites |
| \`pma-analysis-runner.js:191\` | \`estimatedWorkers \|\| 100\` | Manufactured 100-worker zones when LODES data was missing — inflating employment-center density |

All three now return \`null\` + a visible \"unavailable\" signal in the UI.

## Changes per file

### CHFA predictor
- Both fields return null when summary unavailable
- \`competitiveContext.summaryAvailable: boolean\` flag for renderers
- Visible ⚠ caveat prepends to caveats array
- \`note\` field says \"Historical-award summary not available — competitive context omitted.\"

### QAP competitiveness panel
- UI renderer suppresses the \"~N apps / M funded\" line when data unavailable
- Shows \"historical application/funding context unavailable\" instead

### Flood risk
- \`floodRiskScore: null\` when not available (was \`|| 95\`)
- New \`floodRiskAvailable: boolean\` property
- Downstream composites already handle null per the AMI-fix pattern

### Employment workers
- Zones without real worker counts are filtered out, not fabricated
- \`results.employmentZonesSkipped\` surfaces the count to the UI
- Progress string shows \"N zones skipped, no worker count\"

## Verification

- \`npm run test:ci\` → 688/688 HNA + 7 unit suites passing
- \`node test/test_chfa_award_predictor.js\` → 133/133 passing (existing assertions still hold — null fields don't change object shape)
- \`npm run audit:a11y\` → 0 critical / 0 serious (unchanged)

## Still open from issue #712

- **Category B**: product decisions (real CHFA award data sourcing, soft-funding dollar amounts)
- **Category C**: test-breaking refactor (`return 50` neutrals in site-selection-score, `|| 60` defaults in pma-transit/pma-competitive-set)

Each tracked in the parent issue — should ship separately once decisions are made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)