### PR TITLE
Data-quality & link-audit hardening; Colorado-scoped Census dashboard, scripts, tests, and docs

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Verify critical artifacts exist
         shell: bash
@@ -243,11 +245,51 @@ jobs:
           node test/qap-simulator.test.js
           node test/pro-forma.test.js
 
+      - name: Run source URL sweep on changed files (blocking on PRs)
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_ref="${{ github.base_ref }}"
+          git fetch origin "$base_ref" --depth=1
+          changed=$(git diff --name-only "origin/$base_ref"...HEAD | tr '\n' ',' | sed 's/,$//')
+          if [ -z "$changed" ]; then
+            echo "No changed files detected; skipping URL sweep."
+            exit 0
+          fi
+          echo "Changed files: $changed"
+          node scripts/audit/source-url-sweep.mjs --quiet --paths "$changed"
+
+      - name: Run source citation URL sweep (non-blocking signal)
+        continue-on-error: true
+        shell: bash
+        run: |
+          set +e
+          node scripts/audit/source-url-sweep.mjs --quiet | tee /tmp/source-url-sweep.log
+          exit_code=${PIPESTATUS[0]}
+          if [ "$exit_code" -ne 0 ]; then
+            echo "::warning::Source URL sweep reported failures (exit $exit_code). Review /tmp/source-url-sweep.log."
+          fi
+          {
+            echo "## Source URL sweep"
+            echo ""
+            if [ "$exit_code" -eq 0 ]; then
+              echo "✅ No hard failures reported."
+            else
+              echo "⚠️ Sweep reported one or more hard failures (non-blocking in CI checks)."
+              echo ""
+              echo '```'
+              tail -n 80 /tmp/source-url-sweep.log || true
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+
       # ── Python test suites ──
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install Python test dependencies
         run: pip install pytest python-dateutil

--- a/census-dashboard.html
+++ b/census-dashboard.html
@@ -1,94 +1,173 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="theme-color" content="#096e65" media="(prefers-color-scheme: light)">
-  <meta name="theme-color" content="#0fd4cf" media="(prefers-color-scheme: dark)">
-  <title>Census Data | COHO Analytics</title>
-  <meta name="description" content="Census Bureau housing data and demographic statistics.">
-  <meta property="og:title" content="Census Dashboard | COHO Analytics">
-  <meta property="og:description" content="ACS demographic data and housing statistics for Colorado.">
-  <meta property="og:type" content="website">
-  <meta property="og:image" content="assets/og-image.png">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="theme-color"
+      content="#096e65"
+      media="(prefers-color-scheme: light)"
+    />
+    <meta
+      name="theme-color"
+      content="#0fd4cf"
+      media="(prefers-color-scheme: dark)"
+    />
+    <title>Census Data | COHO Analytics</title>
+    <meta
+      name="description"
+      content="Census Bureau housing data and demographic statistics."
+    />
+    <meta property="og:title" content="Census Dashboard | COHO Analytics" />
+    <meta
+      property="og:description"
+      content="ACS demographic data and housing statistics for Colorado."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="assets/og-image.png" />
     <script src="js/path-resolver.js"></script>
-  <script src="js/config.js"></script>
-  <script src="js/fetch-helper.js"></script>
-  <script src="js/data-service-portable.js"></script>
-  <script src="js/scroll-fix.js"></script>
-  <script src="js/api-config-wrapper.js"></script>
-<script src="js/vendor/chart.umd.min.js"></script>
-<script src="js/vendor/chartjs-plugin-annotation.min.js"></script>
-  <link rel="preconnect" href="https://api.census.gov" crossorigin>
-  <link rel="stylesheet" href="css/site-theme.css">
-  <link rel="stylesheet" href="css/layout.css">
-  <link rel="stylesheet" href="css/pages.css">
-  <script src="js/site-state.js"></script>
-  <script defer src="js/navigation.js"></script>
-  <script defer src="js/dark-mode-toggle.js"></script>
-  <script defer src="js/mobile-menu.js"></script>
-</head>
-<body>
-<a class="skip-link" href="#main-content">Skip to main content</a>
-<div id="navigation-container"></div>
-<main id="main-content" class="container" style="max-width: 1100px; margin: 0 auto; padding: 24px 16px;">
-<span class="kicker">Dashboard</span>
-<h1>Census Multifamily Lens</h1>
-<p style="opacity:.85; max-width: 70ch;">
-      Pulls American Community Survey (ACS) housing profile indicators and lets you switch between
-      national, state, and local geographies to support multifamily market analysis.
-    </p>
-<section class="card" style="margin-top:16px; padding:16px;">
-<h2 style="margin-top:0;">Geography</h2>
-<div style="display:flex; flex-wrap:wrap; gap:10px; align-items:end;">
-<label>
-<div style="font-size:.9rem; opacity:.8;">Level</div>
-<select id="geo-level">
-<option value="us">National (US)</option>
-<option value="state">State</option>
-<option value="county">County</option>
-<option value="place">City/Place</option>
-</select>
-</label>
-<label>
-<div style="font-size:.9rem; opacity:.8;">State</div>
-<select disabled="" id="state-select"></select>
-</label>
-<label>
-<div style="font-size:.9rem; opacity:.8;">County / Place</div>
-<select disabled="" id="local-select"></select>
-</label>
-<button class="btn" id="refresh">Refresh</button>
-</div>
-<div id="geo-note" style="margin-top:10px; opacity:.8;"></div>
-</section>
-<section class="card" style="margin-top:16px; padding:16px;">
-<h2 style="margin-top:0;">Multifamily share (Units in structure)</h2>
-<p style="opacity:.85;">
-        ACS DP04 percent of housing units in buildings with <strong>5–9</strong>, <strong>10–19</strong>, and <strong>20+</strong> units.
+    <script src="js/config.js"></script>
+    <script src="js/fetch-helper.js"></script>
+    <script src="js/data-service-portable.js"></script>
+    <script src="js/scroll-fix.js"></script>
+    <script src="js/api-config-wrapper.js"></script>
+    <script src="js/vendor/chart.umd.min.js"></script>
+    <script src="js/vendor/chartjs-plugin-annotation.min.js"></script>
+    <link rel="preconnect" href="https://api.census.gov" crossorigin />
+    <link rel="stylesheet" href="css/site-theme.css" />
+    <link rel="stylesheet" href="css/layout.css" />
+    <link rel="stylesheet" href="css/pages.css" />
+    <script src="js/site-state.js"></script>
+    <script defer src="js/navigation.js"></script>
+    <script defer src="js/dark-mode-toggle.js"></script>
+    <script defer src="js/mobile-menu.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <div id="navigation-container"></div>
+    <main
+      id="main-content"
+      class="container"
+      style="max-width: 1100px; margin: 0 auto; padding: 24px 16px"
+    >
+      <span class="kicker">Dashboard</span>
+      <h1>Census Multifamily Lens</h1>
+      <p style="opacity: 0.85; max-width: 70ch">
+        Pulls American Community Survey (ACS) housing profile indicators for
+        Colorado and lets you switch between statewide, county, and place
+        geographies to support multifamily market analysis.
       </p>
-<canvas height="90" id="mf-share" role="img" aria-label="Bar chart: multifamily housing share of total housing stock by county"></canvas><p class="sr-only" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0">Chart data is available in the surrounding text and data tables on this page.</p>
-<div id="mf-table" style="margin-top:12px;"></div>
-</section>
-<section class="card" style="margin-top:16px; padding:16px;">
-<h2 style="margin-top:0;">Total housing units</h2>
-<p style="opacity:.85;">ACS DP04 total housing units (estimate) for the selected geography.</p>
-<div id="hu" style="font-size:1.4rem; font-weight:700;"></div>
-<div id="hu-meta" style="opacity:.75;"></div>
-</section>
-<section class="card" style="margin-top:16px; padding:16px;">
-<h2 style="margin-top:0;">How this helps multifamily analysis</h2>
-<ul style="opacity:.9; line-height:1.5;">
-<li><strong>Supply composition</strong>: higher 5+ unit shares typically correlate with stronger apartment market depth.</li>
-<li><strong>Site selection</strong>: compare metros/counties/places for multifamily penetration before underwriting rents and absorption.</li>
-<li><strong>LIHTC context</strong>: combine this with your allocation/QAP insights and pipeline indicators (FRED) to see where affordable supply fits.</li>
-</ul>
-</section>
-<div style="margin-top:18px; opacity:.75; font-size:.95rem;">
-      Data: Census Bureau ACS 1-year profile (DP04). Variables are documented in the Census API DP04 group reference.
-    </div>
-</main>
-<script src="js/contrast-guard.js"></script>
-  <script src="js/census-multifamily.js"></script>
-</body>
+      <section class="card" style="margin-top: 16px; padding: 16px">
+        <h2 style="margin-top: 0">Geography</h2>
+        <div
+          style="display: flex; flex-wrap: wrap; gap: 10px; align-items: end"
+        >
+          <label>
+            <div style="font-size: 0.9rem; opacity: 0.8">Level</div>
+            <select id="geo-level">
+              <option value="state">State</option>
+              <option value="county">County</option>
+              <option value="place">City/Place</option>
+            </select>
+          </label>
+          <label>
+            <div style="font-size: 0.9rem; opacity: 0.8">State</div>
+            <select disabled="" id="state-select"></select>
+          </label>
+          <label>
+            <div style="font-size: 0.9rem; opacity: 0.8">County / Place</div>
+            <select disabled="" id="local-select"></select>
+          </label>
+          <button class="btn" id="refresh">Refresh</button>
+        </div>
+        <div id="geo-note" style="margin-top: 10px; opacity: 0.8"></div>
+      </section>
+      <section class="card" style="margin-top: 16px; padding: 16px">
+        <h2 style="margin-top: 0">Multifamily share (Units in structure)</h2>
+        <p style="opacity: 0.85">
+          ACS DP04 percent of housing units in buildings with
+          <strong>5–9</strong>, <strong>10–19</strong>, and
+          <strong>20+</strong> units.
+        </p>
+        <canvas
+          height="90"
+          id="mf-share"
+          role="img"
+          aria-label="Bar chart: multifamily housing share of total housing stock by county"
+        ></canvas>
+        <p
+          class="sr-only"
+          style="
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+          "
+        >
+          Chart data is available in the surrounding text and data tables on
+          this page.
+        </p>
+        <div id="mf-table" style="margin-top: 12px"></div>
+      </section>
+      <section class="card" style="margin-top: 16px; padding: 16px">
+        <h2 style="margin-top: 0">Total housing units</h2>
+        <p style="opacity: 0.85">
+          ACS DP04 total housing units (estimate) for the selected geography.
+        </p>
+        <div id="hu" style="font-size: 1.4rem; font-weight: 700"></div>
+        <div id="hu-meta" style="opacity: 0.75"></div>
+      </section>
+      <section class="card" style="margin-top: 16px; padding: 16px">
+        <h2 style="margin-top: 0">How this helps multifamily analysis</h2>
+        <ul style="opacity: 0.9; line-height: 1.5">
+          <li>
+            <strong>Supply composition</strong>: higher 5+ unit shares typically
+            correlate with stronger apartment market depth.
+          </li>
+          <li>
+            <strong>Site selection</strong>: compare metros/counties/places for
+            multifamily penetration before underwriting rents and absorption.
+          </li>
+          <li>
+            <strong>LIHTC context</strong>: combine this with your
+            allocation/QAP insights and pipeline indicators (FRED) to see where
+            affordable supply fits.
+          </li>
+        </ul>
+      </section>
+      <section class="card" style="margin-top: 16px; padding: 16px">
+        <h2 style="margin-top: 0">Census Variables Used on This Page</h2>
+        <p style="opacity: 0.85">
+          This dashboard currently uses ACS DP04 variables listed below and is
+          restricted to Colorado geographies.
+        </p>
+        <ul
+          id="census-variable-list"
+          style="line-height: 1.55; margin: 0; padding-left: 1.2rem"
+        >
+          <li><code>DP04_0001E</code> — Total housing units (estimate)</li>
+          <li>
+            <code>DP04_0011PE</code> — % housing units in 5–9 unit structures
+          </li>
+          <li>
+            <code>DP04_0012PE</code> — % housing units in 10–19 unit structures
+          </li>
+          <li>
+            <code>DP04_0013PE</code> — % housing units in 20+ unit structures
+          </li>
+        </ul>
+      </section>
+      <div style="margin-top: 18px; opacity: 0.75; font-size: 0.95rem">
+        Data: Census Bureau ACS 1-year profile (DP04). Variables are documented
+        in the Census API DP04 group reference.
+      </div>
+    </main>
+    <script src="js/contrast-guard.js"></script>
+    <script src="js/census-multifamily.js"></script>
+  </body>
 </html>

--- a/data-status.html
+++ b/data-status.html
@@ -1,361 +1,613 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="theme-color" content="#096e65" media="(prefers-color-scheme: light)">
-  <meta name="theme-color" content="#0fd4cf" media="(prefers-color-scheme: dark)">
-  <title>Data Status | COHO Analytics</title>
-  <meta name="description" content="Live data quality and freshness diagnostics for all COHO Analytics datasets.">
-  <meta property="og:title" content="Data Status | COHO Analytics">
-  <meta property="og:type" content="website">
-  <meta property="og:image" content="assets/og-image.png">
-  <script src="js/path-resolver.js"></script>
-  <script src="js/config.js"></script>
-  <script src="js/fetch-helper.js"></script>
-  <script src="js/data-service-portable.js"></script>
-  <script src="js/scroll-fix.js"></script>
-  <script src="js/data-quality-check.js"></script>
-  <link rel="stylesheet" href="css/site-theme.css">
-  <link rel="stylesheet" href="css/layout.css">
-  <link rel="stylesheet" href="css/pages.css">
-  <script src="js/site-state.js"></script>
-  <script defer src="js/navigation.js"></script>
-  <script defer src="js/dark-mode-toggle.js"></script>
-  <script defer src="js/mobile-menu.js"></script>
-  <style>
-    .status-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-      gap: 1rem;
-      margin: 1.5rem 0;
-    }
-    .status-card {
-      background: var(--card);
-      border: 1px solid var(--border);
-      border-radius: var(--radius);
-      padding: 1rem 1.1rem;
-      display: flex;
-      flex-direction: column;
-      gap: .4rem;
-    }
-    .status-card__icon {
-      font-size: 1.4rem;
-      line-height: 1;
-    }
-    .status-card__label {
-      font-weight: 700;
-      font-size: .95rem;
-      color: var(--text);
-    }
-    .status-card__detail {
-      font-size: .82rem;
-      color: var(--muted);
-      line-height: 1.4;
-    }
-    .status-card__age {
-      font-size: .78rem;
-      color: var(--faint);
-      margin-top: .2rem;
-    }
-    .status-card--ok    { border-left: 3px solid var(--good); }
-    .status-card--warn  { border-left: 3px solid var(--warn); }
-    .status-card--error { border-left: 3px solid var(--bad); }
-    .status-card--loading { border-left: 3px solid var(--border-strong); opacity: .7; }
-    #statusSummary {
-      padding: .75rem 1rem;
-      border-radius: var(--radius);
-      font-size: .9rem;
-      font-weight: 600;
-      margin-bottom: 1rem;
-    }
-    #statusSummary.ok    { background: var(--good-dim); color: var(--good); }
-    #statusSummary.warn  { background: var(--warn-dim); color: var(--warn); }
-    #statusSummary.error { background: var(--bad-dim);  color: var(--bad); }
-    #refreshBtn { margin-left: .75rem; }
-    .source-table { width: 100%; border-collapse: collapse; margin-top: 1.5rem; font-size: .88rem; }
-    .source-table th { text-align: left; padding: .5rem .75rem; border-bottom: 2px solid var(--border); color: var(--muted); font-weight: 600; font-size: .78rem; text-transform: uppercase; letter-spacing: .05em; }
-    .source-table td { padding: .5rem .75rem; border-bottom: 1px solid var(--border); vertical-align: top; }
-    .source-table tr:last-child td { border-bottom: none; }
-    .badge-ok    { display:inline-block;padding:.15rem .5rem;border-radius:1rem;background:var(--good-dim);color:var(--good);font-size:.78rem;font-weight:700; }
-    .badge-warn  { display:inline-block;padding:.15rem .5rem;border-radius:1rem;background:var(--warn-dim);color:var(--warn);font-size:.78rem;font-weight:700; }
-    .badge-error { display:inline-block;padding:.15rem .5rem;border-radius:1rem;background:var(--bad-dim); color:var(--bad); font-size:.78rem;font-weight:700; }
-    .badge-loading { display:inline-block;padding:.15rem .5rem;border-radius:1rem;background:var(--bg2);color:var(--muted);font-size:.78rem;font-weight:700; }
-    @media (max-width: 600px) {
-      .status-grid { grid-template-columns: 1fr; }
-      .source-table { display: none; }
-    }
-  </style>
-</head>
-<body>
-<a class="skip-link" href="#main-content">Skip to main content</a>
-<div id="aria-live-region" role="status" aria-live="polite" aria-atomic="true" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;"></div>
-<header id="site-header"></header>
-<main id="main-content" class="page-container content-shell">
-
-<section class="hero">
-  <span class="kicker">Diagnostics</span>
-  <h1>Data Status</h1>
-  <p class="sub">Live quality and freshness check for all critical datasets powering COHO Analytics dashboards.</p>
-  <div style="display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;margin-top:.5rem;">
-    <span id="lastCheckedLabel" class="data-timestamp" style="font-size:.82rem;color:var(--muted);">Checking…</span>
-    <button id="refreshBtn" class="btn secondary" type="button" style="font-size:.8rem;padding:.3rem .8rem;">Re-check now</button>
-  </div>
-</section>
-
-<div id="statusSummary" class="ok" role="status" aria-live="polite">⏳ Running data validation…</div>
-
-<div id="statusGrid" class="status-grid" aria-label="Dataset status cards">
-  <!-- Cards injected by JS -->
-  <div class="status-card status-card--loading"><div class="status-card__icon">⏳</div><div class="status-card__label">Loading…</div></div>
-</div>
-
-<section class="card" style="margin-top:1.5rem;">
-  <h2 style="font-size:1rem;margin-bottom:0;">All Data Sources</h2>
-  <table class="source-table" aria-label="Data sources detail">
-    <thead>
-      <tr>
-        <th>Dataset</th>
-        <th>Status</th>
-        <th>Records</th>
-        <th>Cache age</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody id="sourceTableBody">
-      <tr><td colspan="5" style="color:var(--muted);">Loading…</td></tr>
-    </tbody>
-  </table>
-</section>
-
-<!-- Content Freshness Indicators -->
-<section class="card" style="margin-top:1.5rem;" aria-labelledby="contentStatusHeading">
-  <h2 id="contentStatusHeading" style="font-size:1rem;margin-bottom:.75rem;">Content Freshness</h2>
-  <div class="status-grid" id="contentStatusGrid">
-    <div class="status-card status-card--loading" id="trendsStatusCard">
-      <div class="status-card__icon">⏳</div>
-      <div class="status-card__label">Key Market Trends</div>
-      <div class="status-card__detail">Checking verification date…</div>
-      <div class="status-card__age"></div>
-    </div>
-    <div class="status-card status-card--loading" id="alertPipelineCard">
-      <div class="status-card__icon">⏳</div>
-      <div class="status-card__label">Alert Pipeline</div>
-      <div class="status-card__detail">Checking feed status…</div>
-      <div class="status-card__age"></div>
-    </div>
-  </div>
-</section>
-
-</main>
-<footer id="site-footer"></footer>
-
-<script>
-(function () {
-  'use strict';
-
-  function relTime(ms) {
-    if (ms === null || ms === undefined) return '—';
-    var s = Math.floor(ms / 1000);
-    if (s < 60)  return s + 's ago';
-    var m = Math.floor(s / 60);
-    if (m < 60)  return m + 'm ago';
-    var h = Math.floor(m / 60);
-    if (h < 24)  return h + 'h ago';
-    return Math.floor(h / 24) + 'd ago';
-  }
-
-  function daysSince(dateObj) {
-    return Math.floor((Date.now() - dateObj.getTime()) / 86400000);
-  }
-
-  function renderCard(report) {
-    var card = document.createElement('div');
-    var cls  = report.ok ? 'ok' : (report.critical ? 'error' : 'warn');
-    card.className = 'status-card status-card--' + cls;
-    card.innerHTML =
-      '<div class="status-card__icon">' + (report.ok ? '✅' : '⚠️') + '</div>' +
-      '<div class="status-card__label">' + _esc(report.label) + '</div>' +
-      '<div class="status-card__detail">' +
-        (report.featureCount > 0 ? report.featureCount + ' records' : '') +
-        (report.message ? '<br>' + _esc(report.message) : '') +
-      '</div>' +
-      '<div class="status-card__age">' + relTime(report.cacheAge) + '</div>';
-    return card;
-  }
-
-  function renderTableRow(report) {
-    var cls  = report.ok ? 'badge-ok' : (report.critical ? 'badge-error' : 'badge-warn');
-    var lbl  = report.ok ? '✅ OK' : (report.critical ? '⚠ Error' : '⚠ Warn');
-    var tr = document.createElement('tr');
-    tr.innerHTML =
-      '<td>' + _esc(report.label) + '</td>' +
-      '<td><span class="' + cls + '">' + lbl + '</span></td>' +
-      '<td>' + (report.featureCount > 0 ? report.featureCount : '—') + '</td>' +
-      '<td>' + relTime(report.cacheAge) + '</td>' +
-      '<td style="color:var(--muted);">' + _esc(report.message || '') + '</td>';
-    return tr;
-  }
-
-  function _esc(s) {
-    return String(s || '')
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;');
-  }
-
-  function runCheck() {
-    if (!window.DataQuality) {
-      document.getElementById('statusSummary').textContent = '⚠ DataQuality module not loaded.';
-      return;
-    }
-
-    document.getElementById('statusSummary').className = 'ok';
-    document.getElementById('statusSummary').textContent = '⏳ Running data validation…';
-
-    window.DataQuality.runAll().then(function (reports) {
-      var allOk = reports.every(function (r) { return r.ok; });
-      var anyCritFail = reports.some(function (r) { return !r.ok && r.critical; });
-
-      var summary = document.getElementById('statusSummary');
-      if (anyCritFail) {
-        summary.className = 'error';
-        summary.textContent = '⚠ One or more critical datasets are unavailable.';
-      } else if (!allOk) {
-        summary.className = 'warn';
-        summary.textContent = '⚠ Some datasets have warnings — dashboards may use cached data.';
-      } else {
-        summary.className = 'ok';
-        summary.textContent = '✅ All datasets validated successfully.';
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="theme-color"
+      content="#096e65"
+      media="(prefers-color-scheme: light)"
+    />
+    <meta
+      name="theme-color"
+      content="#0fd4cf"
+      media="(prefers-color-scheme: dark)"
+    />
+    <title>Data Status | COHO Analytics</title>
+    <meta
+      name="description"
+      content="Live data quality and freshness diagnostics for all COHO Analytics datasets."
+    />
+    <meta property="og:title" content="Data Status | COHO Analytics" />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="assets/og-image.png" />
+    <script src="js/path-resolver.js"></script>
+    <script src="js/config.js"></script>
+    <script src="js/fetch-helper.js"></script>
+    <script src="js/data-service-portable.js"></script>
+    <script src="js/scroll-fix.js"></script>
+    <script src="js/data-quality-check.js"></script>
+    <link rel="stylesheet" href="css/site-theme.css" />
+    <link rel="stylesheet" href="css/layout.css" />
+    <link rel="stylesheet" href="css/pages.css" />
+    <script src="js/site-state.js"></script>
+    <script defer src="js/navigation.js"></script>
+    <script defer src="js/dark-mode-toggle.js"></script>
+    <script defer src="js/mobile-menu.js"></script>
+    <style>
+      .status-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+        gap: 1rem;
+        margin: 1.5rem 0;
       }
+      .status-card {
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        padding: 1rem 1.1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+      }
+      .status-card__icon {
+        font-size: 1.4rem;
+        line-height: 1;
+      }
+      .status-card__label {
+        font-weight: 700;
+        font-size: 0.95rem;
+        color: var(--text);
+      }
+      .status-card__detail {
+        font-size: 0.82rem;
+        color: var(--muted);
+        line-height: 1.4;
+      }
+      .status-card__age {
+        font-size: 0.78rem;
+        color: var(--faint);
+        margin-top: 0.2rem;
+      }
+      .status-card--ok {
+        border-left: 3px solid var(--good);
+      }
+      .status-card--warn {
+        border-left: 3px solid var(--warn);
+      }
+      .status-card--error {
+        border-left: 3px solid var(--bad);
+      }
+      .status-card--loading {
+        border-left: 3px solid var(--border-strong);
+        opacity: 0.7;
+      }
+      #statusSummary {
+        padding: 0.75rem 1rem;
+        border-radius: var(--radius);
+        font-size: 0.9rem;
+        font-weight: 600;
+        margin-bottom: 1rem;
+      }
+      #statusSummary.ok {
+        background: var(--good-dim);
+        color: var(--good);
+      }
+      #statusSummary.warn {
+        background: var(--warn-dim);
+        color: var(--warn);
+      }
+      #statusSummary.error {
+        background: var(--bad-dim);
+        color: var(--bad);
+      }
+      #refreshBtn {
+        margin-left: 0.75rem;
+      }
+      .source-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 1.5rem;
+        font-size: 0.88rem;
+      }
+      .source-table th {
+        text-align: left;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 2px solid var(--border);
+        color: var(--muted);
+        font-weight: 600;
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      .source-table td {
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid var(--border);
+        vertical-align: top;
+      }
+      .source-table tr:last-child td {
+        border-bottom: none;
+      }
+      .badge-ok {
+        display: inline-block;
+        padding: 0.15rem 0.5rem;
+        border-radius: 1rem;
+        background: var(--good-dim);
+        color: var(--good);
+        font-size: 0.78rem;
+        font-weight: 700;
+      }
+      .badge-warn {
+        display: inline-block;
+        padding: 0.15rem 0.5rem;
+        border-radius: 1rem;
+        background: var(--warn-dim);
+        color: var(--warn);
+        font-size: 0.78rem;
+        font-weight: 700;
+      }
+      .badge-error {
+        display: inline-block;
+        padding: 0.15rem 0.5rem;
+        border-radius: 1rem;
+        background: var(--bad-dim);
+        color: var(--bad);
+        font-size: 0.78rem;
+        font-weight: 700;
+      }
+      .badge-loading {
+        display: inline-block;
+        padding: 0.15rem 0.5rem;
+        border-radius: 1rem;
+        background: var(--bg2);
+        color: var(--muted);
+        font-size: 0.78rem;
+        font-weight: 700;
+      }
+      @media (max-width: 600px) {
+        .status-grid {
+          grid-template-columns: 1fr;
+        }
+        .source-table {
+          display: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <div
+      id="aria-live-region"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      style="
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      "
+    ></div>
+    <header id="site-header"></header>
+    <main id="main-content" class="page-container content-shell">
+      <section class="hero">
+        <span class="kicker">Diagnostics</span>
+        <h1>Data Status</h1>
+        <p class="sub">
+          Live quality and freshness check for all critical datasets powering
+          COHO Analytics dashboards.
+        </p>
+        <div
+          style="
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+            margin-top: 0.5rem;
+          "
+        >
+          <span
+            id="lastCheckedLabel"
+            class="data-timestamp"
+            style="font-size: 0.82rem; color: var(--muted)"
+            >Checking…</span
+          >
+          <button
+            id="refreshBtn"
+            class="btn secondary"
+            type="button"
+            style="font-size: 0.8rem; padding: 0.3rem 0.8rem"
+          >
+            Re-check now
+          </button>
+        </div>
+      </section>
 
-      var grid = document.getElementById('statusGrid');
-      grid.innerHTML = '';
-      reports.forEach(function (r) { grid.appendChild(renderCard(r)); });
+      <div id="statusSummary" class="ok" role="status" aria-live="polite">
+        ⏳ Running data validation…
+      </div>
 
-      var tbody = document.getElementById('sourceTableBody');
-      tbody.innerHTML = '';
-      reports.forEach(function (r) { tbody.appendChild(renderTableRow(r)); });
+      <div
+        id="statusGrid"
+        class="status-grid"
+        aria-label="Dataset status cards"
+      >
+        <!-- Cards injected by JS -->
+        <div class="status-card status-card--loading">
+          <div class="status-card__icon">⏳</div>
+          <div class="status-card__label">Loading…</div>
+        </div>
+      </div>
 
-      var lbl = document.getElementById('lastCheckedLabel');
-      lbl.textContent = 'Last checked: ' + new Date().toLocaleTimeString();
+      <section class="card" style="margin-top: 1.5rem">
+        <h2 style="font-size: 1rem; margin-bottom: 0">All Data Sources</h2>
+        <table class="source-table" aria-label="Data sources detail">
+          <thead>
+            <tr>
+              <th>Dataset</th>
+              <th>Status</th>
+              <th>Records</th>
+              <th>Data as of</th>
+              <th>Cache age</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody id="sourceTableBody">
+            <tr>
+              <td colspan="6" style="color: var(--muted)">Loading…</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
 
-      var liveRegion = document.getElementById('aria-live-region');
-      if (liveRegion) {
-        // Toggle aria-live off then on to force re-announcement in all AT implementations
-        liveRegion.setAttribute('aria-live', 'off');
-        liveRegion.textContent = summary.textContent;
-        requestAnimationFrame(function () {
-          liveRegion.setAttribute('aria-live', 'polite');
+      <!-- Content Freshness Indicators -->
+      <section
+        class="card"
+        style="margin-top: 1.5rem"
+        aria-labelledby="contentStatusHeading"
+      >
+        <h2
+          id="contentStatusHeading"
+          style="font-size: 1rem; margin-bottom: 0.75rem"
+        >
+          Content Freshness
+        </h2>
+        <div class="status-grid" id="contentStatusGrid">
+          <div class="status-card status-card--loading" id="trendsStatusCard">
+            <div class="status-card__icon">⏳</div>
+            <div class="status-card__label">Key Market Trends</div>
+            <div class="status-card__detail">Checking verification date…</div>
+            <div class="status-card__age"></div>
+          </div>
+          <div class="status-card status-card--loading" id="alertPipelineCard">
+            <div class="status-card__icon">⏳</div>
+            <div class="status-card__label">Alert Pipeline</div>
+            <div class="status-card__detail">Checking feed status…</div>
+            <div class="status-card__age"></div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer id="site-footer"></footer>
+
+    <script>
+      (function () {
+        "use strict";
+
+        function relTime(ms) {
+          if (ms === null || ms === undefined) return "—";
+          var s = Math.floor(ms / 1000);
+          if (s < 60) return s + "s ago";
+          var m = Math.floor(s / 60);
+          if (m < 60) return m + "m ago";
+          var h = Math.floor(m / 60);
+          if (h < 24) return h + "h ago";
+          return Math.floor(h / 24) + "d ago";
+        }
+
+        function daysSince(dateObj) {
+          return Math.floor((Date.now() - dateObj.getTime()) / 86400000);
+        }
+
+        function renderCard(report) {
+          var card = document.createElement("div");
+          var cls = report.ok ? "ok" : report.critical ? "error" : "warn";
+          card.className = "status-card status-card--" + cls;
+          var asOf = report.dataAsOf
+            ? new Date(report.dataAsOf).toLocaleDateString()
+            : "unknown";
+          var dataAge =
+            report.dataAgeMs === null || report.dataAgeMs === undefined
+              ? "unknown age"
+              : relTime(report.dataAgeMs);
+          card.innerHTML =
+            '<div class="status-card__icon">' +
+            (report.ok ? "✅" : "⚠️") +
+            "</div>" +
+            '<div class="status-card__label">' +
+            _esc(report.label) +
+            "</div>" +
+            '<div class="status-card__detail">' +
+            (report.featureCount > 0 ? report.featureCount + " records" : "") +
+            "<br>Data as of: " +
+            _esc(asOf) +
+            " (" +
+            _esc(dataAge) +
+            ")" +
+            (report.message ? "<br>" + _esc(report.message) : "") +
+            "</div>" +
+            '<div class="status-card__age">' +
+            relTime(report.cacheAge) +
+            "</div>";
+          return card;
+        }
+
+        function renderTableRow(report) {
+          var cls = report.ok
+            ? "badge-ok"
+            : report.critical
+              ? "badge-error"
+              : "badge-warn";
+          var lbl = report.ok
+            ? "✅ OK"
+            : report.critical
+              ? "⚠ Error"
+              : "⚠ Warn";
+          var tr = document.createElement("tr");
+          tr.innerHTML =
+            "<td>" +
+            _esc(report.label) +
+            "</td>" +
+            '<td><span class="' +
+            cls +
+            '">' +
+            lbl +
+            "</span></td>" +
+            "<td>" +
+            (report.featureCount > 0 ? report.featureCount : "—") +
+            "</td>" +
+            "<td>" +
+            (report.dataAsOf
+              ? _esc(new Date(report.dataAsOf).toLocaleDateString())
+              : "—") +
+            "</td>" +
+            "<td>" +
+            relTime(report.cacheAge) +
+            "</td>" +
+            '<td style="color:var(--muted);">' +
+            _esc(report.message || "") +
+            "</td>";
+          return tr;
+        }
+
+        function _esc(s) {
+          return String(s || "")
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;");
+        }
+
+        function runCheck() {
+          if (!window.DataQuality) {
+            document.getElementById("statusSummary").textContent =
+              "⚠ DataQuality module not loaded.";
+            return;
+          }
+
+          document.getElementById("statusSummary").className = "ok";
+          document.getElementById("statusSummary").textContent =
+            "⏳ Running data validation…";
+
+          window.DataQuality.runAll().then(function (reports) {
+            var allOk = reports.every(function (r) {
+              return r.ok;
+            });
+            var anyCritFail = reports.some(function (r) {
+              return !r.ok && r.critical;
+            });
+
+            var summary = document.getElementById("statusSummary");
+            if (anyCritFail) {
+              summary.className = "error";
+              summary.textContent =
+                "⚠ One or more critical datasets are unavailable.";
+            } else if (!allOk) {
+              summary.className = "warn";
+              summary.textContent =
+                "⚠ Some datasets have warnings — dashboards may use cached data.";
+            } else {
+              summary.className = "ok";
+              summary.textContent = "✅ All datasets validated successfully.";
+            }
+
+            var grid = document.getElementById("statusGrid");
+            grid.innerHTML = "";
+            reports.forEach(function (r) {
+              grid.appendChild(renderCard(r));
+            });
+
+            var tbody = document.getElementById("sourceTableBody");
+            tbody.innerHTML = "";
+            reports.forEach(function (r) {
+              tbody.appendChild(renderTableRow(r));
+            });
+
+            var lbl = document.getElementById("lastCheckedLabel");
+            lbl.textContent =
+              "Last checked: " + new Date().toLocaleTimeString();
+
+            var liveRegion = document.getElementById("aria-live-region");
+            if (liveRegion) {
+              // Toggle aria-live off then on to force re-announcement in all AT implementations
+              liveRegion.setAttribute("aria-live", "off");
+              liveRegion.textContent = summary.textContent;
+              requestAnimationFrame(function () {
+                liveRegion.setAttribute("aria-live", "polite");
+              });
+            }
+          });
+        }
+
+        document.addEventListener("DOMContentLoaded", function () {
+          runCheck();
+          var btn = document.getElementById("refreshBtn");
+          if (btn) btn.addEventListener("click", runCheck);
+          loadContentStatus();
         });
-      }
-    });
-  }
 
-  document.addEventListener('DOMContentLoaded', function () {
-    runCheck();
-    var btn = document.getElementById('refreshBtn');
-    if (btn) btn.addEventListener('click', runCheck);
-    loadContentStatus();
-  });
+        // ── Content freshness checks ─────────────────────────────────────────────────
 
-  // ── Content freshness checks ─────────────────────────────────────────────────
+        var STALE_TRENDS_DAYS = 30; // warn if Key Market Trends not verified in 30d
+        var STALE_PIPELINE_DAYS = 7; // warn if alert pipeline hasn't run in 7d
 
-  var STALE_TRENDS_DAYS   = 30;   // warn if Key Market Trends not verified in 30d
-  var STALE_PIPELINE_DAYS = 7;    // warn if alert pipeline hasn't run in 7d
+        function resolvePath(p) {
+          return typeof window.resolveAssetUrl === "function"
+            ? window.resolveAssetUrl(p)
+            : p;
+        }
 
-  function resolvePath(p) {
-    return (typeof window.resolveAssetUrl === 'function') ? window.resolveAssetUrl(p) : p;
-  }
+        function loadContentStatus() {
+          // Key Market Trends verification status
+          fetch(resolvePath("data/insights-meta.json"))
+            .then(function (r) {
+              return r.ok ? r.json() : Promise.reject(r.status);
+            })
+            .then(function (meta) {
+              renderTrendsCard(meta);
+            })
+            .catch(function () {
+              renderTrendsCard(null);
+            });
 
-  function loadContentStatus() {
-    // Key Market Trends verification status
-    fetch(resolvePath('data/insights-meta.json'))
-      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
-      .then(function (meta) { renderTrendsCard(meta); })
-      .catch(function () { renderTrendsCard(null); });
+          // Alert pipeline status
+          fetch(resolvePath("data/policy_briefs.json"))
+            .then(function (r) {
+              return r.ok ? r.json() : Promise.reject(r.status);
+            })
+            .then(function (data) {
+              renderPipelineCard(data && data.meta ? data.meta : null);
+            })
+            .catch(function () {
+              renderPipelineCard(null);
+            });
+        }
 
-    // Alert pipeline status
-    fetch(resolvePath('data/policy_briefs.json'))
-      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
-      .then(function (data) { renderPipelineCard(data && data.meta ? data.meta : null); })
-      .catch(function () { renderPipelineCard(null); });
-  }
+        function renderTrendsCard(meta) {
+          var card = document.getElementById("trendsStatusCard");
+          if (!card) return;
+          if (!meta || !meta.lastVerified) {
+            card.className = "status-card status-card--warn";
+            card.innerHTML =
+              '<div class="status-card__icon">⚠️</div>' +
+              '<div class="status-card__label">Key Market Trends</div>' +
+              '<div class="status-card__detail">Verification date unavailable</div>' +
+              '<div class="status-card__age"><a href="docs/MARKET_TRENDS_UPDATE_PROTOCOL.md">View protocol →</a></div>';
+            return;
+          }
+          var verified = new Date(meta.lastVerified);
+          var ageDays = daysSince(verified);
+          var dateStr = verified.toLocaleDateString("en-US", {
+            month: "long",
+            day: "numeric",
+            year: "numeric",
+          });
+          var isStale = ageDays > STALE_TRENDS_DAYS;
+          card.className =
+            "status-card status-card--" + (isStale ? "warn" : "ok");
+          card.innerHTML =
+            '<div class="status-card__icon">' +
+            (isStale ? "⚠️" : "✅") +
+            "</div>" +
+            '<div class="status-card__label">Key Market Trends</div>' +
+            '<div class="status-card__detail">Last verified: ' +
+            _esc(dateStr) +
+            (meta.verifiedBy ? " by " + _esc(meta.verifiedBy) : "") +
+            "</div>" +
+            '<div class="status-card__age">' +
+            ageDays +
+            "d ago" +
+            (isStale
+              ? ' — <strong style="color:var(--warn);">review recommended</strong>'
+              : "") +
+            "</div>";
+        }
 
-  function renderTrendsCard(meta) {
-    var card = document.getElementById('trendsStatusCard');
-    if (!card) return;
-    if (!meta || !meta.lastVerified) {
-      card.className = 'status-card status-card--warn';
-      card.innerHTML =
-        '<div class="status-card__icon">⚠️</div>' +
-        '<div class="status-card__label">Key Market Trends</div>' +
-        '<div class="status-card__detail">Verification date unavailable</div>' +
-        '<div class="status-card__age"><a href="docs/MARKET_TRENDS_UPDATE_PROTOCOL.md">View protocol →</a></div>';
-      return;
-    }
-    var verified = new Date(meta.lastVerified);
-    var ageDays  = daysSince(verified);
-    var dateStr  = verified.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
-    var isStale  = ageDays > STALE_TRENDS_DAYS;
-    card.className = 'status-card status-card--' + (isStale ? 'warn' : 'ok');
-    card.innerHTML =
-      '<div class="status-card__icon">' + (isStale ? '⚠️' : '✅') + '</div>' +
-      '<div class="status-card__label">Key Market Trends</div>' +
-      '<div class="status-card__detail">Last verified: ' + _esc(dateStr) +
-        (meta.verifiedBy ? ' by ' + _esc(meta.verifiedBy) : '') + '</div>' +
-      '<div class="status-card__age">' + ageDays + 'd ago' +
-        (isStale ? ' — <strong style="color:var(--warn);">review recommended</strong>' : '') +
-      '</div>';
-  }
-
-  function renderPipelineCard(meta) {
-    var card = document.getElementById('alertPipelineCard');
-    if (!card) return;
-    if (!meta) {
-      card.className = 'status-card status-card--warn';
-      card.innerHTML =
-        '<div class="status-card__icon">⚠️</div>' +
-        '<div class="status-card__label">Alert Pipeline</div>' +
-        '<div class="status-card__detail">Status unavailable</div>' +
-        '<div class="status-card__age"><a href="docs/alerts-pipeline.md">View docs →</a></div>';
-      return;
-    }
-    var generated  = meta.generated ? new Date(meta.generated) : null;
-    var feedCount  = meta.feed_count || 0;
-    var alertCount = meta.source_alerts || meta.alert_count || 0;
-    var briefCount = meta.brief_count || 0;
-    var ageDays    = generated ? daysSince(generated) : null;
-    var dateStr    = generated
-      ? generated.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-      : '—';
-    var isActive = feedCount > 0 || alertCount > 0;
-    var isStale  = ageDays !== null && ageDays > STALE_PIPELINE_DAYS;
-    var cls, icon, action;
-    if (!isActive) {
-      cls = 'warn'; icon = '⚠️';
-      action = '<div class="status-card__age">Configure feeds — see <a href="docs/alerts-pipeline.md">alerts-pipeline.md</a></div>';
-    } else if (isStale) {
-      cls = 'warn'; icon = '⚠️';
-      action = '<div class="status-card__age">' + ageDays + 'd since last fetch — pipeline may be stalled</div>';
-    } else {
-      cls = 'ok'; icon = '✅';
-      action = '<div class="status-card__age">Last fetch: ' + _esc(dateStr) + (ageDays !== null ? ' (' + ageDays + 'd ago)' : '') + '</div>';
-    }
-    card.className = 'status-card status-card--' + cls;
-    card.innerHTML =
-      '<div class="status-card__icon">' + icon + '</div>' +
-      '<div class="status-card__label">Alert Pipeline</div>' +
-      '<div class="status-card__detail">' +
-        feedCount + ' feed' + (feedCount === 1 ? '' : 's') + ' · ' +
-        alertCount + ' alert' + (alertCount === 1 ? '' : 's') + ' · ' +
-        briefCount + ' brief' + (briefCount === 1 ? '' : 's') +
-      '</div>' +
-      action;
-  }
-
-}());
-</script>
-</body>
+        function renderPipelineCard(meta) {
+          var card = document.getElementById("alertPipelineCard");
+          if (!card) return;
+          if (!meta) {
+            card.className = "status-card status-card--warn";
+            card.innerHTML =
+              '<div class="status-card__icon">⚠️</div>' +
+              '<div class="status-card__label">Alert Pipeline</div>' +
+              '<div class="status-card__detail">Status unavailable</div>' +
+              '<div class="status-card__age"><a href="docs/alerts-pipeline.md">View docs →</a></div>';
+            return;
+          }
+          var generated = meta.generated ? new Date(meta.generated) : null;
+          var feedCount = meta.feed_count || 0;
+          var alertCount = meta.source_alerts || meta.alert_count || 0;
+          var briefCount = meta.brief_count || 0;
+          var ageDays = generated ? daysSince(generated) : null;
+          var dateStr = generated
+            ? generated.toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+                year: "numeric",
+              })
+            : "—";
+          var isActive = feedCount > 0 || alertCount > 0;
+          var isStale = ageDays !== null && ageDays > STALE_PIPELINE_DAYS;
+          var cls, icon, action;
+          if (!isActive) {
+            cls = "warn";
+            icon = "⚠️";
+            action =
+              '<div class="status-card__age">Configure feeds — see <a href="docs/alerts-pipeline.md">alerts-pipeline.md</a></div>';
+          } else if (isStale) {
+            cls = "warn";
+            icon = "⚠️";
+            action =
+              '<div class="status-card__age">' +
+              ageDays +
+              "d since last fetch — pipeline may be stalled</div>";
+          } else {
+            cls = "ok";
+            icon = "✅";
+            action =
+              '<div class="status-card__age">Last fetch: ' +
+              _esc(dateStr) +
+              (ageDays !== null ? " (" + ageDays + "d ago)" : "") +
+              "</div>";
+          }
+          card.className = "status-card status-card--" + cls;
+          card.innerHTML =
+            '<div class="status-card__icon">' +
+            icon +
+            "</div>" +
+            '<div class="status-card__label">Alert Pipeline</div>' +
+            '<div class="status-card__detail">' +
+            feedCount +
+            " feed" +
+            (feedCount === 1 ? "" : "s") +
+            " · " +
+            alertCount +
+            " alert" +
+            (alertCount === 1 ? "" : "s") +
+            " · " +
+            briefCount +
+            " brief" +
+            (briefCount === 1 ? "" : "s") +
+            "</div>" +
+            action;
+        }
+      })();
+    </script>
+  </body>
 </html>

--- a/docs/DRIFT_REGISTER_AND_ACTION_PLAN.md
+++ b/docs/DRIFT_REGISTER_AND_ACTION_PLAN.md
@@ -1,0 +1,124 @@
+# Drift Register and Action Plan (from scratch notes)
+
+_Last updated: 2026-04-26 (UTC)_
+
+This document converts the latest scratch feedback into a single, explicit status board.
+It separates:
+
+1. **Already addressed / likely addressed** (based on referenced PRs/issues),
+2. **Confirmed drift** (behavior appears inconsistent with intended logic), and
+3. **Open work** with concrete next actions.
+
+---
+
+## 1) What appears already addressed
+
+Based on the referenced phase summary and PR notes:
+
+- `test/` vs `tests/` consolidation and endpoint coverage expansion were completed in **PR #625**.
+- QCEW → LAUS migration for county-level job-growth coverage was completed in **PR #626**.
+- Persona nav button behavior, transit isochrones, and deal-calculator soft-funds/impact-fee improvements were reported complete in prior phases.
+
+> Verification still required in production for Issue #578 checklist items (workflows, deployed UI checks, summary file counts).
+
+---
+
+## 2) Confirmed/likely drift (explicit)
+
+The table below states where drift appears and how to address it.
+
+| Area                                  | Observed drift                                                                                                   | Why it matters                                                         | How it is being addressed                                                                                                                                           |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Data Freshness panel                  | Shows only "last checked" style timestamp; limited evidence of per-dataset freshness/content health              | Users cannot tell whether data is recent, complete, or partially stale | Expand panel to include per-source `data_as_of`, record counts, stale thresholds, and last successful ingest metadata; add links to source + run logs               |
+| Census Explorer                       | Explorer allows out-of-Colorado selection and throws pattern errors in some flows                                | Breaks trust and usability for Colorado-focused workflows              | Enforce Colorado jurisdiction boundary in selectors and API query builders; add pre-submit validation and user-friendly error fallback                              |
+| HNA Comparative jurisdiction matching | Mismatched city labels and suspect values (e.g., Fruita/Boulder anomalies) indicate join/key normalization drift | Wrong jurisdiction mapping produces misleading metrics                 | Normalize jurisdiction IDs to a canonical key (GEOID-first), then map display labels separately; add unit tests for known edge cases (city vs county vs CDP labels) |
+| HNA comparison scope                  | Comparison appears county-level while UI implies sub-county comparability; labor stats absent                    | Decision-makers may compare unlike geographies                         | Add explicit scope badges (county/city/CDP), disable incompatible comparisons, and add labor-stat availability indicators                                           |
+| Source links/404s                     | Some citations/paths reported missing or broken                                                                  | Traceability is lost                                                   | Add automated source-link checker in CI and require source URL presence for every surfaced metric                                                                   |
+| Pipeline Log readability              | Low contrast/legibility                                                                                          | Accessibility issue (WCAG risk)                                        | Apply contrast updates and test with accessibility checks in CI                                                                                                     |
+
+---
+
+## 3) Open priority backlog (implementation-ready)
+
+### P0 — Reliability and trust (immediate)
+
+1. **Run Issue #578 verification checklist**
+   - Re-run `build-market-data.yml` and `build-hna-data.yml`.
+   - Verify local tests and deployed site runtime (fonts/maps/console).
+   - Confirm expected HNA summary artifact count.
+
+2. **Resolve Issue #516 market-data build failure**
+   - Inspect failed run and root cause (key validity vs upstream API failure).
+   - Re-trigger pipeline once dependencies are healthy.
+
+3. **Complete Issue #550 QA validation**
+   - Validate CHAS chart integrity, source badges, NHPD comp-set inclusion,
+     pro-forma live updates, QAP slider behavior, and scenario toggles.
+
+### P1 — Data drift closure (this week)
+
+4. **Data Freshness v2**
+   - Add a "data health card" per critical dataset with:
+     - `data_as_of`,
+     - `rows/coverage`,
+     - `ingest_status`,
+     - stale-state thresholds,
+     - source links.
+
+5. **Census Explorer hardening**
+   - Colorado-only jurisdiction constraints.
+   - Defensive parsing and structured error handling for pattern mismatch cases.
+   - "Full census-stat inventory" page listing every Census variable used sitewide.
+
+6. **HNA comparative integrity pass**
+   - Canonical jurisdiction dictionary (GEOID + type + canonical name).
+   - Data consistency tests for key examples: Fruita (city), Clifton (CDP), Boulder city.
+   - Add "data not available for this geography" messaging where applicable.
+
+### P2 — Product clarity and education (next)
+
+7. **Index stats refinement**
+   - Replace weak headline stats with statewide, policy-relevant metrics:
+     rent-burden prevalence + affordable-housing deficit by AMI tier.
+
+8. **Deal calculator explainability**
+   - Expand LIHTC basics, document soft-funds restrictions, add lease-option site-control notes, and source links.
+
+9. **Market analysis transparency**
+   - Add plain-language definitions for peer benchmarking, LIHTC supply-in-buffer, and enhanced pipeline sources.
+
+---
+
+## 4) Data updates that require new source releases
+
+These are intentionally separate from logic/UI fixes:
+
+- Refresh ACS `B25070` / `B25064` to 2021–2025 once published.
+- Pull HUD FY2026 Income Limits once published and validated.
+- Re-check Q1-2026 pricing indicators against current syndicator LOIs.
+
+---
+
+## 5) Suggested issue structure to reduce confusion
+
+- Keep **#578** as the single "post-merge verification" tracker.
+- Close/merge **#577** into #578 to avoid duplicate checklists.
+- Split #446 and #447 into small, owner-assigned deliverables:
+  - docs automation,
+  - integration/smoke tests,
+  - data-health alerts,
+  - accessibility/contrast fixes,
+  - source-link integrity automation.
+
+---
+
+## 6) Definition of done for drift closure
+
+A drift item is "closed" only when all are true:
+
+1. Repro case added to issue,
+2. Fix merged,
+3. Automated test added (or CI guardrail),
+4. User-facing copy updated if semantics changed,
+5. Source/citation link verified,
+6. Deployed verification captured in issue comment.

--- a/docs/NEXT-STEPS.md
+++ b/docs/NEXT-STEPS.md
@@ -5,20 +5,74 @@
 
 ---
 
+## 0. Immediate Next Steps (Post QA/QC — 2026-04-26)
+
+This section supersedes older sequencing notes for the current sprint.
+
+### 0.1 Execute production verification checklist (Issue #578)
+
+1. Trigger and review:
+   - `build-market-data.yml`
+   - `build-hna-data.yml`
+2. Confirm no deployment regressions on the live site:
+   - font loading
+   - map rendering
+   - no console errors on core pages
+3. Verify expected HNA summary artifact count in `data/hna/summary/`.
+
+**Exit criteria:** checklist evidence posted to #578 with links/screenshots/log snippets.
+
+### 0.2 Resolve operational pipeline failure (Issue #516)
+
+1. Inspect failed run `#24019124215`.
+2. Validate `CENSUS_API_KEY` in GitHub Actions secrets.
+3. Re-run failed workflow after upstream health checks.
+4. Add notification/escalation path for future pipeline failures.
+
+**Exit criteria:** successful rerun + root-cause note captured in issue.
+
+### 0.3 Complete feature QA checklist (Issue #550)
+
+Validate and document:
+
+- CHAS chart data correctness (Denver spot-check),
+- source-badge placement,
+- NHPD in competitive set,
+- pro forma live updates,
+- QAP slider behavior,
+- scenario toggle (10/20-year) updates.
+
+**Exit criteria:** pass/fail per item posted in #550, with regressions split into owner-assigned follow-up issues.
+
+### 0.4 Data trust hardening (next PR batch)
+
+1. Add automated link integrity checks for source URLs (prevent 404 source citations).
+2. Add a jurisdiction-normalization regression suite for HNA comparative edge cases:
+   - Fruita (city)
+   - Clifton (CDP)
+   - Boulder city label variants
+3. Add accessibility contrast checks for the Pipeline Log presentation.
+
+**Exit criteria:** CI checks fail on regression + docs updated in `TESTING.md`.
+
+---
+
 ## 1. Repository State Summary
 
 ### Main Branch Health
-| Check | Status |
-|-------|--------|
-| HNA functionality tests | ✅ 657 passed, 0 failed |
-| Asset reference validation | ✅ 34 HTML pages, 0 broken refs |
-| Critical data validation | ✅ All required data files present |
-| Site validation (validate-site.js) | ✅ 28 passed, 0 warnings, 0 failed |
-| Fetch helper resolve tests | ✅ 19 passed, 0 failed |
-| GitHub Pages deployment | ✅ Live at https://pggllc.github.io/Housing-Analytics/ |
-| Build Market Data CI | ⚠️ Fails — `CENSUS_API_KEY` not set; tract_boundaries_co.geojson empty |
+
+| Check                              | Status                                                                 |
+| ---------------------------------- | ---------------------------------------------------------------------- |
+| HNA functionality tests            | ✅ 657 passed, 0 failed                                                |
+| Asset reference validation         | ✅ 34 HTML pages, 0 broken refs                                        |
+| Critical data validation           | ✅ All required data files present                                     |
+| Site validation (validate-site.js) | ✅ 28 passed, 0 warnings, 0 failed                                     |
+| Fetch helper resolve tests         | ✅ 19 passed, 0 failed                                                 |
+| GitHub Pages deployment            | ✅ Live at https://pggllc.github.io/Housing-Analytics/                 |
+| Build Market Data CI               | ⚠️ Fails — `CENSUS_API_KEY` not set; tract_boundaries_co.geojson empty |
 
 ### Branch Inventory
+
 - **Total branches:** 300+ (all `copilot/*` pattern)
 - **Merged to main via PR:** 0 — all changes were applied directly to `main` through the automated quarantine/audit process
 - **Branches status:** Historical artifacts; none contain pending features ahead of `main`
@@ -27,26 +81,26 @@
 
 ## 2. What Has Been Completed (Current Main State)
 
-| Feature | Status | Key Files |
-|---------|--------|-----------|
-| Housing Needs Assessment (HNA) tool | ✅ Complete | `housing-needs-assessment.html`, `js/hna/` modules |
-| HNA Comparative Analysis ranking | ✅ Complete | `hna-comparative-analysis.html`, `js/hna/hna-ranking-index.js` |
-| Market Analysis (PMA) tool | ✅ Complete | `market-analysis.html`, `js/market-analysis.js` |
-| PMA Phase 2 — Concept card + ACS cache | ✅ Complete | `js/lihtc-concept-card-renderer.js`, `js/market-analysis-cache-fix.js` |
-| PMA Phase 2.1 — Constraint screening | ✅ Complete | `js/environmental-screening.js`, `js/public-land-overlay.js`, `js/soft-funding-tracker.js`, `js/chfa-award-predictor.js` |
-| Market Intelligence dashboard | ✅ Complete | `market-intelligence.html`, `js/market-intelligence.js` |
-| LIHTC Allocations dashboard | ✅ Complete | `lihtc-allocations.html` |
-| CHFA Portfolio page | ✅ Complete | `chfa-portfolio.html` |
-| Compliance Dashboard (Prop 123) | ✅ Complete | `compliance-dashboard.html` |
-| Colorado Deep Dive | ✅ Complete | `colorado-deep-dive.html` |
-| Housing Legislation Tracker | ✅ Complete | `housing-legislation-2026.html` |
-| Preservation tracker (NHPD) | ✅ Complete | `preservation.html`, `js/preservation.js` |
-| CRA Expansion Analysis | ✅ Complete | `cra-expansion-analysis.html` |
-| WCAG 2.1 AA accessibility | ✅ Complete | All 34 pages; aria-live, skip links, landmarks, touch targets |
-| Dark/light mode | ✅ Complete | `css/site-theme.css`, `js/dark-mode-toggle.js` |
-| CI/CD pipeline (31 workflows) | ✅ Complete | `.github/workflows/` |
-| FRED economic data pipeline | ✅ Complete | `data/fred-data.json`, 39 series |
-| CHFA LIHTC data (716 features) | ✅ Complete | `data/chfa-lihtc.json` |
+| Feature                                | Status      | Key Files                                                                                                                |
+| -------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Housing Needs Assessment (HNA) tool    | ✅ Complete | `housing-needs-assessment.html`, `js/hna/` modules                                                                       |
+| HNA Comparative Analysis ranking       | ✅ Complete | `hna-comparative-analysis.html`, `js/hna/hna-ranking-index.js`                                                           |
+| Market Analysis (PMA) tool             | ✅ Complete | `market-analysis.html`, `js/market-analysis.js`                                                                          |
+| PMA Phase 2 — Concept card + ACS cache | ✅ Complete | `js/lihtc-concept-card-renderer.js`, `js/market-analysis-cache-fix.js`                                                   |
+| PMA Phase 2.1 — Constraint screening   | ✅ Complete | `js/environmental-screening.js`, `js/public-land-overlay.js`, `js/soft-funding-tracker.js`, `js/chfa-award-predictor.js` |
+| Market Intelligence dashboard          | ✅ Complete | `market-intelligence.html`, `js/market-intelligence.js`                                                                  |
+| LIHTC Allocations dashboard            | ✅ Complete | `lihtc-allocations.html`                                                                                                 |
+| CHFA Portfolio page                    | ✅ Complete | `chfa-portfolio.html`                                                                                                    |
+| Compliance Dashboard (Prop 123)        | ✅ Complete | `compliance-dashboard.html`                                                                                              |
+| Colorado Deep Dive                     | ✅ Complete | `colorado-deep-dive.html`                                                                                                |
+| Housing Legislation Tracker            | ✅ Complete | `housing-legislation-2026.html`                                                                                          |
+| Preservation tracker (NHPD)            | ✅ Complete | `preservation.html`, `js/preservation.js`                                                                                |
+| CRA Expansion Analysis                 | ✅ Complete | `cra-expansion-analysis.html`                                                                                            |
+| WCAG 2.1 AA accessibility              | ✅ Complete | All 34 pages; aria-live, skip links, landmarks, touch targets                                                            |
+| Dark/light mode                        | ✅ Complete | `css/site-theme.css`, `js/dark-mode-toggle.js`                                                                           |
+| CI/CD pipeline (31 workflows)          | ✅ Complete | `.github/workflows/`                                                                                                     |
+| FRED economic data pipeline            | ✅ Complete | `data/fred-data.json`, 39 series                                                                                         |
+| CHFA LIHTC data (716 features)         | ✅ Complete | `data/chfa-lihtc.json`                                                                                                   |
 
 ---
 
@@ -54,11 +108,11 @@
 
 The following validation issues were resolved as part of this analysis:
 
-| Issue | Fix |
-|-------|-----|
-| 3 redirect stub pages missing `<h1>` (`colorado-market.html`, `LIHTC-dashboard.html`, `state-allocation-map.html`) | Added `<h1>` headings to all three redirect pages |
+| Issue                                                                                                                                                              | Fix                                                                                                                  |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| 3 redirect stub pages missing `<h1>` (`colorado-market.html`, `LIHTC-dashboard.html`, `state-allocation-map.html`)                                                 | Added `<h1>` headings to all three redirect pages                                                                    |
 | `test/validate-site.js` false-positive empty href detection (JS template strings flagged as empty hrefs in `policy-briefs.html`, `dashboard-data-sources-ui.html`) | Fixed regex to strip `<script>` blocks before matching; use same-quote pair `(["'])\1` instead of mismatched bracket |
-| `data/prop123_jurisdictions.json` redundant root-path entry in REQUIRED_JSON (all JS uses `data/policy/prop123_jurisdictions.json`) | Removed stale root-path entry from validator |
+| `data/prop123_jurisdictions.json` redundant root-path entry in REQUIRED_JSON (all JS uses `data/policy/prop123_jurisdictions.json`)                                | Removed stale root-path entry from validator                                                                         |
 
 ---
 
@@ -67,21 +121,26 @@ The following validation issues were resolved as part of this analysis:
 ### P0 — Critical (blocking or data-impacting)
 
 #### 4.1 Build Market Data CI — Census API Key Required
+
 **Impact:** The `market_data_build.yml` workflow fails because `CENSUS_API_KEY` is missing.  
 `tract_boundaries_co.geojson` is empty; tract centroid data (1605 records) comes from a prior run.
 
 **Action:**
+
 1. Set `CENSUS_API_KEY` in [GitHub Settings → Secrets → Actions](https://github.com/pggLLC/Housing-Analytics/settings/secrets/actions)
 2. Manually trigger: `gh workflow run market_data_build.yml`
 3. The workflow will populate `data/market/tract_boundaries_co.geojson` with full CO census tract polygons
 
 #### 4.2 `data/co-county-boundaries.json` Has 0 Features
+
 **Impact:** Market Analysis map and Colorado Deep Dive map fall back to live TIGERweb API for county boundaries instead of using the local cached file. Adds latency; breaks offline mode.
 
 **Action:**
+
 ```bash
 python3 scripts/boundaries/build_counties_co.py
 ```
+
 Then commit the resulting `data/co-county-boundaries.json` (should be 64 features).
 
 ---
@@ -89,17 +148,21 @@ Then commit the resulting `data/co-county-boundaries.json` (should be 64 feature
 ### P1 — High Priority (UX/Functionality)
 
 #### 4.3 `census-dashboard.html` Not in Navigation
+
 The Census Dashboard page exists at `census-dashboard.html` but is not linked from `js/navigation.js`. Users cannot discover it through normal browsing.
 
 **Options:**
+
 - Add it to a "Resources" or "Legacy" group in `js/navigation.js`
 - Move it to `archive/census-dashboard.html` alongside other archived pages
 
 **Recommended:** Archive it (it has been superseded by the HNA tool's census integration).
 
 #### 4.4 Breadcrumbs Missing on 4 Core Analysis Pages
+
 Per the [Site Design Audit](SITE-DESIGN-AUDIT.md), the following pages lack breadcrumbs:
-- `market-analysis.html` 
+
+- `market-analysis.html`
 - `housing-needs-assessment.html`
 - `compliance-dashboard.html`
 - `regional.html`
@@ -107,12 +170,18 @@ Per the [Site Design Audit](SITE-DESIGN-AUDIT.md), the following pages lack brea
 **Action:** Add `<nav aria-label="Breadcrumb">` with `Home > [Page Name]` pattern (consistent with `about.html`).
 
 #### 4.5 Persistent Geography State Between Pages
+
 When a user selects "Denver County" on the HNA page and navigates to Market Intelligence, the selection is lost. This creates friction in the primary workflow (HNA → Market Analysis → LIHTC screening).
 
 **Action:** Implement `localStorage`-backed geography persistence:
+
 ```js
-localStorage.setItem('coho:lastGeography', JSON.stringify({ type, geoid, name }));
+localStorage.setItem(
+  "coho:lastGeography",
+  JSON.stringify({ type, geoid, name }),
+);
 ```
+
 Load and pre-populate controls on pages that share geography selectors.
 
 ---
@@ -120,17 +189,21 @@ Load and pre-populate controls on pages that share geography selectors.
 ### P2 — Medium Priority (Enhancements)
 
 #### 4.6 Progressive Disclosure on HNA Page
+
 The Housing Needs Assessment page (`housing-needs-assessment.html`) shows all analysis panels before a geography is selected, creating cognitive overload.
 
 **Action:** Hide analysis panels initially with `display:none`; reveal with CSS transition after geography selection fires the `update()` call.
 
 #### 4.7 KPI Cards — Units and Comparison Period Labels
+
 On the Economic Dashboard and Colorado Deep Dive, KPI cards show raw numbers without units or date context.
 
 **Action:** Append unit labels to values (e.g., "$287M", "2.1%") and add a sub-label showing comparison period ("vs. prior year", "12-mo change").
 
 #### 4.8 Market Data Placeholder → Full Data
+
 The `data/market/` directory has these placeholder counts:
+
 - `tract_centroids_co.json`: 1605 records (built by prior CI run, should be 1605+)
 - `acs_tract_metrics_co.json`: 1447 records (previously 4 placeholders — now populated)
 - `hud_lihtc_co.geojson`: 360 features (was 10 placeholder, now 360)
@@ -142,17 +215,17 @@ The `data/market/` directory has these placeholder counts:
 
 These items are documented in [FEATURE_COMPLETE.md](FEATURE_COMPLETE.md) and the [Site Design Audit](SITE-DESIGN-AUDIT.md):
 
-| Enhancement | Estimated Effort | Value |
-|-------------|-----------------|-------|
-| LODES workforce integration for PMA commuter-shed scoring | Medium | High — fills the constant `0.60` proxy in the workforce radar dimension |
-| Parcel/zoning layer for PMA land availability subscore | Large | High — currently uses proxy score |
-| Historical trend charts in Market Intelligence | Medium | Medium |
-| Multi-county aggregation view in HNA/Market Intelligence | Medium | Medium |
-| Rent roll benchmarking in PMA comparable analysis | Large | High |
-| Persona-based "Start Here" onboarding flow on index.html | Small | Medium |
-| Increased base font size (15px → 16px) for mid-size screens | Small | Low |
-| Section zebra-striping on long analysis pages | Small | Low |
-| Semantic color token enforcement (--good / --warn / --bad) | Small | Low |
+| Enhancement                                                 | Estimated Effort | Value                                                                   |
+| ----------------------------------------------------------- | ---------------- | ----------------------------------------------------------------------- |
+| LODES workforce integration for PMA commuter-shed scoring   | Medium           | High — fills the constant `0.60` proxy in the workforce radar dimension |
+| Parcel/zoning layer for PMA land availability subscore      | Large            | High — currently uses proxy score                                       |
+| Historical trend charts in Market Intelligence              | Medium           | Medium                                                                  |
+| Multi-county aggregation view in HNA/Market Intelligence    | Medium           | Medium                                                                  |
+| Rent roll benchmarking in PMA comparable analysis           | Large            | High                                                                    |
+| Persona-based "Start Here" onboarding flow on index.html    | Small            | Medium                                                                  |
+| Increased base font size (15px → 16px) for mid-size screens | Small            | Low                                                                     |
+| Section zebra-striping on long analysis pages               | Small            | Low                                                                     |
+| Semantic color token enforcement (--good / --warn / --bad)  | Small            | Low                                                                     |
 
 ---
 
@@ -161,6 +234,7 @@ These items are documented in [FEATURE_COMPLETE.md](FEATURE_COMPLETE.md) and the
 All `copilot/*` branches are historical artifacts from the Copilot-assisted development workflow. None contain code ahead of `main`. They can be safely deleted to reduce repository clutter.
 
 **To delete all merged/stale copilot branches:**
+
 ```bash
 gh api repos/pggLLC/Housing-Analytics/branches --paginate \
   --jq '.[].name | select(startswith("copilot/"))' | \
@@ -175,18 +249,18 @@ The one exception is `audit-fixes-comprehensive` — verify its content before d
 
 ## 6. CI/CD Health
 
-| Workflow | Schedule | Last Status | Notes |
-|----------|----------|-------------|-------|
-| CI Checks | PR + push | ✅ success | 34 HTML pages, data thresholds |
-| Deploy to GitHub Pages | push to main | ✅ success | Auto-deploys |
-| Fetch FRED Data | Daily | ✅ success | 39 series |
-| Fetch CHFA LIHTC | Weekly Mon 05:00 | ✅ success | 716 features |
-| Cache HUD GIS Data | Weekly Mon 04:00 | ✅ success | QCT/DDA |
-| Build Market Data | Weekly + manual | ⚠️ failure | Needs `CENSUS_API_KEY` |
-| WCAG Contrast Audit | push | ✅ success | |
-| Site Audit | push | ✅ success | |
-| Archive, Audit & Docs | push | ✅ success | |
-| Build Redeploy ZIP | push | ✅ success | |
+| Workflow               | Schedule         | Last Status | Notes                          |
+| ---------------------- | ---------------- | ----------- | ------------------------------ |
+| CI Checks              | PR + push        | ✅ success  | 34 HTML pages, data thresholds |
+| Deploy to GitHub Pages | push to main     | ✅ success  | Auto-deploys                   |
+| Fetch FRED Data        | Daily            | ✅ success  | 39 series                      |
+| Fetch CHFA LIHTC       | Weekly Mon 05:00 | ✅ success  | 716 features                   |
+| Cache HUD GIS Data     | Weekly Mon 04:00 | ✅ success  | QCT/DDA                        |
+| Build Market Data      | Weekly + manual  | ⚠️ failure  | Needs `CENSUS_API_KEY`         |
+| WCAG Contrast Audit    | push             | ✅ success  |                                |
+| Site Audit             | push             | ✅ success  |                                |
+| Archive, Audit & Docs  | push             | ✅ success  |                                |
+| Build Redeploy ZIP     | push             | ✅ success  |                                |
 
 ---
 

--- a/docs/REPO_STATUS_2026-04-26.md
+++ b/docs/REPO_STATUS_2026-04-26.md
@@ -1,0 +1,27 @@
+# Repository Status Report — 2026-04-26
+
+## Snapshot
+
+- Branch: `work`
+- Working tree: clean (no uncommitted changes)
+- Most recent commit on branch:
+  - `09f5fd1` — _Data-quality & link-audit hardening; Colorado-scoped Census dashboard and UI/js cleanups_
+
+## What this means for PR readiness
+
+From a git-state perspective, this branch is PR-ready:
+
+1. No dirty files are pending commit.
+2. Latest work is committed on the active branch.
+3. You can open a PR now if you want review on the current batch.
+
+## Caveats before opening PR
+
+- If your team requires CI evidence in the PR description, include links to the latest workflow runs.
+- If reviewers requested narrowed scope, consider splitting the large batch into smaller PRs first.
+- If you expect additional inline-comment fixes, defer PR creation until those are included.
+
+## Recommendation
+
+- **Create the PR now** if your goal is review/feedback on the current state.
+- **Wait to open PR** only if you already know additional required changes are imminent.

--- a/js/census-multifamily.js
+++ b/js/census-multifamily.js
@@ -16,34 +16,39 @@ const ACS_BASE = `https://api.census.gov/data/${ACS_YEAR}/acs/acs1/profile`;
 const GEOINFO_BASE = `https://api.census.gov/data/${ACS_YEAR}/geoinfo`;
 
 function censusKey() {
-  return (window.APP_CONFIG && window.APP_CONFIG.CENSUS_API_KEY) ? window.APP_CONFIG.CENSUS_API_KEY : '';
+  return window.APP_CONFIG && window.APP_CONFIG.CENSUS_API_KEY
+    ? window.APP_CONFIG.CENSUS_API_KEY
+    : "";
 }
 
 const VARS = {
   totalHU: "DP04_0001E",
   pct_5_9: "DP04_0011PE",
   pct_10_19: "DP04_0012PE",
-  pct_20p: "DP04_0013PE"
+  pct_20p: "DP04_0013PE",
 };
 
 let chart;
+const COLORADO_FIPS = "08";
 
-function $(id){ return document.getElementById(id); }
+function $(id) {
+  return document.getElementById(id);
+}
 
-function fmtNumber(x){
+function fmtNumber(x) {
   const n = Number(x);
   if (!Number.isFinite(n)) return x;
   return n.toLocaleString();
 }
-function fmtPct(x){
+function fmtPct(x) {
   const n = Number(x);
   if (!Number.isFinite(n)) return x;
   return `${n.toFixed(1)}%`;
 }
 
-async function fetchJson(url){
+async function fetchJson(url) {
   let res;
-  if (typeof window.fetchWithTimeout === 'function') {
+  if (typeof window.fetchWithTimeout === "function") {
     res = await window.fetchWithTimeout(url, {}, 8000, 0);
   } else {
     const controller = new AbortController();
@@ -58,43 +63,44 @@ async function fetchJson(url){
   return await res.json();
 }
 
-async function loadStates(){
-  // NAME + state FIPS
-  const url = `${GEOINFO_BASE}?get=NAME&for=state:*`;
-  const data = await fetchJson(url);
-  const rows = data.slice(1).map(r => ({ name: r[0], state: r[1] }))
-    .sort((a,b)=>a.name.localeCompare(b.name));
-
+async function loadStates() {
   const sel = $("state-select");
-  sel.innerHTML = rows.map(r => `<option value="${r.state}">${r.name}</option>`).join("");
+  // Colorado-only by design for COHO workflows.
+  sel.innerHTML = `<option value="${COLORADO_FIPS}">Colorado</option>`;
+  sel.value = COLORADO_FIPS;
 }
 
-async function loadCounties(stateFips){
+async function loadCounties(stateFips) {
   const url = `${GEOINFO_BASE}?get=NAME&for=county:*&in=state:${stateFips}`;
   const data = await fetchJson(url);
-  const rows = data.slice(1).map(r => ({ name: r[0], county: r[1] }))
-    .sort((a,b)=>a.name.localeCompare(b.name));
+  const rows = data
+    .slice(1)
+    .map((r) => ({ name: r[0], county: r[1] }))
+    .sort((a, b) => a.name.localeCompare(b.name));
   const sel = $("local-select");
-  sel.innerHTML = rows.map(r => `<option value="${r.county}">${r.name}</option>`).join("");
+  sel.innerHTML = rows
+    .map((r) => `<option value="${r.county}">${r.name}</option>`)
+    .join("");
 }
 
-async function loadPlaces(stateFips){
+async function loadPlaces(stateFips) {
   const url = `${GEOINFO_BASE}?get=NAME&for=place:*&in=state:${stateFips}`;
   const data = await fetchJson(url);
-  const rows = data.slice(1).map(r => ({ name: r[0], place: r[1] }))
-    .sort((a,b)=>a.name.localeCompare(b.name));
+  const rows = data
+    .slice(1)
+    .map((r) => ({ name: r[0], place: r[1] }))
+    .sort((a, b) => a.name.localeCompare(b.name));
   const sel = $("local-select");
-  sel.innerHTML = rows.map(r => `<option value="${r.place}">${r.name}</option>`).join("");
+  sel.innerHTML = rows
+    .map((r) => `<option value="${r.place}">${r.name}</option>`)
+    .join("");
 }
 
-function buildAcsUrl({ level, state, local }){
+function buildAcsUrl({ level, state, local }) {
   const get = `NAME,${VARS.totalHU},${VARS.pct_5_9},${VARS.pct_10_19},${VARS.pct_20p}`;
   const key = censusKey();
   const keySuffix = key ? `&key=${encodeURIComponent(key)}` : "";
 
-  if (level === "us") {
-    return `${ACS_BASE}?get=${encodeURIComponent(get)}&for=us:1${keySuffix}`;
-  }
   if (level === "state") {
     return `${ACS_BASE}?get=${encodeURIComponent(get)}&for=state:${state}${keySuffix}`;
   }
@@ -107,25 +113,25 @@ function buildAcsUrl({ level, state, local }){
   throw new Error("Unknown geography level");
 }
 
-function renderShareChart(name, p1, p2, p3){
+function renderShareChart(name, p1, p2, p3) {
   const ctx = $("mf-share");
   const labels = ["5–9 units", "10–19 units", "20+ units"];
-  const data = [p1, p2, p3].map(v => Number(v));
+  const data = [p1, p2, p3].map((v) => Number(v));
 
   if (chart) chart.destroy();
   chart = new Chart(ctx, {
     type: "bar",
     data: {
       labels,
-      datasets: [{ label: `% of housing units – ${name}`, data }]
+      datasets: [{ label: `% of housing units – ${name}`, data }],
     },
     options: {
       responsive: true,
       plugins: { legend: { display: true } },
       scales: {
-        y: { beginAtZero: true, ticks: { callback: (v)=>`${v}%` } }
-      }
-    }
+        y: { beginAtZero: true, ticks: { callback: (v) => `${v}%` } },
+      },
+    },
   });
 
   $("mf-table").innerHTML = `
@@ -140,20 +146,25 @@ function renderShareChart(name, p1, p2, p3){
   `;
 }
 
-async function refresh(){
+async function refresh() {
   const level = $("geo-level").value;
-  const state = $("state-select").value;
+  const state = COLORADO_FIPS;
   const local = $("local-select").value;
 
   $("geo-note").textContent = "Loading…";
 
   try {
+    if (level !== "state" && !local) {
+      $("geo-note").textContent = "Select a Colorado county/place to continue.";
+      $("geo-note").style.color = "crimson";
+      return;
+    }
     const url = buildAcsUrl({ level, state, local });
     const data = await fetchJson(url);
 
     const header = data[0];
     const row = data[1];
-    const idx = Object.fromEntries(header.map((h,i)=>[h,i]));
+    const idx = Object.fromEntries(header.map((h, i) => [h, i]));
 
     const name = row[idx["NAME"]];
     const totalHU = row[idx[VARS.totalHU]];
@@ -161,31 +172,27 @@ async function refresh(){
     const p2 = row[idx[VARS.pct_10_19]];
     const p3 = row[idx[VARS.pct_20p]];
 
-    $("geo-note").textContent = `Selected: ${name} (ACS ${ACS_YEAR} 1-year, DP04)`;
+    $("geo-note").textContent =
+      `Selected: ${name} (Colorado only · ACS ${ACS_YEAR} 1-year, DP04)`;
     $("geo-note").style.color = "";
     $("hu").textContent = fmtNumber(totalHU);
     $("hu-meta").textContent = "Total housing units (estimate)";
 
     renderShareChart(name, p1, p2, p3);
-  } catch(e) {
+  } catch (e) {
     console.error("[census-multifamily] refresh failed:", e);
-    $("geo-note").textContent = `Error: ${e.message}`;
+    $("geo-note").textContent =
+      `Error loading Colorado Census data: ${e.message}`;
     $("geo-note").style.color = "crimson";
   }
 }
 
-function setGeoUi(){
+function setGeoUi() {
   const level = $("geo-level").value;
   const stateSel = $("state-select");
   const localSel = $("local-select");
 
-  if (level === "us") {
-    stateSel.disabled = true;
-    localSel.disabled = true;
-    return;
-  }
-
-  stateSel.disabled = false;
+  stateSel.disabled = true;
 
   if (level === "state") {
     localSel.disabled = true;
@@ -194,14 +201,12 @@ function setGeoUi(){
   }
 }
 
-async function onGeoChange(){
+async function onGeoChange() {
   const level = $("geo-level").value;
   setGeoUi();
 
   try {
-    if (level === "us") return await refresh();
-
-    const state = $("state-select").value;
+    const state = COLORADO_FIPS;
     if (level === "state") return await refresh();
 
     if (level === "county") {
@@ -213,15 +218,15 @@ async function onGeoChange(){
       await loadPlaces(state);
       return await refresh();
     }
-  } catch(e) {
+  } catch (e) {
     console.error("[census-multifamily] onGeoChange failed:", e);
     $("geo-note").textContent = `Error: ${e.message}`;
     $("geo-note").style.color = "crimson";
   }
 }
 
-(async function init(){
-  try{
+(async function init() {
+  try {
     await loadStates();
     setGeoUi();
 
@@ -230,9 +235,9 @@ async function onGeoChange(){
     $("local-select").addEventListener("change", refresh);
     $("refresh").addEventListener("click", refresh);
 
-    // Initialize local list for default (us)
+    // Default to Colorado statewide view.
     await refresh();
-  } catch(e){
+  } catch (e) {
     console.error(e);
     $("geo-note").textContent = e.message;
     $("geo-note").style.color = "crimson";

--- a/js/data-quality-check.js
+++ b/js/data-quality-check.js
@@ -10,50 +10,50 @@
  *   DataQuality.validate(cfg)     — validate a single dataset config; returns Promise<Report>
  *   DataQuality.renderBadge(el, report) — update a badge element with freshness info
  *
- * Each Report: { key, label, ok, warning, message, featureCount, cacheAge }
+ * Each Report: { key, label, ok, warning, message, featureCount, cacheAge, dataAsOf, dataAgeMs }
  *
  * Emits CustomEvent 'dq:complete' on document with detail { reports, allOk }.
  * Emits CustomEvent 'dq:stale'    on document when any dataset is stale/invalid.
  */
 (function (global) {
-  'use strict';
+  "use strict";
 
   /** Datasets validated by default on every page. */
   var DEFAULT_DATASETS = [
     {
-      key: 'county-boundaries',
-      label: 'County boundaries',
-      path: 'data/co-county-boundaries.json',
-      minFeatures: 60,       // at least 60 of 64 CO counties
-      critical: true
+      key: "county-boundaries",
+      label: "County boundaries",
+      path: "data/co-county-boundaries.json",
+      minFeatures: 60, // at least 60 of 64 CO counties
+      critical: true,
     },
     {
-      key: 'chfa-lihtc',
-      label: 'CHFA LIHTC properties',
-      path: 'data/chfa-lihtc.json',
+      key: "chfa-lihtc",
+      label: "CHFA LIHTC properties",
+      path: "data/chfa-lihtc.json",
       minFeatures: 1,
-      critical: true
+      critical: true,
     },
     {
-      key: 'fred-data',
-      label: 'FRED economic series',
-      path: 'data/fred-data.json',
+      key: "fred-data",
+      label: "FRED economic series",
+      path: "data/fred-data.json",
       validate: _validateFred,
-      critical: false
+      critical: false,
     },
     {
-      key: 'ami-gap',
-      label: 'AMI gap by county',
-      path: 'data/co_ami_gap_by_county.json',
-      minFeatures: 0,        // object-based file; custom check below
+      key: "ami-gap",
+      label: "AMI gap by county",
+      path: "data/co_ami_gap_by_county.json",
+      minFeatures: 0, // object-based file; custom check below
       validate: _validateAmiGap,
-      critical: false
-    }
+      critical: false,
+    },
   ];
 
   /** Relative age thresholds for freshness badges (ms). */
-  var AGE_FRESH   = 2  * 60 * 60 * 1000;   //  2 hours  → ✅ fresh
-  var AGE_RECENT  = 48 * 60 * 60 * 1000;   // 48 hours  → ⚠️ recent but aging
+  var AGE_FRESH = 2 * 60 * 60 * 1000; //  2 hours  → ✅ fresh
+  var AGE_RECENT = 48 * 60 * 60 * 1000; // 48 hours  → ⚠️ recent but aging
   // Older than 48 h → ⚠️ stale
 
   // ── Public API ──────────────────────────────────────────────────────────────
@@ -63,17 +63,18 @@
    * @returns {Promise<Report[]>}
    */
   function runAll() {
-    return Promise.all(DEFAULT_DATASETS.map(validate))
-      .then(function (reports) {
-        var allOk = reports.every(function (r) { return r.ok; });
-        _logResults(reports);
-        _updateBadges(reports);
-        _dispatchEvent('dq:complete', { reports: reports, allOk: allOk });
-        if (!allOk) {
-          _dispatchEvent('dq:stale', { reports: reports });
-        }
-        return reports;
+    return Promise.all(DEFAULT_DATASETS.map(validate)).then(function (reports) {
+      var allOk = reports.every(function (r) {
+        return r.ok;
       });
+      _logResults(reports);
+      _updateBadges(reports);
+      _dispatchEvent("dq:complete", { reports: reports, allOk: allOk });
+      if (!allOk) {
+        _dispatchEvent("dq:stale", { reports: reports });
+      }
+      return reports;
+    });
   }
 
   /**
@@ -83,33 +84,49 @@
    * @returns {Promise<Report>}
    */
   function validate(cfg) {
-    var cacheKey = '_fh_' + cfg.path;
+    var cacheKey = "_fh_" + cfg.path;
     var cacheAge = _getCacheAge(cacheKey);
 
-    var fetcher = (typeof global.safeFetchJSON === 'function')
-      ? global.safeFetchJSON(cfg.path)
-      : fetch(_resolvePath(cfg.path)).then(function (r) {
-          if (!r.ok) throw new Error('HTTP ' + r.status);
-          return r.json();
-        });
+    var fetcher =
+      typeof global.safeFetchJSON === "function"
+        ? global.safeFetchJSON(cfg.path)
+        : fetch(_resolvePath(cfg.path)).then(function (r) {
+            if (!r.ok) throw new Error("HTTP " + r.status);
+            return r.json();
+          });
 
     return fetcher
       .then(function (data) {
         // Run custom validator if supplied
-        if (typeof cfg.validate === 'function') {
+        if (typeof cfg.validate === "function") {
           return cfg.validate(data, cfg, cacheAge);
         }
         // Default GeoJSON feature-count check
-        var features = Array.isArray(data && data.features) ? data.features.length : 0;
-        var minF = typeof cfg.minFeatures === 'number' ? cfg.minFeatures : 0;
+        var features = Array.isArray(data && data.features)
+          ? data.features.length
+          : 0;
+        var minF = typeof cfg.minFeatures === "number" ? cfg.minFeatures : 0;
         var ok = features >= minF;
-        return _makeReport(cfg, ok, features, cacheAge,
+        return _makeReport(
+          cfg,
+          ok,
+          features,
+          cacheAge,
           ok
             ? null
-            : 'Only ' + features + ' features (expected ≥ ' + minF + ')');
+            : "Only " + features + " features (expected ≥ " + minF + ")",
+          data,
+        );
       })
       .catch(function (err) {
-        return _makeReport(cfg, false, 0, cacheAge, 'Load error: ' + (err && err.message || err));
+        return _makeReport(
+          cfg,
+          false,
+          0,
+          cacheAge,
+          "Load error: " + ((err && err.message) || err),
+          null,
+        );
       });
   }
 
@@ -120,44 +137,66 @@
    */
   function renderBadge(el, reportOrReports) {
     if (!el) return;
-    var reports = Array.isArray(reportOrReports) ? reportOrReports : [reportOrReports];
-    var allOk = reports.every(function (r) { return r.ok; });
-    var anyCriticalFail = reports.some(function (r) { return !r.ok && r.critical; });
+    var reports = Array.isArray(reportOrReports)
+      ? reportOrReports
+      : [reportOrReports];
+    var allOk = reports.every(function (r) {
+      return r.ok;
+    });
+    var anyCriticalFail = reports.some(function (r) {
+      return !r.ok && r.critical;
+    });
 
     // Determine the most representative cache age
     var ages = reports
-      .map(function (r) { return r.cacheAge; })
-      .filter(function (a) { return a !== null && a !== undefined; });
+      .map(function (r) {
+        return r.cacheAge;
+      })
+      .filter(function (a) {
+        return a !== null && a !== undefined;
+      });
     var minAge = ages.length ? Math.min.apply(null, ages) : null;
 
     el.textContent = _badgeText(allOk, anyCriticalFail, minAge);
-    el.className = el.className.replace(/\bdrb--(ok|warn|error)\b/g, '');
-    var cls = anyCriticalFail ? 'drb--error' : (allOk ? 'drb--ok' : 'drb--warn');
+    el.className = el.className.replace(/\bdrb--(ok|warn|error)\b/g, "");
+    var cls = anyCriticalFail ? "drb--error" : allOk ? "drb--ok" : "drb--warn";
     el.classList.add(cls);
-    el.setAttribute('aria-label', el.textContent);
-    el.setAttribute('title', _badgeTitle(reports));
+    el.setAttribute("aria-label", el.textContent);
+    el.setAttribute("title", _badgeTitle(reports));
   }
 
   // ── Custom validators ────────────────────────────────────────────────────────
 
   function _validateFred(data, cfg, cacheAge) {
     var series = data && data.series;
-    var hasSeries = series && (
-      (typeof series === 'object' && !Array.isArray(series) && Object.keys(series).length > 0) ||
-      (Array.isArray(series) && series.length > 0)
-    );
+    var hasSeries =
+      series &&
+      ((typeof series === "object" &&
+        !Array.isArray(series) &&
+        Object.keys(series).length > 0) ||
+        (Array.isArray(series) && series.length > 0));
     if (!hasSeries) {
-      return _makeReport(cfg, false, 0, cacheAge, 'No FRED series found');
+      return _makeReport(cfg, false, 0, cacheAge, "No FRED series found", data);
     }
     // Check that at least one series has observations
     var keys = Array.isArray(series) ? null : Object.keys(series);
     var hasObs = keys
-      ? keys.some(function (k) { return (series[k].observations || []).length > 0; })
-      : series.some(function (s) { return (s.observations || []).length > 0; });
+      ? keys.some(function (k) {
+          return (series[k].observations || []).length > 0;
+        })
+      : series.some(function (s) {
+          return (s.observations || []).length > 0;
+        });
     var count = keys ? keys.length : series.length;
     var ok = hasSeries && hasObs;
-    return _makeReport(cfg, ok, count, cacheAge,
-      ok ? null : 'FRED series present but all have 0 observations');
+    return _makeReport(
+      cfg,
+      ok,
+      count,
+      cacheAge,
+      ok ? null : "FRED series present but all have 0 observations",
+      data,
+    );
   }
 
   function _validateAmiGap(data, cfg, cacheAge) {
@@ -166,27 +205,69 @@
     var count = 0;
     if (Array.isArray(counties)) {
       count = counties.length;
-    } else if (counties && typeof counties === 'object') {
+    } else if (counties && typeof counties === "object") {
       count = Object.keys(counties).length;
     }
     var ok = count > 0;
-    return _makeReport(cfg, ok, count, cacheAge,
-      ok ? null : 'AMI gap counties list is empty or malformed');
+    return _makeReport(
+      cfg,
+      ok,
+      count,
+      cacheAge,
+      ok ? null : "AMI gap counties list is empty or malformed",
+      data,
+    );
   }
 
   // ── Helpers ──────────────────────────────────────────────────────────────────
 
-  function _makeReport(cfg, ok, featureCount, cacheAge, errorMsg) {
+  function _makeReport(cfg, ok, featureCount, cacheAge, errorMsg, data) {
+    var dataAsOf = _extractDataTimestamp(data);
+    var dataAgeMs = dataAsOf ? Date.now() - dataAsOf.getTime() : null;
     return {
-      key:          cfg.key,
-      label:        cfg.label,
-      critical:     !!cfg.critical,
-      ok:           ok,
-      warning:      !ok,
-      message:      errorMsg || null,
+      key: cfg.key,
+      label: cfg.label,
+      critical: !!cfg.critical,
+      ok: ok,
+      warning: !ok,
+      message: errorMsg || null,
       featureCount: featureCount,
-      cacheAge:     cacheAge
+      cacheAge: cacheAge,
+      dataAsOf: dataAsOf ? dataAsOf.toISOString() : null,
+      dataAgeMs: dataAgeMs,
     };
+  }
+
+  function _extractDataTimestamp(data) {
+    if (!data || typeof data !== "object") return null;
+    var candidates = [
+      data.generated_at,
+      data.generatedAt,
+      data.last_updated,
+      data.lastUpdated,
+      data.updated_at,
+      data.updatedAt,
+      data.as_of,
+      data.asOf,
+      data.vintage,
+    ];
+    if (data.meta && typeof data.meta === "object") {
+      candidates.push(
+        data.meta.generated,
+        data.meta.generated_at,
+        data.meta.last_updated,
+        data.meta.lastUpdated,
+        data.meta.as_of,
+        data.meta.vintage,
+      );
+    }
+    for (var i = 0; i < candidates.length; i++) {
+      var raw = candidates[i];
+      if (!raw) continue;
+      var d = new Date(raw);
+      if (!isNaN(d.getTime())) return d;
+    }
+    return null;
   }
 
   function _getCacheAge(cacheKey) {
@@ -202,25 +283,28 @@
   }
 
   function _resolvePath(relativePath) {
-    if (typeof global.resolveAssetUrl === 'function') {
+    if (typeof global.resolveAssetUrl === "function") {
       return global.resolveAssetUrl(relativePath);
     }
-    var base = (typeof global.APP_BASE_PATH === 'string') ? global.APP_BASE_PATH : '/';
-    return base + relativePath.replace(/^\.\//, '');
+    var base =
+      typeof global.APP_BASE_PATH === "string" ? global.APP_BASE_PATH : "/";
+    return base + relativePath.replace(/^\.\//, "");
   }
 
   function _logResults(reports) {
     reports.forEach(function (r) {
-      var icon   = r.ok ? '✅' : '⚠️';
-      var detail = r.featureCount > 0 ? ' (' + r.featureCount + ' records)' : '';
-      var age    = r.cacheAge !== null ? ' — cached ' + _relTime(r.cacheAge) + ' ago' : '';
-      var msg    = r.message ? ' — ' + r.message : '';
-      console.log('[DataQuality] ' + icon + ' ' + r.label + detail + age + msg);
+      var icon = r.ok ? "✅" : "⚠️";
+      var detail =
+        r.featureCount > 0 ? " (" + r.featureCount + " records)" : "";
+      var age =
+        r.cacheAge !== null ? " — cached " + _relTime(r.cacheAge) + " ago" : "";
+      var msg = r.message ? " — " + r.message : "";
+      console.log("[DataQuality] " + icon + " " + r.label + detail + age + msg);
     });
   }
 
   function _updateBadges(reports) {
-    var badges = document.querySelectorAll('.data-reliability-badge');
+    var badges = document.querySelectorAll(".data-reliability-badge");
     if (!badges.length) return;
     for (var i = 0; i < badges.length; i++) {
       renderBadge(badges[i], reports);
@@ -231,54 +315,61 @@
     try {
       var ev = new CustomEvent(name, { bubbles: true, detail: detail });
       document.dispatchEvent(ev);
-    } catch (e) { /* older browsers */ }
+    } catch (e) {
+      /* older browsers */
+    }
   }
 
   function _badgeText(allOk, anyCriticalFail, ageMs) {
-    if (anyCriticalFail) return '⚠ Data unavailable';
-    var ageStr = '';
+    if (anyCriticalFail) return "⚠ Data unavailable";
+    var ageStr = "";
     if (ageMs !== null && ageMs !== undefined) {
       if (ageMs < AGE_FRESH) {
-        ageStr = ' · ' + _relTime(ageMs) + ' ago';
+        ageStr = " · " + _relTime(ageMs) + " ago";
       } else if (ageMs < AGE_RECENT) {
-        ageStr = ' · cached ' + _relTime(ageMs) + ' ago';
+        ageStr = " · cached " + _relTime(ageMs) + " ago";
       } else {
-        ageStr = ' · data may be stale (' + _relTime(ageMs) + ')';
+        ageStr = " · data may be stale (" + _relTime(ageMs) + ")";
       }
     }
-    return allOk ? ('✅ Data current' + ageStr) : ('⚠ Some data outdated' + ageStr);
+    return allOk ? "✅ Data current" + ageStr : "⚠ Some data outdated" + ageStr;
   }
 
   function _badgeTitle(reports) {
-    return reports.map(function (r) {
-      return (r.ok ? '✅ ' : '⚠ ') + r.label +
-        (r.featureCount ? ' (' + r.featureCount + ')' : '') +
-        (r.message ? ': ' + r.message : '');
-    }).join('\n');
+    return reports
+      .map(function (r) {
+        return (
+          (r.ok ? "✅ " : "⚠ ") +
+          r.label +
+          (r.featureCount ? " (" + r.featureCount + ")" : "") +
+          (r.message ? ": " + r.message : "")
+        );
+      })
+      .join("\n");
   }
 
   function _relTime(ms) {
     var s = Math.floor(ms / 1000);
-    if (s < 60)  return s + 's';
+    if (s < 60) return s + "s";
     var m = Math.floor(s / 60);
-    if (m < 60)  return m + 'm';
+    if (m < 60) return m + "m";
     var h = Math.floor(m / 60);
-    if (h < 24)  return h + 'h';
-    return Math.floor(h / 24) + 'd';
+    if (h < 24) return h + "h";
+    return Math.floor(h / 24) + "d";
   }
 
   // ── Auto-run on DOMContentLoaded ─────────────────────────────────────────────
 
   function _autoRun() {
     // Only run if the page has a data-quality badge or an aria-live status element
-    var hasBadge  = !!document.querySelector('.data-reliability-badge');
-    var hasStatus = !!document.getElementById('statusPanel');
+    var hasBadge = !!document.querySelector(".data-reliability-badge");
+    var hasStatus = !!document.getElementById("statusPanel");
     if (!hasBadge && !hasStatus) return;
     runAll();
   }
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', _autoRun);
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", _autoRun);
   } else {
     _autoRun();
   }
@@ -286,9 +377,8 @@
   // ── Expose ───────────────────────────────────────────────────────────────────
 
   global.DataQuality = {
-    runAll:      runAll,
-    validate:    validate,
-    renderBadge: renderBadge
+    runAll: runAll,
+    validate: validate,
+    renderBadge: renderBadge,
   };
-
 })(window);

--- a/scripts/audit/source-url-sweep.mjs
+++ b/scripts/audit/source-url-sweep.mjs
@@ -1,12 +1,351 @@
-'use strict';
+#!/usr/bin/env node
+/**
+ * source-url-sweep.mjs
+ *
+ * Verify external source-citation URLs are still reachable.
+ *
+ * Scans:
+ *   - DATA-MANIFEST.json
+ *   - js/citations.js
+ *   - root-level *.html href attributes
+ *
+ * Exit codes:
+ *   0 => all URLs are OK (or allow-listed / timeout-only outcomes)
+ *   1 => at least one hard failure (404/5xx/network)
+ *   2 => script-level failure
+ */
 
-const ALLOW_LIST = [
-  'https://example.com', // Example Site
-  // Add the new URLs below
-  'https://www.bls.gov/cew/', // Current Employment Statistics
-  'https://www.bls.gov/cps', // Current Population Survey
-  'https://www.bls.gov/jlt', // Job Openings and Labor Turnover Survey
-  'https://www.novoco.com/resource-centers/affordable-housing-tax-credits/lihtc-basics', // LIHTC Basics
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..", "..");
+
+const TIMEOUT_MS = 10_000;
+const CONCURRENT = 8;
+
+const ALLOW_LIST = new Set([
+  "https://overpass-api.de/api/interpreter", // POST-only API
+  // Known sources that frequently block CI user-agents.
+  "https://www.novoco.com",
+  "https://www.novoco.com/resource-centers/affordable-housing-tax-credits",
+  "https://www.ncsha.org",
+  "https://www.congress.gov/",
+  "https://www.cbre.com/insights",
+  "https://www.ffiec.gov/craadweb/main.aspx",
+  "https://cdola.colorado.gov/commitment-filings",
+  "https://cdola.colorado.gov/housing",
+  "https://cdola.colorado.gov/prop123",
+]);
+
+const SKIP_PATTERNS = [
+  /^mailto:/i,
+  /^tel:/i,
+  /^javascript:/i,
+  /^#/,
+  /localhost/i,
+  /^\/\//,
+  /\$\{/,
+  /^https?:\/\/fonts\.googleapis\.com/i,
+  /^https?:\/\/fonts\.gstatic\.com/i,
+  /^https?:\/\/cdn\.jsdelivr\.net/i,
+  /^https?:\/\/unpkg\.com/i,
+  /^https?:\/\/cdnjs\.cloudflare\.com/i,
 ];
 
-// Other script logic
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const paths = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--paths" && args[i + 1]) {
+      paths.push(
+        ...args[i + 1]
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean),
+      );
+      i++;
+    }
+  }
+  return {
+    quiet: args.includes("--quiet"),
+    json: args.includes("--json"),
+    paths,
+  };
+}
+
+function isHttpUrl(v) {
+  return typeof v === "string" && /^https?:\/\//i.test(v);
+}
+
+function shouldSkip(url) {
+  return SKIP_PATTERNS.some((rx) => rx.test(url));
+}
+
+function normalizeUrl(url) {
+  try {
+    const u = new URL(url);
+    u.hash = "";
+    return u.toString();
+  } catch (_) {
+    return url;
+  }
+}
+
+function collectUrlsFromObject(obj, out = []) {
+  if (obj === null || obj === undefined) return out;
+  if (typeof obj === "string") {
+    if (isHttpUrl(obj)) out.push(obj);
+    return out;
+  }
+  if (Array.isArray(obj)) {
+    for (const item of obj) collectUrlsFromObject(item, out);
+    return out;
+  }
+  if (typeof obj === "object") {
+    for (const v of Object.values(obj)) collectUrlsFromObject(v, out);
+  }
+  return out;
+}
+
+async function readManifestUrls() {
+  const p = path.join(ROOT, "DATA-MANIFEST.json");
+  const raw = await fs.readFile(p, "utf8");
+  const parsed = JSON.parse(raw);
+  return collectUrlsFromObject(parsed);
+}
+
+async function readCitations() {
+  const p = path.join(ROOT, "js", "citations.js");
+  const src = await fs.readFile(p, "utf8");
+  const urls = [];
+  const rx = /https?:\/\/[^\s"'`<>)]*/g;
+  let m;
+  while ((m = rx.exec(src)) !== null) {
+    urls.push(m[0]);
+  }
+  return urls;
+}
+
+async function readHtmlUrls() {
+  return readHtmlUrlsFromFiles();
+}
+
+async function readHtmlUrlsFromFiles(files = null) {
+  const entries = await fs.readdir(ROOT, { withFileTypes: true });
+  const rootHtmlFiles = entries
+    .filter((e) => e.isFile() && e.name.toLowerCase().endsWith(".html"))
+    .map((e) => path.join(ROOT, e.name));
+  const htmlFiles = files
+    ? files
+        .map((f) => path.join(ROOT, f))
+        .filter((p) => p.toLowerCase().endsWith(".html"))
+    : rootHtmlFiles;
+
+  const hrefRx = /href\s*=\s*["']([^"']+)["']/gi;
+  const urls = [];
+  for (const file of htmlFiles) {
+    const src = await fs.readFile(file, "utf8");
+    let m;
+    while ((m = hrefRx.exec(src)) !== null) {
+      const href = (m[1] || "").trim();
+      if (isHttpUrl(href)) urls.push(href);
+    }
+  }
+  return urls;
+}
+
+async function readUrlsFromExplicitPaths(pathsArg) {
+  const files = pathsArg
+    .map((p) => p.replace(/^\.\//, ""))
+    .filter((p) => !p.includes(".."));
+  const urls = [];
+
+  for (const rel of files) {
+    const abs = path.join(ROOT, rel);
+    try {
+      const src = await fs.readFile(abs, "utf8");
+      if (rel === "DATA-MANIFEST.json" || rel.toLowerCase().endsWith(".json")) {
+        try {
+          const parsed = JSON.parse(src);
+          collectUrlsFromObject(parsed, urls);
+        } catch (_) {
+          const rx = /https?:\/\/[^\s"'`<>)]*/g;
+          let m;
+          while ((m = rx.exec(src)) !== null) urls.push(m[0]);
+        }
+      } else if (rel.toLowerCase().endsWith(".html")) {
+        const hrefRx = /href\s*=\s*["']([^"']+)["']/gi;
+        let m;
+        while ((m = hrefRx.exec(src)) !== null) {
+          const href = (m[1] || "").trim();
+          if (isHttpUrl(href)) urls.push(href);
+        }
+      } else {
+        const rx = /https?:\/\/[^\s"'`<>)]*/g;
+        let m;
+        while ((m = rx.exec(src)) !== null) urls.push(m[0]);
+      }
+    } catch (_) {
+      // Ignore absent/renamed files in diff lists.
+    }
+  }
+  return urls;
+}
+
+async function checkUrl(url) {
+  if (ALLOW_LIST.has(url)) {
+    return { url, status: "ALLOW", http: null, message: "allow-listed" };
+  }
+
+  const ac = new AbortController();
+  const timeout = setTimeout(() => ac.abort(), TIMEOUT_MS);
+  try {
+    // Try HEAD first; fallback to GET if server disallows HEAD.
+    let res;
+    try {
+      res = await fetch(url, {
+        method: "HEAD",
+        redirect: "follow",
+        signal: ac.signal,
+      });
+      if (res.status === 405 || res.status === 403) {
+        res = await fetch(url, {
+          method: "GET",
+          redirect: "follow",
+          signal: ac.signal,
+          headers: { Range: "bytes=0-0" },
+        });
+      }
+    } catch (_) {
+      res = await fetch(url, {
+        method: "GET",
+        redirect: "follow",
+        signal: ac.signal,
+        headers: { Range: "bytes=0-0" },
+      });
+    }
+
+    clearTimeout(timeout);
+    if (res.ok) return { url, status: "OK", http: res.status, message: "" };
+    if (res.status === 404) {
+      return { url, status: "404", http: 404, message: "not found" };
+    }
+    if (res.status >= 500) {
+      return { url, status: "5XX", http: res.status, message: "server error" };
+    }
+    return {
+      url,
+      status: "FAIL",
+      http: res.status,
+      message: "unexpected status",
+    };
+  } catch (err) {
+    clearTimeout(timeout);
+    if (
+      err &&
+      (err.name === "AbortError" || /aborted|timeout/i.test(String(err)))
+    ) {
+      return {
+        url,
+        status: "TIMEOUT",
+        http: null,
+        message: "request timed out",
+      };
+    }
+    return {
+      url,
+      status: "FAIL",
+      http: null,
+      message: (err && err.message) || String(err),
+    };
+  }
+}
+
+async function mapLimit(items, limit, mapper) {
+  const results = new Array(items.length);
+  let idx = 0;
+  async function worker() {
+    while (idx < items.length) {
+      const cur = idx++;
+      results[cur] = await mapper(items[cur], cur);
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, worker),
+  );
+  return results;
+}
+
+function printTable(results, quiet) {
+  if (quiet) {
+    results
+      .filter((r) => !["OK", "ALLOW", "TIMEOUT"].includes(r.status))
+      .forEach((r) => {
+        console.log(`${r.status}\t${r.http || "-"}\t${r.url}\t${r.message}`);
+      });
+    return;
+  }
+  for (const r of results) {
+    console.log(
+      `${r.status.padEnd(7)} ${String(r.http || "-").padStart(3)}  ${r.url}`,
+    );
+  }
+}
+
+async function main() {
+  const args = parseArgs();
+  let rawUrls;
+  if (args.paths.length > 0) {
+    rawUrls = await readUrlsFromExplicitPaths(args.paths);
+  } else {
+    const [manifestUrls, citationUrls, htmlUrls] = await Promise.all([
+      readManifestUrls().catch(() => []),
+      readCitations().catch(() => []),
+      readHtmlUrls().catch(() => []),
+    ]);
+    rawUrls = [...manifestUrls, ...citationUrls, ...htmlUrls];
+  }
+
+  const urls = Array.from(
+    new Set(
+      rawUrls
+        .map((u) => normalizeUrl(u))
+        .filter((u) => isHttpUrl(u) && !shouldSkip(u)),
+    ),
+  );
+
+  const results = await mapLimit(urls, CONCURRENT, checkUrl);
+  const hardFailures = results.filter((r) =>
+    ["404", "5XX", "FAIL"].includes(r.status),
+  );
+  const nonAllowTimeouts = results.filter((r) => r.status === "TIMEOUT");
+
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        {
+          scanned: urls.length,
+          hardFailures: hardFailures.length,
+          timeouts: nonAllowTimeouts.length,
+          results,
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    printTable(results, args.quiet);
+    console.log(
+      `\nScanned ${urls.length} URLs · hard failures: ${hardFailures.length} · timeouts: ${nonAllowTimeouts.length}`,
+    );
+  }
+
+  process.exitCode = hardFailures.length > 0 ? 1 : 0;
+}
+
+main().catch((err) => {
+  console.error("[source-url-sweep] fatal:", err);
+  process.exit(2);
+});

--- a/test/census-dashboard-scope.test.js
+++ b/test/census-dashboard-scope.test.js
@@ -1,0 +1,53 @@
+// test/census-dashboard-scope.test.js
+// Ensures Census dashboard stays Colorado-scoped and lists variables used.
+
+const fs = require("fs");
+const path = require("path");
+
+function assert(cond, msg) {
+  if (!cond) {
+    console.error(`❌ FAIL: ${msg}`);
+    process.exitCode = 1;
+  } else {
+    console.log(`✅ PASS: ${msg}`);
+  }
+}
+
+const htmlPath = path.join(__dirname, "..", "census-dashboard.html");
+const jsPath = path.join(__dirname, "..", "js", "census-multifamily.js");
+
+const html = fs.readFileSync(htmlPath, "utf8");
+const js = fs.readFileSync(jsPath, "utf8");
+
+console.log("\n[test] Census dashboard is Colorado-only");
+assert(
+  /<option value="state">State<\/option>/.test(html),
+  "State level option exists",
+);
+assert(
+  /<option value="county">County<\/option>/.test(html),
+  "County level option exists",
+);
+assert(
+  /<option value="place">City\/Place<\/option>/.test(html),
+  "Place level option exists",
+);
+assert(!/value="us"/.test(html), "US level option is not present");
+assert(
+  /COLORADO_FIPS\s*=\s*["']08["']/.test(js),
+  "Colorado FIPS constant is set to 08",
+);
+
+console.log("\n[test] Census variable inventory is present");
+assert(
+  /Census Variables Used on This Page/.test(html),
+  "Variable inventory heading exists",
+);
+assert(/DP04_0001E/.test(html), "DP04_0001E is listed");
+assert(/DP04_0011PE/.test(html), "DP04_0011PE is listed");
+assert(/DP04_0012PE/.test(html), "DP04_0012PE is listed");
+assert(/DP04_0013PE/.test(html), "DP04_0013PE is listed");
+
+if (!process.exitCode) {
+  console.log("\nAll checks passed ✅");
+}


### PR DESCRIPTION
### Motivation

- Improve data trust and observability by expanding data-quality reports with per-source timestamps and richer badges. 
- Prevent regressions from broken external citations by adding an automated source-URL sweep in CI. 
- Scope and harden the Census Multifamily dashboard to Colorado-only to avoid cross-jurisdiction errors and to document the variables used. 
- Capture analysis and follow-up actions in repository documentation for drift management and next steps.

### Description

- CI/workflow: updated `.github/workflows/ci-checks.yml` to fetch full history (`fetch-depth: 0`) and added a blocking PR step that runs `node scripts/audit/source-url-sweep.mjs --paths "<changed files>"` plus a non-blocking summary sweep step that writes results to the job summary. 
- URL audit script: added `scripts/audit/source-url-sweep.mjs`, a concurrent, timeout-aware URL validator with allow-listing and HTML/JSON/js manifest scanning. 
- Data-status UI: rewrote `data-status.html` HTML/JS to display per-dataset `data_as_of`, record counts, improved accessibility (aria-live handling), content-freshness cards, and detailed table columns. 
- Data-quality logic: updated `js/data-quality-check.js` to include `dataAsOf`/`dataAgeMs` in reports, extract timestamps from common fields, improve badge text/title logic, and emit the same public API (`DataQuality.runAll`, `validate`, `renderBadge`). 
- Census dashboard: updated `census-dashboard.html` and `js/census-multifamily.js` to default and restrict to Colorado (constant `COLORADO_FIPS = "08"`), remove US-level queries, improve UX and error messaging, and add a visible inventory of Census variables used on the page. 
- Tests & docs: added `test/census-dashboard-scope.test.js` asserting Colorado scope and variable inventory, added `docs/DRIFT_REGISTER_AND_ACTION_PLAN.md` and `docs/REPO_STATUS_2026-04-26.md`, and updated `docs/NEXT-STEPS.md` with immediate action items and CI notes.

### Testing

- JavaScript CI/test steps are exercised by the workflow and include `npm ci` and `npm run test:ci`, and those suites were invoked in CI as part of the updated `ci-checks` job (no test regressions introduced by these changes). 
- Node smoke tests (`node test/*.js`) were run as part of the CI job and completed successfully in the test runs. 
- The new unit check `test/census-dashboard-scope.test.js` was executed and passed, verifying Colorado scoping and presence of the DP04 variable inventory. 
- Python tests were run via `pytest tests/ -v --tb=short` as configured in the workflow and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed91f5eb20832386993c9b92685397)