### PR TITLE
feat(hna): scope badges + mixed-scope warning on side-by-side comparison

### DIFF
--- a/js/hna/hna-comparison.js
+++ b/js/hna/hna-comparison.js
@@ -823,6 +823,29 @@
     });
   }
 
+  // Geography-type badge for side-by-side names. Surfaces whether each
+  // jurisdiction is a county / city / CDP / town / state so users don't
+  // accidentally compare apples-to-oranges.
+  function _scopeBadge(type) {
+    var t = String(type || '').toLowerCase();
+    var label, bg, fg;
+    if (t === 'county')      { label = 'County'; bg = 'var(--info-dim, #dbeafe)'; fg = 'var(--info, #2563eb)'; }
+    else if (t === 'state')  { label = 'State';  bg = 'var(--accent-dim, #d1fae5)'; fg = 'var(--accent, #096e65)'; }
+    else if (t === 'cdp')    { label = 'CDP';    bg = 'color-mix(in oklab, var(--card,#fff) 90%, var(--warn,#d97706) 10%)'; fg = 'var(--warn, #d97706)'; }
+    else if (t === 'place')  { label = 'City';   bg = 'var(--good-dim, #d1fae5)'; fg = 'var(--good, #047857)'; }
+    else if (t === 'town')   { label = 'Town';   bg = 'var(--good-dim, #d1fae5)'; fg = 'var(--good, #047857)'; }
+    else                     { label = (type || 'Other'); bg = 'var(--bg2, #f4f4f4)'; fg = 'var(--muted, #555)'; }
+    return '<span class="hca-cp-scope-badge" style="display:inline-block;font-size:.66rem;font-weight:700;padding:1px 6px;border-radius:3px;background:' + bg + ';color:' + fg + ';margin-left:.5rem;letter-spacing:.02em;text-transform:uppercase;vertical-align:middle;" title="Geography type: ' + label + '">' + label + '</span>';
+  }
+
+  // CDP-specific advisory: the user should know CDPs are statistical
+  // areas, not legal jurisdictions.
+  function _scopeNote(type) {
+    var t = String(type || '').toLowerCase();
+    if (t === 'cdp') return 'Census-Designated Place — statistical boundary, not a legal jurisdiction';
+    return null;
+  }
+
   function _renderPanelHTML(panel, entryA, entryB, summaryA, summaryB) {
     var state = window.HNARanking && HNARanking._get();
     var total = state ? state.allEntries.length : 0;
@@ -836,15 +859,36 @@
       '<button type="button" class="hca-cp-close" id="hcaCpClose" title="Close comparison panel" aria-label="Close comparison panel">✕</button>' +
     '</div>';
 
-    // Names row
+    // Mismatched-scope warning — comparing a county to a city/CDP is
+    // apples-to-oranges. ACS values are at different population scales,
+    // labor stats may be unavailable for sub-county geos, and percentages
+    // can mislead. Surface this prominently.
+    var typeA = String(entryA.type || '').toLowerCase();
+    var typeB = String(entryB.type || '').toLowerCase();
+    var typesMatch = (typeA === typeB);
+    if (!typesMatch && typeA && typeB) {
+      var labelA = (typeA === 'place' ? 'city' : typeA);
+      var labelB = (typeB === 'place' ? 'city' : typeB);
+      html += '<div role="note" class="hca-cp-scope-warning" style="margin-bottom:.75rem;padding:.5rem .75rem;border-left:3px solid var(--warn,#d97706);border-radius:0 4px 4px 0;background:var(--warn-dim,#fef3c7);font-size:.78rem;line-height:1.45;color:var(--text);">' +
+        '<strong style="color:var(--warn,#d97706);">⚠ Mixed-scope comparison.</strong> ' +
+        'You\u2019re comparing a ' + labelA + ' to a ' + labelB + '. ACS values are at different population scales; labor stats may be unavailable for sub-county geographies; percentage metrics can be misleading across scopes. ' +
+        'Use the absolute counts and treat the comparison as directional.' +
+      '</div>';
+    }
+
+    // Names row — scope badges next to each name
+    var noteA = _scopeNote(entryA.type);
+    var noteB = _scopeNote(entryB.type);
     html += '<div class="hca-cp-names">' +
       '<div class="hca-cp-names__label"></div>' +
-      '<div class="hca-cp-names__a">' + entryA.name +
+      '<div class="hca-cp-names__a">' + entryA.name + _scopeBadge(entryA.type) +
         '<div class="hca-cp-rank">#' + entryA.rank + ' of ' + total + ' · ' + entryA.percentileRank + 'th pctile</div>' +
+        (noteA ? '<div class="hca-cp-scope-note" style="font-size:.66rem;color:var(--muted);font-style:italic;margin-top:2px;">' + noteA + '</div>' : '') +
       '</div>' +
       '<div class="hca-cp-names__vs">vs</div>' +
-      '<div class="hca-cp-names__b">' + entryB.name +
+      '<div class="hca-cp-names__b">' + entryB.name + _scopeBadge(entryB.type) +
         '<div class="hca-cp-rank">#' + entryB.rank + ' of ' + total + ' · ' + entryB.percentileRank + 'th pctile</div>' +
+        (noteB ? '<div class="hca-cp-scope-note" style="font-size:.66rem;color:var(--muted);font-style:italic;margin-top:2px;">' + noteB + '</div>' : '') +
       '</div>' +
     '</div>';
 
@@ -1018,6 +1062,9 @@
     swap: function () { var t = _compA; _compA = _compB; _compB = t; _persist(); _renderSetupBar(); _updateRowHighlights(); _dispatchUpdate(); },
     reset: function () { _compA = null; _compB = null; _persist(); _renderSetupBar(); _updateRowHighlights(); _dispatchUpdate(); },
     getState: function () { return { a: _compA, b: _compB, countyFilter: _countyFilter }; },
+    /* Exposed for testing — pure functions, no DOM access */
+    _scopeBadge: _scopeBadge,
+    _scopeNote:  _scopeNote
   };
 
   // Auto-init after DOMContentLoaded

--- a/test/hna-scope-badges.test.js
+++ b/test/hna-scope-badges.test.js
@@ -1,0 +1,136 @@
+'use strict';
+/**
+ * test/hna-scope-badges.test.js
+ *
+ * Validates the scope-badge helpers in js/hna/hna-comparison.js:
+ *   - _scopeBadge: produces a labeled span for county/city/CDP/state
+ *   - _scopeNote: surfaces the CDP advisory note when applicable
+ *
+ * The badges are how users distinguish a county-vs-city comparison
+ * from an apples-to-apples city-vs-city comparison.
+ *
+ * Run: node test/hna-scope-badges.test.js
+ */
+
+const { JSDOM } = require('jsdom');
+const dom = new JSDOM('<!DOCTYPE html><body></body>', { url: 'http://localhost/' });
+global.document = dom.window.document;
+global.window   = dom.window;
+global.location = dom.window.location;
+
+// hna-comparison.js depends on a few window-level helpers — stub minimally
+window.HNARanking  = { _get: function () { return null; }, getScorecardData: function () { return {}; } };
+window.HNAUtils    = window.HNAUtils || {};
+window.HNAState    = { state: {} };
+// Aliased on global so the auto-init setTimeout doesn't ReferenceError
+global.HNARanking  = window.HNARanking;
+global.HNAComparison = null;
+
+require('../js/hna/hna-comparison.js');
+const C = window.HNAComparison;
+
+let passed = 0, failed = 0;
+function assert(cond, msg) {
+  if (cond) { console.log('  ✅ PASS:', msg); passed++; }
+  else       { console.error('  ❌ FAIL:', msg); failed++; }
+}
+function test(name, fn) {
+  console.log('\n[test]', name);
+  try { fn(); } catch (e) { console.error('  ❌ FAIL: threw —', e.message); failed++; }
+}
+
+test('API exposed', function () {
+  assert(typeof C._scopeBadge === 'function', '_scopeBadge exposed');
+  assert(typeof C._scopeNote  === 'function', '_scopeNote exposed');
+});
+
+test('_scopeBadge — county type renders "County" badge', function () {
+  const html = C._scopeBadge('county');
+  assert(html.indexOf('>County<') > -1, 'badge contains "County" label');
+  assert(html.indexOf('class="hca-cp-scope-badge"') > -1, 'has scope-badge class');
+});
+
+test('_scopeBadge — place type renders "City" (not "Place")', function () {
+  const html = C._scopeBadge('place');
+  assert(html.indexOf('>City<') > -1, 'place type renders as "City"');
+});
+
+test('_scopeBadge — cdp type renders "CDP" badge', function () {
+  const html = C._scopeBadge('cdp');
+  assert(html.indexOf('>CDP<') > -1, 'cdp type renders as "CDP"');
+});
+
+test('_scopeBadge — town type renders "Town"', function () {
+  const html = C._scopeBadge('town');
+  assert(html.indexOf('>Town<') > -1, 'town type renders as "Town"');
+});
+
+test('_scopeBadge — state type renders "State"', function () {
+  const html = C._scopeBadge('state');
+  assert(html.indexOf('>State<') > -1, 'state type renders as "State"');
+});
+
+test('_scopeBadge — handles undefined / null / empty', function () {
+  // Should produce a benign fallback, not throw
+  assert(typeof C._scopeBadge(undefined) === 'string', 'undefined → string');
+  assert(typeof C._scopeBadge(null)      === 'string', 'null → string');
+  assert(typeof C._scopeBadge('')        === 'string', '"" → string');
+});
+
+test('_scopeBadge — case-insensitive ("COUNTY", "County", "county" all equivalent)', function () {
+  // Strip the inline style + class for comparison; just confirm same label
+  function _label(html) {
+    const m = html.match(/>([^<]+)<\/span>/);
+    return m ? m[1] : null;
+  }
+  assert(_label(C._scopeBadge('county')) === _label(C._scopeBadge('County')),
+    'lowercase / titlecase match');
+  assert(_label(C._scopeBadge('COUNTY')) === _label(C._scopeBadge('county')),
+    'uppercase normalizes');
+});
+
+test('_scopeNote — CDP gets an advisory note', function () {
+  const note = C._scopeNote('cdp');
+  assert(typeof note === 'string',                            'cdp returns a note');
+  assert(note.toLowerCase().indexOf('census-designated') > -1, 'note mentions Census-Designated');
+  assert(note.toLowerCase().indexOf('not a legal') > -1,       'note explains it\'s not a legal jurisdiction');
+});
+
+test('_scopeNote — non-CDP types return null (no note)', function () {
+  assert(C._scopeNote('county') === null, 'county → null');
+  assert(C._scopeNote('place')  === null, 'place → null');
+  assert(C._scopeNote('state')  === null, 'state → null');
+  assert(C._scopeNote('town')   === null, 'town → null');
+});
+
+test('_scopeNote — null/undefined input returns null safely', function () {
+  assert(C._scopeNote(null)      === null, 'null → null');
+  assert(C._scopeNote(undefined) === null, 'undefined → null');
+  assert(C._scopeNote('')        === null, '"" → null');
+});
+
+test('color coding differs by type (visual differentiation)', function () {
+  // Each type should produce a different background color so users can
+  // visually distinguish in the comparison panel
+  const countyColors = C._scopeBadge('county');
+  const placeColors  = C._scopeBadge('place');
+  const cdpColors    = C._scopeBadge('cdp');
+  // Extract background-color tokens
+  function _bg(html) {
+    const m = html.match(/background:([^;]+);/);
+    return m ? m[1].trim() : '';
+  }
+  const cBg = _bg(countyColors);
+  const pBg = _bg(placeColors);
+  const dBg = _bg(cdpColors);
+  assert(cBg !== pBg, 'county and place have different backgrounds');
+  assert(pBg !== dBg, 'place and CDP have different backgrounds');
+  assert(cBg !== dBg, 'county and CDP have different backgrounds');
+});
+
+console.log('\n' + '='.repeat(50));
+console.log('Results:', passed, 'passed,', failed, 'failed');
+// hna-comparison.js sets a setTimeout for auto-init that requires DOM
+// elements not present in the test env — exit cleanly so the auto-init
+// doesn't keep the process alive.
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Why

A user comparing **\"Boulder city\"** to **\"Boulder County\"** sees absolute counts side-by-side without realising one is a sub-county place (~110k pop) and the other is a county (~330k pop). ACS percentage metrics are at different scales, labor stats are often unavailable for sub-county geographies, and the comparison can mislead.

Listed in the drift register (#723) as: *\"HNA comparison scope: Comparison appears county-level while UI implies sub-county comparability; labor stats absent → Add explicit scope badges (county/city/CDP), disable incompatible comparisons, and add labor-stat availability indicators.\"*

## What ships

### Scope badges next to each name (color-coded)

| | Badge | Color |
|---|---|---|
| Boulder (city) | **CITY** | green |
| Boulder County | **COUNTY** | blue |
| Clifton (CDP) | **CDP** | amber |
| Colorado | **STATE** | teal |

### CDP-specific advisory note

CDPs are statistical boundaries, **not legal jurisdictions** — most users don't know this. When a CDP is selected, a small italic line appears under the name:

> Clifton (CDP) **CDP**  
> #X of Y · Nth pctile  
> *Census-Designated Place — statistical boundary, not a legal jurisdiction*

### Mixed-scope warning banner

When two compared jurisdictions are different types, a prominent banner appears above the names row:

> ⚠ **Mixed-scope comparison.** You're comparing a *city* to a *county*. ACS values are at different population scales; labor stats may be unavailable for sub-county geographies; percentage metrics can be misleading across scopes. Use the absolute counts and treat the comparison as directional.

This is the most important addition — stops users from treating mixed-scope comparisons as apples-to-apples.

## Tests

\`test/hna-scope-badges.test.js\` — **26/26 passing**:

- API exposure (\`_scopeBadge\`, \`_scopeNote\`)
- Each type renders correct label (county / place→\"City\" / cdp / town / state)
- Case-insensitive (\`'COUNTY'\`, \`'County'\`, \`'county'\` all equivalent)
- Undefined / null / empty input handled
- \`_scopeNote\` returns CDP advisory only for cdp, null otherwise
- Visual differentiation: county / place / CDP have distinct backgrounds

Regression sweep — all clean:
- \`hna-ranking-index.test.js\` — 16/16
- \`dc-dscr-stress.test.js\` — 22/22
- \`pro-forma.test.js\` — 24/24

## Stacking

Independent of PR B (#728 — Fruita/Boulder fix) but they pair naturally: #728 makes the country lookups correct, and this PR makes the comparison panel show the user when they're crossing scope levels. Either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)