### PR TITLE
chore(honesty): annotate undated statistics with sources/verify pointers

### DIFF
--- a/article-co-housing-costs.html
+++ b/article-co-housing-costs.html
@@ -103,12 +103,16 @@
         <div class="callout">
           <h3>Key Findings</h3>
           <ul>
-            <li><strong>Median Gross Rent (2020–2024):</strong> Statewide median of $1,412/month, up ~28% from the 2010–2014 cohort</li>
-            <li><strong>Rent Burden (≥30% of income):</strong> 47% of renter households statewide; highest in resort and rural counties</li>
-            <li><strong>FHFA HPI 10-Year Change:</strong> Statewide average appreciation of 112% (2014–2024), far outpacing income growth</li>
-            <li><strong>Construction Wages:</strong> QCEW NAICS 23 wages grew 31% over the same period, a significant component of cost pressure</li>
+            <li><strong>Median Gross Rent (ACS 2020–2024, B25064):</strong> Statewide median of $1,412/month, up ~28% from the 2010–2014 cohort</li>
+            <li><strong>Rent Burden ≥30% of income (ACS 2020–2024, B25070):</strong> 47% of renter households statewide; highest in resort and rural counties</li>
+            <li><strong>FHFA HPI 10-Year Change (2014–2024):</strong> Statewide average appreciation of 112%, far outpacing income growth</li>
+            <li><strong>Construction Wages (QCEW NAICS 23, 2014–2024):</strong> Wages grew 31% over the same period, a significant component of cost pressure</li>
             <li><strong>Top Driver of HPI Change:</strong> Permit issuance per capita emerged as the strongest predictor in the ElasticNetCV model, followed by income growth and rent burden</li>
           </ul>
+          <p style="font-size:.78rem;color:var(--muted);margin-top:.5rem;margin-bottom:0;">
+            Sources: U.S. Census Bureau ACS 5-year estimates (table IDs shown above) · FHFA House Price Index ·
+            BLS QCEW construction wages. Verify specific figures against the underlying tables before citing.
+          </p>
         </div>
 
         <p style="font-size:0.85rem;color:var(--muted);padding:var(--sp2) var(--sp3);border-left:3px solid var(--border);margin:var(--sp3) 0;">

--- a/docs/AFFORDABILITY-METHODOLOGY.md
+++ b/docs/AFFORDABILITY-METHODOLOGY.md
@@ -63,7 +63,7 @@ The old 3× rule (`affordable_price = income × 3`) is a rough heuristic that:
 - Ignores PMI for low-down-payment buyers
 - Uses a single income multiple rather than a DTI-based qualification threshold
 
-**Example — Denver metro (2026):**
+**Example — Denver metro (illustrative, not a current forecast):**
 
 | Metric | 3× Rule | PITI Model |
 |--------|---------|-----------|
@@ -72,6 +72,13 @@ The old 3× rule (`affordable_price = income × 3`) is a rough heuristic that:
 | Estimated affordable price | $258,000 | $258,000 |
 | Gap (% over affordable) | ~117% | ~206% |
 | Required income to qualify | $86,000 ÷ 3 × 3 ≈ $187k | ~$133k (20% down, 6.5%) |
+
+> **Figures shown are an illustrative example of the methodology, not the
+> current Denver MSA values.** Median home price corresponds to ACS 5-year
+> B25077 (Median Value of Owner-Occupied Housing Units); median household
+> income corresponds to ACS 5-year B19013 / S1901. Pull the current vintage
+> from [data.census.gov](https://data.census.gov) before citing these
+> numbers in a pro forma — they move ±5–10% between 5-year releases.
 
 The PITI model shows a larger gap because it reflects the actual cash flow impact on buyers.
 

--- a/docs/DATA-AND-CALCULATIONS-REPORT.md
+++ b/docs/DATA-AND-CALCULATIONS-REPORT.md
@@ -239,12 +239,20 @@ The platform counts the number of renter households in each cost-burden category
 
 **Definition:** AMI is the median household income for a specific area, as calculated by HUD for each metropolitan statistical area and county. "Area" refers to a HUD-defined geographic unit, not simply the city limits.
 
-**How affordability tiers work:**
-- **30% AMI** — Extremely low income (e.g., ~$28,500/year for a family of four in Denver metro in 2025)
-- **50% AMI** — Very low income (~$47,500/year)
+**How affordability tiers work (illustrative dollar examples — verify for current year):**
+
+The dollar figures below are example values *based on* HUD FY2025 Income Limits for the Denver-Aurora-Lakewood MSA, family of four. They are illustrative of the tier structure, not current underwriting numbers.
+
+- **30% AMI** — Extremely low income (e.g., ~$28,500/year)
+- **50% AMI** — Very low income (e.g., ~$47,500/year)
 - **60% AMI** — Low income — the typical LIHTC targeting threshold (~$57,000/year)
 - **80% AMI** — Moderate income — upper boundary for most federal housing programs (~$76,000/year)
 - **120% AMI** — Middle income — sometimes used for workforce housing (~$114,000/year)
+
+> For the current-year values used in a specific underwriting, pull the
+> latest HUD Income Limits from [huduser.gov/portal/datasets/il](https://www.huduser.gov/portal/datasets/il.html)
+> — HUD publishes new MSA/county tables every April (FY2026 release
+> expected shortly after 2026-04-01 if not already posted).
 
 **Affordable rent formula:**  
 A unit is considered "affordable" for a household at a given AMI tier if the monthly rent does not exceed 30% of the monthly income at that tier.

--- a/lihtc-guide-for-stakeholders.html
+++ b/lihtc-guide-for-stakeholders.html
@@ -99,7 +99,7 @@
 <li><strong>Partnership Structure:</strong> LP/GP agreement, investor admission</li>
 <li><strong>Closing Timeline:</strong> Coordinate all funding sources</li>
 </ul>
-<div class="data-source">Current Market (2026): 9% credits trading at $0.87/dollar; 4% credits at $0.85/dollar. Factor 40% cost increases since 2019.</div>
+<div class="data-source">Indicative Q1 2026 pricing: 9% credits ~$0.87/dollar, 4% credits ~$0.85/dollar; ~40% total development-cost increase since 2019 in Rocky Mountain region. <strong>Directional only — credit pricing moves week to week and is syndicator-specific; confirm the current letter-of-intent range with your syndicator before modelling a capital stack.</strong></div>
 </div>
 <div style="padding: 1.5rem; background: var(--mcm-graphite); border-left: 4px solid var(--mcm-teal); border-radius: 4px;">
 <h4 style="margin: 0 0 0.75rem 0; color: var(--mcm-teal);">Phase 4: Construction (Months 19-30)</h4>
@@ -170,7 +170,7 @@
 </tr>
 </tbody>
 </table>
-<div class="data-source">Note: Percentages vary by market. High-cost areas may need 60-70% equity; rural areas often need more gap financing.</div>
+<div class="data-source">Note: Percentages vary by market and deal structure. Directional guidance only — high-cost areas may need 60–70% LIHTC-equity share; rural areas often need more gap financing. <strong>Verify against peer benchmarks in the Deal Calculator and your QAP's permitted capital-stack mix.</strong></div>
 <h4 style="color: var(--mcm-burnt-orange); margin: 2rem 0 1rem 0;">Typical Uses of Funds:</h4>
 <table>
 <thead>
@@ -220,7 +220,7 @@
 </tr>
 </tbody>
 </table>
-<div class="data-source">Rocky Mountain region seeing 40% cost increases since 2019. Colorado urban areas: $250-300K/unit; rural: $200-250K/unit.</div>
+<div class="data-source">Indicative per-unit TDC ranges for Colorado: urban $250–300K/unit, rural $200–250K/unit (~40% higher than 2019 baseline). <strong>Ranges only — actual per-unit TDC varies with building type, unit mix, and local construction market. Check peer projects for your county + year in the Historical Trends page before underwriting a specific TDC.</strong></div>
 </div>
 </section>
 


### PR DESCRIPTION
## Summary

Surfaces inline citations (or explicit \"directional — verify before using\" language) on four surfaces where user-facing statistics appeared without attribution or a staleness marker. Discovered by the accuracy sub-agent sweep that followed the hallucination-cleanup close-out.

**No numbers are being removed.** They're being *labeled* — readers now know what vintage / source a figure came from, or that it's directional and should be re-verified.

## Files changed

### \`article-co-housing-costs.html\` (Key Findings callout)
The bulleted stats (47% rent burden, $1,412 median rent, +112% HPI, +31% construction wages) now carry inline ACS table IDs (**B25064**, **B25070**) and a small sources footnote. Previously the sources list was ~280 lines away in a collapsible \"Data Sources\" section.

### \`lihtc-guide-for-stakeholders.html\` (3 data-source divs)
Pricing/cost blocks now explicitly say \"directional only\":
- 9%/4% credit pricing → \"credit pricing moves week to week… confirm with your syndicator\"
- Equity-share percentages → \"verify against peer benchmarks in the Deal Calculator\"
- Per-unit TDC ranges → \"check peer projects for your county + year in the Historical Trends page\"

### \`docs/AFFORDABILITY-METHODOLOGY.md\` (Denver metro example)
Labels the \$560K/\$86K figures as **illustrative**, cites ACS table IDs (**B25077** for home value, **B19013 / S1901** for household income), and tells readers to pull the current vintage from data.census.gov.

### \`docs/DATA-AND-CALCULATIONS-REPORT.md\` (AMI tier examples)
Clarifies that the dollar figures are based on **HUD FY2025 Income Limits** for the Denver-Aurora-Lakewood MSA, family of four, and points readers at huduser.gov for current-year (FY2026) values.

## Test plan
- [x] All 4 files are text-only edits; no syntax to break
- [ ] Visual smoke: \`article-co-housing-costs.html\` — the Key Findings bullets now show the table IDs
- [ ] Visual smoke: \`lihtc-guide-for-stakeholders.html\` — the 3 \"data-source\" captions now include the verify-before-modeling guidance

## Known follow-ups (out of scope)

A separate, data-driven PR can update specific figures once new source data is pulled:
- Refresh ACS B25070 / B25064 to the 2021-2025 release when Census publishes it
- Pull HUD FY2026 Income Limits once published (typically ~April of each year)
- Re-check the Q1-2026 pricing indicators against current syndicator LOIs

## Relationship to prior cleanup
Third in the post-\`#712\` accuracy sweep. Pairs with #716 (stale CHAS vintage labels) and #717 (delete dead \`regional.js\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)