### PR TITLE
refactor(honesty): scorers return {score,unavailable} — no fabricated 50

### DIFF
--- a/docs/api/js__market-analysis__site-selection-score.md
+++ b/docs/api/js__market-analysis__site-selection-score.md
@@ -12,6 +12,31 @@ Component weights (must sum to 1.0):
   policy      0.15
   market      0.10
 
+## Null-propagation contract (data-unavailable dimensions)
+
+The three "data-driven" scorers — `scoreDemand`, `scoreAccess`,
+`scoreLandSupply` — previously returned a neutral `50` when their
+input was missing (no ACS aggregate, no amenity distances, etc.).
+That silently injected a fabricated "moderate" signal into the
+composite score, which for many real sites flipped their opportunity
+band (e.g. a pure subsidy+policy site with no ACS data was ranked
+identical to a genuinely moderate site). That was dishonest.
+
+Those three scorers now return `{ score: number|null, unavailable:
+boolean, reason?: string }`. When any component returns
+`unavailable: true`, `computeScore` drops its contribution and
+proportionally redistributes its weight across the remaining
+available components — the same pattern used for rent-pressure in
+`js/market-analysis.js` (see PR #693). The composite output
+surfaces `dimensionsAvailable`, `dimensionsUnavailable`, and
+`unavailableDimensions` so UI can show "scored on N of 6
+dimensions" rather than fake 100% confidence.
+
+The remaining three scorers (`scoreSubsidy`, `scoreFeasibility`,
+`scorePolicy`, `scoreMarket`) accept primitive numeric/boolean
+inputs and are treated as always-available — a missing flag is
+the absence of a bonus, not the absence of measurement.
+
 ## Symbols
 
 ### `COMPONENT_WEIGHTS`
@@ -48,7 +73,11 @@ Drivers:
 
 @param {object|null} acs - Aggregated ACS object.
   Expected keys: cost_burden_rate (0–1), renter_share (0–1), poverty_rate (0–1).
-@returns {number} 0–100
+@returns {{ score: number|null, unavailable: boolean, reason?: string }}
+  When `acs` is missing or not an object, returns
+  `{ score: null, unavailable: true, reason: 'ACS aggregate unavailable' }`
+  so the composite can redistribute this dimension's weight rather than
+  scoring the site as "moderate" against a fabricated baseline.
 
 ### `scoreSubsidy(qctFlag, ddaFlag, fmrRatio, nearbySubsidized, basis_boost_eligible)`
 
@@ -95,7 +124,10 @@ With walkability context: 55% distance + 25% walkability + 20% bikeability.
   Keys: grocery, transit, parks, healthcare, schools.
 @param {object|null} [walkabilityCtx] - From EpaWalkability.getScores().
   Keys: walkScore (0-100), bikeScore (0-100).
-@returns {number} 0–100
+@returns {{ score: number|null, unavailable: boolean, reason?: string }}
+  When `amenities` is missing or not an object, returns
+  `{ score: null, unavailable: true, reason: 'amenity distances unavailable' }`
+  so the composite can redistribute this dimension's weight.
 
 ### `scorePolicy(zoningCapacity, publicOwnership, overlayCount)`
 
@@ -136,6 +168,7 @@ Distance at or below `near` earns full points; at or above `far` earns 0.
     }
 
     var distanceScore = _clamp(grocery + transitPts + parks + healthcare + schools);
+    var finalScore = distanceScore;
 
     // If walkability context is available, blend it into the access score.
     // This captures whether the measured distances are actually traversable
@@ -144,14 +177,14 @@ Distance at or below `near` earns full points; at or above `far` earns 0.
     if (walkabilityCtx && typeof walkabilityCtx.walkScore === 'number') {
       var walkPts = _clamp(walkabilityCtx.walkScore);
       var bikePts = _clamp(_safe(walkabilityCtx.bikeScore, walkPts));
-      return _clamp(Math.round(
+      finalScore = _clamp(Math.round(
         distanceScore * 0.55 +
         walkPts       * 0.25 +
         bikePts       * 0.20
       ));
     }
 
-    return distanceScore;
+    return { score: finalScore, unavailable: false };
   }
 
   /**
@@ -176,6 +209,11 @@ Score market conditions for affordable housing viability.
 
 Compute the composite site selection score.
 
+When the data-driven scorers (`scoreDemand`, `scoreAccess`) return
+`unavailable: true`, their weights are redistributed proportionally
+across the remaining available components — no fabricated neutral
+50 injected into the composite.
+
 @param {object} inputs
 @param {object}  inputs.acs               - ACS aggregate (see scoreDemand).
 @param {boolean} inputs.qctFlag            - QCT designation.
@@ -194,21 +232,29 @@ Compute the composite site selection score.
 @param {number}  inputs.concentration      - Market concentration 0–1.
 @param {number}  inputs.serviceStrength    - Service employment share 0–1.
 @returns {{
-  demand_score: number,
+  demand_score: number|null,
   subsidy_score: number,
   feasibility_score: number,
-  access_score: number,
+  access_score: number|null,
   policy_score: number,
   market_score: number,
   final_score: number,
   opportunity_band: string,
   component_weights: object,
+  dimensionsAvailable: number,
+  dimensionsUnavailable: number,
+  unavailableDimensions: string[],
   narrative: string
 }}
 
-### `_buildNarrative(final, band, demand, subsidy, feasibility, access, policy, market)`
+### `_buildNarrative(final, band, demand, subsidy, feasibility, access, policy, market, unavailableDimensions)`
 
 Build a plain-English narrative summarizing the scoring result.
+
+When some dimensions are unavailable (null scores), the narrative
+disclaims this explicitly instead of treating nulls as zeros — a
+zero would mislead the "top driver" / "risk" ranking.
+
 @private
 
 ### `scoreLandSupply(acs)`
@@ -220,17 +266,20 @@ for new construction. Low vacancy = tight market = demand signal.
 Function name retained for backward compatibility.
 
 @param {object|null} acs - ACS aggregate. Expected key: vacancy_rate (0–1 decimal).
-@returns {number} 0–100
+@returns {{ score: number|null, unavailable: boolean, reason?: string }}
+  When `acs` is missing, returns `{ score: null, unavailable: true }`
+  so the composite can redistribute this dimension's weight.
 
 ### `scoreLandSupplyWithBridge(acs, bridgeContext)`
 
 Enhanced land-supply score that incorporates Bridge assessed land value data.
 When Bridge data is unavailable, falls back to pure ACS vacancy-based scoring.
+When ACS is also unavailable, propagates the unavailable flag.
 
 @param {object} acs - ACS data (vacancy_rate etc.)
 @param {object|null} bridgeContext - from BridgeMarketSummary.getLandCostContext()
   { tier: 'low'|'moderate'|'high'|'unknown', medianLandValue: number|null, isRural: boolean }
-@returns {number} 0-100
+@returns {{ score: number|null, unavailable: boolean, reason?: string }}
 
 ### `scoreMarketWithBridge(rentTrend, jobTrend, concentration, serviceStrength, bridgeContext)`
 

--- a/js/market-analysis.js
+++ b/js/market-analysis.js
@@ -501,9 +501,19 @@
       ? window.BridgeMarketSummary.getLandCostContext(lat, lon)
       : null;
     var SSS = window.SiteSelectionScore || {};
-    var marketTightnessScore = (SSS.scoreLandSupplyWithBridge && _bridgeLandCtx)
+    // scoreLandSupplyWithBridge now returns { score, unavailable } per the
+    // null-propagation refactor — unwrap defensively. If the Bridge path
+    // reports unavailable (ACS missing), fall back to the local
+    // scoreMarketTightness which accepts a defaulted vacancy_rate.
+    var _landResult = (SSS.scoreLandSupplyWithBridge && _bridgeLandCtx)
       ? SSS.scoreLandSupplyWithBridge(acs, _bridgeLandCtx)
-      : scoreMarketTightness(acs);
+      : null;
+    var marketTightnessScore;
+    if (_landResult && !_landResult.unavailable && typeof _landResult.score === 'number') {
+      marketTightnessScore = _landResult.score;
+    } else {
+      marketTightnessScore = scoreMarketTightness(acs);
+    }
 
     // Enhance market score with Bridge transaction velocity
     var _bridgeVelCtx = (window.BridgeMarketSummary && window.BridgeMarketSummary.isAvailable())

--- a/js/market-analysis/site-selection-score.js
+++ b/js/market-analysis/site-selection-score.js
@@ -10,6 +10,31 @@
  *   access      0.15
  *   policy      0.15
  *   market      0.10
+ *
+ * ## Null-propagation contract (data-unavailable dimensions)
+ *
+ * The three "data-driven" scorers — `scoreDemand`, `scoreAccess`,
+ * `scoreLandSupply` — previously returned a neutral `50` when their
+ * input was missing (no ACS aggregate, no amenity distances, etc.).
+ * That silently injected a fabricated "moderate" signal into the
+ * composite score, which for many real sites flipped their opportunity
+ * band (e.g. a pure subsidy+policy site with no ACS data was ranked
+ * identical to a genuinely moderate site). That was dishonest.
+ *
+ * Those three scorers now return `{ score: number|null, unavailable:
+ * boolean, reason?: string }`. When any component returns
+ * `unavailable: true`, `computeScore` drops its contribution and
+ * proportionally redistributes its weight across the remaining
+ * available components — the same pattern used for rent-pressure in
+ * `js/market-analysis.js` (see PR #693). The composite output
+ * surfaces `dimensionsAvailable`, `dimensionsUnavailable`, and
+ * `unavailableDimensions` so UI can show "scored on N of 6
+ * dimensions" rather than fake 100% confidence.
+ *
+ * The remaining three scorers (`scoreSubsidy`, `scoreFeasibility`,
+ * `scorePolicy`, `scoreMarket`) accept primitive numeric/boolean
+ * inputs and are treated as always-available — a missing flag is
+ * the absence of a bonus, not the absence of measurement.
  */
 (function () {
   'use strict';
@@ -73,10 +98,20 @@
    *
    * @param {object|null} acs - Aggregated ACS object.
    *   Expected keys: cost_burden_rate (0–1), renter_share (0–1), poverty_rate (0–1).
-   * @returns {number} 0–100
+   * @returns {{ score: number|null, unavailable: boolean, reason?: string }}
+   *   When `acs` is missing or not an object, returns
+   *   `{ score: null, unavailable: true, reason: 'ACS aggregate unavailable' }`
+   *   so the composite can redistribute this dimension's weight rather than
+   *   scoring the site as "moderate" against a fabricated baseline.
    */
   function scoreDemand(acs) {
-    if (!acs || typeof acs !== 'object') return 50; // neutral fallback
+    if (!acs || typeof acs !== 'object') {
+      return {
+        score: null,
+        unavailable: true,
+        reason: 'ACS aggregate unavailable'
+      };
+    }
 
     // Cost-burden component: 45 %+ is the high-pressure ceiling.
     var cb    = _safe(acs.cost_burden_rate, 0.30);
@@ -90,7 +125,10 @@
     var pov    = _safe(acs.poverty_rate, 0.12);
     var povPts = _clamp((pov / 0.20) * 20);
 
-    return _clamp(cbPts + rsPts + povPts);
+    return {
+      score: _clamp(cbPts + rsPts + povPts),
+      unavailable: false
+    };
   }
 
   /**
@@ -190,10 +228,19 @@
    *   Keys: grocery, transit, parks, healthcare, schools.
    * @param {object|null} [walkabilityCtx] - From EpaWalkability.getScores().
    *   Keys: walkScore (0-100), bikeScore (0-100).
-   * @returns {number} 0–100
+   * @returns {{ score: number|null, unavailable: boolean, reason?: string }}
+   *   When `amenities` is missing or not an object, returns
+   *   `{ score: null, unavailable: true, reason: 'amenity distances unavailable' }`
+   *   so the composite can redistribute this dimension's weight.
    */
   function scoreAccess(amenities, walkabilityCtx) {
-    if (!amenities || typeof amenities !== 'object') return 50;
+    if (!amenities || typeof amenities !== 'object') {
+      return {
+        score: null,
+        unavailable: true,
+        reason: 'amenity distances unavailable'
+      };
+    }
 
     /**
      * Convert a distance to a 0–maxPts score.
@@ -233,6 +280,7 @@
     }
 
     var distanceScore = _clamp(grocery + transitPts + parks + healthcare + schools);
+    var finalScore = distanceScore;
 
     // If walkability context is available, blend it into the access score.
     // This captures whether the measured distances are actually traversable
@@ -241,14 +289,14 @@
     if (walkabilityCtx && typeof walkabilityCtx.walkScore === 'number') {
       var walkPts = _clamp(walkabilityCtx.walkScore);
       var bikePts = _clamp(_safe(walkabilityCtx.bikeScore, walkPts));
-      return _clamp(Math.round(
+      finalScore = _clamp(Math.round(
         distanceScore * 0.55 +
         walkPts       * 0.25 +
         bikePts       * 0.20
       ));
     }
 
-    return distanceScore;
+    return { score: finalScore, unavailable: false };
   }
 
   /**
@@ -308,6 +356,11 @@
   /**
    * Compute the composite site selection score.
    *
+   * When the data-driven scorers (`scoreDemand`, `scoreAccess`) return
+   * `unavailable: true`, their weights are redistributed proportionally
+   * across the remaining available components — no fabricated neutral
+   * 50 injected into the composite.
+   *
    * @param {object} inputs
    * @param {object}  inputs.acs               - ACS aggregate (see scoreDemand).
    * @param {boolean} inputs.qctFlag            - QCT designation.
@@ -326,58 +379,84 @@
    * @param {number}  inputs.concentration      - Market concentration 0–1.
    * @param {number}  inputs.serviceStrength    - Service employment share 0–1.
    * @returns {{
-   *   demand_score: number,
+   *   demand_score: number|null,
    *   subsidy_score: number,
    *   feasibility_score: number,
-   *   access_score: number,
+   *   access_score: number|null,
    *   policy_score: number,
    *   market_score: number,
    *   final_score: number,
    *   opportunity_band: string,
    *   component_weights: object,
+   *   dimensionsAvailable: number,
+   *   dimensionsUnavailable: number,
+   *   unavailableDimensions: string[],
    *   narrative: string
    * }}
    */
   function computeScore(inputs) {
     var i = inputs || {};
+    var W = COMPONENT_WEIGHTS;
 
-    var demand_score      = Math.round(scoreDemand(i.acs));
+    var demandResult  = scoreDemand(i.acs);
+    var accessResult  = scoreAccess(i.amenities, i.walkabilityCtx);
+
+    // Subsidy, feasibility, policy, market take primitive inputs — a missing
+    // flag is the absence of a bonus, not the absence of measurement, so
+    // they are always treated as available.
     var subsidy_score     = Math.round(scoreSubsidy(i.qctFlag, i.ddaFlag, i.fmrRatio, i.nearbySubsidized, i.basisBoostEligible));
     var feasibility_score = Math.round(scoreFeasibility(i.floodRisk, i.soilScore, i.cleanupFlag));
-    var access_score      = Math.round(scoreAccess(i.amenities, i.walkabilityCtx));
     var policy_score      = Math.round(scorePolicy(i.zoningCapacity, i.publicOwnership, i.overlayCount));
     var market_score      = Math.round(scoreMarket(i.rentTrend, i.jobTrend, i.concentration, i.serviceStrength));
 
-    var W = COMPONENT_WEIGHTS;
-    var final_score = Math.round(
-      demand_score      * W.demand      +
-      subsidy_score     * W.subsidy     +
-      feasibility_score * W.feasibility +
-      access_score      * W.access      +
-      policy_score      * W.policy      +
-      market_score      * W.market
-    );
-    final_score = _clamp(final_score);
+    var demand_score = demandResult.unavailable ? null : Math.round(demandResult.score);
+    var access_score = accessResult.unavailable ? null : Math.round(accessResult.score);
+
+    // Build the list of contributing components. Unavailable components
+    // drop out — their weight is redistributed proportionally across
+    // the remaining contributors (same pattern used for rent-pressure
+    // in js/market-analysis.js).
+    var contributors = [];
+    if (!demandResult.unavailable) contributors.push({ key: 'demand',      weight: W.demand,      score: demand_score });
+    contributors.push({ key: 'subsidy',     weight: W.subsidy,     score: subsidy_score });
+    contributors.push({ key: 'feasibility', weight: W.feasibility, score: feasibility_score });
+    if (!accessResult.unavailable) contributors.push({ key: 'access',      weight: W.access,      score: access_score });
+    contributors.push({ key: 'policy',      weight: W.policy,      score: policy_score });
+    contributors.push({ key: 'market',      weight: W.market,      score: market_score });
+
+    var unavailableDimensions = [];
+    if (demandResult.unavailable) unavailableDimensions.push('demand');
+    if (accessResult.unavailable) unavailableDimensions.push('access');
+
+    var effectiveWeightSum = contributors.reduce(function (s, c) { return s + c.weight; }, 0);
+    var weighted = contributors.reduce(function (s, c) { return s + c.score * c.weight; }, 0);
+    var final_score = effectiveWeightSum > 0
+      ? _clamp(Math.round(weighted / effectiveWeightSum))
+      : 0;
 
     var opportunity_band = _band(final_score);
 
     var narrative = _buildNarrative(
       final_score, opportunity_band,
       demand_score, subsidy_score, feasibility_score,
-      access_score, policy_score, market_score
+      access_score, policy_score, market_score,
+      unavailableDimensions
     );
 
     return {
-      demand_score:      demand_score,
-      subsidy_score:     subsidy_score,
-      feasibility_score: feasibility_score,
-      access_score:      access_score,
-      policy_score:      policy_score,
-      market_score:      market_score,
-      final_score:       final_score,
-      opportunity_band:  opportunity_band,
-      component_weights: COMPONENT_WEIGHTS,
-      narrative:         narrative
+      demand_score:          demand_score,
+      subsidy_score:         subsidy_score,
+      feasibility_score:     feasibility_score,
+      access_score:          access_score,
+      policy_score:          policy_score,
+      market_score:          market_score,
+      final_score:           final_score,
+      opportunity_band:      opportunity_band,
+      component_weights:     COMPONENT_WEIGHTS,
+      dimensionsAvailable:   contributors.length,
+      dimensionsUnavailable: unavailableDimensions.length,
+      unavailableDimensions: unavailableDimensions,
+      narrative:             narrative
     };
   }
 
@@ -385,32 +464,48 @@
 
   /**
    * Build a plain-English narrative summarizing the scoring result.
+   *
+   * When some dimensions are unavailable (null scores), the narrative
+   * disclaims this explicitly instead of treating nulls as zeros — a
+   * zero would mislead the "top driver" / "risk" ranking.
+   *
    * @private
    */
-  function _buildNarrative(final, band, demand, subsidy, feasibility, access, policy, market) {
+  function _buildNarrative(final, band, demand, subsidy, feasibility, access, policy, market, unavailableDimensions) {
     var parts = [];
+    unavailableDimensions = unavailableDimensions || [];
+
+    var availableNote = unavailableDimensions.length > 0
+      ? ' (scored on ' + (6 - unavailableDimensions.length) + ' of 6 dimensions — '
+          + unavailableDimensions.join(', ') + ' data unavailable)'
+      : '';
 
     parts.push(
-      'This site received an overall score of ' + final + '/100, ' +
+      'This site received an overall score of ' + final + '/100' + availableNote + ', ' +
       'placing it in the \u201c' + band + '\u201d opportunity band.'
     );
 
-    // Identify the top driver (highest scoring component).
-    // Sort a copy so the original declaration order is preserved.
+    // Identify the top driver (highest scoring component). Unavailable
+    // components drop out of the ranking rather than being treated as 0.
     var comps = [
-      { label: 'housing demand', score: demand },
-      { label: 'subsidy eligibility', score: subsidy },
+      { label: 'housing demand',       score: demand },
+      { label: 'subsidy eligibility',  score: subsidy },
       { label: 'physical feasibility', score: feasibility },
-      { label: 'neighborhood access', score: access },
-      { label: 'policy environment', score: policy },
-      { label: 'market conditions', score: market }
-    ].slice().sort(function (a, b) { return b.score - a.score; });
+      { label: 'neighborhood access',  score: access },
+      { label: 'policy environment',   score: policy },
+      { label: 'market conditions',    score: market }
+    ].filter(function (c) { return c.score != null; })
+      .slice().sort(function (a, b) { return b.score - a.score; });
 
-    parts.push(
-      'The strongest driver is ' + comps[0].label +
-      ' (' + comps[0].score + '), followed by ' +
-      comps[1].label + ' (' + comps[1].score + ').'
-    );
+    if (comps.length >= 2) {
+      parts.push(
+        'The strongest driver is ' + comps[0].label +
+        ' (' + comps[0].score + '), followed by ' +
+        comps[1].label + ' (' + comps[1].score + ').'
+      );
+    } else if (comps.length === 1) {
+      parts.push('The only available driver is ' + comps[0].label + ' (' + comps[0].score + ').');
+    }
 
     // Flag any component below 40 as a risk.
     var risks = comps.filter(function (c) { return c.score < 40; });
@@ -419,8 +514,8 @@
       parts.push(
         'Areas requiring attention: ' + riskLabels + '.'
       );
-    } else {
-      parts.push('No components scored below the moderate threshold.');
+    } else if (comps.length > 0) {
+      parts.push('No available components scored below the moderate threshold.');
     }
 
     return parts.join(' ');
@@ -434,27 +529,42 @@
    * Function name retained for backward compatibility.
    *
    * @param {object|null} acs - ACS aggregate. Expected key: vacancy_rate (0–1 decimal).
-   * @returns {number} 0–100
+   * @returns {{ score: number|null, unavailable: boolean, reason?: string }}
+   *   When `acs` is missing, returns `{ score: null, unavailable: true }`
+   *   so the composite can redistribute this dimension's weight.
    */
   function scoreLandSupply(acs) {
-    if (!acs || typeof acs !== 'object') return 50;
+    if (!acs || typeof acs !== 'object') {
+      return {
+        score: null,
+        unavailable: true,
+        reason: 'ACS vacancy data unavailable'
+      };
+    }
     var vac = _safe(acs.vacancy_rate, 0.05);
     // Very low vacancy (<1%) → score ≈ 92; at 12%+ vacancy → score ≈ 0.
-    return _clamp(Math.round((1 - vac / 0.12) * 100));
+    return {
+      score: _clamp(Math.round((1 - vac / 0.12) * 100)),
+      unavailable: false
+    };
   }
 
   /**
    * Enhanced land-supply score that incorporates Bridge assessed land value data.
    * When Bridge data is unavailable, falls back to pure ACS vacancy-based scoring.
+   * When ACS is also unavailable, propagates the unavailable flag.
    *
    * @param {object} acs - ACS data (vacancy_rate etc.)
    * @param {object|null} bridgeContext - from BridgeMarketSummary.getLandCostContext()
    *   { tier: 'low'|'moderate'|'high'|'unknown', medianLandValue: number|null, isRural: boolean }
-   * @returns {number} 0-100
+   * @returns {{ score: number|null, unavailable: boolean, reason?: string }}
    */
   function scoreLandSupplyWithBridge(acs, bridgeContext) {
-    var base = scoreLandSupply(acs);   // ACS vacancy-rate base score
-    if (!bridgeContext || bridgeContext.tier === 'unknown') return base;
+    var baseResult = scoreLandSupply(acs);   // ACS vacancy-rate base score
+    if (baseResult.unavailable) return baseResult;
+
+    var base = baseResult.score;
+    if (!bridgeContext || bridgeContext.tier === 'unknown') return baseResult;
 
     // Blend: 60% ACS vacancy signal, 40% Bridge land cost signal
     var landCostScore;
@@ -465,7 +575,10 @@
     // Rural bonus: rural markets have structurally more developable land
     if (bridgeContext.isRural) landCostScore = Math.min(100, landCostScore + 10);
 
-    return _clamp(Math.round(base * 0.60 + landCostScore * 0.40));
+    return {
+      score: _clamp(Math.round(base * 0.60 + landCostScore * 0.40)),
+      unavailable: false
+    };
   }
 
   /**

--- a/js/pma-competitive-set.js
+++ b/js/pma-competitive-set.js
@@ -136,6 +136,14 @@
       if (nhpdMatch) {
         expiryYear = _propExpiryYear(nhpdMatch);
       }
+      // AMI targeting: preserve null when unknown rather than defaulting
+      // to 60% — the previous `|| 60` fallback fabricated a concrete
+      // targeting level for records that simply didn't report one,
+      // which corrupted downstream comparisons against this property's
+      // "AMI mix" in a competitive-set view.
+      var rawAmi = props.AMI_PCT != null ? props.AMI_PCT
+                 : props.amiPercent != null ? props.amiPercent
+                 : null;
       return {
         id:              props.HUDID || props.id || ('lihtc-' + Math.random().toString(36).slice(2)),
         name:            _propName(f),
@@ -144,7 +152,7 @@
         distanceMiles:   Math.round(dist * 10) / 10,
         units:           _propUnits(f),
         programType:     props.PROGRAM || props.programType || 'LIHTC',
-        amiPercent:      toNum(props.AMI_PCT || props.amiPercent || 60),
+        amiPercent:      rawAmi != null ? toNum(rawAmi) : null,
         yearPlaced:      toNum(props.YR_PIS || props.yearPlaced || 0),
         yearAllocated:   toNum(props.YR_ALLOC || props.YEAR_ALLOC || props.yearAllocated || 0),
         creditType:      props.CREDIT || props.creditType || '',
@@ -172,7 +180,8 @@
           distanceMiles:   Math.round(dist * 10) / 10,
           units:           _propUnits(f),
           programType:     props.program || props.PROGRAM || props.subsidy_type || 'Section 8',
-          amiPercent:      toNum(props.amiPercent || 60),
+          // Preserve null for unknown AMI targeting (see LIHTC branch above).
+          amiPercent:      props.amiPercent != null ? toNum(props.amiPercent) : null,
           yearPlaced:      toNum(props.yearPlaced || 0),
           hasNhpd:         true,
           subsidyExpiryYear: expYear,

--- a/js/pma-transit.js
+++ b/js/pma-transit.js
@@ -114,8 +114,13 @@
       });
     });
 
+    // High-frequency classification: only count routes whose headway is
+    // actually known. Previously used `r.headwayMinutes || 60` which
+    // silently treated unknown headways as 60-minute service — effectively
+    // penalising routes with missing metadata. Routes with no reported
+    // headway now drop out of the high-frequency bucket transparently.
     var highFreqCount = nearbyRoutes.filter(function (r) {
-      return toNum(r.headwayMinutes || 60) <= HIGH_FREQUENCY_MIN;
+      return r.headwayMinutes != null && toNum(r.headwayMinutes) <= HIGH_FREQUENCY_MIN;
     }).length;
     var freqScore = nearbyRoutes.length
       ? clamp((highFreqCount / nearbyRoutes.length) * 100 + (nearbyRoutes.length > 2 ? 20 : 0), 0, 100)
@@ -229,7 +234,10 @@
           properties: {
             routeId:   r.routeId || r.id || 'unknown',
             routeName: r.name || r.routeName || 'Transit Route',
-            headway:   toNum(r.headwayMinutes || 60),
+            // Pass through null when headway is unknown rather than
+            // fabricating a 60-minute default. Map layers / downstream
+            // consumers should render "—" for null.
+            headway:   r.headwayMinutes != null ? toNum(r.headwayMinutes) : null,
             mode:      r.mode || 'Bus'
           }
         };
@@ -257,7 +265,10 @@
       nearbyRouteCount:          _lastDataSources.nearbyRouteCount || lastRoutes.length,
       serviceGaps:               lastDeserts.length,
       hasHighFrequencyService:   lastRoutes.some(function (r) {
-        return toNum(r.headwayMinutes || 60) <= HIGH_FREQUENCY_MIN;
+        // Only "known high-frequency" counts — unknown headways don't
+        // get a manufactured 60-minute default that would exclude them
+        // or (worse) falsely include them in the justification.
+        return r.headwayMinutes != null && toNum(r.headwayMinutes) <= HIGH_FREQUENCY_MIN;
       }),
       // Extended EPA SLD metrics (available when _dataSource is epa-sld-local)
       jobAccess:                 epa.jobAccess != null ? epa.jobAccess : null,

--- a/test/unit/site-selection-score.test.js
+++ b/test/unit/site-selection-score.test.js
@@ -5,7 +5,7 @@
 // Verifies:
 //   1. Public API is fully exposed on window.
 //   2. Component weights sum to 1.0.
-//   3. scoreDemand — null/missing input returns 50.
+//   3. scoreDemand — null/missing input returns { score: null, unavailable: true }.
 //   4. scoreDemand — high cost burden, renter share, poverty yields high score.
 //   5. scoreDemand — all-zero inputs yield 0.
 //   6. scoreSubsidy — QCT flag awards 30 pts without basis_boost_eligible.
@@ -18,7 +18,7 @@
 //  13. scoreFeasibility — cleanupFlag deducts 10 pts.
 //  14. scoreAccess — all amenities close scores near 100.
 //  15. scoreAccess — all amenities far scores 0.
-//  16. scoreAccess — null input returns 50.
+//  16. scoreAccess — null input returns { score: null, unavailable: true }.
 //  17. scorePolicy — public ownership adds 30 pts.
 //  18. scorePolicy — overlayCount contributes up to 20 pts.
 //  19. scoreMarket — all drivers at ceiling = 100.
@@ -27,6 +27,8 @@
 //  22. computeScore — final_score is within [0, 100].
 //  23. computeScore — opportunity_band matches final_score tier.
 //  24. computeScore — narrative is a non-empty string referencing score.
+//  25. computeScore — unavailable demand/access redistributes weight (no fabricated 50).
+//  26. computeScore — unavailableDimensions array surfaces missing inputs.
 //
 // Usage: node test/unit/site-selection-score.test.js
 
@@ -88,13 +90,23 @@ test('COMPONENT_WEIGHTS sum to exactly 1.0', function () {
 });
 
 // ---------------------------------------------------------------------------
-// 3. scoreDemand — null/missing input
+// 3. scoreDemand — null/missing input signals unavailability (no fabricated 50)
 // ---------------------------------------------------------------------------
 
-test('scoreDemand returns 50 for null input', function () {
-  assert(SSS.scoreDemand(null)      === 50, 'null → 50');
-  assert(SSS.scoreDemand(undefined) === 50, 'undefined → 50');
-  assert(SSS.scoreDemand('string')  === 50, 'string → 50');
+test('scoreDemand returns { score:null, unavailable:true } for missing input', function () {
+  const nullResult = SSS.scoreDemand(null);
+  assert(nullResult && typeof nullResult === 'object',      'null → object');
+  assert(nullResult.score === null,                         'null → score === null');
+  assert(nullResult.unavailable === true,                   'null → unavailable === true');
+  assert(typeof nullResult.reason === 'string',             'null → reason string present');
+
+  const undefResult = SSS.scoreDemand(undefined);
+  assert(undefResult.score === null && undefResult.unavailable === true,
+    'undefined → { score:null, unavailable:true }');
+
+  const strResult = SSS.scoreDemand('string');
+  assert(strResult.score === null && strResult.unavailable === true,
+    'string → { score:null, unavailable:true }');
 });
 
 // ---------------------------------------------------------------------------
@@ -102,13 +114,14 @@ test('scoreDemand returns 50 for null input', function () {
 // ---------------------------------------------------------------------------
 
 test('scoreDemand returns high score for high cost burden / renter share / poverty', function () {
-  const score = SSS.scoreDemand({
+  const result = SSS.scoreDemand({
     cost_burden_rate: 0.55, // above 0.45 ceiling
     renter_share:     0.70, // above 0.60 ceiling
     poverty_rate:     0.25, // above 0.20 ceiling
   });
   // Expected: cbPts=50 + rsPts=30 + povPts=20 = 100 (clamped)
-  assert(score === 100, 'max stress inputs → 100 (got ' + score + ')');
+  assert(result.unavailable === false, 'with data → unavailable === false');
+  assert(result.score === 100, 'max stress inputs → 100 (got ' + result.score + ')');
 });
 
 // ---------------------------------------------------------------------------
@@ -116,8 +129,9 @@ test('scoreDemand returns high score for high cost burden / renter share / pover
 // ---------------------------------------------------------------------------
 
 test('scoreDemand returns 0 for all-zero ACS fields', function () {
-  const score = SSS.scoreDemand({ cost_burden_rate: 0, renter_share: 0, poverty_rate: 0 });
-  assert(score === 0, 'all zeros → 0 (got ' + score + ')');
+  const result = SSS.scoreDemand({ cost_burden_rate: 0, renter_share: 0, poverty_rate: 0 });
+  assert(result.unavailable === false, 'zeros → unavailable === false');
+  assert(result.score === 0, 'all zeros → 0 (got ' + result.score + ')');
 });
 
 // ---------------------------------------------------------------------------
@@ -225,14 +239,15 @@ test('scoreFeasibility deducts 10 pts for cleanupFlag=true', function () {
 // ---------------------------------------------------------------------------
 
 test('scoreAccess returns 100 when all amenities are at or below near threshold', function () {
-  const score = SSS.scoreAccess({
+  const result = SSS.scoreAccess({
     grocery:    0.3,  // ≤0.5
     transit:    0.2,  // ≤0.25
     parks:      0.2,  // ≤0.25
     healthcare: 0.9,  // ≤1.0
     schools:    0.4,  // ≤0.5
   });
-  assert(score === 100, 'all close amenities → 100 (got ' + score + ')');
+  assert(result.unavailable === false, 'with data → unavailable === false');
+  assert(result.score === 100, 'all close amenities → 100 (got ' + result.score + ')');
 });
 
 // ---------------------------------------------------------------------------
@@ -240,23 +255,30 @@ test('scoreAccess returns 100 when all amenities are at or below near threshold'
 // ---------------------------------------------------------------------------
 
 test('scoreAccess returns 0 when all amenities exceed far threshold', function () {
-  const score = SSS.scoreAccess({
+  const result = SSS.scoreAccess({
     grocery:    5.0,
     transit:    5.0,
     parks:      5.0,
     healthcare: 5.0,
     schools:    5.0,
   });
-  assert(score === 0, 'all far amenities → 0 (got ' + score + ')');
+  assert(result.unavailable === false, 'far amenities → unavailable === false');
+  assert(result.score === 0, 'all far amenities → 0 (got ' + result.score + ')');
 });
 
 // ---------------------------------------------------------------------------
-// 16. scoreAccess — null input
+// 16. scoreAccess — null input signals unavailability (no fabricated 50)
 // ---------------------------------------------------------------------------
 
-test('scoreAccess returns 50 for null input', function () {
-  assert(SSS.scoreAccess(null) === 50, 'null → 50');
-  assert(SSS.scoreAccess()     === 50, 'undefined → 50');
+test('scoreAccess returns { score:null, unavailable:true } for missing input', function () {
+  const nullResult = SSS.scoreAccess(null);
+  assert(nullResult && typeof nullResult === 'object', 'null → object');
+  assert(nullResult.score === null,                    'null → score === null');
+  assert(nullResult.unavailable === true,              'null → unavailable === true');
+
+  const undefResult = SSS.scoreAccess();
+  assert(undefResult.score === null && undefResult.unavailable === true,
+    'undefined → { score:null, unavailable:true }');
 });
 
 // ---------------------------------------------------------------------------
@@ -415,6 +437,71 @@ test('computeScore narrative is non-empty and references the score', function ()
     'narrative references the final score');
   assert(result.narrative.includes(result.opportunity_band),
     'narrative references the opportunity band');
+});
+
+// ---------------------------------------------------------------------------
+// 25. computeScore — unavailable demand/access redistributes weight
+// ---------------------------------------------------------------------------
+
+test('computeScore redistributes weight when demand+access unavailable (no fabricated 50)', function () {
+  // Same site with and without ACS + amenities. Composite should be
+  // computed from ONLY the available dimensions — no neutral 50
+  // silently averaged in.
+  const baseInputs = {
+    qctFlag: true, ddaFlag: true, fmrRatio: 1.2, nearbySubsidized: 50,
+    floodRisk: 0, soilScore: 80, cleanupFlag: false,
+    zoningCapacity: 120, publicOwnership: true, overlayCount: 3,
+    rentTrend: 0.05, jobTrend: 0.03, concentration: 0.2, serviceStrength: 0.30,
+  };
+
+  const allAvail = SSS.computeScore(Object.assign({}, baseInputs, {
+    acs: { cost_burden_rate: 0.30, renter_share: 0.40, poverty_rate: 0.10 },
+    amenities: { grocery: 1.0, transit: 0.5, parks: 0.5, healthcare: 2.0, schools: 1.0 },
+  }));
+
+  const demandMissing = SSS.computeScore(Object.assign({}, baseInputs, {
+    amenities: { grocery: 1.0, transit: 0.5, parks: 0.5, healthcare: 2.0, schools: 1.0 },
+    // no acs
+  }));
+
+  const bothMissing = SSS.computeScore(baseInputs);
+  // (no acs, no amenities)
+
+  assert(allAvail.dimensionsAvailable === 6, 'all 6 dims available when inputs complete');
+  assert(demandMissing.dimensionsAvailable === 5, 'demand missing → 5 dims available');
+  assert(demandMissing.dimensionsUnavailable === 1, 'demand missing → 1 unavailable');
+  assert(demandMissing.unavailableDimensions.indexOf('demand') >= 0,
+    'unavailableDimensions lists demand');
+  assert(demandMissing.demand_score === null, 'demand_score is null when ACS missing');
+  assert(typeof demandMissing.final_score === 'number' && demandMissing.final_score >= 0,
+    'final_score is still a valid number when a dim is unavailable');
+
+  assert(bothMissing.dimensionsAvailable === 4, 'both missing → 4 dims');
+  assert(bothMissing.demand_score === null && bothMissing.access_score === null,
+    'both null when both inputs missing');
+  assert(bothMissing.unavailableDimensions.length === 2,
+    'unavailableDimensions lists both');
+});
+
+// ---------------------------------------------------------------------------
+// 26. computeScore — narrative discloses unavailable dimensions
+// ---------------------------------------------------------------------------
+
+test('computeScore narrative mentions unavailable dimensions when present', function () {
+  const result = SSS.computeScore({
+    qctFlag: true, ddaFlag: false, fmrRatio: 1.0, nearbySubsidized: 50,
+    floodRisk: 0, soilScore: 70, cleanupFlag: false,
+    zoningCapacity: 100, publicOwnership: false, overlayCount: 1,
+    rentTrend: 0.02, jobTrend: 0.02, concentration: 0.4, serviceStrength: 0.25,
+    // no acs, no amenities
+  });
+  assert(result.unavailableDimensions.length === 2, 'two dims unavailable');
+  assert(result.narrative.indexOf('demand') >= 0,
+    'narrative references missing demand dimension');
+  assert(result.narrative.indexOf('access') >= 0,
+    'narrative references missing access dimension');
+  assert(result.narrative.indexOf('4 of 6') >= 0,
+    'narrative says "scored on 4 of 6 dimensions"');
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Category **C** of the hallucination-cleanup staged plan (after #710/#711/#713/#714).

The three data-driven scorers used to return a neutral `50` when their input was missing — silently injecting a fabricated "moderate" signal into the composite and into the UI. For sites missing ACS or amenity data, the composite score ranked identical to genuinely moderate sites.

This ships the **null-propagation pattern already used for rent-pressure in PR #693** to the remaining scorers.

### Public shape change
```js
// before
scoreDemand(null)       // → 50
scoreAccess(null)       // → 50
scoreLandSupply(null)   // → 50

// after
scoreDemand(null)       // → { score: null, unavailable: true, reason: 'ACS aggregate unavailable' }
scoreAccess(null)       // → { score: null, unavailable: true, reason: 'amenity distances unavailable' }
scoreLandSupply(null)   // → { score: null, unavailable: true, reason: 'ACS vacancy data unavailable' }
```

### computeScore
- Unavailable dimensions drop out; their weight is redistributed proportionally across the remaining available components.
- New output fields: `dimensionsAvailable`, `dimensionsUnavailable`, `unavailableDimensions` (string[]).
- `demand_score` / `access_score` now return `null` when the underlying input was unavailable (they previously silently became 50).
- Narrative prefixes `"scored on N of 6 dimensions"` when any dim is unavailable and filters null components out of the top-driver / risk ranking.

### Incidental fabricated-default cleanup
- `pma-transit.js`: `r.headwayMinutes || 60` → null-preserving. Unknown headways no longer get a fabricated 60-minute default (which silently excluded them from the high-frequency bucket).
- `pma-competitive-set.js`: `amiPercent: toNum(... || 60)` → null when AMI targeting is unreported.
- `market-analysis.js` `computePma`: unwraps `scoreLandSupplyWithBridge`'s new object shape and falls back to local `scoreMarketTightness` when the Bridge path reports unavailable.

## Test plan

- [x] `node test/unit/site-selection-score.test.js` — 83/83 pass (67 passed before; 16 new from updated assertions + 2 new tests)
- [x] `node --test test/unit/pma-transit.test.js` — 21/21 pass
- [x] `node --test test/unit/pma-competitive-set.test.js` — 25/25 pass
- [x] `node --test test/pma-transit.test.js` — 24/24 pass
- [x] `node --test test/pma-competitive-set.test.js`
- [x] `node test/pma-scoring.test.js` — 38/38 pass
- [x] `node test/pma-confidence.test.js` — 76/76 pass
- [ ] Visual smoke: open `market-analysis.html` for a site without ACS coverage, confirm composite score is "scored on N of 6 dimensions" rather than silently 50
- [ ] Visual smoke: open deal calculator with a LIHTC competitor that has no AMI metadata — confirm no "60%" appears where the data didn't exist

## Updated tests

Three scoreDemand assertions and three scoreAccess assertions were updated to destructure `.score` / `.unavailable` from the new object return (previously compared `=== 50` / `=== 100`). Two new tests added:

- Test 25: `computeScore redistributes weight when demand+access unavailable (no fabricated 50)` — verifies dimensionsAvailable counts + weight redistribution.
- Test 26: `computeScore narrative mentions unavailable dimensions when present` — verifies the narrative says "scored on 4 of 6 dimensions" with the missing dim names.

## Composite-score numerical invariant

When all 6 dimensions ARE available, the composite equals exactly what it did before the refactor. The weight-redistribution only kicks in when a dimension is missing — so this PR **cannot** change the score of any site whose ACS + amenity data was complete.

## Relationship to prior cleanup
- #710 — stripped my own session's unverified claims
- #711 — trend-analysis.js DEMO banner
- #713 — Category A null-propagation (chfa-award-predictor, floodRiskScore, estimatedWorkers)
- #714 — Category B (CHFA predictor banner + soft-funding dollar strip)
- **this PR** — Category C (scorer null-propagation, last of the staged plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)