### PR TITLE
feat(transit): expand CO transit coverage from 4 to 55 agencies via Mobility Database catalog

### DIFF
--- a/scripts/audit/data-freshness-check.mjs
+++ b/scripts/audit/data-freshness-check.mjs
@@ -48,6 +48,7 @@ const SLA_CONFIG = [
   { file: 'data/co_ami_gap_by_county.json',                 slaDays: 95,  cadence: 'quarterly (AMI gap build)' },
   { file: 'data/co_ami_gap_by_place.json',                  slaDays: 9,   cadence: 'weekly (build-hna-data.yml Phase 6.5)' },
   { file: 'data/market/cdphe_county_boundaries_co.geojson', slaDays: 400, cadence: 'annual (CDPHE boundary refresh)' },
+  { file: 'data/market/transit_routes_co.geojson',          slaDays: 95,  cadence: 'monthly (GTFS feed refresh from Mobility Database)' },
 ];
 
 // Fields to probe for an in-file "updated" timestamp, in priority order.

--- a/scripts/market/fetch_gtfs_transit.py
+++ b/scripts/market/fetch_gtfs_transit.py
@@ -2,23 +2,48 @@
 """
 scripts/market/fetch_gtfs_transit.py
 
-Fetch Colorado transit route data from GTFS feeds published by Colorado
-transit agencies via the National Transit Database (NTD) and agency portals.
+Fetch Colorado transit route data from GTFS feeds published by ALL Colorado
+transit agencies — sourced dynamically from the Mobility Database catalog
+(formerly the TransitFeeds.com / Google Transit feed registry).
 
-Primary sources:
-  - RTD (Denver Regional Transit) — GTFS feed
-  - Bustang (CDOT intercity bus) — GTFS feed
-  - Additional Front Range agencies
+Background — why catalog-driven instead of hardcoded list
+----------------------------------------------------------
+The pre-2026-05-08 version of this script had 5 hand-curated agency feeds
+(RTD, Bustang, Mountain Metro, Transfort, Greeley-Evans) — but Mountain
+Metro's URL was dead, leaving only 4 working agencies in production
+data. That covered <5% of CO transit (RTD + 3 small Front Range systems).
 
-Output:
+The Mobility Database (https://mobilitydata.org/) maintains a registry
+of ~88 active CO GTFS feeds covering: Mountain Metropolitan (Colorado
+Springs, ~700K pop), Roaring Fork Transportation Authority (Aspen/
+Glenwood), Eagle County (Vail), Summit Stage (Breckenridge), Pueblo
+Transit, Vail Transit, Steamboat Springs, Durango Transit, Mountain
+Express (Crested Butte), Town of Telluride, plus ~20 senior /
+dial-a-ride / county-level services across rural CO.
+
+This script reads the MDB catalog dynamically, filters to CO active
+feeds, and fetches each. Per-feed timeouts + graceful failure mean
+one broken feed doesn't sink the whole run. Final output is a single
+merged GeoJSON FeatureCollection.
+
+Sources
+-------
+  - Mobility Database catalog: https://bit.ly/catalogs-csv (CSV mirror;
+    redirects to GitHub raw URL maintained by mobilitydata.org)
+  - Each agency's GTFS .zip from the `urls.latest` column
+
+Output
+------
     data/market/transit_routes_co.geojson
 
-Usage:
+Usage
+-----
     python3 scripts/market/fetch_gtfs_transit.py
-
-All sources are free and publicly accessible without authentication.
+    python3 scripts/market/fetch_gtfs_transit.py --max-agencies 10  # for testing
+    python3 scripts/market/fetch_gtfs_transit.py --use-cache         # use cached catalog
 """
 
+import argparse
 import csv
 import io
 import json
@@ -41,34 +66,67 @@ STATE_FIPS = "08"
 CACHE_DIR = Path(os.environ.get("TMPDIR", "/tmp")) / "pma_gtfs_cache"
 CACHE_TTL_HOURS = 168  # 1 week
 
-# Colorado transit agency GTFS feeds (public)
-GTFS_FEEDS = [
-    {
-        "agency": "RTD Denver",
-        "agency_id": "rtd",
-        "url": "https://www.rtd-denver.com/files/gtfs/google_transit.zip",
-    },
-    {
-        "agency": "Bustang (CDOT)",
-        "agency_id": "bustang",
-        "url": "https://www.rtd-denver.com/files/gtfs/bustang-co-us.zip",
-    },
-    {
-        "agency": "Mountain Metropolitan Transit",
-        "agency_id": "mountain_metro",
-        "url": "https://coloradosprings.gov/sites/default/files/google_transit_0.zip",
-    },
-    {
-        "agency": "Transfort (Fort Collins)",
-        "agency_id": "transfort",
-        "url": "https://ridetransfort.com/wp-content/uploads/transfort_gtfs.zip",
-    },
-    {
-        "agency": "Greeley-Evans Transit",
-        "agency_id": "get",
-        "url": "https://data.trilliumtransit.com/gtfs/greeleyevans-co-us/greeleyevans-co-us.zip",
-    },
-]
+# Mobility Database catalog. Stable redirect to the latest CSV.
+# Mirror: https://github.com/MobilityData/mobility-database-catalogs
+MDB_CATALOG_URL = "https://bit.ly/catalogs-csv"
+MDB_CACHE_FILE = CACHE_DIR / "mdb_catalog.csv"
+
+
+def fetch_mdb_catalog(use_cache: bool = False) -> str:
+    """Fetch the Mobility Database catalog CSV. Caches under TMPDIR."""
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    if use_cache and MDB_CACHE_FILE.exists():
+        log(f"Using cached MDB catalog: {MDB_CACHE_FILE}")
+        return MDB_CACHE_FILE.read_text()
+    log(f"Fetching MDB catalog from {MDB_CATALOG_URL}...")
+    req = urllib.request.Request(
+        MDB_CATALOG_URL,
+        headers={"User-Agent": "HousingAnalytics/1.0 fetch_gtfs_transit.py"},
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        text = resp.read().decode("utf-8")
+    MDB_CACHE_FILE.write_text(text)
+    return text
+
+
+def load_co_feeds(catalog_csv: str) -> list[dict]:
+    """Parse MDB catalog → list of active CO transit feeds.
+
+    Returns: [{agency, agency_id, url, municipality, status}, ...]
+    Filters to: subdivision_name == 'Colorado' AND status != 'deprecated'.
+    Deduplicates by `urls.latest` (MDB has multiple entries per agency in
+    some cases; canonical URL is the dedup key).
+    """
+    feeds: list[dict] = []
+    seen_urls: set[str] = set()
+    reader = csv.DictReader(io.StringIO(catalog_csv))
+    for row in reader:
+        if row.get("location.subdivision_name", "").strip().lower() != "colorado":
+            continue
+        if row.get("status", "").strip().lower() == "deprecated":
+            continue
+        if row.get("data_type", "").strip().lower() != "gtfs":
+            continue  # skip GTFS-RT / other feeds
+        url = (row.get("urls.latest") or row.get("urls.direct_download") or "").strip()
+        if not url or url in seen_urls:
+            continue
+        seen_urls.add(url)
+
+        provider = (row.get("provider") or row.get("name") or "?").strip()
+        # Build a stable agency_id from provider + municipality
+        muni = row.get("location.municipality", "").strip()
+        slug = ("_".join((provider, muni)) if muni else provider).lower()
+        agency_id = "".join(c if c.isalnum() else "_" for c in slug).strip("_")[:50]
+
+        feeds.append({
+            "agency":       provider,
+            "agency_id":    agency_id,
+            "municipality": muni,
+            "url":          url,
+            "status":       row.get("status", "active"),
+            "mdb_id":       row.get("mdb_source_id", ""),
+        })
+    return feeds
 
 
 def utc_now() -> str:
@@ -192,54 +250,159 @@ def parse_gtfs_shapes(zip_bytes: bytes, agency_id: str, agency_name: str) -> lis
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--max-agencies", type=int, default=None,
+                        help="Limit to first N agencies (for testing)")
+    parser.add_argument("--use-cache", action="store_true",
+                        help="Use cached MDB catalog instead of refetching")
+    args = parser.parse_args()
+
     OUT_FILE.parent.mkdir(parents=True, exist_ok=True)
     generated = utc_now()
     all_features = []
     agencies_ok = []
+    agencies_failed = []
 
-    for feed in GTFS_FEEDS:
+    # Read MDB catalog → CO active feeds
+    try:
+        catalog_csv = fetch_mdb_catalog(use_cache=args.use_cache)
+        feeds = load_co_feeds(catalog_csv)
+        log(f"Mobility Database: {len(feeds)} active CO transit feeds discovered.")
+    except Exception as exc:
+        log(f"✗ MDB catalog fetch failed: {exc}", level="ERROR")
+        log("  Falling back to existing transit_routes_co.geojson if present.", level="WARN")
+        feeds = []
+
+    if args.max_agencies:
+        feeds = feeds[: args.max_agencies]
+        log(f"  (limited to first {len(feeds)} agencies for testing)")
+
+    for i, feed in enumerate(feeds, 1):
         agency_id = feed["agency_id"]
         agency_name = feed["agency"]
         url = feed["url"]
-        log(f"Fetching GTFS for {agency_name}…")
+        log(f"[{i}/{len(feeds)}] Fetching GTFS for {agency_name} ({feed.get('municipality') or 'CO'})…")
         try:
             zip_bytes = fetch_url(url)
             features = parse_gtfs_shapes(zip_bytes, agency_id, agency_name)
-            all_features.extend(features)
-            agencies_ok.append(agency_name)
-            log(f"  ✓ {agency_name}: {len(features)} shapes")
+            if features:
+                all_features.extend(features)
+                agencies_ok.append(agency_name)
+                log(f"  ✓ {agency_name}: {len(features)} shapes")
+            else:
+                # Empty ZIP or no shapes.txt — soft failure
+                agencies_failed.append({"agency": agency_name, "reason": "no shapes parsed"})
+                log(f"  ⚠ {agency_name}: no shapes parsed (empty or malformed GTFS)", level="WARN")
         except Exception as exc:
+            agencies_failed.append({"agency": agency_name, "reason": str(exc)[:200]})
             log(f"  ✗ {agency_name}: {exc}", level="WARN")
-        time.sleep(1.0)
+        time.sleep(0.5)  # be polite to upstreams
 
     result = {
         "type": "FeatureCollection",
         "meta": {
-            "source": "Colorado Transit Agency GTFS Feeds (public)",
+            "source": "Colorado Transit Agency GTFS feeds via Mobility Database catalog",
             "agencies": agencies_ok,
+            "agencies_failed": agencies_failed,
             "state": "Colorado",
             "state_fips": STATE_FIPS,
             "vintage": generated[:10],
             "generated": generated,
             "feature_count": len(all_features),
-            "coverage_pct": round(len(agencies_ok) / len(GTFS_FEEDS) * 100, 1),
-            "note": "Rebuild via scripts/market/fetch_gtfs_transit.py",
+            "agency_count_total":  len(feeds),
+            "agency_count_ok":     len(agencies_ok),
+            "agency_count_failed": len(agencies_failed),
+            "coverage_pct": round(
+                len(agencies_ok) / max(len(feeds), 1) * 100, 1
+            ),
+            "note": "Rebuild via scripts/market/fetch_gtfs_transit.py. "
+                    "MDB catalog drives the agency list; per-feed failures "
+                    "are surfaced in agencies_failed without blocking other agencies.",
         },
         "features": all_features,
     }
 
-    # Fallback to existing file
+    # Fallback to existing file when fetch produced nothing
     if not all_features and OUT_FILE.exists():
         existing = json.loads(OUT_FILE.read_text())
         if existing.get("features"):
             log("[fallback] Using existing transit_routes_co.geojson", level="WARN")
             result = existing
 
+    # Dedup duplicate routes from agencies with multiple MDB feeds
+    # (e.g. RTD Denver appears in MDB twice with slightly different
+    # bundles, producing 7x duplicate route geometries). Dedup key is
+    # (normalized_agency_name, shape_id) — same shape from same agency
+    # is the same route regardless of which MDB feed it came through.
+    import re as _re
+    def _norm_agency(name: str) -> str:
+        if not name: return ""
+        n = _re.sub(r"\([^)]*\)", "", name)        # strip parenthetical suffixes
+        n = _re.sub(r"[^a-z0-9]+", "_", n.lower()).strip("_")
+        return n
+
+    seen_keys: set[tuple[str, str]] = set()
+    deduped: list[dict] = []
+    pre_count = len(all_features)
+    for f in all_features:
+        p = f.get("properties", {})
+        key = (_norm_agency(p.get("agency", "")), p.get("shape_id", ""))
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        # Canonicalize known duplicate-prone agency names so display is
+        # consistent regardless of which MDB feed published the route.
+        if _norm_agency(p.get("agency", "")) == "regional_transportation_district":
+            p["agency"] = "RTD Denver"
+            p["agency_id"] = "rtd"
+        deduped.append(f)
+    all_features = deduped
+    log(f"Dedup: {pre_count} → {len(all_features)} unique routes "
+        f"({pre_count - len(all_features)} duplicates removed across "
+        f"agencies with multiple MDB entries)")
+    # Reflect the dedup back into the result dict (assignment above
+    # broke the original reference, so result["features"] still points
+    # at the un-deduped list).
+    result["features"] = all_features
+    result["meta"]["feature_count"] = len(all_features)
+
+    # Trim coordinate precision to 5 decimal places (~1.1m at equator,
+    # ample for transit route polylines). Combined with compact JSON
+    # (no indent), this keeps the output ~50 MB even at 60+ agencies —
+    # well under GitHub's 100 MB single-file limit.
+    def _trim_coords(geom: dict) -> dict:
+        if not geom:
+            return geom
+        gt = geom.get("type")
+        coords = geom.get("coordinates")
+        if gt == "LineString":
+            geom["coordinates"] = [[round(c[0], 5), round(c[1], 5)] for c in coords]
+        elif gt == "MultiLineString":
+            geom["coordinates"] = [
+                [[round(c[0], 5), round(c[1], 5)] for c in line] for line in coords
+            ]
+        elif gt == "Polygon":
+            geom["coordinates"] = [
+                [[round(c[0], 5), round(c[1], 5)] for c in ring] for ring in coords
+            ]
+        return geom
+
+    for f in result.get("features", []):
+        if "geometry" in f:
+            _trim_coords(f["geometry"])
+
     with open(OUT_FILE, "w", encoding="utf-8") as fh:
-        json.dump(result, fh, indent=2, ensure_ascii=False)
+        # Compact: no indent, no whitespace separators. Saves ~70% of file
+        # size vs `indent=2`. The file is read programmatically; pretty-
+        # printing adds no human value at this scale.
+        json.dump(result, fh, separators=(",", ":"), ensure_ascii=False)
 
     n = len(result.get("features", []))
-    log(f"✓ Wrote {n} transit route features to {OUT_FILE}")
+    out_size_mb = OUT_FILE.stat().st_size / 1024 / 1024
+    log(f"✓ Wrote {n} transit route features from "
+        f"{len(agencies_ok)}/{len(feeds)} agencies to {OUT_FILE} ({out_size_mb:.1f} MB)")
+    if agencies_failed:
+        log(f"  ⚠ {len(agencies_failed)} agencies failed (see agencies_failed in output)", level="WARN")
     return 0
 
 

--- a/tests/test_data_plausibility.py
+++ b/tests/test_data_plausibility.py
@@ -367,6 +367,61 @@ def test_ranking_ami_source_flag_present(ranking):
     assert not missing, f'{len(missing)} entries missing _ami_gap_source flag'
 
 
+# ── Transit coverage plausibility ───────────────────────────────────
+
+def test_transit_routes_minimum_agency_coverage():
+    """transit_routes_co.geojson must include ≥30 distinct agencies.
+
+    Pre-2026-05-08 only 4 agencies were ingested (RTD, Bustang, Transfort,
+    Greeley-Evans), missing ~95% of CO transit including Mountain Metro
+    (Colorado Springs), Pueblo Transit, RFTA, ECO Transit, Summit Stage,
+    etc. The MDB-driven fetcher should now cover 30+ agencies.
+    """
+    transit = _load('data/market/transit_routes_co.geojson')
+    features = transit.get('features', [])
+    agencies = set()
+    for f in features:
+        a = f.get('properties', {}).get('agency')
+        if a:
+            agencies.add(a)
+    assert len(agencies) >= 30, (
+        f'Only {len(agencies)} transit agencies in transit_routes_co.geojson; '
+        f'expected ≥30 (MDB catalog has ~88 active CO feeds). '
+        f'Agencies: {sorted(agencies)[:10]}...'
+    )
+
+
+def test_transit_routes_features_plausible():
+    """transit_routes_co.geojson must have ≥1000 route features (was 587 pre-fix)."""
+    transit = _load('data/market/transit_routes_co.geojson')
+    features = transit.get('features', [])
+    assert len(features) >= 1000, (
+        f'Only {len(features)} transit features; expected ≥1000 after '
+        f'MDB-driven expansion.'
+    )
+
+
+def test_transit_includes_major_co_systems():
+    """Sanity: the major CO transit agencies are all present in the data."""
+    transit = _load('data/market/transit_routes_co.geojson')
+    agencies = {f.get('properties', {}).get('agency', '') for f in transit.get('features', [])}
+    expected_substrings = [
+        'RTD',
+        'Mountain Metropolitan',
+        'Pueblo',
+        'Roaring Fork',
+        'Transfort',
+    ]
+    missing = []
+    for needle in expected_substrings:
+        if not any(needle.lower() in a.lower() for a in agencies):
+            missing.append(needle)
+    assert not missing, (
+        f'Expected agencies missing from transit_routes_co.geojson: {missing}. '
+        f'Actual agencies: {sorted(agencies)[:15]}...'
+    )
+
+
 # ── Cross-source: CDPHE county boundaries vs TIGER ──────────────────
 
 def test_cdphe_boundaries_match_tiger_county_count():


### PR DESCRIPTION
**User-flagged gap.** PMA transit scoring was effectively blind for ~95% of Colorado. \`data/market/transit_routes_co.geojson\` contained only 4 agencies — missing every major CO transit system outside Denver/Fort Collins/Greeley.

## Coverage delta

| Metric | Before | After | Δ |
|---|---|---|---|
| Agencies in data | 4 | **55** | +51 |
| Route features | 587 | **1,264** | +677 |
| File size | 67 MB | 33 MB | -50% |
| Pueblo Transit | none | **31 routes** | |
| Colorado Springs (Mountain Metro) | none | **72 routes** | |
| Roaring Fork Transportation Authority (Aspen/Glenwood) | none | **43 routes** | |
| Town of Telluride | none | **39 routes** | |
| Summit Stage (Breckenridge) | none | **39 routes** | |
| Eagle County Transit (Vail) | none | **27 routes** | |
| Bustang Outrider (rural connections) | none | **16 routes** | |
| Vail Transit | none | 13 routes | |
| Town of Estes Park / Steamboat / Durango / etc. | none | covered | |

## What changed

\`scripts/market/fetch_gtfs_transit.py\` rewritten to drive from the **Mobility Database catalog** at runtime instead of a 5-entry hardcoded list. Fetches the catalog (~88 active CO feeds), filters by \`subdivision_name == Colorado\`, and pulls each GTFS ZIP with per-agency timeout + graceful failure handling.

Three additional improvements during the rewrite:

1. **Dedup duplicate routes** by \`(normalized_agency, shape_id)\` — MDB occasionally lists the same agency twice with overlapping bundles (RTD appeared twice, producing 7× duplicate geometry). Canonicalizes RTD's display name back to \"RTD Denver\".
2. **Compact JSON output** — dropped \`indent=2\`, trimmed coordinates to 5 decimal places (~1.1m precision). 33 MB output, well under GitHub's 100 MB single-file limit.
3. **3 new plausibility tests** asserting ≥30 agencies, ≥1000 features, and that 5 named major CO systems are all present.

## Limitations / follow-up

- **25 of 88 MDB feeds returned valid GTFS but no \`shapes.txt\`** (an optional GTFS file). These are small senior/dial-a-ride services. Could be backfilled via a stops-based fallback (Point features from \`stops.txt\`) — separate follow-up.
- **\`WALK_TO_TRANSIT_MILES = 0.5\`** in \`js/pma-transit.js\` is still a binary catchment. Rural sites with intercity bus access 1.5 miles away still get 0 transit credit. Distance-decay scoring discussed earlier but pending sign-off on breakpoints.

## Test results

- \`pytest tests/test_data_plausibility.py\` → **17/17 pass** (3 new)
- \`node scripts/audit/data-freshness-check.mjs\` → 12/12 OK including new transit SLA entry (95-day, monthly cadence)
- File size 33 MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)