### PR TITLE
chore(honesty): CHFA predictor banner + strip soft-funding dollar fields

### DIFF
--- a/js/chfa-award-predictor.js
+++ b/js/chfa-award-predictor.js
@@ -5,6 +5,16 @@
  * Estimates award likelihood and competitive score for a LIHTC concept
  * based on historical CHFA QAP award patterns (2015–2025).
  *
+ * ⚠ DATA SOURCE DISCLOSURE:
+ *   The underlying dataset (`data/policy/chfa-awards-historical.json`) is
+ *   a **synthesized sample** assembled from CHFA's public award
+ *   announcements — see `meta.note` in that file. It is suitable for
+ *   directional calibration but is NOT CHFA's authoritative award record.
+ *   UI surfaces that consume this predictor (see qap-competitiveness-panel.js
+ *   and lihtc-concept-card-renderer.js) render a visible banner above any
+ *   predicted score. Verify specific figures against CHFA's current award
+ *   history before citing them: https://www.chfainfo.com/developers/rental-housing-and-funding
+ *
  * Non-goals:
  *   - Does NOT predict the actual CHFA score (CHFA is the sole arbiter)
  *   - Does NOT guarantee an award — estimates only

--- a/js/components/qap-competitiveness-panel.js
+++ b/js/components/qap-competitiveness-panel.js
@@ -293,6 +293,18 @@
         '<h2 id="qapHeading" style="margin:0;font-size:1.1rem;">QAP Competitiveness</h2>' +
         '<span style="font-size:.72rem;color:var(--muted);">9% Competitive Credit Application</span>' +
       '</div>' +
+      // Synthesized-data banner — the historical dataset is a public-sources
+      // sample (see chfa-awards-historical.json meta.note), not CHFA's
+      // authoritative award record. Keep directional reads but verify
+      // specifics against CHFA before citing.
+      '<div role="note" style="margin:.5rem 0 .75rem;padding:8px 12px;border-left:3px solid var(--warn,#d97706);border-radius:0 4px 4px 0;background:var(--warn-dim,#fef3c7);font-size:.76rem;line-height:1.45;color:var(--text);">' +
+        '<strong style="color:var(--warn,#d97706);">⚠ Synthesized sample data.</strong> ' +
+        'Scores and factor averages are modelled from a public-sources sample of CHFA award announcements ' +
+        '(<code style="font-size:.72rem;">data/policy/chfa-awards-historical.json</code>, see <code style="font-size:.72rem;">meta.note</code>). ' +
+        'Use for directional calibration only — verify specifics against ' +
+        '<a href="https://www.chfainfo.com/developers/rental-housing-and-funding" target="_blank" rel="noopener">CHFA\u2019s current award history</a> ' +
+        'before citing in an application.' +
+      '</div>' +
       '<p style="font-size:.82rem;color:var(--muted);margin:.25rem 0 .75rem;">' +
         'Estimated CHFA QAP scoring based on historical award patterns (2015–2025). Not a guarantee — CHFA is the sole arbiter of competitive awards.' +
       '</p>' +

--- a/js/components/soft-funding-breakdown.js
+++ b/js/components/soft-funding-breakdown.js
@@ -5,9 +5,19 @@
  *
  * Shows:
  *   - All eligible programs for the selected county + execution type (9%/4%)
- *   - Per-program: available $, max per project, deadline, competitiveness
- *   - PAB volume cap warning for 4% deals
- *   - Total theoretical soft-funding capacity vs the gap
+ *   - Per-program: max per project (published rule), deadline, competitiveness,
+ *     eligibility restrictions, admin entity
+ *   - PAB volume cap qualitative warning for 4% deals
+ *
+ * ⚠ Dollar-figure policy (2026-04):
+ *   This renderer intentionally does NOT display the `available`, `awarded`,
+ *   or `capacity` fields from `data/policy/soft-funding-status.json`. Those
+ *   figures are quarterly admin-maintained estimates that drift between
+ *   refresh cycles; showing stale balances was confusing users. Tracker API
+ *   methods (`sumEligible`, `getPabStatus`) still expose them for non-UI
+ *   use, but the surface shown to users is verification-pointed, not
+ *   dollar-valued. Verify current balances with the admin entity before
+ *   citing to a client.
  *
  * Depends on: js/soft-funding-tracker.js (must load first)
  * Mount: renders into #dcSoftFundingBreakdown (created dynamically)
@@ -96,12 +106,10 @@
     var SFT = global.SoftFundingTracker;
     if (!SFT) return;
 
-    var pab = SFT.getPabStatus();
-    if (!pab) return;
-
-    var pctUsed = pab.pctCommitted;
-    var isUrgent = pctUsed >= 60;
-
+    // Qualitative PAB warning only — historical dollar/percentage figures
+    // for the state PAB ceiling and committed-to-date were
+    // admin-maintained estimates that drifted; users are now directed
+    // to CHFA's live tracker rather than shown a synthesized progress bar.
     // Find or create mount
     var mount = existing;
     if (!mount) {
@@ -112,22 +120,18 @@
       pabNote.parentNode.insertBefore(mount, pabNote.nextSibling);
     }
 
-    var barColor = isUrgent ? 'var(--warn, #d97706)' : 'var(--accent, #096e65)';
-    var bgColor = isUrgent ? 'var(--warn-dim, #fef3c7)' : 'var(--info-dim, #dbeafe)';
-    var borderColor = isUrgent ? 'var(--warn, #d97706)' : 'var(--info, #2563eb)';
-
-    mount.style.cssText = 'margin-top:8px;padding:8px 12px;border-left:3px solid ' + borderColor +
-      ';border-radius:0 4px 4px 0;background:' + bgColor + ';font-size:.78rem;';
+    mount.style.cssText = 'margin-top:8px;padding:8px 12px;border-left:3px solid var(--info, #2563eb)' +
+      ';border-radius:0 4px 4px 0;background:var(--info-dim, #dbeafe);font-size:.78rem;';
     mount.innerHTML =
-      '<div style="display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap;">' +
-        '<strong style="color:' + barColor + ';">PAB Volume Cap: ' + pctUsed + '% Committed</strong>' +
-        '<span style="color:var(--muted);font-size:.72rem;">' + _fmtDollars(pab.remaining) + ' of ' + _fmtDollars(pab.totalCap) + ' remaining</span>' +
-      '</div>' +
-      '<div style="height:6px;background:var(--border);border-radius:3px;margin:6px 0 4px;overflow:hidden;">' +
-        '<div style="height:100%;width:' + Math.min(pctUsed, 100) + '%;background:' + barColor + ';border-radius:3px;transition:width .4s;"></div>' +
-      '</div>' +
-      (pab.warning ? '<div style="font-size:.72rem;color:' + barColor + ';margin-top:2px;">' + pab.warning + '</div>' : '') +
-      (isUrgent ? '<div style="font-size:.72rem;color:var(--muted);margin-top:2px;">4% deals require PAB allocation before LIHTC determination. Apply early — when cap is exhausted, 4% deals cannot proceed until next calendar year.</div>' : '');
+      '<strong style="color:var(--info, #2563eb);">PAB Volume Cap — verify current availability</strong>' +
+      '<p style="font-size:.72rem;color:var(--muted);margin:4px 0 0;line-height:1.5;">' +
+        '4% deals require Private Activity Bond (PAB) allocation before LIHTC determination. ' +
+        'Colorado\u2019s state PAB ceiling is set annually and commitments accrue through the year — ' +
+        'apply early, and when the cap is exhausted 4% deals cannot proceed until the next calendar year. ' +
+        'Check current cap status at ' +
+        '<a href="https://cdola.colorado.gov/privateactivitybonds" target="_blank" rel="noopener">CDOLA\u2019s PAB program page</a> ' +
+        'or confirm directly with CHFA before finalizing a 4% structure.' +
+      '</p>';
     mount.hidden = false;
   }
 
@@ -164,7 +168,6 @@
     }
 
     var programs = SFT.getEligiblePrograms(countyFips, executionType);
-    var sum = SFT.sumEligible(countyFips, executionType);
     var updated = SFT.getLastUpdated();
 
     if (!programs || programs.length === 0) {
@@ -172,27 +175,20 @@
       return;
     }
 
-    // Gap coverage assessment
-    var gapCoverage = '';
-    if (typeof gapAmount === 'number' && gapAmount > 0 && sum.total > 0) {
-      var coverPct = Math.min(100, Math.round(sum.total / gapAmount * 100));
-      var coverColor = coverPct >= 100 ? 'var(--good, #047857)' : coverPct >= 50 ? 'var(--warn, #d97706)' : 'var(--bad, #dc2626)';
-      gapCoverage =
-        '<div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;padding:6px 10px;border-radius:4px;background:var(--bg2);">' +
-          '<span style="font-size:.78rem;color:var(--muted);">Theoretical coverage of gap:</span>' +
-          '<strong style="color:' + coverColor + ';font-size:.85rem;">' + coverPct + '%</strong>' +
-          '<span style="font-size:.72rem;color:var(--muted);">(' + _fmtDollars(sum.total) + ' available across ' + sum.programCount + ' programs vs ' + _fmtDollars(gapAmount) + ' gap)</span>' +
-        '</div>' +
-        (coverPct < 100 ? '<div style="font-size:.72rem;color:var(--muted);margin-bottom:6px;">Note: Not all programs can be stacked. Actual coverage depends on application success, timing, and program rules. Max per-project limits apply.</div>' : '');
-    }
+    // Dollar-figure policy (2026-04): dollar balances from the underlying
+    // JSON (available/awarded/capacity) are intentionally NOT rendered —
+    // quarterly admin-maintained estimates drift too quickly to show
+    // live. Users see the qualitative program list and are pointed at
+    // the admin entity for a current balance. `gapAmount` is accepted
+    // for interface compatibility but no longer drives a dollar-coverage
+    // readout.
+    void gapAmount;
 
     // Build program rows
     var rows = '';
     for (var i = 0; i < programs.length; i++) {
       var p = programs[i];
-      var hasAvail = p.available !== null && p.available > 0;
-      var rowOpacity = hasAvail ? '1' : '0.55';
-      var maxNote = p.maxPerProject ? ' (max ' + _fmtDollars(p.maxPerProject) + '/project)' : '';
+      var maxNote = p.maxPerProject ? ' (published max ' + _fmtDollars(p.maxPerProject) + '/project)' : '';
       var amiNote = p.amiTargeting ? '<span style="display:inline-block;padding:1px 5px;border-radius:3px;font-size:.66rem;font-weight:600;background:var(--accent-dim,#d1fae5);color:var(--accent,#096e65);margin-left:4px;">' + p.amiTargeting + '</span>' : '';
 
       // Restrictions — rendered as collapsible <details> inside the program
@@ -214,15 +210,12 @@
       }
 
       rows +=
-        '<tr style="opacity:' + rowOpacity + ';border-bottom:1px solid var(--border);">' +
+        '<tr style="border-bottom:1px solid var(--border);">' +
           '<td style="padding:5px 4px;font-size:.78rem;line-height:1.4;">' +
             '<strong>' + p.name + '</strong>' + amiNote + maxNote +
             (p.adminEntity ? '<br><span style="font-size:.68rem;color:var(--muted);">Admin: ' + p.adminEntity + '</span>' : '') +
             (p.warning ? '<br><span style="font-size:.68rem;color:var(--warn,#d97706);">' + p.warning + '</span>' : '') +
             restrictionsHtml +
-          '</td>' +
-          '<td style="text-align:right;padding:5px 4px;font-size:.78rem;font-weight:700;white-space:nowrap;">' +
-            (hasAvail ? _fmtDollars(p.available) : '<span style="color:var(--muted);">—</span>') +
           '</td>' +
           '<td style="text-align:center;padding:5px 4px;">' + _competBadge(p.competitiveness) + '</td>' +
           '<td style="text-align:right;padding:5px 4px;font-size:.75rem;white-space:nowrap;">' +
@@ -236,20 +229,24 @@
       '<details open style="margin-top:4px;">' +
         '<summary style="font-size:.82rem;font-weight:700;cursor:pointer;user-select:none;list-style:none;display:flex;align-items:center;gap:4px;padding:4px 0;">' +
           '<span>&#9660;</span> Eligible Soft-Funding Sources (' + programs.length + ' programs)' +
-          '<span style="font-size:.68rem;font-weight:400;color:var(--muted);margin-left:auto;">Updated ' + (updated || '—') + '</span>' +
+          '<span style="font-size:.68rem;font-weight:400;color:var(--muted);margin-left:auto;">Last catalog update ' + (updated || '—') + '</span>' +
         '</summary>' +
-        gapCoverage +
+        // Policy banner explaining the missing dollar column.
+        '<div role="note" style="margin:4px 0 8px;padding:6px 10px;border-left:3px solid var(--info,#2563eb);border-radius:0 4px 4px 0;background:var(--info-dim,#dbeafe);font-size:.72rem;line-height:1.45;color:var(--text);">' +
+          '<strong style="color:var(--info,#2563eb);">Balances not shown.</strong> ' +
+          'Dollar-level availability for these programs drifts quarterly and is best confirmed directly with the admin entity. ' +
+          'This catalog shows eligibility, deadline, and competition level only — call CHFA, DOLA, or the listed admin before modelling a specific source.' +
+        '</div>' +
         '<table style="width:100%;border-collapse:collapse;font-size:.78rem;">' +
           '<thead><tr style="border-bottom:2px solid var(--border);">' +
             '<th style="text-align:left;padding:4px;color:var(--muted);font-weight:600;font-size:.72rem;">Program</th>' +
-            '<th style="text-align:right;padding:4px;color:var(--muted);font-weight:600;font-size:.72rem;">Available</th>' +
             '<th style="text-align:center;padding:4px;color:var(--muted);font-weight:600;font-size:.72rem;">Competition</th>' +
             '<th style="text-align:right;padding:4px;color:var(--muted);font-weight:600;font-size:.72rem;">Deadline</th>' +
           '</tr></thead>' +
           '<tbody>' + rows + '</tbody>' +
         '</table>' +
         '<p style="font-size:.68rem;color:var(--muted);margin:6px 0 0;">' +
-          'Estimates only — verify availability with CHFA, DOH, or county housing offices before advising clients. ' +
+          'Catalog only — verify availability with CHFA, DOH, or county housing offices before advising clients. ' +
           'Programs may have additional eligibility criteria not shown here.' +
         '</p>' +
       '</details>';

--- a/js/lihtc-concept-card-renderer.js
+++ b/js/lihtc-concept-card-renderer.js
@@ -266,20 +266,26 @@
     if (fund && typeof fund === 'object') {
       var compBadge = { high: '🟡 High competition', moderate: '🟢 Moderate competition', low: '🟢 Low competition' }[fund.competitiveness]
         || _cap(fund.competitiveness || '');
+      // Dollar-figure policy (2026-04): the Available $ readout was pulled
+      // because quarterly admin-maintained balances drifted between
+      // refreshes. Users now see program + deadline + competition and
+      // are pointed at the admin for a live number.
       sections.push([
         '<details class="lihtc-cc-constraint">',
           '<summary role="button"><h4>💰 Soft Funding Status</h4></summary>',
           '<dl class="lihtc-cc-constraint-grid">',
             '<dt>Program</dt><dd>' + _esc(fund.program || '—') + '</dd>',
-            '<dt>Available</dt><dd>' + _esc(_fmtM(fund.available || 0)) + '</dd>',
             '<dt>Deadline</dt><dd>' + (fund.deadline
               ? _esc(fund.deadline) + (fund.daysRemaining !== null ? ' (' + fund.daysRemaining + ' days)' : '')
               : '—') + '</dd>',
             '<dt>Competition</dt><dd>' + _esc(compBadge) + '</dd>',
           '</dl>',
+          '<p style="margin:.35rem 0 0;font-size:.72rem;color:var(--muted);line-height:1.45;">' +
+            'Current balance not shown — verify with the program admin before modelling a specific source.' +
+          '</p>',
           fund.warning ? '<p style="margin:.35rem 0 0;font-size:.8rem;color:var(--warning,#c0392b);">⚠ ' + _esc(fund.warning) + '</p>' : '',
           fund.narrative ? '<p class="lihtc-cc-constraint-narrative">' + _esc(fund.narrative) + '</p>' : '',
-          fund.lastUpdated ? '<p class="lihtc-cc-constraint-narrative">Last updated: ' + _esc(fund.lastUpdated) + '</p>' : '',
+          fund.lastUpdated ? '<p class="lihtc-cc-constraint-narrative">Catalog last updated: ' + _esc(fund.lastUpdated) + '</p>' : '',
         '</details>'
       ].join(''));
     }
@@ -290,9 +296,19 @@
       var pct  = Math.round((award.awardLikelihood || 0) * 100);
       var band = award.competitiveBand || 'unknown';
       var bandBadge = { strong: '🟢 Strong', moderate: '🟡 Moderate', weak: '🔴 Weak' }[band] || _cap(band);
+      // Synthesized-data banner mirrors the deal-calculator panel. Underlying
+      // dataset is a public-sources sample, not CHFA's authoritative record.
+      var chfaBanner =
+        '<p style="margin:.35rem 0 .5rem;padding:6px 10px;border-left:3px solid var(--warn,#d97706);' +
+          'border-radius:0 4px 4px 0;background:var(--warn-dim,#fef3c7);font-size:.72rem;line-height:1.45;color:var(--text);">' +
+          '<strong style="color:var(--warn,#d97706);">⚠ Synthesized sample data.</strong> ' +
+          'Modelled from public CHFA announcements — directional only. Verify at ' +
+          '<a href="https://www.chfainfo.com/developers/rental-housing-and-funding" target="_blank" rel="noopener">CHFA award history</a>.' +
+        '</p>';
       sections.push([
         '<details class="lihtc-cc-constraint">',
           '<summary role="button"><h4>🏆 CHFA Competitiveness ' + _esc(bandBadge) + '</h4></summary>',
+          chfaBanner,
           '<dl class="lihtc-cc-constraint-grid">',
             '<dt>Award Likelihood</dt><dd>' + _esc(bandBadge) + ' (' + pct + '%)</dd>',
             '<dt>Est. QAP Score</dt><dd>' + _esc(String(award.scoreEstimate || '—')) + ' / 100</dd>',


### PR DESCRIPTION
## Summary

Category **B** of the hallucination-cleanup staged plan (after #710/#711/#713). Two surfaces whose data *shape* is correct but whose numbers are either synthesized (CHFA predictor) or drift between quarterly refreshes (soft-funding balances). Both are now flagged in place instead of being rendered as if they were authoritative.

### B1 — CHFA Award Predictor banner
The underlying `data/policy/chfa-awards-historical.json` already self-declares in `meta.note`: *"Data synthesized from publicly available CHFA award announcements and QAP documentation."* That disclosure was invisible to the end user.

- `qap-competitiveness-panel.js` — warn-color banner above the 0–100 score, with deep-link to CHFA's current award history
- `lihtc-concept-card-renderer.js` — compact banner inside the concept card's CHFA Competitiveness `<details>` block
- `chfa-award-predictor.js` — docstring now surfaces the synthesized-data disclosure so future maintainers know what's in the box

### B2 — Soft-funding dollar policy
Strip `available` / `awarded` / `capacity` dollar fields from all **render paths**. The tracker API (`soft-funding-tracker.js`) is untouched — dollar fields still flow internally (e.g. to the QAP predictor's `localSoftFunding` factor), just not to the user's eyes.

- `soft-funding-breakdown.js` — drop "Available \$" column, drop "Theoretical coverage of gap" block, replace the PAB progress-bar with a qualitative "verify at CDOLA/CHFA" warning, add info banner above the catalog
- `lihtc-concept-card-renderer.js` — drop `<dt>Available</dt>` row from the soft-funding details; add verify-with-admin note

## What users see now

**Before:** "CHFA Competitiveness: 82/100 Strong (73% likelihood)" — numbers look authoritative.
**After:** same numbers, prefixed with an amber "⚠ Synthesized sample data — modelled from public CHFA announcements. Verify at CHFA's award history."

**Before:** Soft-funding table with Program / Available \$ / Competition / Deadline columns, plus a "Theoretical coverage of gap: 47%" strip.
**After:** Program / Competition / Deadline. Info banner: *"Balances not shown — dollar-level availability drifts quarterly; confirm directly with the admin entity."*

## Test plan
- [x] `node --check` on all 4 modified files
- [x] `node --test test/soft-funding-tracker.test.js` — 40/40 pass (no API shape change)
- [x] `node test/test_chfa_award_predictor.js` — 133/133 pass
- [ ] Visual smoke: open `deal-calculator.html`, switch to 9%, confirm QAP banner renders
- [ ] Visual smoke: open `deal-calculator.html`, switch to 4%, confirm qualitative PAB warning renders (no progress bar, no dollar figures)
- [ ] Visual smoke: open concept card — soft-funding section has no "Available" row; CHFA section has banner

## Relationship to prior cleanup
- #710 — stripped my own session's unverified claims
- #711 — trend-analysis.js DEMO banner
- #713 — Category A null-propagation (chfa-award-predictor, floodRiskScore, estimatedWorkers)
- **this PR** — Category B (B1 CHFA banner + B2 soft-funding dollars)
- next — Category C (scorer refactor to `{score, available}` pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)