### PR TITLE
fix(pma): surface absorption risk + clean up discarded expiry var

### DIFF
--- a/js/pma-analysis-runner.js
+++ b/js/pma-analysis-runner.js
@@ -279,7 +279,11 @@
               : [];
             var lihtcFeatures = (window.PMAEngine && window.PMAEngine._lihtcFeatures) || [];
             var set = pmaCompetitive.buildCompetitiveSet(lihtcFeatures, nhpdFeatures, lat, lon, bufferMiles);
-            var expiry = pmaCompetitive.flagSubsidyExpiryRisk(nhpdFeatures);
+            // flagSubsidyExpiryRisk is called for its side effect — it
+            // populates lastExpiryRisk inside pma-competitive-set, which
+            // getCompetitiveJustification() then exposes via the
+            // subsidyExpiryRisk field consumed by pma-ui-controller.
+            pmaCompetitive.flagSubsidyExpiryRisk(nhpdFeatures);
             var absorption = pmaCompetitive.calculateAbsorptionRisk(set, proposedUnits);
             results.competitiveSet = pmaCompetitive.getCompetitiveJustification();
             results.absorptionRisk = absorption;

--- a/js/pma-ui-controller.js
+++ b/js/pma-ui-controller.js
@@ -457,6 +457,45 @@
       }
     }
 
+    // Absorption / capture risk — was previously computed by the PMA
+    // runner (results.absorptionRisk) but never rendered. Surfacing it
+    // here so a banker can see whether the proposed unit count vs the
+    // existing competitive set raises a saturation flag.
+    var absorption = scoreRun.absorptionRisk || null;
+    var absWrap = $id('pmaAbsorptionRiskWrap');
+    var absBody = $id('pmaAbsorptionRiskBody');
+    if (absWrap && absBody) {
+      if (absorption && typeof absorption.captureRate === 'number') {
+        var risk = String(absorption.risk || 'unknown');
+        var riskColor = risk === 'low'      ? 'var(--good,#047857)'
+                      : risk === 'moderate' ? 'var(--warn,#d97706)'
+                      : risk === 'high'     ? 'var(--bad,#dc2626)'
+                      :                       'var(--muted,#888)';
+        var riskLabel = risk.charAt(0).toUpperCase() + risk.slice(1);
+        var captureRatePct = (absorption.captureRate * 100).toFixed(1);
+        var compUnits = absorption.totalCompetitiveUnits || 0;
+        var compCount = absorption.competitivePropertyCount || 0;
+        var propUnits = absorption.proposedUnits || 0;
+        absBody.innerHTML =
+          '<div><strong style="color:' + riskColor + ';">' + _esc(riskLabel) + '</strong> ' +
+            '— capture rate: <strong>' + captureRatePct + '%</strong> ' +
+            '(' + propUnits + ' proposed / ' + (compUnits + propUnits) + ' total).' +
+          '</div>' +
+          '<div style="font-size:.92em;color:var(--muted,#888);margin-top:.25rem;">' +
+            'Based on ' + compCount + ' nearby competitive ' +
+            (compCount === 1 ? 'property' : 'properties') + ' totaling ' + compUnits + ' units. ' +
+            (risk === 'high'
+               ? 'High capture rate suggests the proposed deal may struggle to lease at proforma absorption rates.'
+            : risk === 'moderate'
+               ? 'Moderate capture — verify lease-up assumptions vs comparable lease-up timelines.'
+            :  'Low capture — proposed unit count is well-absorbed by the local market.') +
+          '</div>';
+        absWrap.hidden = false;
+      } else {
+        absWrap.hidden = true;
+      }
+    }
+
     // Incentive eligibility badges
     var badgeWrap = $id('pmaIncentiveBadges');
     if (badgeWrap) {

--- a/market-analysis.html
+++ b/market-analysis.html
@@ -643,6 +643,11 @@
             <p style="font-size:.78em;font-weight:600;margin-bottom:.35rem;">⚠ At-risk subsidy properties near site:</p>
             <div id="pmaSubsidyRiskList" style="font-size:.78em;"></div>
           </div>
+          <!-- Absorption risk card — proposed units vs total competitive set -->
+          <div id="pmaAbsorptionRiskWrap" hidden style="margin-top:.75rem;padding:.5rem .65rem;border-left:3px solid var(--border,#333);border-radius:0 4px 4px 0;background:var(--bg2,#1a1a1a);font-size:.78em;">
+            <p style="font-weight:600;margin:0 0 .35rem;">Absorption / Capture Risk</p>
+            <div id="pmaAbsorptionRiskBody" style="line-height:1.55;"></div>
+          </div>
           <!-- Opportunity / incentive badges -->
           <div id="pmaIncentiveBadges" style="margin-top:.65rem;display:flex;flex-wrap:wrap;gap:.4rem;"></div>
           <div style="margin-top:.75rem;display:flex;flex-wrap:wrap;gap:.5rem;">


### PR DESCRIPTION
## Two findings, one PR

### 1. Absorption / capture risk computed but never rendered

\`pma-competitive-set.calculateAbsorptionRisk()\` is called by the runner and stored to \`scoreRun.absorptionRisk\` — but **no UI consumer reads the field**. A banker evaluating a deal couldn't see whether the proposed unit count saturates the local competitive set.

This PR adds a render hook in \`pma-ui-controller.js\` and a small card under the PMA Justification Narrative.

### 2. Discarded \`var expiry =\` cleanup

The audit report flagged \`flagSubsidyExpiryRisk()\` as \"result discarded\" because the runner stored it to a local variable never referenced. Verification revealed: the function is actually called for its **side effect** (populating internal \`lastExpiryRisk\` state) which \`getCompetitiveJustification()\` exposes via \`subsidyExpiryRisk\`, and \`pma-ui-controller\` already renders it. So that finding was a false alarm in the agent report — but the unused local var was real noise.

Cleaned up the var + added a comment so future readers know the call is intentional.

## What a banker now sees

Before:
> ⚠ At-risk subsidy properties: …  
> [Opportunity Zone] [LIHTC Basis Step-down]

After:
> ⚠ At-risk subsidy properties: …  
> **Absorption / Capture Risk**  
> **Moderate** — capture rate: **8.5%** (60 proposed / 705 total).  
> Based on 11 nearby competitive properties totaling 645 units.  
> Moderate capture — verify lease-up assumptions vs comparable lease-up timelines.  
> [Opportunity Zone] [LIHTC Basis Step-down]

Color-coded risk band:
- Low → green
- Moderate → amber
- High → red

## What's NOT in this PR

- Audit's \"8 layer functions never called\" claim — verified WRONG (each has a real caller). No action needed.
- Audit's \"PMAConfidence.compute() dormant\" — verified TRUE. Held for separate refactor PR (no user-visible change).
- Audit's \"identifyExcludedTracts not wired into runner\" — verified TRUE. Held because it changes ACS aggregation results and warrants focused PR with regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)