### PR TITLE
feat(pma): fill competitive-set AMI from NHPD when LIHTC lacks it

### DIFF
--- a/js/pma-competitive-set.js
+++ b/js/pma-competitive-set.js
@@ -45,6 +45,30 @@
 
   function toNum(v) { var n = parseFloat(v); return isFinite(n) ? n : 0; }
 
+  /**
+   * Parse an AMI targeting value into a number 0–100, or null when
+   * unreported / unparseable. Accepts numeric (60), string with pct
+   * sign ("60%"), or bare string ("60"). Range strings like "30-60%"
+   * return the upper bound (the most permissive target in the range).
+   *
+   * Returns null — NOT a default — so downstream composites can
+   * distinguish "targeting unknown" from "targeting 60%".
+   */
+  function _parseAmi(v) {
+    if (v == null) return null;
+    if (typeof v === 'number') return isFinite(v) && v > 0 ? v : null;
+    var s = String(v).trim();
+    if (!s) return null;
+    // "30-60%" → take the upper bound
+    var rangeMatch = s.match(/(\d+(?:\.\d+)?)\s*[-–]\s*(\d+(?:\.\d+)?)/);
+    if (rangeMatch) {
+      var upper = parseFloat(rangeMatch[2]);
+      return isFinite(upper) && upper > 0 ? upper : null;
+    }
+    var single = parseFloat(s);
+    return isFinite(single) && single > 0 ? single : null;
+  }
+
   function _propLat(f) {
     if (!f) return 0;
     if (f.geometry && f.geometry.coordinates) return toNum(f.geometry.coordinates[1]);
@@ -136,14 +160,22 @@
       if (nhpdMatch) {
         expiryYear = _propExpiryYear(nhpdMatch);
       }
-      // AMI targeting: preserve null when unknown rather than defaulting
-      // to 60% — the previous `|| 60` fallback fabricated a concrete
-      // targeting level for records that simply didn't report one,
-      // which corrupted downstream comparisons against this property's
-      // "AMI mix" in a competitive-set view.
-      var rawAmi = props.AMI_PCT != null ? props.AMI_PCT
-                 : props.amiPercent != null ? props.amiPercent
-                 : null;
+      // AMI targeting precedence (all null-preserving, no fabricated default):
+      //   1. The LIHTC record's own AMI_PCT / amiPercent field
+      //   2. If an NHPD record matched by name, its `ami_targeting` field
+      //      (e.g. "60%" → 60). NHPD has this populated on ~every subsidized
+      //      property in Colorado — filling in HUD's LIHTC DB where
+      //      per-unit AMI mix isn't published.
+      //   3. Otherwise null (unknown targeting, not "60% default").
+      var ami = _parseAmi(
+        props.AMI_PCT != null ? props.AMI_PCT :
+        props.amiPercent != null ? props.amiPercent :
+        null
+      );
+      if (ami == null && nhpdMatch) {
+        var nprops = nhpdMatch.properties || nhpdMatch;
+        ami = _parseAmi(nprops.ami_targeting != null ? nprops.ami_targeting : nprops.amiPercent);
+      }
       return {
         id:              props.HUDID || props.id || ('lihtc-' + Math.random().toString(36).slice(2)),
         name:            _propName(f),
@@ -152,7 +184,10 @@
         distanceMiles:   Math.round(dist * 10) / 10,
         units:           _propUnits(f),
         programType:     props.PROGRAM || props.programType || 'LIHTC',
-        amiPercent:      rawAmi != null ? toNum(rawAmi) : null,
+        amiPercent:      ami,
+        amiSource:       ami == null ? 'unknown'
+                       : (props.AMI_PCT != null || props.amiPercent != null) ? 'lihtc'
+                       : 'nhpd',
         yearPlaced:      toNum(props.YR_PIS || props.yearPlaced || 0),
         yearAllocated:   toNum(props.YR_ALLOC || props.YEAR_ALLOC || props.yearAllocated || 0),
         creditType:      props.CREDIT || props.creditType || '',
@@ -172,6 +207,11 @@
         var dist = haversine(siteLat, siteLon, _propLat(f), _propLon(f));
         var props = f.properties || f;
         var expYear = _propExpiryYear(f);
+        // NHPD's canonical field is `ami_targeting` (string like "60%").
+        // Previously this branch read `props.amiPercent`, which NHPD does
+        // not populate, so every NHPD-only record got amiPercent: null.
+        // Read the right field and parse the percentage.
+        var ami = _parseAmi(props.ami_targeting != null ? props.ami_targeting : props.amiPercent);
         merged.push({
           id:              props.id || props.nhpd_id || ('nhpd-' + Math.random().toString(36).slice(2)),
           name:            _propName(f),
@@ -180,8 +220,8 @@
           distanceMiles:   Math.round(dist * 10) / 10,
           units:           _propUnits(f),
           programType:     props.program || props.PROGRAM || props.subsidy_type || 'Section 8',
-          // Preserve null for unknown AMI targeting (see LIHTC branch above).
-          amiPercent:      props.amiPercent != null ? toNum(props.amiPercent) : null,
+          amiPercent:      ami,
+          amiSource:       ami == null ? 'unknown' : 'nhpd',
           yearPlaced:      toNum(props.yearPlaced || 0),
           hasNhpd:         true,
           subsidyExpiryYear: expYear,
@@ -317,7 +357,9 @@
       calculateAbsorptionRisk:   calculateAbsorptionRisk,
       getCompetitiveSetLayer:    getCompetitiveSetLayer,
       getCompetitiveJustification: getCompetitiveJustification,
-      SUBSIDY_EXPIRY_RISK_YEARS: SUBSIDY_EXPIRY_RISK_YEARS
+      SUBSIDY_EXPIRY_RISK_YEARS: SUBSIDY_EXPIRY_RISK_YEARS,
+      /* Exposed for testing */
+      _parseAmi:                 _parseAmi
     };
   }
 

--- a/test/unit/pma-competitive-set.test.js
+++ b/test/unit/pma-competitive-set.test.js
@@ -66,6 +66,77 @@ test('buildCompetitiveSet — merges NHPD data', function () {
   assert(set.length >= 1,                     'set length is valid');
 });
 
+test('_parseAmi — accepts numbers, "60%" strings, bare "60", ranges, null', function () {
+  assert(CS._parseAmi(60)        === 60,   'number 60 → 60');
+  assert(CS._parseAmi('60%')     === 60,   '"60%" → 60');
+  assert(CS._parseAmi('60')      === 60,   '"60" → 60');
+  assert(CS._parseAmi(' 50 %')   === 50,   '" 50 %" → 50 (whitespace tolerated)');
+  assert(CS._parseAmi('30-60%')  === 60,   '"30-60%" → 60 (upper bound of range)');
+  assert(CS._parseAmi('30–60%')  === 60,   '"30–60%" → 60 (en-dash range)');
+  assert(CS._parseAmi(null)      === null, 'null → null');
+  assert(CS._parseAmi(undefined) === null, 'undefined → null');
+  assert(CS._parseAmi('')        === null, 'empty string → null');
+  assert(CS._parseAmi('unknown') === null, '"unknown" → null');
+  assert(CS._parseAmi(0)         === null, '0 → null (zero rejected as falsy target)');
+  assert(CS._parseAmi(-5)        === null, 'negative → null');
+});
+
+test('buildCompetitiveSet — NHPD ami_targeting fills when LIHTC AMI is missing', function () {
+  // LIHTC record with NO AMI_PCT; NHPD match carries ami_targeting='60%'
+  const lihtc = [{
+    geometry: { type: 'Point', coordinates: [-104.98, 39.74] },
+    properties: { PROJECT_NAME: 'Housing Commons', LI_UNITS: 80, PROGRAM: 'LIHTC' }
+  }];
+  const nhpd  = [{
+    geometry: { type: 'Point', coordinates: [-104.98, 39.74] },
+    properties: { property_name: 'Housing Commons', ami_targeting: '60%', assisted_units: 80 }
+  }];
+  const set = CS.buildCompetitiveSet(lihtc, nhpd, 39.7392, -104.9847, 5);
+  assert(set.length === 1,                'merged to one record');
+  const merged = set[0];
+  assert(merged.hasNhpd === true,         'record marked hasNhpd (merge succeeded)');
+  assert(merged.amiPercent === 60,        'NHPD ami_targeting filled the gap (got ' + merged.amiPercent + ')');
+  assert(merged.amiSource === 'nhpd',     'amiSource identifies NHPD as the source (got ' + merged.amiSource + ')');
+});
+
+test('buildCompetitiveSet — LIHTC AMI takes precedence when both present', function () {
+  const lihtc = [{
+    geometry: { type: 'Point', coordinates: [-104.98, 39.74] },
+    properties: { PROJECT_NAME: 'Housing Commons', LI_UNITS: 80, PROGRAM: 'LIHTC', AMI_PCT: 50 }
+  }];
+  const nhpd  = [{
+    geometry: { type: 'Point', coordinates: [-104.98, 39.74] },
+    properties: { property_name: 'Housing Commons', ami_targeting: '60%', assisted_units: 80 }
+  }];
+  const set = CS.buildCompetitiveSet(lihtc, nhpd, 39.7392, -104.9847, 5);
+  assert(set[0].amiPercent === 50,        'LIHTC 50% wins over NHPD 60%');
+  assert(set[0].amiSource === 'lihtc',    'amiSource reports LIHTC');
+});
+
+test('buildCompetitiveSet — NHPD-only property reads ami_targeting (not broken amiPercent)', function () {
+  // Previously the NHPD-only branch read props.amiPercent which doesn't
+  // exist on NHPD records, so every NHPD-only record got amiPercent: null.
+  // Verify the fix reads ami_targeting.
+  const nhpd = [{
+    geometry: { type: 'Point', coordinates: [-104.98, 39.74] },
+    properties: { property_name: 'Section 8 Only', ami_targeting: '50%', assisted_units: 120 }
+  }];
+  const set = CS.buildCompetitiveSet([], nhpd, 39.7392, -104.9847, 5);
+  assert(set.length === 1,                   'NHPD-only record included');
+  assert(set[0].amiPercent === 50,           'NHPD-only record reports 50% AMI (got ' + set[0].amiPercent + ')');
+  assert(set[0].amiSource === 'nhpd',        'amiSource is nhpd');
+});
+
+test('buildCompetitiveSet — no AMI anywhere → null, amiSource: unknown', function () {
+  const lihtc = [{
+    geometry: { type: 'Point', coordinates: [-104.98, 39.74] },
+    properties: { PROJECT_NAME: 'Mystery Property', LI_UNITS: 60, PROGRAM: 'LIHTC' }
+  }];
+  const set = CS.buildCompetitiveSet(lihtc, [], 39.7392, -104.9847, 5);
+  assert(set[0].amiPercent === null,     'unknown AMI → null (no fabricated 60% default)');
+  assert(set[0].amiSource === 'unknown', 'amiSource reports unknown');
+});
+
 test('flagSubsidyExpiryRisk — flags properties within threshold', function () {
   const nhpd = [
     { properties: { PROPERTY_NAME: 'At Risk',  expiryYear: CURRENT_YEAR + 2, units: 80 } },


### PR DESCRIPTION
## Summary

Raises the competitive-set AMI-targeting fill rate from ~0% to full-coverage-of-NHPD-matched-records, using data **already loaded** in the repo (`data/market/nhpd_co.geojson`). No new ETL, no new dependencies — just reading a field that was previously ignored.

## Two bugs fixed

### 1. LIHTC-merge branch didn't look at NHPD for AMI fallback

HUD's LIHTC DB rarely carries per-unit AMI targeting, so pre-fix every LIHTC record reported \`amiPercent: null\` — even when the matching NHPD row clearly said \"60%\". NHPD has \`ami_targeting\` populated on 100% of current Colorado records (20/20 in the sample).

**After:** the LIHTC branch falls back to the matched NHPD record's \`ami_targeting\` before giving up.

### 2. NHPD-only branch read the wrong field name

Pre-fix read \`props.amiPercent\` — but NHPD's canonical field is \`ami_targeting\`. Every NHPD-only record returned \`null\` even though the data was right there. Simple rename with back-compat for legacy tests.

## Design: null-preserving all the way

Precedence chain:
1. LIHTC's own \`AMI_PCT\` / \`amiPercent\`
2. Matched NHPD's \`ami_targeting\` (new)
3. Otherwise \`null\` — never a fabricated 60% default

Consistent with the null-propagation pattern shipped in #713 and #715.

## New output field: \`amiSource\`

Every competitive-set record now carries:

\`\`\`js
amiSource: 'lihtc' | 'nhpd' | 'unknown'
\`\`\`

So future UI/audit surfaces can show provenance (\"60% AMI per HUD LIHTC DB\" vs \"60% AMI per NHPD\" vs \"unknown targeting\"). Not rendered yet — the field is available for use.

## \`_parseAmi\` helper

NHPD stores AMI as a string (\`\"60%\"\`, \`\"50%\"\`, sometimes \`\"30-60%\"\` for range-targeted properties). Added a small null-preserving parser:

| Input | Output |
|---|---|
| \`60\` | \`60\` |
| \`'60%'\` | \`60\` |
| \`'30-60%'\` | \`60\` (upper bound) |
| \`null\`, \`''\`, \`'unknown'\` | \`null\` |
| \`0\`, \`-5\` | \`null\` (not a real target) |

Exposed as \`PMACompetitiveSet._parseAmi\` for testing only.

## Test plan

- [x] \`node test/unit/pma-competitive-set.test.js\` — 48/48 passing (was 25; +23 new assertions)
- [x] \`node --test test/pma-competitive-set.test.js\` (integration) — 23/23 passing
- [ ] Visual smoke: open a site's PMA analysis, confirm the competitive-set table shows AMI% values for LIHTC properties that previously showed \"—\"

## Scope note

This is the one item from my rebuild-with-real-data list that actually penciled out — 2 hours of work, uses data that's already loaded, raises display fill rate materially. I explicitly pulled back from the other recommendations (GTFS headway rebuild, HUD hard-cost rebuild, CHFA predictor rebuild, public-parcel feeds) because they were either marginal improvements, lag-induced regressions, or don't address a real user problem beyond what the existing banners already cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)