### PR TITLE
chore(honesty): update stale CHAS vintage labels to 2018–2022

### DIFF
--- a/.github/workflows/fetch-chas-data.yml
+++ b/.github/workflows/fetch-chas-data.yml
@@ -1,6 +1,6 @@
 name: Fetch HUD CHAS Affordability Data
 
-# Downloads HUD CHAS 2016-2020 cost-burden cross-tabulations for Colorado,
+# Downloads HUD CHAS 2018-2022 cost-burden cross-tabulations for Colorado,
 # aggregates to county level, and writes:
 #   data/market/chas_co.json              — raw Colorado CHAS records
 #   data/hna/chas_affordability_gap.json  — county-level affordability gap for HNA dashboard

--- a/colorado-deep-dive.html
+++ b/colorado-deep-dive.html
@@ -1652,7 +1652,7 @@ document.addEventListener('DOMContentLoaded', function () {
         <div style="padding:.75rem 0 .25rem;font-size:.88rem;color:var(--muted);line-height:1.7;">
           <ul style="margin:.5rem 0;padding-left:1.4rem;">
             <li><strong>ACS 5-year tract-level estimates</strong> — American Community Survey (U.S. Census Bureau), 2023 5-year estimates. Fields used: median gross rent, median household income, cost burden rate. 1,447 Colorado census tracts.</li>
-            <li><strong>CHAS data (HUD)</strong> — HUD Comprehensive Housing Affordability Strategy, 2016–2020 5-year estimates. County-level counts of renter households by AMI tier and cost-burden status.</li>
+            <li><strong>CHAS data (HUD)</strong> — HUD Comprehensive Housing Affordability Strategy, 2018–2022 5-year estimates (most recent release, Dec 2025). County-level counts of renter households by AMI tier and cost-burden status.</li>
             <li><strong>AMI gap calculations</strong> — Derived from HUD Fair Market Rents (FY2025) and Area Median Income income limits, compared against ACS-estimated household income distributions. Gap = affordable units supply minus households at each AMI threshold.</li>
             <li><strong>County boundaries</strong> — U.S. Census Bureau TIGER/Line 2024 county boundary files for Colorado.</li>
           </ul>

--- a/data/provenance/housing-needs-assessment.json
+++ b/data/provenance/housing-needs-assessment.json
@@ -40,9 +40,9 @@
     {
       "id": "chartChasGap",
       "label": "Cost burden by AMI tier (HUD CHAS)",
-      "source": "HUD CHAS 2017-2021",
+      "source": "HUD CHAS 2018-2022",
       "source_url": "https://www.huduser.gov/portal/datasets/cp.html",
-      "vintage": "CHAS 2017–2021",
+      "vintage": "CHAS 2018–2022",
       "type": "raw",
       "notes": "Renter households by AMI tier and burden status. For place/CDP geographies, values are scaled from the containing county (proxy)."
     },

--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -379,7 +379,7 @@
       <div class="chart-card span-6">
         <h2>Cost burden by AMI tier (HUD CHAS)<span id="chasApproxHint" class="data-approx-hint" hidden title="When a place or CDP is selected, CHAS tiers are scaled from the containing county — the selected geography may not have its own CHAS breakdown. See comparative-analysis detail panel for full disclaimer.">(county-approx)</span></h2>
         <p>Renter households by income tier (% of Area Median Income) showing not-burdened, moderately burdened (30–50% of income), and severely burdened (&gt;50%) households. Source: HUD Comprehensive Housing Affordability Strategy (CHAS).</p>
-        <div class="chart-box" data-source="HUD CHAS 2017-2021" data-source-url="https://www.huduser.gov/portal/datasets/cp.html" data-vintage="CHAS 2017–2021" data-source-type="raw"><canvas id="chartChasGap" role="img" aria-label="Renter cost burden by AMI income tier chart (HUD CHAS)"></canvas></div>
+        <div class="chart-box" data-source="HUD CHAS 2018-2022" data-source-url="https://www.huduser.gov/portal/datasets/cp.html" data-vintage="CHAS 2018–2022" data-source-type="raw"><canvas id="chartChasGap" role="img" aria-label="Renter cost burden by AMI income tier chart (HUD CHAS)"></canvas></div>
         <p class="sr-only">Stacked bar chart showing renter households at each AMI income tier (≤30%, 31–50%, 51–80%, 81–100%) broken down by housing cost burden status.</p>
         <p id="chasGapStatus" style="margin-top:6px;color:var(--muted);font-size:.82rem">—</p>
       </div>

--- a/js/colorado-deep-dive.js
+++ b/js/colorado-deep-dive.js
@@ -452,7 +452,7 @@ function initPolicyPanel(panelId) {
         }).addTo(map);
 
         var st = document.getElementById('affBurdenMapStatus');
-        if (st) st.textContent = 'County-level data · HUD CHAS 2016–2020 5-year estimates';
+        if (st) st.textContent = 'County-level data · HUD CHAS 2018–2022 5-year estimates';
       }).catch(function () {
         var st = document.getElementById('affBurdenMapStatus');
         if (st) st.textContent = 'Cost burden data currently unavailable.';


### PR DESCRIPTION
## Summary

Fixes 5 stale vintage labels that lied to users about which CHAS cycle they were looking at. The repo has been loading HUD CHAS 2018-2022 data since the Apr-23 refresh, but UI copy and metadata still said "2016-2020" or "2017-2021".

Verified the actual live data vintage:
- \`data/market/chas_co.json\` → \`meta.vintage = \"2018-2022\"\`
- \`scripts/fetch_chas.py\` → \`VINTAGE = '2018-2022'\`

## Files changed

| File | Was | Now |
|------|-----|-----|
| \`js/colorado-deep-dive.js:455\` | \`HUD CHAS 2016–2020 5-year\` | \`HUD CHAS 2018–2022 5-year\` |
| \`colorado-deep-dive.html:1655\` | \`2016–2020 5-year estimates\` | \`2018–2022 5-year estimates (most recent release, Dec 2025)\` |
| \`housing-needs-assessment.html:382\` | \`data-source=\"HUD CHAS 2017-2021\"\` | \`data-source=\"HUD CHAS 2018-2022\"\` |
| \`data/provenance/housing-needs-assessment.json\` | \`CHAS 2017–2021\` | \`CHAS 2018–2022\` |
| \`.github/workflows/fetch-chas-data.yml:3\` | \`HUD CHAS 2016-2020\` | \`HUD CHAS 2018-2022\` |

Skipped docstring example in \`js/components/source-badge.js\` — illustrative, not a real vintage claim.

## Test plan
- [x] \`node --check js/colorado-deep-dive.js\` — passes
- [x] JSON parses cleanly
- [ ] Visual smoke: open \`colorado-deep-dive.html\`, trigger the affordability-burden map, confirm status text now says \"2018-2022\"
- [ ] Visual smoke: open \`housing-needs-assessment.html\`, confirm CHAS chart source badge shows \"HUD CHAS 2018-2022\"

## Relationship to prior cleanup
Part of the post-hallucination audit sweep (issue #712 closed). This PR addresses one of the findings from the sub-agent accuracy sweep run after Category A/B/C shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)