### PR TITLE
fix(hna): disclose county-scaled AMI mix on comparison page

### DIFF
--- a/js/hna/hna-comparison.js
+++ b/js/hna/hna-comparison.js
@@ -710,6 +710,34 @@
     var html = '<div class="hca-cp-ami">';
     html += '<h4 class="hca-cp-ami__title">Recommended AMI Unit Mix <span class="hca-cp-source">HUD CHAS · AMI Gap Model</span></h4>';
 
+    // Surface the systemic county-scaling pattern: the underlying
+    // ami_gap_30pct/50pct/60pct fields in ranking-index.json are
+    // computed at the COUNTY level and proportionally scaled to
+    // sub-county geographies by population share. Result: every
+    // place/CDP in the same county shows the same mix percentages —
+    // the absolute counts differ, but the % distribution is
+    // county-level, not place-specific. Without this disclosure a
+    // user comparing two places in Mesa County (e.g. Fruita vs
+    // Clifton) would see identical mix and reasonably assume real
+    // demographic similarity, when it's actually a data artifact.
+    var typeA = String((entryA && entryA.type) || '').toLowerCase();
+    var typeB = String((entryB && entryB.type) || '').toLowerCase();
+    var anyProxy = (typeA === 'place' || typeA === 'cdp' ||
+                    typeB === 'place' || typeB === 'cdp');
+    if (anyProxy) {
+      html += '<div class="hca-cp-ami__proxy-note" role="note" style="' +
+        'margin:0 0 .75rem;padding:.5rem .75rem;border-left:3px solid var(--warn,#d97706);' +
+        'border-radius:0 4px 4px 0;background:var(--warn-dim,#fef3c7);' +
+        'font-size:.78rem;line-height:1.45;color:var(--text);">' +
+        '<strong style="color:var(--warn,#d97706);">⚠ Mix percentages are county-scaled, not place-specific.</strong> ' +
+        'The HUD CHAS / AMI Gap Model publishes its tier breakdown at county granularity. ' +
+        'For places and CDPs we proportionally scale county totals by renter population — so every ' +
+        'place/CDP in the same county shows the same percentage distribution (only absolute counts differ). ' +
+        'Use the totals for sizing and the percentages for directional context only — actual per-place mix ' +
+        'may vary materially within a county.' +
+      '</div>';
+    }
+
     // Stacked bar comparison
     html += '<div class="hca-cp-ami__bars">';
     [{ label: 'A', mix: mixA, entry: entryA, cls: 'a' },


### PR DESCRIPTION
## The systemic problem (verified)

The \"Recommended AMI Unit Mix\" panel on \`hna-comparative-analysis.html\` shows **identical percentage distributions for every sub-county geography in the same county**:

\`\`\`
Mesa County (08077) — 10 sub-county geos:
  Grand Junction       47.7 / 35.6 / 16.7
  Clifton (CDP)        47.7 / 35.6 / 16.7
  Fruita (city)        47.7 / 35.7 / 16.7
  ... (all 10 within ±0.1%)

Boulder County (08013) — 31 sub-county geos:
  Boulder, Longmont, Lafayette, Louisville, Niwot...
  All show 47.3 / 35.7 / 17.0
\`\`\`

**Root cause:** \`scripts/hna/build_ranking_index.py\` computes \`ami_gap_30pct/50pct/60pct\` at the **county level** and proportionally scales them to sub-county geos by renter population share. Absolute counts differ but the percentage distribution is identical — slices of the same county pie.

A user comparing two demographically-different places in the same county (Fruita = suburban working-class, Clifton = poorer rural CDP) sees identical mix and reasonably assumes real similarity. It's a data artifact.

## What this PR ships

The honesty layer: when either side of the comparison is a \`place\` or \`cdp\`, render an inline warn-color banner above the AMI Mix section explaining the percentages are county-scaled, not place-specific.

Same disclosure pattern as #733 (CHAS gap chart on housing-needs-assessment.html). Silent for county-vs-county comparisons.

## What this does NOT do

The proper fix — replacing the proportional-scaling hack with HUD CHAS tract-level aggregation mapped to places via Census place-tract crosswalks — is a separate, larger data-pipeline project (~1-2 days). That work would replace the ranking-index build's per-place AMI gaps with real per-place data so percentages actually vary across places in the same county.

For now: **stop showing dishonest place-specific numbers as if they were real.** Add the disclosure. Build the proper data path next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)