### PR TITLE
chore(ci): use npm ci instead of npm install in 5 auxiliary workflows

### DIFF
--- a/.github/workflows/archive-audit-post-merge.yml
+++ b/.github/workflows/archive-audit-post-merge.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: '20'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run audit/archive/docs automation
         run: node scripts/sync-docs.mjs

--- a/.github/workflows/cache-hud-gis-data.yml
+++ b/.github/workflows/cache-hud-gis-data.yml
@@ -57,7 +57,7 @@ jobs:
           echo "  Run ID     : $GITHUB_RUN_ID"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Fetch HUD QCT data (Colorado)
         run: |

--- a/.github/workflows/console-error-audit.yml
+++ b/.github/workflows/console-error-audit.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Install Playwright browsers
         run: npx playwright install chromium --with-deps

--- a/.github/workflows/contrast-audit.yml
+++ b/.github/workflows/contrast-audit.yml
@@ -43,7 +43,7 @@ jobs:
           echo "  Run ID     : $GITHUB_RUN_ID"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Install Playwright browsers
         run: npx playwright install chromium --with-deps

--- a/.github/workflows/site-audit.yml
+++ b/.github/workflows/site-audit.yml
@@ -22,7 +22,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Install Playwright browsers
         run: npm run audit:install


### PR DESCRIPTION
Follow-up to the jsdom-version-drift incident on 2026-05-08. \`ci-checks.yml\` (the workflow running the actual test suite, including all jsdom-using tests) was already using \`npm ci\`, so CI was never at risk. This PR brings the 5 remaining npm-using workflows into the same lockfile-enforced regime for consistency.

## Changes

| Workflow | Before | After |
|---|---|---|
| archive-audit-post-merge.yml | \`npm install\` | \`npm ci\` |
| cache-hud-gis-data.yml | \`npm install\` | \`npm ci\` |
| console-error-audit.yml | \`npm install\` | \`npm ci\` |
| contrast-audit.yml | \`npm install\` | \`npm ci\` |
| site-audit.yml | \`npm install\` | \`npm ci\` |

Three workflows intentionally untouched:
- \`daily-audit-system.yml\` already uses \`npm ci --ignore-scripts\`
- \`fetch-county-data.yml\` uses \`npm install --omit=dev node-fetch@2\` (single-package install, not lockfile-managed)
- \`test-sentinel-normalization.yml\` already uses \`npm ci\`

## Why

\`npm ci\` enforces an exact match against \`package-lock.json\` and refuses to silently mutate it; \`npm install\` reconciles the manifest and can introduce lockfile drift between local dev and CI.

Benefits:
- ✅ CI installs are reproducible from the lockfile every run
- ✅ Lockfile/manifest drift fails loud (\`npm ci\`) instead of silently rewriting (\`npm install\`)
- ✅ ~30% faster installs (\`npm ci\` skips manifest reconciliation)

Risk:
- If any of these workflows depended on a transient dep not in the lockfile, \`npm ci\` would break. None observed in code review; the listed devDependencies in \`package.json\` cover what each workflow needs.

## Test plan
- [ ] PR's own CI run verifies the changed workflows still install successfully on Ubuntu 24
- [ ] Spot-check post-merge: cache-hud-gis-data scheduled run completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)