### PR TITLE
fix(ci): wire build_ranking_index.py into scheduled HNA build

### DIFF
--- a/.github/workflows/build-hna-data.yml
+++ b/.github/workflows/build-hna-data.yml
@@ -84,6 +84,22 @@ jobs:
           echo "── Building housing policy scorecard ──"
           python3 scripts/policy/build_housing_scorecard.py 2>&1 || echo "::warning::Housing scorecard build failed (non-critical; existing file will be used)"
 
+      - name: Phase 7 — Rebuild HNA ranking index
+        # Regenerates data/hna/ranking-index.json — the file consumed by
+        # the Comparative Analysis page (hna-comparative-analysis.html).
+        # Reads the freshly built summary/projections/CHAS files from the
+        # earlier phases and re-derives the comparative metrics + scores.
+        #
+        # Wired here on 2026-05-06 to close the structural gap that drove
+        # data-freshness alerts #744-#748 (file aging past 9-day SLA with
+        # no scheduled regen path). PR #749 had only band-aided the
+        # generatedAt timestamp; the actual rebuild was never automated.
+        # Non-blocking: existing file is preserved if the script fails so
+        # one bad rebuild doesn't take the comparative-analysis page down.
+        run: |
+          echo "── Rebuilding HNA ranking index ──"
+          python3 scripts/hna/build_ranking_index.py 2>&1 || echo "::warning::Ranking-index rebuild failed (non-critical; existing file will be used)"
+
       - name: Post-build verification
         id: verify
         run: |
@@ -112,6 +128,22 @@ jobs:
           if [ "$total_files" -eq 0 ]; then
             echo "::error::No HNA output files were produced"
             exit 1
+          fi
+
+          # Verify ranking-index.json was actually regenerated this run.
+          # If Phase 7 silently used the existing file (script crash, no
+          # output written), the data-freshness alert that opened #744-
+          # #748 will keep firing — surface this as a CI warning so the
+          # next run has a chance to fix it before the SLA breach repeats.
+          if [ -f data/hna/ranking-index.json ]; then
+            file_age_secs=$(( $(date +%s) - $(stat -c%Y data/hna/ranking-index.json) ))
+            file_age_days=$(( file_age_secs / 86400 ))
+            echo "── data/hna/ranking-index.json mtime age: ${file_age_days} days ──"
+            if [ "$file_age_days" -gt 1 ]; then
+              echo "::warning::ranking-index.json mtime is ${file_age_days} days old — Phase 7 likely failed to regenerate it. Check Phase 7 logs above."
+            fi
+          else
+            echo "::warning::data/hna/ranking-index.json missing after build"
           fi
 
       - name: Alert on build failure


### PR DESCRIPTION
## The structural gap

Five auto-generated data-freshness issues (#744–#748) have been flagging \`data/hna/ranking-index.json\` as stale (12.8d → 15.6d, SLA 9d). **PR #749 (Copilot) tried to band-aid it** by bumping the \`generatedAt\` timestamp by one byte — that change got silently reverted by subsequent merges.

Root cause: nothing was actually rebuilding the file. \`scripts/hna/build_ranking_index.py\` existed and was correct; it just wasn't wired into any scheduled workflow. Only \`test-sentinel-normalization.yml\` referenced it — and that workflow runs **on changes to the script**, not on a schedule.

So every Monday's \`Build HNA Data Cache\` run was producing fresh \`summary/projections/CHAS\` files but never refreshing the ranking index that depends on them.

## What this PR does

Adds **Phase 7** to \`build-hna-data.yml\` — runs \`python3 scripts/hna/build_ranking_index.py\` after the housing-policy scorecard build.

Non-blocking: if the rebuild script fails, the existing file is preserved (so one bad rebuild doesn't take the comparative-analysis page down) and a CI warning is emitted.

Plus a small mtime check in **Post-build verification** that surfaces a CI warning if the ranking-index file is >1 day old after the build, so future Phase 7 failures don't go silent.

## Why only this fix

Audit also flagged \"consolidate \`test/\` vs \`tests/\` directories\" but **\`tests/\` is NOT empty** — it holds 14 Python test files (\`*_test.py\` and \`test_*.py\`) while \`test/\` holds 55 JavaScript tests. The split is intentional and correct; merging them would break pytest paths. Dropped that \"fix.\"

The original audit's claim was based on a wrong assumption (only checked for \`*.test.js\` filenames).

## Expected impact

- **Next scheduled Monday run** (cron: \`30 6 * * 1\`) produces a fresh \`ranking-index.json\`
- **Auto-issue workflow #656** closes stale freshness alerts once the file is fresh
- **#744–#748 should self-close** within one or two scheduled runs

## Verification

\`\`\`bash
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build-hna-data.yml'))"
YAML OK
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)