### PR TITLE
feat(site-score): scoreDemand uses severe-burden signal when available

### DIFF
--- a/js/market-analysis/site-selection-score.js
+++ b/js/market-analysis/site-selection-score.js
@@ -91,13 +91,32 @@
   /**
    * Score the housing demand signal from ACS tract metrics.
    *
-   * Drivers:
-   *   cost_burden_rate – higher burden → higher demand pressure (0–50 pts)
-   *   renter_share     – higher renter concentration → higher need  (0–30 pts)
-   *   poverty_rate     – higher poverty → deeper affordability gap   (0–20 pts)
+   * The market-analysis controller aggregates an extra signal — the
+   * **severe** cost-burden rate (renters paying ≥50 % of income on
+   * rent). It's a strict subset of the regular cost-burden rate, but
+   * it's a much more specific market-stress signal: severely burdened
+   * renters are at-risk for displacement and represent the deepest
+   * affordability gap. When that field is present in the input,
+   * scoreDemand uses 4 sub-factors. When it's absent (older callers
+   * or test fixtures), scoreDemand falls back to the original
+   * 3-factor weighting so historical scores don't shift.
+   *
+   * 4-factor weights (when severe_burden_rate is present):
+   *   cost_burden_rate    (0–0.45 → 0–40 pts)
+   *   renter_share        (0–0.60 → 0–25 pts)
+   *   poverty_rate        (0–0.20 → 0–15 pts)
+   *   severe_burden_rate  (0–0.25 → 0–20 pts)   NEW
+   *   = 100 pts total
+   *
+   * 3-factor fallback (back-compat when severe_burden_rate missing):
+   *   cost_burden_rate    (0–0.45 → 0–50 pts)
+   *   renter_share        (0–0.60 → 0–30 pts)
+   *   poverty_rate        (0–0.20 → 0–20 pts)
+   *   = 100 pts total
    *
    * @param {object|null} acs - Aggregated ACS object.
-   *   Expected keys: cost_burden_rate (0–1), renter_share (0–1), poverty_rate (0–1).
+   *   Expected keys: cost_burden_rate (0–1), renter_share (0–1),
+   *   poverty_rate (0–1). Optional: severe_burden_rate (0–1).
    * @returns {{ score: number|null, unavailable: boolean, reason?: string }}
    *   When `acs` is missing or not an object, returns
    *   `{ score: null, unavailable: true, reason: 'ACS aggregate unavailable' }`
@@ -113,18 +132,36 @@
       };
     }
 
-    // Cost-burden component: 45 %+ is the high-pressure ceiling.
-    var cb    = _safe(acs.cost_burden_rate, 0.30);
-    var cbPts = _clamp((cb / 0.45) * 50);
+    var cb  = _safe(acs.cost_burden_rate, 0.30);
+    var rs  = _safe(acs.renter_share,     0.35);
+    var pov = _safe(acs.poverty_rate,     0.12);
 
-    // Renter-share component: 60 %+ represents high renter concentration.
-    var rs    = _safe(acs.renter_share, 0.35);
-    var rsPts = _clamp((rs / 0.60) * 30);
+    // Use severe_burden_rate as a 4th factor only when it's actually
+    // present and finite. null/undefined/NaN → fall back to the
+    // 3-factor weighting so historical scores are preserved.
+    var severeRaw = acs.severe_burden_rate;
+    var severeAvailable = severeRaw !== null && severeRaw !== undefined &&
+                          isFinite(+severeRaw);
 
-    // Poverty-rate component: 20 %+ is the high-poverty ceiling.
-    var pov    = _safe(acs.poverty_rate, 0.12);
+    if (severeAvailable) {
+      // 4-factor scoring — uses the available severe-burden signal.
+      var cbPts4  = _clamp((cb  / 0.45) * 40);
+      var rsPts4  = _clamp((rs  / 0.60) * 25);
+      var povPts4 = _clamp((pov / 0.20) * 15);
+      var sev     = _safe(+severeRaw, 0);
+      var sevPts  = _clamp((sev / 0.25) * 20);
+      return {
+        score: _clamp(cbPts4 + rsPts4 + povPts4 + sevPts),
+        unavailable: false
+      };
+    }
+
+    // 3-factor back-compat — preserves historical scoring when severe
+    // burden isn't supplied (older callers, test fixtures, or older
+    // controller code paths that haven't been updated).
+    var cbPts  = _clamp((cb  / 0.45) * 50);
+    var rsPts  = _clamp((rs  / 0.60) * 30);
     var povPts = _clamp((pov / 0.20) * 20);
-
     return {
       score: _clamp(cbPts + rsPts + povPts),
       unavailable: false

--- a/test/unit/site-selection-score.test.js
+++ b/test/unit/site-selection-score.test.js
@@ -134,6 +134,69 @@ test('scoreDemand returns 0 for all-zero ACS fields', function () {
   assert(result.score === 0, 'all zeros → 0 (got ' + result.score + ')');
 });
 
+// ── 4-factor scoring (when severe_burden_rate present) ────────────────
+
+test('scoreDemand uses 4-factor scoring when severe_burden_rate is present', function () {
+  // Same 3 inputs as Test 4 + max severe burden → still 100 (all ceilings met)
+  const result = SSS.scoreDemand({
+    cost_burden_rate:   0.55,
+    renter_share:       0.70,
+    poverty_rate:       0.25,
+    severe_burden_rate: 0.30,  // above 0.25 ceiling
+  });
+  assert(result.score === 100, 'all 4 ceilings → 100 (got ' + result.score + ')');
+});
+
+test('scoreDemand 4-factor: severe burden boosts score over 3-factor case', function () {
+  const baseInputs = {
+    cost_burden_rate: 0.30,  // mid
+    renter_share:     0.35,  // mid
+    poverty_rate:     0.10,  // mid
+  };
+  const without = SSS.scoreDemand(baseInputs);
+  const with10  = SSS.scoreDemand(Object.assign({}, baseInputs, { severe_burden_rate: 0.10 }));
+  const with20  = SSS.scoreDemand(Object.assign({}, baseInputs, { severe_burden_rate: 0.20 }));
+  // The 3-factor and 4-factor weightings differ so the no-severe vs has-severe
+  // scores aren't directly comparable, but: more severe burden should always
+  // produce a higher 4-factor score than less severe burden.
+  assert(with20.score > with10.score,
+    'higher severe burden → higher demand score (with10=' + with10.score + ', with20=' + with20.score + ')');
+  assert(without.unavailable === false,             'without severe → still scored (3-factor fallback)');
+  assert(typeof without.score === 'number',         '3-factor returns numeric score');
+});
+
+test('scoreDemand: severe_burden_rate=0 explicitly uses 4-factor (not falls back to 3-factor)', function () {
+  // When severe_burden_rate is present but zero, the 4-factor path runs
+  // and contributes 0 pts from that component. NOT the same as omitting
+  // the field (which falls back to 3-factor).
+  const explicit = SSS.scoreDemand({
+    cost_burden_rate:   0.45, renter_share: 0.60, poverty_rate: 0.20,
+    severe_burden_rate: 0,
+  });
+  // 4-factor max for the first 3 components: 40+25+15=80 (severe contributes 0)
+  assert(explicit.score === 80,
+    'explicit severe=0 → 4-factor max minus severe (80, got ' + explicit.score + ')');
+});
+
+test('scoreDemand: null/undefined/NaN severe_burden_rate falls back to 3-factor', function () {
+  const baseInputs = {
+    cost_burden_rate: 0.45, renter_share: 0.60, poverty_rate: 0.20,
+  };
+  const noField = SSS.scoreDemand(baseInputs);
+  // 3-factor max: 50+30+20=100
+  assert(noField.score === 100,
+    'no severe field → 3-factor max=100 (got ' + noField.score + ')');
+
+  const nullField = SSS.scoreDemand(Object.assign({}, baseInputs, { severe_burden_rate: null }));
+  assert(nullField.score === 100, 'null severe → 3-factor (got ' + nullField.score + ')');
+
+  const undefField = SSS.scoreDemand(Object.assign({}, baseInputs, { severe_burden_rate: undefined }));
+  assert(undefField.score === 100, 'undefined severe → 3-factor (got ' + undefField.score + ')');
+
+  const nanField = SSS.scoreDemand(Object.assign({}, baseInputs, { severe_burden_rate: NaN }));
+  assert(nanField.score === 100, 'NaN severe → 3-factor (got ' + nanField.score + ')');
+});
+
 // ---------------------------------------------------------------------------
 // 6. scoreSubsidy — QCT flag
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The gap (verified)

The market-analysis controller already aggregates \`severe_burden_rate\` (HUD's threshold for renters paying ≥50% of income on rent) at line 229 of \`market-analysis-controller.js\`, weighted by renter households. The renderer at \`market-report-renderers.js:220\` already displays the value in the Market Demand panel.

**But \`scoreDemand()\` in \`site-selection-score.js\` was reading only 3 fields** — \`cost_burden_rate\`, \`renter_share\`, \`poverty_rate\`. The severe-burden signal flowed through the inputs object and the scorer ignored it.

Pure data-utilization gap: a real, computed, ACS-grounded demand signal sat on the input object and the scorer never weighed it into the headline 0–100 site-selection composite.

## What changes

\`scoreDemand\` now uses **4-factor scoring** when \`severe_burden_rate\` is present, with the original 3-factor weighting as back-compat fallback.

| Input | 4-factor weight | 3-factor weight | Ceiling |
|---|---|---|---|
| cost_burden_rate | 0–40 | 0–50 | 0.45 |
| renter_share | 0–25 | 0–30 | 0.60 |
| poverty_rate | 0–15 | 0–20 | 0.20 |
| **severe_burden_rate** | **0–20** | n/a | **0.25** |
| **total** | **100** | **100** | |

Switch happens automatically: if \`acs.severe_burden_rate\` is finite, 4-factor runs; if it's null/undefined/NaN, 3-factor runs (preserving historical scores for any caller that doesn't populate the field).

Same null-propagation pattern as the rent-pressure fix in #693.

## Tests

\`test/unit/site-selection-score.test.js\` — **92/92 passing** (was 83 before; +9 new assertions across 4 new tests):

- 4-factor scoring with all ceilings hit → 100
- Higher severe burden produces higher score (monotonic)
- Explicit \`severe_burden_rate: 0\` produces 80, NOT 100 (zero contribution from severe; not a fallback to 3-factor)
- null / undefined / NaN severe → 3-factor fallback (back-compat preserved)

Regression sweep — all green:
- dc-dscr-stress 22/22 · dc-rent-achievability 28/28 · dc-peer-deals 38/38
- dc-constants 29/29 · pro-forma 24/24 · data-freshness-v2 27/27
- hna-jurisdiction-normalization 13/13 · hna-scope-badges 26/26

## Score impact in real-world CO data

Typical CO sites where \`severe_burden_rate\` is in the 0.15–0.25 range will see demand-score shifts of **±5–10 pts** depending on whether the prior 3-factor score was hitting ceilings. Sites with very high severe burden (>25% severely burdened) get the full +20 pt contribution. Sites with low severe burden get a smaller bump (or could even score slightly lower vs the 3-factor case at very high overall burden — by design, the score now distinguishes \"high cost burden + low severe\" from \"high cost burden + high severe\").

## What this does NOT do

- Doesn't change controller inputs (severe_burden_rate already in the acs object since #723 era)
- Doesn't change the renderer (already displays the value)
- Doesn't add a tunable constant to the Methodology & Formulas panel — kept scope tight; if users want to override the 0.25 ceiling or 20-pt weight, that's a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)