### PR TITLE
fix(hna,site-score): honor ?auto=1 URL override and tighten vacancy ceiling

### DIFF
--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -2155,8 +2155,22 @@
     let restoredGeoType = null;
     let restoredGeoId   = null;
 
+    // Priority 0: Explicit URL override (?auto=1 from comparative analysis links).
+    // When the user clicks a "View HNA" link from another page, the link sets
+    // ?auto=1 to signal "honor these URL params even if WorkflowState has a
+    // different stale jurisdiction selected." Without this, clicking a link
+    // for Fruita while WorkflowState holds Boulder would silently load Boulder.
+    const urlParams = new URLSearchParams(window.location.search);
+    const urlAutoFlag = urlParams.get('auto') === '1';
+    const urlGeoType = urlParams.get('geoType');
+    const urlGeoid   = urlParams.get('geoid') || urlParams.get('fips');
+    if (urlAutoFlag && urlGeoType && urlGeoid) {
+      restoredGeoType = urlGeoType === 'cdp' ? 'place' : urlGeoType;
+      restoredGeoId   = urlGeoid;
+    }
+
     // Priority 1: WorkflowState (set by select-jurisdiction.html)
-    if (window.WorkflowState && typeof window.WorkflowState.getJurisdiction === 'function') {
+    if (!restoredGeoType && window.WorkflowState && typeof window.WorkflowState.getJurisdiction === 'function') {
       const jx = window.WorkflowState.getJurisdiction();
       if (jx && jx.fips) {
         if (jx.type === 'city' && jx.displayName) {
@@ -2191,15 +2205,12 @@
       }
     }
 
-    // Priority 2: URL parameters (geoType + geoid from comparative analysis redirect)
-    if (!restoredGeoType) {
-      const urlParams = new URLSearchParams(window.location.search);
-      const urlGeoType = urlParams.get('geoType');
-      const urlGeoid   = urlParams.get('geoid') || urlParams.get('fips');
-      if (urlGeoType && urlGeoid) {
-        restoredGeoType = urlGeoType === 'cdp' ? 'place' : urlGeoType; // CDPs use 'place' geoType selector
-        restoredGeoId   = urlGeoid;
-      }
+    // Priority 2: URL parameters without explicit auto flag (legacy fallback).
+    // Reuses the urlParams parsed at Priority 0 — only fires when WorkflowState
+    // wasn't set and the URL had geoType+geoid but no auto=1 marker.
+    if (!restoredGeoType && urlGeoType && urlGeoid) {
+      restoredGeoType = urlGeoType === 'cdp' ? 'place' : urlGeoType; // CDPs use 'place' geoType selector
+      restoredGeoId   = urlGeoid;
     }
 
     // Priority 3: SiteState.getGeography (sub-county selection from comparative analysis)

--- a/js/market-analysis/site-selection-score.js
+++ b/js/market-analysis/site-selection-score.js
@@ -604,9 +604,12 @@
       };
     }
     var vac = _safe(acs.vacancy_rate, 0.05);
-    // Very low vacancy (<1%) → score ≈ 92; at 12%+ vacancy → score ≈ 0.
+    // Very low vacancy (<1%) → score ≈ 90; at 10%+ vacancy → score ≈ 0.
+    // 10% is the threshold where lease-up risk and absorption pace begin to
+    // materially threaten LIHTC underwriting. Above this, the market signals
+    // either oversupply or weak demand — neither is a healthy site.
     return {
-      score: _clamp(Math.round((1 - vac / 0.12) * 100)),
+      score: _clamp(Math.round((1 - vac / 0.10) * 100)),
       unavailable: false
     };
   }

--- a/test/pma-scoring.test.js
+++ b/test/pma-scoring.test.js
@@ -79,7 +79,9 @@ function scoreRentPressure(acs) {
 
 function scoreLandSupply(acs) {
   const vac = acs.vacancy_rate || 0;
-  return Math.max(0, Math.min(100, (1 - vac / 0.12) * 100));
+  // Mirror site-selection-score.js: 10% vacancy is the ceiling where lease-up
+  // risk and absorption pace materially threaten LIHTC underwriting.
+  return Math.max(0, Math.min(100, (1 - vac / 0.10) * 100));
 }
 
 function scoreWorkforce() { return 60; }


### PR DESCRIPTION
## Summary
- **HNA URL-param priority.** New Priority 0 honors `?auto=1` URL params over stale WorkflowState. Previously, clicking a "View HNA" link for Fruita while WorkflowState held Boulder silently loaded Boulder. The `?auto=1` flag is the explicit "honor these params" contract that comparative-analysis links already emit.
- **Site-selection vacancy ceiling.** `scoreLandSupply` ceiling tightened from 12% to 10% vacancy. 10% is the underwriting threshold where lease-up risk and absorption pace materially threaten LIHTC deals — above that, the market signals oversupply or weak demand. `scoreLandSupplyWithBridge` inherits the change via its base call.

## Test plan
- [x] `node test/unit/site-selection-score.test.js` — 102/102 pass
- [x] `node test/pma-scoring.test.js` — 38/38 pass (local-copy ceiling mirrored)
- [ ] Manual: from comparative-analysis, click "View HNA" for a place that differs from current WorkflowState → confirm correct place loads, not the stored one
- [ ] Manual: spot-check a few places' Site Selection Score panel — markets with 5–8% vacancy should now score lower than before, 10%+ should score 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)