### PR TITLE
feat(data): CDPHE county boundaries (second independent source)

### DIFF
--- a/.github/workflows/fetch-cdphe-boundaries.yml
+++ b/.github/workflows/fetch-cdphe-boundaries.yml
@@ -1,0 +1,52 @@
+name: Fetch CDPHE County Boundaries
+
+# Refreshes data/market/cdphe_county_boundaries_co.geojson from the CDPHE
+# Open Data Portal. CDPHE updates these boundaries rarely (annual at most),
+# so the cron is monthly — frequent enough to catch changes within a
+# reasonable window without unnecessary API hits.
+#
+# This file is the SECOND, INDEPENDENT county boundary source (TIGER is
+# primary at data/co-county-boundaries.json). See the file's header
+# comment in scripts/market/fetch_cdphe_county_boundaries.py for why
+# both sources are kept.
+
+on:
+  schedule:
+    - cron: '0 3 1 * *'   # 1st of each month, 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: data-commits
+  cancel-in-progress: false
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Fetch CDPHE county boundaries
+        run: |
+          echo "── Fetching CDPHE county boundaries ──"
+          python3 scripts/market/fetch_cdphe_county_boundaries.py
+
+      - name: Plausibility check (matches TIGER)
+        run: |
+          echo "── Cross-source plausibility check ──"
+          python3 -m pytest \
+            tests/test_data_plausibility.py::test_cdphe_boundaries_match_tiger_county_count \
+            -v
+
+      - name: Commit and push
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/market/cdphe_county_boundaries_co.geojson
+          git diff --cached --quiet || git commit -m "chore: refresh CDPHE county boundaries $(date -u +'%Y-%m-%d')"
+          git fetch origin main
+          git merge --strategy=ours -m "Merge main (keeping refreshed CDPHE boundaries)" origin/main || true
+          git push

--- a/docs/DATA-SOURCES.md
+++ b/docs/DATA-SOURCES.md
@@ -135,6 +135,21 @@ Tier 2: cfg.PROP123_API_URL (if set in APP_CONFIG)
 Geometry: Census TIGERweb ArcGIS (public; 20s timeout)
 ```
 
+#### CDPHE County Boundaries — `data/market/cdphe_county_boundaries_co.geojson`
+```
+Source:       CDPHE Open Data Portal (Colorado Department of Public Health & Environment)
+ArcGIS Item:  66c2642209684b90af84afcc559a5a02 (owner: CDPHE_user_community)
+Endpoint:     www.cohealthmaps.dphe.state.co.us/.../cdphe_geographic_analysis_boundaries/MapServer/5
+Refresh:      Monthly (cron: 0 3 1 * *) — boundaries change rarely; see fetch-cdphe-boundaries.yml
+Auth:         Public; no key required
+Purpose:      Independent county boundary source for cross-validation against TIGER
+              (data/co-county-boundaries.json). Also carries CDPHE-specific attributes
+              (CENT_LAT/LONG centroids; link to Health Statistics Regions) useful for
+              healthcare-access proxies in PMA scoring.
+Plausibility: tests/test_data_plausibility.py::test_cdphe_boundaries_match_tiger_county_count
+              asserts CDPHE features = TIGER features = 64 + identical FIPS list
+```
+
 ---
 
 ## Redundancy Analysis

--- a/scripts/audit/data-freshness-check.mjs
+++ b/scripts/audit/data-freshness-check.mjs
@@ -47,6 +47,7 @@ const SLA_CONFIG = [
   { file: 'data/market/nhpd_co.geojson',                    slaDays: 95,  cadence: 'quarterly (NHPD export)' },
   { file: 'data/co_ami_gap_by_county.json',                 slaDays: 95,  cadence: 'quarterly (AMI gap build)' },
   { file: 'data/co_ami_gap_by_place.json',                  slaDays: 9,   cadence: 'weekly (build-hna-data.yml Phase 6.5)' },
+  { file: 'data/market/cdphe_county_boundaries_co.geojson', slaDays: 400, cadence: 'annual (CDPHE boundary refresh)' },
 ];
 
 // Fields to probe for an in-file "updated" timestamp, in priority order.

--- a/scripts/market/fetch_cdphe_county_boundaries.py
+++ b/scripts/market/fetch_cdphe_county_boundaries.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+scripts/market/fetch_cdphe_county_boundaries.py
+
+Fetch Colorado county boundaries from the CDPHE (Colorado Department of
+Public Health and Environment) Open Data Portal.
+
+Why CDPHE in addition to TIGER?
+-------------------------------
+The repo already has TIGER-derived county boundaries at
+``data/co-county-boundaries.json`` and ``data/boundaries/counties_co.geojson``.
+CDPHE's version is provided here as a SECOND, INDEPENDENT source for two
+purposes:
+
+  1. **Cross-validation** — when a CHAS / ACS / DOLA build produces
+     unexpected county aggregates, having two independent boundary files
+     lets us bisect: "is the discrepancy in the data, or in the geometry?"
+     A CDPHE boundary that disagrees with TIGER is a strong signal that
+     a county-level join is mis-keyed.
+
+  2. **Health-region attributes** — CDPHE's feature class carries
+     additional attributes (CENT_LAT, CENT_LONG centroid coords; the
+     ability to join to CDPHE's Health Statistics Regions) not present
+     in TIGER. Useful for healthcare-access proxies in PMA scoring.
+
+Output
+------
+    data/market/cdphe_county_boundaries_co.geojson  — 64 CO counties
+
+Source
+------
+CDPHE Open Data Portal — "Colorado County Boundaries" feature class.
+Resolved via ArcGIS ItemID 66c2642209684b90af84afcc559a5a02 to the
+authoritative MapServer at:
+
+    https://www.cohealthmaps.dphe.state.co.us/arcgis/rest/services/
+    OPEN_DATA/cdphe_geographic_analysis_boundaries/MapServer/5
+
+Usage
+-----
+    python3 scripts/market/fetch_cdphe_county_boundaries.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+OUT_FILE = ROOT / "data" / "market" / "cdphe_county_boundaries_co.geojson"
+
+# Resolved from ArcGIS Item 66c2642209684b90af84afcc559a5a02
+CDPHE_BOUNDARIES_URL = (
+    "https://www.cohealthmaps.dphe.state.co.us/arcgis/rest/services/"
+    "OPEN_DATA/cdphe_geographic_analysis_boundaries/MapServer/5/query"
+    "?where=1=1&outFields=*&f=geojson"
+)
+TIMEOUT = 60
+EXPECTED_COUNT = 64  # All CO counties; deviation = upstream issue
+
+USER_AGENT = "HousingAnalytics/1.0 fetch_cdphe_county_boundaries.py"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def http_get_json(url: str) -> dict:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def main() -> int:
+    print(f"Fetching CDPHE county boundaries from {CDPHE_BOUNDARIES_URL}...")
+    try:
+        raw = http_get_json(CDPHE_BOUNDARIES_URL)
+    except Exception as err:  # noqa: BLE001
+        print(f"✗ Fetch failed: {err}", file=sys.stderr)
+        return 1
+
+    features = raw.get("features", [])
+    print(f"  Got {len(features)} features")
+    if len(features) != EXPECTED_COUNT:
+        print(
+            f"⚠ Expected {EXPECTED_COUNT} CO counties; got {len(features)}. "
+            f"Check upstream for boundary changes.",
+            file=sys.stderr,
+        )
+
+    # Normalize: ensure each feature carries a 5-digit county FIPS as
+    # `properties.county_fips5`. CDPHE ships US_FIPS as 5-digit string,
+    # but we set the canonical key explicitly so downstream consumers
+    # don't have to know the upstream column naming.
+    for f in features:
+        props = f.setdefault("properties", {})
+        us_fips = str(props.get("US_FIPS", "")).strip().zfill(5)
+        props["county_fips5"] = us_fips
+        # Stable name fallback chain
+        props["county_name"] = (
+            props.get("FULL")
+            or props.get("LABEL")
+            or props.get("COUNTY")
+            or ""
+        )
+
+    # Sort by FIPS for deterministic output (helps git diff readability)
+    features.sort(key=lambda f: f.get("properties", {}).get("county_fips5", ""))
+
+    output = {
+        "type": "FeatureCollection",
+        "meta": {
+            "source": "CDPHE Open Data Portal — Colorado County Boundaries",
+            "url": CDPHE_BOUNDARIES_URL,
+            "arcgis_item_id": "66c2642209684b90af84afcc559a5a02",
+            "owner": "CDPHE_user_community",
+            "generated": utc_now(),
+            "feature_count": len(features),
+            "note": (
+                "Independent county boundary source for cross-validation. "
+                "Primary boundary file is data/co-county-boundaries.json "
+                "(TIGER-derived). Use this file for: (1) cross-checking "
+                "county-level join results, (2) accessing CDPHE-specific "
+                "attributes (CENT_LAT/LONG centroids, link to Health "
+                "Statistics Regions)."
+            ),
+        },
+        "features": features,
+    }
+
+    OUT_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(OUT_FILE, "w", encoding="utf-8") as f:
+        json.dump(output, f, ensure_ascii=False)
+    print(f"✓ Wrote {len(features)} county boundaries to {OUT_FILE}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_data_plausibility.py
+++ b/tests/test_data_plausibility.py
@@ -367,6 +367,46 @@ def test_ranking_ami_source_flag_present(ranking):
     assert not missing, f'{len(missing)} entries missing _ami_gap_source flag'
 
 
+# ── Cross-source: CDPHE county boundaries vs TIGER ──────────────────
+
+def test_cdphe_boundaries_match_tiger_county_count():
+    """CDPHE Open Data Portal county boundaries should have 64 features
+    matching TIGER's count exactly. Catches: incomplete fetch, upstream
+    boundary change, FIPS mismatch."""
+    cdphe = _load('data/market/cdphe_county_boundaries_co.geojson')
+    tiger = _load('data/co-county-boundaries.json')
+
+    cdphe_count = len(cdphe.get('features', []))
+    tiger_count = len(tiger.get('features', []))
+
+    assert cdphe_count == 64, f'CDPHE county count = {cdphe_count}; expected 64'
+    assert tiger_count == 64, f'TIGER county count = {tiger_count}; expected 64'
+
+    cdphe_fips = sorted(
+        f['properties'].get('county_fips5', '')
+        for f in cdphe['features']
+    )
+    # TIGER feature properties vary; try a few likely keys
+    def _tiger_fips(props):
+        for k in ('GEOID', 'FIPS', 'fips', 'COUNTYFP', 'GEOID20'):
+            v = props.get(k)
+            if v:
+                v = str(v)
+                # GEOID is 5-digit (state+county); COUNTYFP alone is 3-digit
+                return v.zfill(5) if len(v) == 5 else f'08{v.zfill(3)}'
+        return ''
+    tiger_fips = sorted(
+        _tiger_fips(f.get('properties', {}))
+        for f in tiger['features']
+    )
+
+    assert cdphe_fips == tiger_fips, (
+        f'CDPHE FIPS list does not match TIGER FIPS list. '
+        f'CDPHE-only: {set(cdphe_fips) - set(tiger_fips)}; '
+        f'TIGER-only: {set(tiger_fips) - set(cdphe_fips)}'
+    )
+
+
 # NOTE: _chas_source flag was previously present (PR #769 foundation work)
 # but was removed when #769 was closed in favor of the simpler #770 Table 7
 # fix. CHAS for places is unconditionally county-inherited at present, so


### PR DESCRIPTION
First of the new-data-source PRs from the audit follow-up. Demonstrates the QA-hardening pattern (#773) end-to-end on a small surface area.

## What this adds

| File | Purpose |
|---|---|
| \`scripts/market/fetch_cdphe_county_boundaries.py\` | Fetch script for CDPHE feature class |
| \`data/market/cdphe_county_boundaries_co.geojson\` | 64 CO county boundaries (generated) |
| \`.github/workflows/fetch-cdphe-boundaries.yml\` | Monthly cron refresh |
| \`tests/test_data_plausibility.py\` | Cross-source test (CDPHE = TIGER count + FIPS) |
| \`scripts/audit/data-freshness-check.mjs\` | Freshness SLA entry (400 days) |
| \`docs/DATA-SOURCES.md\` | Documentation |

## Why a second boundary source?

The repo already has TIGER boundaries at \`data/co-county-boundaries.json\`. CDPHE adds value as:

1. **Independent cross-validation** — when CHAS/ACS/DOLA aggregates produce unexpected county-level joins, having two independent geometries lets us bisect "data bug vs geometry bug"
2. **CDPHE-specific attributes** — CENT_LAT/CENT_LONG centroids + link to CDPHE Health Statistics Regions, useful for PMA healthcare-access proxies

## Source

CDPHE Open Data Portal — \"Colorado County Boundaries\" feature class.
- ArcGIS ItemID: \`66c2642209684b90af84afcc559a5a02\`
- Owner: \`CDPHE_user_community\`
- Endpoint: \`www.cohealthmaps.dphe.state.co.us/.../cdphe_geographic_analysis_boundaries/MapServer/5\`
- Public; no auth required

## Plausibility test

\`tests/test_data_plausibility.py::test_cdphe_boundaries_match_tiger_county_count\` asserts:
- Both files have exactly 64 features
- The sorted FIPS list matches across both sources

If CDPHE drops a county or renames a FIPS column, this test fails at PR time.

## Test results

- \`pytest tests/\` → **423 pass** (+1 new test)
- \`data-freshness-check.mjs\` → 11/11 OK including the new file

## Test plan

- [x] \`python3 scripts/market/fetch_cdphe_county_boundaries.py\` produces 64 features
- [x] Output geometry valid GeoJSON; properties carry normalized county_fips5
- [x] Plausibility test passes
- [x] Freshness check picks up the new file
- [ ] Manual: trigger the workflow once via \`gh workflow run fetch-cdphe-boundaries.yml\` and confirm the auto-commit lands

## Follow-up (separate PRs)

- DOLA ACS spreadsheets (fills 31-place ACS coverage gap)
- data.colorado.gov broader catalog (eviction filings, HMDA)
- tax.colorado.gov GIS-API (sales-tax-rate boundaries — lower priority)
- Phase 4: upstream schema snapshots + QA visibility dashboard
- Phase 5: upstream-vintage tracker + reference docs mirror

🤖 Generated with [Claude Code](https://claude.com/claude-code)