### PR TITLE
restore(deal-calc): re-apply rent-achievability + Methodology panels lost in stack-merge

### DIFF
--- a/js/deal-calculator.js
+++ b/js/deal-calculator.js
@@ -17,6 +17,27 @@
   const CREDIT_YEARS = 10;
 
   // -------------------------------------------------------------------
+  // Tunable constants — shown in the Methodology & Formulas panel and
+  // editable by users (bankers/syndicators with non-standard underwriting
+  // boxes). Defaults mirror standard LIHTC industry practice; deviating
+  // is appropriate when, e.g., a particular bank or program uses a 28%
+  // rent burden, a -8% rent stress, or different combined-stress
+  // assumptions. All values are stored in their natural units:
+  //   rentBurdenPct, *StressPct       — fractional (0.30 = 30 %)
+  //   *StressPp                        — percentage points (0.05 = 5 pp)
+  // -------------------------------------------------------------------
+  var DEFAULT_CONSTANTS = {
+    rentBurdenPct:   0.30,   // HUD-standard share of income spent on rent
+    rentStressPct:   0.10,   // single-variable: -10% to gross rent
+    vacStressPp:     0.05,   // single-variable: +5 pp to vacancy
+    opexStressPct:   0.10,   // single-variable: +10% to operating expenses
+    combinedRentPct: 0.05,   // combined-scenario: -5% to gross rent
+    combinedVacPp:   0.03,   // combined-scenario: +3 pp to vacancy
+    combinedOpexPct: 0.05    // combined-scenario: +5% to operating expenses
+  };
+  var _constants = Object.assign({}, DEFAULT_CONSTANTS);
+
+  // -------------------------------------------------------------------
   // Mortgage constant helper
   // Annual mortgage constant for a fully-amortising loan.
   // -------------------------------------------------------------------
@@ -184,8 +205,9 @@
   // (e.g. zero debt service, zero rents). This is the function the
   // banker/syndicator table reads.
   // -------------------------------------------------------------------
-  function computeDscrStressScenarios(inputs) {
+  function computeDscrStressScenarios(inputs, constants) {
     if (!inputs) return null;
+    constants = constants || DEFAULT_CONSTANTS;
     var annualRents      = +inputs.annualRents || 0;
     var vacancyPct       = +inputs.vacancyPct  || 0;
     var annualOpex       = +inputs.annualOpex       || 0;
@@ -194,6 +216,13 @@
     var annualDebtService = +inputs.annualDebtService || 0;
     if (annualDebtService <= 0 || annualRents <= 0) return null;
 
+    var rentS = +constants.rentStressPct;
+    var vacS  = +constants.vacStressPp;
+    var opexS = +constants.opexStressPct;
+    var cR    = +constants.combinedRentPct;
+    var cV    = +constants.combinedVacPp;
+    var cO    = +constants.combinedOpexPct;
+
     function _noiFor(rentMult, vacDelta, opexMult) {
       var effVac = Math.min(1, Math.max(0, vacancyPct + vacDelta));
       var eff    = annualRents * rentMult * (1 - effVac);
@@ -201,32 +230,43 @@
     }
     var baseNoi = _noiFor(1.00, 0, 1.00);
     return {
-      base:     { noi: baseNoi,                    dscr: baseNoi / annualDebtService },
-      rent10:   { noi: _noiFor(0.90, 0,    1.00),  dscr: _noiFor(0.90, 0,    1.00) / annualDebtService },
-      vac5:     { noi: _noiFor(1.00, 0.05, 1.00),  dscr: _noiFor(1.00, 0.05, 1.00) / annualDebtService },
-      opex10:   { noi: _noiFor(1.00, 0,    1.10),  dscr: _noiFor(1.00, 0,    1.10) / annualDebtService },
-      combined: { noi: _noiFor(0.95, 0.03, 1.05),  dscr: _noiFor(0.95, 0.03, 1.05) / annualDebtService }
+      base:     { noi: baseNoi,                       dscr: baseNoi / annualDebtService },
+      rent10:   { noi: _noiFor(1 - rentS, 0,    1.00), dscr: _noiFor(1 - rentS, 0,    1.00) / annualDebtService },
+      vac5:     { noi: _noiFor(1.00,  vacS, 1.00),     dscr: _noiFor(1.00,  vacS, 1.00) / annualDebtService },
+      opex10:   { noi: _noiFor(1.00,  0,    1 + opexS),dscr: _noiFor(1.00,  0,    1 + opexS) / annualDebtService },
+      combined: { noi: _noiFor(1 - cR, cV,   1 + cO),  dscr: _noiFor(1 - cR, cV,   1 + cO) / annualDebtService }
     };
   }
 
   /**
    * Update _amiLimits from HudFmr for the given county FIPS.
-   * Falls back to the default Denver MSA values if data is unavailable.
+   *
+   * LIHTC rent ceiling formula:
+   *   monthly_rent_limit = (AMI_4person × tier_pct × rent_burden_pct) / 12
+   *
+   * The rent_burden_pct is a tunable constant (`_constants.rentBurdenPct`,
+   * default 0.30). When the user changes it via the Methodology &
+   * Formulas panel, the ceilings recompute and propagate to the deal.
+   *
+   * Computed locally rather than calling HudFmr.getGrossRentLimit so the
+   * burden % is honored — that helper has 0.30 hardcoded.
+   *
    * @param {string} fips  5-digit county FIPS, or null/'' for default.
    */
   function updateAmiLimitsFromFmr(fips) {
     var hudFmr = window.HudFmr;
     if (!fips || !hudFmr || !hudFmr.isLoaded()) return;
+    var il = hudFmr.getIncomeLimitsByFips(fips);
+    if (!il || !il.ami_4person) return;
+    var burden = +_constants.rentBurdenPct;
+    if (!isFinite(burden) || burden <= 0) burden = DEFAULT_CONSTANTS.rentBurdenPct;
+    var ami4 = +il.ami_4person;
     var computed = {};
     [30, 40, 50, 60].forEach(function (pct) {
-      var limit = hudFmr.getGrossRentLimit(fips, pct);
-      if (limit !== null && limit > 0) computed[pct] = limit;
+      computed[pct] = Math.round((ami4 * (pct / 100) * burden) / 12);
     });
-    // Only apply if all tiers are present
-    if (Object.keys(computed).length === 4) {
-      _amiLimits = computed;
-      _countyFips = fips;
-    }
+    _amiLimits = computed;
+    _countyFips = fips;
   }
 
   /**
@@ -559,6 +599,148 @@
 
     <!-- Outputs column -->
     <div>
+
+      <!-- Methodology & Formulas — collapsed by default. Shows every formula
+           the calculator uses with the current numbers substituted in, plus
+           inline-editable tunable constants for non-standard underwriting
+           boxes (e.g. a bank using 28 % rent burden, or a lender using
+           tighter stress percentages). -->
+      <details id="dc-formulas-panel" style="border:1px solid var(--border);border-radius:var(--radius);padding:var(--sp3);margin-bottom:var(--sp3);background:var(--bg2);">
+        <summary style="font-size:var(--small);font-weight:700;cursor:pointer;list-style:none;display:flex;align-items:center;gap:0.5rem;">
+          <span aria-hidden="true">▶</span>
+          Methodology &amp; Formulas
+          <span style="font-weight:400;font-size:var(--tiny);color:var(--muted);">— see every formula, override industry-standard constants</span>
+        </summary>
+        <div style="margin-top:var(--sp3);font-size:var(--small);line-height:1.6;">
+          <p style="font-size:var(--tiny);color:var(--muted);margin:0 0 var(--sp2);">
+            All numbers in the calculator are computed from the inputs above plus the constants below.
+            Constants in <strong>highlighted boxes</strong> are editable — change them when your bank or
+            program uses different underwriting standards. Click "Reset to defaults" to restore industry-standard values.
+          </p>
+
+          <div style="margin-bottom:var(--sp3);">
+            <strong style="display:block;margin-bottom:0.25rem;">1. LIHTC monthly rent ceiling (per AMI tier)</strong>
+            <code style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.82rem;background:var(--card);padding:0.15rem 0.45rem;border-radius:3px;display:inline-block;">
+              ceiling = AMI<sub>4-person</sub> × tier_pct × <span style="background:var(--warn-dim,#fef3c7);padding:0 0.15rem;">rent_burden</span> ÷ 12
+            </code>
+            <div style="margin-top:0.4rem;display:flex;align-items:center;gap:0.5rem;flex-wrap:wrap;">
+              <label style="font-size:var(--tiny);color:var(--muted);">rent_burden:</label>
+              <input id="dc-const-rent-burden" type="number" min="20" max="50" step="1" value="30"
+                style="width:5rem;padding:0.25rem 0.4rem;border:1px solid var(--border);border-radius:var(--radius);background:var(--card);color:var(--text);font-size:var(--small);"> <span style="font-size:var(--tiny);color:var(--muted);">%</span>
+              <span id="dc-formula-ceiling-eg" style="font-size:var(--tiny);color:var(--muted);margin-left:auto;">—</span>
+            </div>
+            <p style="font-size:var(--tiny);color:var(--muted);margin:0.4rem 0 0;">
+              HUD-standard 30 % share of income spent on rent. Some affordable programs (FHA 221(d)(4), select state HFAs) underwrite at 28 %; reducing pulls all LIHTC ceilings down proportionally.
+            </p>
+          </div>
+
+          <div style="margin-bottom:var(--sp3);">
+            <strong style="display:block;margin-bottom:0.25rem;">2. Annual gross rents</strong>
+            <code style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.82rem;background:var(--card);padding:0.15rem 0.45rem;border-radius:3px;display:inline-block;">
+              gross_rents = Σ<sub>tier ∈ {30,40,50,60}</sub> ( units_at_tier × ceiling<sub>tier</sub> × 12 )
+            </code>
+            <p style="font-size:var(--tiny);color:var(--muted);margin:0.4rem 0 0;">
+              Sums the rent rolls for each AMI-tier checkbox you've enabled. Driven by the unit-mix inputs above.
+            </p>
+          </div>
+
+          <div style="margin-bottom:var(--sp3);">
+            <strong style="display:block;margin-bottom:0.25rem;">3. Stabilized NOI (auto-compute mode)</strong>
+            <code style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.82rem;background:var(--card);padding:0.15rem 0.45rem;border-radius:3px;display:inline-block;">
+              NOI = gross_rents × (1 − vacancy) − opex − rep_reserve − net_property_tax
+            </code>
+            <p style="font-size:var(--tiny);color:var(--muted);margin:0.4rem 0 0;">
+              Standard pro forma. Vacancy, per-unit opex, replacement reserve, and property tax are all inputs above. In manual-NOI mode, you type a total and the breakdown is opaque.
+            </p>
+          </div>
+
+          <div style="margin-bottom:var(--sp3);">
+            <strong style="display:block;margin-bottom:0.25rem;">4. Supportable first mortgage</strong>
+            <code style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.82rem;background:var(--card);padding:0.15rem 0.45rem;border-radius:3px;display:inline-block;">
+              mortgage = (NOI ÷ DCR_target) ÷ mortgage_constant
+            </code>
+            <p style="font-size:var(--tiny);color:var(--muted);margin:0.4rem 0 0;">
+              DCR target is an input above (default 1.20×; conservative lenders use 1.25×, aggressive 1.15×). Mortgage constant is derived from the rate and term inputs (annualised debt-service-per-dollar).
+            </p>
+          </div>
+
+          <div style="margin-bottom:var(--sp3);">
+            <strong style="display:block;margin-bottom:0.25rem;">5. DSCR + stress scenarios</strong>
+            <code style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.82rem;background:var(--card);padding:0.15rem 0.45rem;border-radius:3px;display:inline-block;margin-bottom:0.35rem;">
+              DSCR = NOI ÷ annual_debt_service
+            </code>
+            <div style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.78rem;background:var(--card);padding:0.4rem 0.5rem;border-radius:3px;line-height:1.7;">
+              stress_NOI = (rents × rent_mult) × (1 − (vacancy + vac_delta)) − (opex × opex_mult) − reserve − tax
+            </div>
+            <div style="margin-top:0.5rem;display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:0.5rem;">
+              <label style="font-size:var(--tiny);color:var(--muted);display:flex;align-items:center;gap:0.4rem;">
+                Rent stress &minus;
+                <input id="dc-const-rent-stress" type="number" min="0" max="50" step="1" value="10"
+                  style="width:4rem;padding:0.2rem 0.35rem;border:1px solid var(--border);border-radius:var(--radius);background:var(--card);color:var(--text);font-size:var(--small);">%
+              </label>
+              <label style="font-size:var(--tiny);color:var(--muted);display:flex;align-items:center;gap:0.4rem;">
+                Vacancy stress +
+                <input id="dc-const-vac-stress" type="number" min="0" max="50" step="1" value="5"
+                  style="width:4rem;padding:0.2rem 0.35rem;border:1px solid var(--border);border-radius:var(--radius);background:var(--card);color:var(--text);font-size:var(--small);">pp
+              </label>
+              <label style="font-size:var(--tiny);color:var(--muted);display:flex;align-items:center;gap:0.4rem;">
+                OpEx stress +
+                <input id="dc-const-opex-stress" type="number" min="0" max="50" step="1" value="10"
+                  style="width:4rem;padding:0.2rem 0.35rem;border:1px solid var(--border);border-radius:var(--radius);background:var(--card);color:var(--text);font-size:var(--small);">%
+              </label>
+            </div>
+            <div style="margin-top:0.4rem;font-size:var(--tiny);color:var(--muted);">Combined-stress (multi-variable) deltas:</div>
+            <div style="margin-top:0.25rem;display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:0.5rem;">
+              <label style="font-size:var(--tiny);color:var(--muted);display:flex;align-items:center;gap:0.4rem;">
+                Rent &minus;
+                <input id="dc-const-comb-rent" type="number" min="0" max="50" step="1" value="5"
+                  style="width:4rem;padding:0.2rem 0.35rem;border:1px solid var(--border);border-radius:var(--radius);background:var(--card);color:var(--text);font-size:var(--small);">%
+              </label>
+              <label style="font-size:var(--tiny);color:var(--muted);display:flex;align-items:center;gap:0.4rem;">
+                Vacancy +
+                <input id="dc-const-comb-vac" type="number" min="0" max="50" step="1" value="3"
+                  style="width:4rem;padding:0.2rem 0.35rem;border:1px solid var(--border);border-radius:var(--radius);background:var(--card);color:var(--text);font-size:var(--small);">pp
+              </label>
+              <label style="font-size:var(--tiny);color:var(--muted);display:flex;align-items:center;gap:0.4rem;">
+                OpEx +
+                <input id="dc-const-comb-opex" type="number" min="0" max="50" step="1" value="5"
+                  style="width:4rem;padding:0.2rem 0.35rem;border:1px solid var(--border);border-radius:var(--radius);background:var(--card);color:var(--text);font-size:var(--small);">%
+              </label>
+            </div>
+          </div>
+
+          <div style="margin-bottom:var(--sp3);">
+            <strong style="display:block;margin-bottom:0.25rem;">6. LIHTC equity (10-year credit value)</strong>
+            <code style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.82rem;background:var(--card);padding:0.15rem 0.45rem;border-radius:3px;display:inline-block;">
+              equity = eligible_basis × credit_rate × 10 × equity_price
+            </code>
+            <p style="font-size:var(--tiny);color:var(--muted);margin:0.4rem 0 0;">
+              Credit rate: 9 % (competitive) or ≈ 4 % (4-percent / PAB-backed). Equity price ($/credit) is an input — confirm with your syndicator. Standard amortization over 10 years.
+            </p>
+          </div>
+
+          <div style="margin-bottom:var(--sp3);">
+            <strong style="display:block;margin-bottom:0.25rem;">7. Sources &amp; Uses gap</strong>
+            <code style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.82rem;background:var(--card);padding:0.15rem 0.45rem;border-radius:3px;display:inline-block;">
+              gap = TDC − equity − supportable_mortgage − deferred_dev_fee − impact_fee_grant
+            </code>
+            <p style="font-size:var(--tiny);color:var(--muted);margin:0.4rem 0 0;">
+              Whatever's left after equity, perm debt, deferred fee, and grants. Bridged by soft-funding, subordinate loans, or developer contribution.
+            </p>
+          </div>
+
+          <div style="display:flex;gap:0.5rem;margin-top:var(--sp3);">
+            <button type="button" id="dc-const-reset"
+              style="padding:0.4rem 1rem;font-size:var(--tiny);font-weight:600;background:var(--bg2);color:var(--text);border:1px solid var(--border);border-radius:var(--radius);cursor:pointer;">
+              Reset all to industry defaults
+            </button>
+            <span id="dc-const-modified-flag" style="font-size:var(--tiny);color:var(--warn,#d97706);font-weight:600;align-self:center;display:none;">
+              ⚠ Custom underwriting constants in use — your numbers reflect non-standard assumptions.
+            </span>
+          </div>
+        </div>
+      </details>
+
       <fieldset style="border:1px solid var(--border);border-radius:var(--radius);padding:var(--sp3);margin-bottom:var(--sp3);">
         <legend style="font-size:var(--small);font-weight:700;padding:0 0.4rem;">LIHTC Credit Estimates <span style="font-weight:400;font-size:var(--tiny);color:var(--muted);">(screening-level)</span></legend>
         <dl id="dc-results" style="display:grid;grid-template-columns:1fr auto;gap:0.5rem 1rem;font-size:var(--small);">
@@ -1024,7 +1206,73 @@
       });
     });
 
+    // Methodology & Formulas panel — wire constants inputs to _constants
+    // and recalculate. Each input edits one entry in _constants and
+    // forces a full recalc so every panel (LIHTC equity, NOI, DSCR,
+    // stress, rent achievability, gap) reflects the new assumption.
+    var _constMap = {
+      'dc-const-rent-burden': { key: 'rentBurdenPct',   factor: 0.01 },
+      'dc-const-rent-stress': { key: 'rentStressPct',   factor: 0.01 },
+      'dc-const-vac-stress':  { key: 'vacStressPp',     factor: 0.01 },
+      'dc-const-opex-stress': { key: 'opexStressPct',   factor: 0.01 },
+      'dc-const-comb-rent':   { key: 'combinedRentPct', factor: 0.01 },
+      'dc-const-comb-vac':    { key: 'combinedVacPp',   factor: 0.01 },
+      'dc-const-comb-opex':   { key: 'combinedOpexPct', factor: 0.01 }
+    };
+    Object.keys(_constMap).forEach(function (inputId) {
+      var el = document.getElementById(inputId);
+      if (!el) return;
+      el.addEventListener('input', function () {
+        var spec = _constMap[inputId];
+        var v = parseFloat(el.value);
+        if (isFinite(v) && v >= 0) {
+          _constants[spec.key] = v * spec.factor;
+        }
+        // If rent burden changes, recompute AMI ceilings before recalc
+        if (spec.key === 'rentBurdenPct' && _countyFips) {
+          updateAmiLimitsFromFmr(_countyFips);
+        }
+        _renderConstantModifiedFlag();
+        recalculate();
+      });
+    });
+    var resetBtn = document.getElementById('dc-const-reset');
+    if (resetBtn) {
+      resetBtn.addEventListener('click', function () {
+        _constants = Object.assign({}, DEFAULT_CONSTANTS);
+        // Restore default values to the input fields
+        var def = {
+          'dc-const-rent-burden': 30,
+          'dc-const-rent-stress': 10,
+          'dc-const-vac-stress':  5,
+          'dc-const-opex-stress': 10,
+          'dc-const-comb-rent':   5,
+          'dc-const-comb-vac':    3,
+          'dc-const-comb-opex':   5
+        };
+        Object.keys(def).forEach(function (id) {
+          var fEl = document.getElementById(id);
+          if (fEl) fEl.value = def[id];
+        });
+        if (_countyFips) updateAmiLimitsFromFmr(_countyFips);
+        _renderConstantModifiedFlag();
+        recalculate();
+      });
+    }
+
     recalculate();
+  }
+
+  // Show a "custom constants in use" warning when the user has overridden
+  // any default. Helps bankers avoid forgetting they're not on industry
+  // standard assumptions.
+  function _renderConstantModifiedFlag() {
+    var flag = document.getElementById('dc-const-modified-flag');
+    if (!flag) return;
+    var modified = Object.keys(DEFAULT_CONSTANTS).some(function (k) {
+      return Math.abs(_constants[k] - DEFAULT_CONSTANTS[k]) > 1e-9;
+    });
+    flag.style.display = modified ? '' : 'none';
   }
 
   // -------------------------------------------------------------------
@@ -1208,7 +1456,7 @@
         annualRepReserve: annualRepReserve || 0,
         netPropTax:       netPropTax       || 0,
         annualDebtService: annualDebtService
-      });
+      }, _constants);
     }
 
     // Sources & uses — deferred dev fee + impact-fee grant (if any) fill gap
@@ -1301,6 +1549,24 @@
         _setDscr('dc-r-stress-' + k + '-dscr', row.dscr);
         _setMargin('dc-r-stress-' + k + '-margin', row.dscr, dcr);
       });
+    }
+
+    // ── Render the live formula example (60% AMI ceiling) ──────────
+    // Surfaces "AMI 124,100 × 60% × 30% / 12 = $1,862" so the user
+    // can see what their rent-burden % choice produces at the most
+    // common LIHTC tier.
+    var ceilingEgEl = document.getElementById('dc-formula-ceiling-eg');
+    if (ceilingEgEl) {
+      var hudFmr2 = window.HudFmr;
+      var il = (hudFmr2 && _countyFips) ? hudFmr2.getIncomeLimitsByFips(_countyFips) : null;
+      if (il && il.ami_4person) {
+        var burdenPct = (_constants.rentBurdenPct * 100).toFixed(0);
+        var ceilingAt60 = Math.round((il.ami_4person * 0.60 * _constants.rentBurdenPct) / 12);
+        ceilingEgEl.textContent = '@ 60% AMI: $' + il.ami_4person.toLocaleString() +
+          ' × 60% × ' + burdenPct + '% ÷ 12 = ' + fmt(ceilingAt60) + '/mo';
+      } else {
+        ceilingEgEl.textContent = 'Select a county to see the live example';
+      }
     }
 
     // ── Render rent-achievability table ────────────────────────────
@@ -1835,7 +2101,16 @@
     /* Exposed for testing — pure functions, no DOM access */
     computeDscrStressScenarios: computeDscrStressScenarios,
     findPeerDeals:              findPeerDeals,
-    computeRentAchievability:   computeRentAchievability
+    computeRentAchievability:   computeRentAchievability,
+    DEFAULT_CONSTANTS:          DEFAULT_CONSTANTS,
+    /* Test helpers — mutate the live constants and read back */
+    _getConstants:              function () { return Object.assign({}, _constants); },
+    _setConstantsForTest:       function (overrides) {
+      Object.keys(overrides || {}).forEach(function (k) {
+        if (Object.prototype.hasOwnProperty.call(DEFAULT_CONSTANTS, k)) _constants[k] = overrides[k];
+      });
+    },
+    _resetConstantsForTest:     function () { _constants = Object.assign({}, DEFAULT_CONSTANTS); }
   };
 
   if (document.readyState === 'loading') {

--- a/js/deal-calculator.js
+++ b/js/deal-calculator.js
@@ -114,6 +114,65 @@
   }
 
   // -------------------------------------------------------------------
+  // Rent-achievability check (pure function, testable)
+  //
+  // Compares the LIHTC rent ceiling at each AMI tier to HUD FMR 2BR
+  // for the selected county. Answers the banker/syndicator question:
+  // "will the LIHTC ceiling rents actually clear the market, or is
+  //  the proforma over-stated because the ceiling is above market?"
+  //
+  // Status thresholds (rule-of-thumb for banker review):
+  //   gap ≤ 0     clear       — LIHTC ceiling at/below market, achievable
+  //   gap ≤ $50   tight       — close to market, thin buffer
+  //   gap ≤ $200  concerning  — ceiling meaningfully above market
+  //   gap > $200  misaligned  — proforma at ceiling likely overstates revenue
+  //
+  // Positive gap = LIHTC ceiling > market rent (concerning).
+  // Negative gap = LIHTC ceiling < market rent (good — ceiling is binding).
+  //
+  // Uses HUD FMR 2BR as the market benchmark because most LIHTC projects
+  // are 2BR-dominated. A future refinement could weight by the project's
+  // actual bedroom mix.
+  //
+  // Inputs:
+  //   amiLimits — { 30: 931, 40: 1241, 50: 1551, 60: 1862 } monthly $USD
+  //   fmr       — { efficiency, one_br, two_br, three_br, four_br } monthly $USD
+  //
+  // Returns null when data isn't available (county not selected, FMR 2BR
+  // missing, or no AMI tier rent limits).
+  // -------------------------------------------------------------------
+  function computeRentAchievability(inputs) {
+    if (!inputs || !inputs.amiLimits || !inputs.fmr) return null;
+    var fmr = inputs.fmr;
+    if (typeof fmr.two_br !== 'number' || fmr.two_br <= 0) return null;
+    var fmr2br = fmr.two_br;
+
+    function _status(gap) {
+      if (gap <= 0)   return 'clear';
+      if (gap <= 50)  return 'tight';
+      if (gap <= 200) return 'concerning';
+      return 'misaligned';
+    }
+
+    var tiers = [30, 40, 50, 60]
+      .filter(function (p) { return typeof inputs.amiLimits[p] === 'number' && inputs.amiLimits[p] > 0; })
+      .map(function (pct) {
+        var ceiling = inputs.amiLimits[pct];
+        var gap = ceiling - fmr2br;
+        return {
+          pct:     pct,
+          ceiling: ceiling,
+          fmr2br:  fmr2br,
+          gap:     gap,
+          status:  _status(gap)
+        };
+      });
+
+    if (tiers.length === 0) return null;
+    return { tiers: tiers, fmr: fmr };
+  }
+
+  // -------------------------------------------------------------------
   // DSCR stress-scenario math (pure function, testable)
   //
   // Given the same inputs auto-NOI uses (rents, vacancy, opex, reserves,
@@ -631,6 +690,59 @@
           ⚠ Banker / syndicator rule of thumb: conservative lenders want DSCR ≥ 1.15 under a moderate stress scenario
           and DSCR ≥ 1.10 under combined stress. A deal that falls below 1.00 under the combined case may need
           additional credit enhancement, a lower DCR sizing target, or a smaller loan.
+        </p>
+      </fieldset>
+
+      <!-- Rent Achievability Check -->
+      <fieldset style="border:1px solid var(--border);border-radius:var(--radius);padding:var(--sp3);margin-bottom:var(--sp3);">
+        <legend style="font-size:var(--small);font-weight:700;padding:0 0.4rem;">Rent Achievability Check</legend>
+        <p id="dc-rent-ach-intro" style="font-size:var(--tiny);color:var(--muted);margin:0 0 var(--sp2);">
+          Compares LIHTC rent ceilings (at each AMI tier) against the county's HUD FMR 2BR market rent.
+          When the ceiling exceeds market rent, proforma revenue at the ceiling is over-stated and the
+          deal's actual DSCR will come in below underwriting.
+        </p>
+        <table id="dc-rent-ach-table" style="width:100%;border-collapse:collapse;font-size:var(--small);">
+          <thead>
+            <tr>
+              <th style="text-align:left;color:var(--muted);font-weight:600;padding:0.3rem 0.25rem;border-bottom:1px solid var(--border);">AMI Tier</th>
+              <th style="text-align:right;color:var(--muted);font-weight:600;padding:0.3rem 0.25rem;border-bottom:1px solid var(--border);">LIHTC Ceiling</th>
+              <th style="text-align:right;color:var(--muted);font-weight:600;padding:0.3rem 0.25rem;border-bottom:1px solid var(--border);">HUD FMR 2BR</th>
+              <th style="text-align:right;color:var(--muted);font-weight:600;padding:0.3rem 0.25rem;border-bottom:1px solid var(--border);">Gap</th>
+              <th style="text-align:left;color:var(--muted);font-weight:600;padding:0.3rem 0.25rem;border-bottom:1px solid var(--border);">Status</th>
+            </tr>
+          </thead>
+          <tbody id="dc-rent-ach-body">
+            <tr><td colspan="5" style="padding:0.5rem;text-align:center;color:var(--muted);font-size:var(--tiny);">Select a county to see rent-achievability check.</td></tr>
+          </tbody>
+        </table>
+        <div id="dc-rent-ach-fmr-grid" style="margin-top:var(--sp3);display:none;">
+          <div style="font-size:var(--tiny);color:var(--muted);font-weight:600;margin-bottom:0.35rem;">HUD FMR by bedroom size (FY2025, gross rent $USD/mo)</div>
+          <table style="width:100%;border-collapse:collapse;font-size:var(--tiny);">
+            <thead>
+              <tr>
+                <th style="text-align:right;color:var(--muted);font-weight:600;padding:0.25rem 0.25rem;">Studio</th>
+                <th style="text-align:right;color:var(--muted);font-weight:600;padding:0.25rem 0.25rem;">1BR</th>
+                <th style="text-align:right;color:var(--muted);font-weight:600;padding:0.25rem 0.25rem;">2BR</th>
+                <th style="text-align:right;color:var(--muted);font-weight:600;padding:0.25rem 0.25rem;">3BR</th>
+                <th style="text-align:right;color:var(--muted);font-weight:600;padding:0.25rem 0.25rem;">4BR</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td id="dc-fmr-studio"  style="text-align:right;padding:0.25rem 0.25rem;">—</td>
+                <td id="dc-fmr-1br"     style="text-align:right;padding:0.25rem 0.25rem;">—</td>
+                <td id="dc-fmr-2br"     style="text-align:right;padding:0.25rem 0.25rem;font-weight:700;">—</td>
+                <td id="dc-fmr-3br"     style="text-align:right;padding:0.25rem 0.25rem;">—</td>
+                <td id="dc-fmr-4br"     style="text-align:right;padding:0.25rem 0.25rem;">—</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="kpi-source kpi-verify" style="margin-top:var(--sp2);">
+          ⚠ LIHTC rent ceilings assume 4-person AMI (HUD standard); actual per-bedroom limits vary ±10%. HUD FMR is the 40th-percentile
+          market rent for the area and lags ~18 mo. For a binding market-rent test, commission a rent comparability study
+          before closing. Source:
+          <a href="https://www.huduser.gov/portal/datasets/fmr.html" target="_blank" rel="noopener">HUD FMR FY2025</a>.
         </p>
       </fieldset>
 
@@ -1191,6 +1303,67 @@
       });
     }
 
+    // ── Render rent-achievability table ────────────────────────────
+    // Pulls the AMI-tier rent ceilings from _amiLimits (already populated
+    // by HudFmr for the selected county) and the HUD FMR 2BR benchmark
+    // via HudFmr.getFmrByFips. Null-safe: shows the "select a county"
+    // message when data isn't available yet.
+    var achBody = document.getElementById('dc-rent-ach-body');
+    var fmrGrid = document.getElementById('dc-rent-ach-fmr-grid');
+    var fmrData = (window.HudFmr && _countyFips) ? window.HudFmr.getFmrByFips(_countyFips) : null;
+    var achResult = (_amiLimits && fmrData) ? computeRentAchievability({
+      amiLimits: _amiLimits,
+      fmr:       fmrData
+    }) : null;
+
+    if (achBody && achResult) {
+      var statusLabel = {
+        clear:       '✓ Rents clear market',
+        tight:       '~ Tight — thin buffer',
+        concerning:  '⚠ Above market',
+        misaligned:  '⚠⚠ Ceiling > market'
+      };
+      var statusColor = {
+        clear:       'var(--good, #047857)',
+        tight:       'var(--text)',
+        concerning:  'var(--warn, #d97706)',
+        misaligned:  'var(--bad, #dc2626)'
+      };
+      achBody.innerHTML = achResult.tiers.map(function (t) {
+        var gapSign = t.gap > 0 ? '+' : (t.gap < 0 ? '' : '');
+        var gapColor = t.gap <= 0 ? 'var(--good, #047857)'
+                     : t.gap <= 50 ? 'var(--text)'
+                     : t.gap <= 200 ? 'var(--warn, #d97706)'
+                     : 'var(--bad, #dc2626)';
+        return '<tr>' +
+          '<td style="padding:0.3rem 0.25rem;">' + t.pct + '% AMI</td>' +
+          '<td style="text-align:right;font-weight:700;padding:0.3rem 0.25rem;">' + fmt(t.ceiling) + '/mo</td>' +
+          '<td style="text-align:right;padding:0.3rem 0.25rem;">' + fmt(t.fmr2br) + '/mo</td>' +
+          '<td style="text-align:right;font-weight:600;padding:0.3rem 0.25rem;color:' + gapColor + ';">' + gapSign + fmt(t.gap) + '</td>' +
+          '<td style="padding:0.3rem 0.25rem;color:' + statusColor[t.status] + ';font-weight:600;">' + statusLabel[t.status] + '</td>' +
+        '</tr>';
+      }).join('');
+
+      // Populate the per-bedroom FMR row
+      if (fmrGrid) {
+        fmrGrid.style.display = '';
+        var bedroomCells = [
+          ['dc-fmr-studio', fmrData.efficiency],
+          ['dc-fmr-1br',    fmrData.one_br],
+          ['dc-fmr-2br',    fmrData.two_br],
+          ['dc-fmr-3br',    fmrData.three_br],
+          ['dc-fmr-4br',    fmrData.four_br]
+        ];
+        bedroomCells.forEach(function (c) {
+          var el = document.getElementById(c[0]);
+          if (el) el.textContent = (typeof c[1] === 'number' && c[1] > 0) ? fmt(c[1]) : '—';
+        });
+      }
+    } else if (achBody) {
+      achBody.innerHTML = '<tr><td colspan="5" style="padding:0.5rem;text-align:center;color:var(--muted);font-size:var(--tiny);">Select a county to see rent-achievability check.</td></tr>';
+      if (fmrGrid) fmrGrid.style.display = 'none';
+    }
+
     // ── Render Peer Deals table ────────────────────────────────────
     // Pulls comparable LIHTC projects from window.HudLihtc (loaded
     // lazily on first county selection) and renders the top 5 by
@@ -1661,7 +1834,8 @@
     setDesignationContext: setDesignationContext,
     /* Exposed for testing — pure functions, no DOM access */
     computeDscrStressScenarios: computeDscrStressScenarios,
-    findPeerDeals:              findPeerDeals
+    findPeerDeals:              findPeerDeals,
+    computeRentAchievability:   computeRentAchievability
   };
 
   if (document.readyState === 'loading') {

--- a/test/dc-constants.test.js
+++ b/test/dc-constants.test.js
@@ -1,0 +1,155 @@
+'use strict';
+/**
+ * test/dc-constants.test.js
+ *
+ * Validates that the Methodology & Formulas panel's editable constants
+ * actually flow through to the math:
+ *   - rentBurdenPct affects the LIHTC ceiling formula
+ *   - rent/vac/opex stress percentages affect computeDscrStressScenarios
+ *   - combined-stress trio affects the combined scenario
+ *   - DEFAULT_CONSTANTS exposes the industry-standard defaults
+ *
+ * Run: node test/dc-constants.test.js
+ */
+
+const { JSDOM } = require('jsdom');
+const dom = new JSDOM('<!DOCTYPE html><body><div id="dealCalcMount"></div></body>', {
+  url: 'http://localhost/'
+});
+global.document = dom.window.document;
+global.window   = dom.window;
+global.HTMLElement = dom.window.HTMLElement;
+
+require('../js/deal-calculator.js');
+const dc = window.__DealCalc;
+
+let passed = 0, failed = 0;
+function assert(cond, msg) {
+  if (cond) { console.log('  ✅ PASS:', msg); passed++; }
+  else       { console.error('  ❌ FAIL:', msg); failed++; }
+}
+function test(name, fn) {
+  console.log('\n[test]', name);
+  try { fn(); } catch (e) { console.error('  ❌ FAIL: threw —', e.message); failed++; }
+}
+function nearly(a, b, tol) {
+  tol = tol == null ? 1 : tol;
+  return Math.abs(a - b) <= tol;
+}
+
+const CANONICAL = {
+  annualRents:       1000000,
+  vacancyPct:        0.07,
+  annualOpex:        324000,
+  annualRepReserve:  21000,
+  netPropTax:        48000,
+  annualDebtService: 447500
+};
+
+test('DEFAULT_CONSTANTS exported and matches industry standards', function () {
+  const D = dc.DEFAULT_CONSTANTS;
+  assert(typeof D === 'object',                 'DEFAULT_CONSTANTS is an object');
+  assert(D.rentBurdenPct   === 0.30,            'rentBurdenPct = 30% (HUD standard)');
+  assert(D.rentStressPct   === 0.10,            'rentStressPct = 10%');
+  assert(D.vacStressPp     === 0.05,            'vacStressPp   = 5 pp');
+  assert(D.opexStressPct   === 0.10,            'opexStressPct = 10%');
+  assert(D.combinedRentPct === 0.05,            'combinedRentPct = 5%');
+  assert(D.combinedVacPp   === 0.03,            'combinedVacPp   = 3 pp');
+  assert(D.combinedOpexPct === 0.05,            'combinedOpexPct = 5%');
+});
+
+test('test helpers _getConstants / _setConstantsForTest / _resetConstantsForTest exposed', function () {
+  assert(typeof dc._getConstants          === 'function', '_getConstants exported');
+  assert(typeof dc._setConstantsForTest   === 'function', '_setConstantsForTest exported');
+  assert(typeof dc._resetConstantsForTest === 'function', '_resetConstantsForTest exported');
+});
+
+test('reset returns to industry defaults', function () {
+  dc._setConstantsForTest({ rentBurdenPct: 0.28 });
+  assert(dc._getConstants().rentBurdenPct === 0.28, 'override applied');
+  dc._resetConstantsForTest();
+  assert(dc._getConstants().rentBurdenPct === 0.30, 'reset restores default');
+});
+
+test('default stress matches the original hard-coded behavior', function () {
+  dc._resetConstantsForTest();
+  const s = dc.computeDscrStressScenarios(CANONICAL, dc.DEFAULT_CONSTANTS);
+  // baseline regressions from #720's test:
+  // base NOI = 537000, rent10 NOI = 444000, vac5 = 487000, opex10 = 504600,
+  // combined = 445800
+  assert(nearly(s.base.noi, 537000),     'default base NOI = 537,000');
+  assert(nearly(s.rent10.noi, 444000),   'default rent10 NOI = 444,000');
+  assert(nearly(s.vac5.noi, 487000),     'default vac5 NOI = 487,000');
+  assert(nearly(s.opex10.noi, 504600),   'default opex10 NOI = 504,600');
+  assert(nearly(s.combined.noi, 445800), 'default combined NOI = 445,800');
+});
+
+test('non-default rent stress percentage flows through', function () {
+  // Tighten rent stress from 10% to 15%
+  const constants = Object.assign({}, dc.DEFAULT_CONSTANTS, { rentStressPct: 0.15 });
+  const s = dc.computeDscrStressScenarios(CANONICAL, constants);
+  // EGI at 85% rent = 1,000,000 × 0.85 × 0.93 = 790,500
+  // NOI = 790,500 − 324,000 − 21,000 − 48,000 = 397,500
+  assert(nearly(s.rent10.noi, 397500),
+    '15% rent stress NOI = 397,500 (got ' + Math.round(s.rent10.noi) + ')');
+  // DSCR = 397,500 / 447,500 ≈ 0.888
+  assert(nearly(s.rent10.dscr, 397500 / 447500, 0.001),
+    '15% rent stress DSCR ≈ 0.89 (got ' + s.rent10.dscr.toFixed(3) + ')');
+  // Should be lower than the 10%-stress DSCR (0.99) — tighter stress = worse
+  const sDefault = dc.computeDscrStressScenarios(CANONICAL, dc.DEFAULT_CONSTANTS);
+  assert(s.rent10.dscr < sDefault.rent10.dscr,
+    'tighter rent stress (15% > 10%) produces lower DSCR');
+});
+
+test('non-default vacancy stress flows through', function () {
+  const constants = Object.assign({}, dc.DEFAULT_CONSTANTS, { vacStressPp: 0.10 });
+  const s = dc.computeDscrStressScenarios(CANONICAL, constants);
+  // Vac = 0.07 + 0.10 = 0.17; EGI = 1,000,000 × 0.83 = 830,000
+  // NOI = 830,000 − 324,000 − 21,000 − 48,000 = 437,000
+  assert(nearly(s.vac5.noi, 437000),
+    '10pp vacancy stress NOI = 437,000 (got ' + Math.round(s.vac5.noi) + ')');
+});
+
+test('non-default opex stress flows through', function () {
+  const constants = Object.assign({}, dc.DEFAULT_CONSTANTS, { opexStressPct: 0.20 });
+  const s = dc.computeDscrStressScenarios(CANONICAL, constants);
+  // EGI unchanged at 930,000
+  // NOI = 930,000 − 324,000×1.20 − 21,000 − 48,000 = 472,200
+  assert(nearly(s.opex10.noi, 472200),
+    '20% opex stress NOI = 472,200 (got ' + Math.round(s.opex10.noi) + ')');
+});
+
+test('combined stress respects all three constants together', function () {
+  const constants = Object.assign({}, dc.DEFAULT_CONSTANTS, {
+    combinedRentPct: 0.10,
+    combinedVacPp:   0.05,
+    combinedOpexPct: 0.10
+  });
+  const s = dc.computeDscrStressScenarios(CANONICAL, constants);
+  // Vac = 0.07+0.05 = 0.12; EGI = 1,000,000 × 0.90 × 0.88 = 792,000
+  // NOI = 792,000 − 324,000×1.10 − 21,000 − 48,000 = 366,600
+  assert(nearly(s.combined.noi, 366600),
+    'tighter combined stress NOI = 366,600 (got ' + Math.round(s.combined.noi) + ')');
+});
+
+test('zero stress percentages → stressed NOI == base NOI', function () {
+  const noStress = Object.assign({}, dc.DEFAULT_CONSTANTS, {
+    rentStressPct: 0, vacStressPp: 0, opexStressPct: 0,
+    combinedRentPct: 0, combinedVacPp: 0, combinedOpexPct: 0
+  });
+  const s = dc.computeDscrStressScenarios(CANONICAL, noStress);
+  assert(nearly(s.rent10.noi,   s.base.noi),   'rent10 NOI = base when no stress');
+  assert(nearly(s.vac5.noi,     s.base.noi),   'vac5 NOI = base when no stress');
+  assert(nearly(s.opex10.noi,   s.base.noi),   'opex10 NOI = base when no stress');
+  assert(nearly(s.combined.noi, s.base.noi),   'combined NOI = base when no stress');
+});
+
+test('omitted constants argument falls back to defaults (back-compat)', function () {
+  const s = dc.computeDscrStressScenarios(CANONICAL); // no second arg
+  // Should match #720's original assertions exactly
+  assert(nearly(s.rent10.noi, 444000),   'default behavior preserved when constants omitted');
+});
+
+console.log('\n' + '='.repeat(50));
+console.log('Results:', passed, 'passed,', failed, 'failed');
+if (failed > 0) process.exitCode = 1;

--- a/test/dc-rent-achievability.test.js
+++ b/test/dc-rent-achievability.test.js
@@ -1,0 +1,145 @@
+'use strict';
+/**
+ * test/dc-rent-achievability.test.js
+ *
+ * Unit tests for the pure `computeRentAchievability` function exposed by
+ * js/deal-calculator.js. Validates the LIHTC ceiling vs HUD FMR 2BR
+ * comparison + status thresholds that drive the new Rent Achievability
+ * Check panel.
+ *
+ * Run: node test/dc-rent-achievability.test.js
+ */
+
+const { JSDOM } = require('jsdom');
+const dom = new JSDOM('<!DOCTYPE html><body><div id="dealCalcMount"></div></body>', {
+  url: 'http://localhost/'
+});
+global.document = dom.window.document;
+global.window   = dom.window;
+global.HTMLElement = dom.window.HTMLElement;
+
+require('../js/deal-calculator.js');
+const dc = window.__DealCalc;
+
+let passed = 0, failed = 0;
+function assert(cond, msg) {
+  if (cond) { console.log('  ✅ PASS:', msg); passed++; }
+  else       { console.error('  ❌ FAIL:', msg); failed++; }
+}
+function test(name, fn) {
+  console.log('\n[test]', name);
+  try { fn(); } catch (e) { console.error('  ❌ FAIL: threw —', e.message); failed++; }
+}
+
+// ── Fixtures ──
+// Adams County (Denver MSA): strong rental market — LIHTC 60% ceiling
+// is below HUD FMR 2BR, so rents clear comfortably.
+const ADAMS = {
+  amiLimits: { 30: 931, 40: 1241, 50: 1551, 60: 1862 },
+  fmr:       { efficiency: 1348, one_br: 1484, two_br: 1802, three_br: 2386, four_br: 2750 }
+};
+
+// Otero County: weak rural market — LIHTC ceilings approach or exceed
+// HUD FMR 2BR, signalling that proforma rents at the ceiling won't
+// actually clear and revenue assumptions need a haircut.
+const OTERO = {
+  amiLimits: { 30: 412, 40: 549, 50: 686, 60: 824 },
+  fmr:       { efficiency: 720, one_br: 815, two_br: 950, three_br: 1305, four_br: 1448 }
+};
+
+test('API exposed', function () {
+  assert(typeof dc.computeRentAchievability === 'function', 'computeRentAchievability exported');
+});
+
+test('null / missing input → null', function () {
+  assert(dc.computeRentAchievability(null) === null,                 'null → null');
+  assert(dc.computeRentAchievability({}) === null,                   '{} → null');
+  assert(dc.computeRentAchievability({ amiLimits: {} }) === null,    'missing fmr → null');
+  assert(dc.computeRentAchievability({ fmr: {} }) === null,          'missing amiLimits → null');
+});
+
+test('FMR 2BR missing or zero → null', function () {
+  assert(dc.computeRentAchievability({
+    amiLimits: ADAMS.amiLimits,
+    fmr: { two_br: 0 }
+  }) === null, 'zero 2BR → null');
+  assert(dc.computeRentAchievability({
+    amiLimits: ADAMS.amiLimits,
+    fmr: { efficiency: 1000 }
+  }) === null, 'no 2BR field → null');
+});
+
+test('Adams (Denver MSA) — all tiers clear market', function () {
+  const r = dc.computeRentAchievability(ADAMS);
+  assert(r !== null && Array.isArray(r.tiers),  'returns tiers array');
+  assert(r.tiers.length === 4,                   'all 4 AMI tiers present');
+
+  const t30 = r.tiers.find(t => t.pct === 30);
+  const t60 = r.tiers.find(t => t.pct === 60);
+  assert(t30.gap === 931 - 1802,                'gap = ceiling − FMR (30% AMI)');
+  assert(t30.gap < 0,                            '30% AMI ceiling well below FMR (clear)');
+  assert(t30.status === 'clear',                 'status: clear');
+
+  // 60% AMI: 1862 − 1802 = 60 → "tight" (gap > 50 wait, 60 > 50)
+  assert(t60.gap === 60,                         'gap = +60 (60% AMI ceiling slightly above FMR)');
+  assert(t60.status === 'concerning',            '60-dollar gap is "concerning" (> $50 threshold)');
+});
+
+test('Otero (rural) — high tiers misaligned', function () {
+  const r = dc.computeRentAchievability(OTERO);
+  const t30 = r.tiers.find(t => t.pct === 30);
+  const t60 = r.tiers.find(t => t.pct === 60);
+  assert(t30.gap === 412 - 950,                 '30% AMI very far below FMR');
+  assert(t30.status === 'clear',                 '30% AMI: clear');
+  // 60% AMI: 824 − 950 = -126 → still clear
+  assert(t60.gap === -126,                       '60% AMI gap = -126');
+  assert(t60.status === 'clear',                 '60% AMI: clear (FMR is HIGH relative to AMI in rural Otero)');
+});
+
+test('synthetic — concerning + misaligned status thresholds', function () {
+  // Force gaps on each side of the threshold:
+  //   gap = 0  → clear
+  //   gap = 1  → tight (≤ $50)
+  //   gap = 51 → concerning (> $50, ≤ $200)
+  //   gap = 201 → misaligned
+  const r = dc.computeRentAchievability({
+    amiLimits: { 30: 1000, 40: 1001, 50: 1051, 60: 1201 },
+    fmr: { efficiency: 800, one_br: 900, two_br: 1000, three_br: 1100, four_br: 1200 }
+  });
+  const byPct = {};
+  r.tiers.forEach(t => byPct[t.pct] = t);
+  assert(byPct[30].status === 'clear',       '30% AMI gap=0 → clear');
+  assert(byPct[40].status === 'tight',       '40% AMI gap=+1 → tight');
+  assert(byPct[50].status === 'concerning',  '50% AMI gap=+51 → concerning');
+  assert(byPct[60].status === 'misaligned',  '60% AMI gap=+201 → misaligned');
+});
+
+test('partial AMI tier coverage — only present tiers returned', function () {
+  // If only 50% and 60% AMI are populated (some counties may lack 30/40 limits),
+  // the result should include only those tiers, not synthesized fillers.
+  const r = dc.computeRentAchievability({
+    amiLimits: { 50: 1000, 60: 1200 },
+    fmr: { two_br: 1100 }
+  });
+  assert(r.tiers.length === 2,             'only 2 tiers returned');
+  assert(r.tiers[0].pct === 50,            'first tier is 50% AMI');
+  assert(r.tiers[1].pct === 60,            'second tier is 60% AMI');
+});
+
+test('all amiLimits zero/null → null result (no tiers)', function () {
+  const r = dc.computeRentAchievability({
+    amiLimits: { 30: 0, 40: null, 50: undefined, 60: 0 },
+    fmr: { two_br: 1500 }
+  });
+  assert(r === null, 'no valid tiers → null');
+});
+
+test('fmr passes through for downstream rendering', function () {
+  const r = dc.computeRentAchievability(ADAMS);
+  assert(r.fmr === ADAMS.fmr,                   'fmr returned unchanged for downstream UI');
+  assert(r.fmr.three_br === 2386,               'bedroom data accessible');
+});
+
+console.log('\n' + '='.repeat(50));
+console.log('Results:', passed, 'passed,', failed, 'failed');
+if (failed > 0) process.exitCode = 1;


### PR DESCRIPTION
## What happened

PRs **#721 (Rent Achievability)** and **#722 (Methodology & Formulas)** were both merged via the GitHub UI on 2026-04-25 and show as **MERGED** in the PR list — but their changes are **not in main**.

Root cause: I created them as a stacked PR chain. #721's base was \`feat/dc-dscr-stress-panel\` (#720's branch); #722's base was \`feat/dc-rent-achievability\` (#721's branch). When the stack was merged, **#721 merged into #720's branch (not main)** and **#722 merged into #721's branch (not main)**. Then #720 was squash-merged into main with only the DSCR commits — and the rent-achievability + methodology commits stayed on the dead stack branches.

I noticed this just now during a code-level QA pass when I went looking for the panels in main and they weren't there.

Verified:
\`\`\`
$ git merge-base --is-ancestor 8c9ec092 origin/main && echo "in" || echo "not in"
not in   ← #721's merge commit
$ git merge-base --is-ancestor 7e8428f8 origin/main && echo "in" || echo "not in"
not in   ← #722's merge commit
\`\`\`

## What this PR does

Brings the rent-achievability + Methodology & Formulas changes forward to main, with the conflicts against #727 (Peer Deals) resolved by placing the panels in this order:

1. LIHTC Credit Estimates (existing)
2. Supportable First Mortgage (existing)
3. **DSCR + Stress Tests** (#720, already on main)
4. **Rent Achievability Check** (#721, restored here)
5. **Peer Deals** (#727, already on main)
6. Sources & Uses (existing)

Plus the **Methodology & Formulas** collapsible panel sits at the top of the outputs column with 7 editable constants.

## Tests

All 5 test suites pass on the merged state:

| Test | Result |
|---|---|
| \`dc-rent-achievability.test.js\` | 28/28 |
| \`dc-dscr-stress.test.js\` | 22/22 |
| \`dc-peer-deals.test.js\` | 38/38 |
| \`dc-constants.test.js\` | 29/29 |
| \`pro-forma.test.js\` | 24/24 |

**141/141 across the Deal Calculator + adjacent surface.**

## Why two commits

I split the restoration into two commits — one for #721, one for #722 — so the history reflects what \"should have happened\" had each PR cleanly merged into main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)