### PR TITLE
feat(site-score): scoreAccess uses PMA transit composite when available

### DIFF
--- a/js/market-analysis/market-analysis-controller.js
+++ b/js/market-analysis/market-analysis-controller.js
@@ -793,6 +793,27 @@
             ' — ' + policyMetrics.overlayCount + ' supportive overlays, score=' + policyMetrics.totalScore);
         }
 
+        // ── PMA transit metrics — wire the real transit composite into
+        // scoreAccess instead of relying solely on nearest-stop distance.
+        // PMATransit.calculateTransitScore() (called by the PMA runner
+        // when present) blends frequency, coverage, and EPA SLD walk-to-
+        // transit; its output captures bus + rail service quality, not
+        // just proximity. When the runner hasn't been invoked or PMATransit
+        // isn't loaded, leave transitMetrics undefined and scoreAccess
+        // falls back to the legacy distance proxy.
+        var transitMetrics = null;
+        if (typeof window !== 'undefined' && window.PMATransit &&
+            typeof window.PMATransit.getTransitJustification === 'function') {
+          var tj = _safe(function () { return window.PMATransit.getTransitJustification(); }, null);
+          if (tj && typeof tj.transitAccessibilityScore === 'number') {
+            transitMetrics = {
+              transitAccessibilityScore: tj.transitAccessibilityScore,
+              nearbyRouteCount:          tj.nearbyRouteCount,
+              hasHighFrequencyService:   tj.hasHighFrequencyService
+            };
+          }
+        }
+
         // Build scoring inputs from available data.
         var inputs = {
           acs:              acs,
@@ -805,6 +826,7 @@
           cleanupFlag:      ejiMetrics.riskCategory === 'high',
           amenities:        amenityInputs,
           walkabilityCtx:   walkabilityCtx,
+          transitMetrics:   transitMetrics,
           ejiMetrics:       ejiMetrics,
           zoningCapacity:   policyMetrics.zoningCapacity,
           publicOwnership:  policyMetrics.publicOwnership,

--- a/js/market-analysis/site-selection-score.js
+++ b/js/market-analysis/site-selection-score.js
@@ -265,12 +265,22 @@
    *   Keys: grocery, transit, parks, healthcare, schools.
    * @param {object|null} [walkabilityCtx] - From EpaWalkability.getScores().
    *   Keys: walkScore (0-100), bikeScore (0-100).
+   * @param {object|null} [transitMetrics] - From PMATransit.getTransitJustification().
+   *   Optional richer transit data than distance-based proxy. Keys:
+   *     transitAccessibilityScore (0-100) — composite from
+   *       calculateTransitScore() blending frequency + coverage + EPA index
+   *     nearbyRouteCount (number) — distinct routes within walk-to-transit dist
+   *     hasHighFrequencyService (boolean) — any nearby route ≤ 30-min headway
+   *   When present, replaces the distance-based 25-pt transit component
+   *   with a real-data-driven score. Closes the gap where map-rendered
+   *   transit routes (bus + rail) weren't influencing the composite — the
+   *   distance proxy only captured nearest-stop, not service quality.
    * @returns {{ score: number|null, unavailable: boolean, reason?: string }}
    *   When `amenities` is missing or not an object, returns
    *   `{ score: null, unavailable: true, reason: 'amenity distances unavailable' }`
    *   so the composite can redistribute this dimension's weight.
    */
-  function scoreAccess(amenities, walkabilityCtx) {
+  function scoreAccess(amenities, walkabilityCtx, transitMetrics) {
     if (!amenities || typeof amenities !== 'object') {
       return {
         score: null,
@@ -295,25 +305,36 @@
     var healthcare = _distPts(_safe(amenities.healthcare, 3), 1.0,  3.0, 20);
     var schools    = _distPts(_safe(amenities.schools,    1), 0.5,  2.0, 15);
 
-    // Transit scoring: differentiate fixed rail/tram from bus stops.
-    // Rail/tram within 0.5mi earns full points; bus requires closer proximity.
-    // Falls back to generic transit distance if no type data available.
-    var transitPts = 0;
-    var railDist  = _safe(amenities.transit_rail, 99);
-    var busDist   = _safe(amenities.transit_bus, 99);
-    var anyDist   = _safe(amenities.transit, 1);
+    // Transit scoring: prefer the real PMA transit composite when
+    // available (it accounts for bus + rail routes, headway, coverage,
+    // and EPA SLD walk-to-transit). Fall back to nearest-stop distance
+    // proxy when not.
+    var transitPts;
+    var hasRealTransitScore = transitMetrics && typeof transitMetrics === 'object' &&
+      typeof transitMetrics.transitAccessibilityScore === 'number' &&
+      isFinite(transitMetrics.transitAccessibilityScore);
 
-    if (railDist < 99) {
-      // Rail/tram: best within 0.5mi, good within 1.5mi
-      transitPts = Math.max(transitPts, _distPts(railDist, 0.5, 1.5, 25));
-    }
-    if (busDist < 99) {
-      // Bus: best within 0.25mi, good within 1mi
-      transitPts = Math.max(transitPts, _distPts(busDist, 0.25, 1.0, 20));
-    }
-    if (transitPts === 0) {
-      // No typed transit data — use generic distance (legacy behavior)
-      transitPts = _distPts(anyDist, 0.25, 1.0, 25);
+    if (hasRealTransitScore) {
+      // PMA transit composite is on a 0–100 scale; rescale to the 25-pt
+      // budget allocated to transit within scoreAccess.
+      var pmaTransit = _clamp(+transitMetrics.transitAccessibilityScore);
+      transitPts = _clamp((pmaTransit / 100) * 25);
+    } else {
+      // Distance-based fallback: differentiate fixed rail/tram from bus stops.
+      transitPts = 0;
+      var railDist  = _safe(amenities.transit_rail, 99);
+      var busDist   = _safe(amenities.transit_bus, 99);
+      var anyDist   = _safe(amenities.transit, 1);
+
+      if (railDist < 99) {
+        transitPts = Math.max(transitPts, _distPts(railDist, 0.5, 1.5, 25));
+      }
+      if (busDist < 99) {
+        transitPts = Math.max(transitPts, _distPts(busDist, 0.25, 1.0, 20));
+      }
+      if (transitPts === 0) {
+        transitPts = _distPts(anyDist, 0.25, 1.0, 25);
+      }
     }
 
     var distanceScore = _clamp(grocery + transitPts + parks + healthcare + schools);
@@ -333,7 +354,11 @@
       ));
     }
 
-    return { score: finalScore, unavailable: false };
+    return {
+      score: finalScore,
+      unavailable: false,
+      transitSource: hasRealTransitScore ? 'pma' : 'distance'
+    };
   }
 
   /**
@@ -436,7 +461,7 @@
     var W = COMPONENT_WEIGHTS;
 
     var demandResult  = scoreDemand(i.acs);
-    var accessResult  = scoreAccess(i.amenities, i.walkabilityCtx);
+    var accessResult  = scoreAccess(i.amenities, i.walkabilityCtx, i.transitMetrics);
 
     // Subsidy, feasibility, policy, market take primitive inputs — a missing
     // flag is the absence of a bonus, not the absence of measurement, so

--- a/test/unit/site-selection-score.test.js
+++ b/test/unit/site-selection-score.test.js
@@ -344,6 +344,60 @@ test('scoreAccess returns { score:null, unavailable:true } for missing input', f
     'undefined → { score:null, unavailable:true }');
 });
 
+// ── transitMetrics: PMA transit composite replaces distance proxy ─────
+
+test('scoreAccess uses PMA transitMetrics when provided (transitSource: pma)', function () {
+  const farAmenities = {
+    grocery: 99, transit: 99, parks: 99, healthcare: 99, schools: 99
+  };
+  // Without transitMetrics: distance proxy → 0 (everything far)
+  const distOnly = SSS.scoreAccess(farAmenities);
+  assert(distOnly.score === 0,                        'no metrics + far amenities → 0');
+  assert(distOnly.transitSource === 'distance',       'transitSource: distance');
+
+  // With a strong PMA transit score, transit contributes 25 pts max
+  const withPmaHigh = SSS.scoreAccess(farAmenities, null,
+    { transitAccessibilityScore: 100, nearbyRouteCount: 12, hasHighFrequencyService: true });
+  assert(withPmaHigh.score === 25,
+    'PMA score=100 → 25 transit pts (got ' + withPmaHigh.score + ')');
+  assert(withPmaHigh.transitSource === 'pma',         'transitSource: pma');
+
+  const withPmaMid = SSS.scoreAccess(farAmenities, null,
+    { transitAccessibilityScore: 60 });
+  // 60/100 * 25 = 15 pts
+  assert(withPmaMid.score === 15,
+    'PMA score=60 → 15 transit pts (got ' + withPmaMid.score + ')');
+});
+
+test('scoreAccess: missing transitAccessibilityScore falls back to distance', function () {
+  const amenities = { grocery: 0.4, transit: 0.2, parks: 0.2, healthcare: 0.9, schools: 0.4 };
+  // transitMetrics provided but without transitAccessibilityScore — falls back
+  const fallback = SSS.scoreAccess(amenities, null,
+    { nearbyRouteCount: 12, hasHighFrequencyService: true });
+  assert(fallback.transitSource === 'distance',
+    'metrics without numeric transitAccessibilityScore → distance fallback');
+
+  // null/undefined transitMetrics → distance
+  const nullM = SSS.scoreAccess(amenities, null, null);
+  assert(nullM.transitSource === 'distance', 'null → distance');
+  const noArg = SSS.scoreAccess(amenities, null);
+  assert(noArg.transitSource === 'distance', 'omitted → distance');
+});
+
+test('scoreAccess: PMA transit + walkability blend correctly', function () {
+  const amenities = { grocery: 99, transit: 99, parks: 99, healthcare: 99, schools: 99 };
+  const result = SSS.scoreAccess(
+    amenities,
+    { walkScore: 80, bikeScore: 80 },
+    { transitAccessibilityScore: 100 }
+  );
+  // distanceScore = 25 (transit only, all else far)
+  // finalScore = 25 * 0.55 + 80 * 0.25 + 80 * 0.20 = 13.75 + 20 + 16 = 49.75 → 50
+  assert(result.score === 50,
+    'PMA transit (25) + walk/bike (80) blend = 50 (got ' + result.score + ')');
+  assert(result.transitSource === 'pma',          'transitSource preserved through blend');
+});
+
 // ---------------------------------------------------------------------------
 // 17. scorePolicy — public ownership bonus
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The gap

\`PMATransit.calculateTransitScore()\` builds a real 0–100 transit composite from local GTFS + EPA SLD data (frequency, coverage, walk-to-transit). It runs as part of every PMA analysis and stores its output to \`window.PMATransit.getTransitJustification().transitAccessibilityScore\`.

**But the headline SiteSelectionScore composite was computing access from amenity DISTANCES only.** The 25-pt transit budget within \`scoreAccess\` used nearest-stop distance to bus/rail, ignoring the real composite.

Net effect: bus routes visible on the map with their actual headways/coverage didn't influence the headline score. This is the \"transit scoring not working\" complaint — the module **was** computing real numbers, the access scorer was just throwing them away.

## What this PR ships

\`scoreAccess()\` now accepts an optional 3rd arg:

\`\`\`js
transitMetrics: {
  transitAccessibilityScore: number,  // 0–100 from PMATransit
  nearbyRouteCount:          number,
  hasHighFrequencyService:   boolean
}
\`\`\`

When `transitAccessibilityScore` is a finite number, it replaces the 25-pt distance-based transit component:

\`\`\`
transitPts = (transitAccessibilityScore / 100) × 25
\`\`\`

When absent, falls back to the existing distance proxy. Output now exposes \`transitSource: 'pma' | 'distance'\` for telemetry.

The market-analysis controller reads \`PMATransit.getTransitJustification()\` before each \`computeScore()\` call and passes the metrics through.

## Tests

**102/102 passing** in \`test/unit/site-selection-score.test.js\` (was 92; +10 new assertions across 3 new tests):

- PMA score 100 → 25 transit pts (max)
- PMA score 60 → 15 transit pts (linear)
- transitMetrics without \`transitAccessibilityScore\` → distance fallback
- null / undefined transitMetrics → distance fallback (back-compat preserved)
- PMA transit + walkability blend produces correct combined score

## Score impact in practice

Conservative: the transit budget stays 25 pts (out of 100 in \`scoreAccess\`). I'm not boosting transit's weight — just replacing a thin proxy with a richer signal. Sites with good bus service get small bumps; sites with poor service get small dings. Both directions reflect reality better than distance alone.

## What's NOT in this PR

The audit also found schools, employment centers, parcel zoning, infrastructure, and barriers data on the map but not in the score. Each is a separate, larger PR. This one closes the most user-visible complaint with the smallest blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)