### PR TITLE
feat(fred): housing-cycle indicators (HSN1F, TLRESCONS, USCONS)

### DIFF
--- a/.github/workflows/fetch-fred-data.yml
+++ b/.github/workflows/fetch-fred-data.yml
@@ -95,6 +95,19 @@ jobs:
             "COMPUTSA": "Multifamily Completions (5+ units)",
             "MSACSR": "Monthly Supply of Houses (months)",  # NEW — tight-vs-loose market signal
             "EXHOSLUSM495S": "Existing Home Sales",         # NEW — transaction volume
+            # ── Housing cycle indicators (added 2026-05-09) ───────
+            # These three round out the leading/coincident/lagging
+            # framework analysts use when reading the housing cycle:
+            #   HSN1F   — leading (sales lead starts ~3-6 mo)
+            #   TLRESCONS — coincident-to-lagging (spending follows
+            #               permits/starts ~6-12 mo)
+            #   USCONS  — lagging (employment trails spending)
+            # Together with PERMIT/HOUST/MSACSR/CSUSHPISA/RRVRUSQ156N
+            # already in the dashboard, this gives a complete cycle
+            # readout for LIHTC timing decisions.
+            "HSN1F": "New One-Family Houses Sold",
+            "TLRESCONS": "Total Construction Spending: Residential",
+            "USCONS": "Construction Employment (National)",
 
             # ── Prices / affordability ────────────────────────────
             "CSUSHPISA": "Case-Shiller Home Price Index",

--- a/economic-dashboard.html
+++ b/economic-dashboard.html
@@ -83,7 +83,7 @@ document.addEventListener('DOMContentLoaded', function () {
   if (window.DataQualitySummary) {
     window.DataQualitySummary.render('econDataQuality', {
       sources: [
-        { name: 'FRED Economic Data', status: 'primary', vintage: '2026', coverage: '30+ series', note: 'CPI, unemployment, mortgage rates, housing starts' },
+        { name: 'FRED Economic Data', status: 'primary', vintage: '2026', coverage: '50+ series', note: 'CPI, unemployment, mortgage rates, housing starts, cycle indicators' },
         { name: 'Census ACS State Data', status: 'primary', vintage: '2024', coverage: 'Colorado statewide' },
         { name: 'Prediction Markets', status: 'cached', vintage: '2026', coverage: 'Housing contracts', note: 'Kalshi + Polymarket — sentiment indicators only' }
       ],
@@ -214,6 +214,18 @@ document.addEventListener('DOMContentLoaded', function () {
 <div class="section-body">
 <p class="section-desc">Starts, permits, prices, and affordability signals that shape pipeline and underwriting assumptions.</p>
 <div class="metric-grid" id="sec-housing"></div>
+</div>
+</details>
+<details class="card" open="">
+<summary>
+        Housing Cycle Indicators
+        <span class="pill small">3 indicators</span>
+</summary>
+<div class="section-body">
+<p class="section-desc">
+  Leading / coincident / lagging indicators for reading the housing cycle. New home sales lead starts by ~3-6 months; residential construction spending follows permits/starts by ~6-12 months; construction employment is the lagging signal. Use these alongside permits, starts, and Months' Supply (above) for cycle-stage timing on LIHTC application windows and pricing-locked debt.
+</p>
+<div class="metric-grid" id="sec-housing-cycle"></div>
 </div>
 </details>
 <details class="card" open="">
@@ -504,6 +516,11 @@ document.addEventListener('DOMContentLoaded', function () {
     {section:"housing", id:"UNDCONTSA",   title:"Units Under Construction", units:"thousands", fmt:"int"},
     {section:"housing", id:"COMPUTSA",    title:"Multifamily Completions (5+ units)", units:"thousands", fmt:"int"},
 
+    // Housing cycle (3) — leading / coincident / lagging
+    {section:"housingCycle", id:"HSN1F",     title:"New One-Family Houses Sold (Leading)", units:"thousands", fmt:"int"},
+    {section:"housingCycle", id:"TLRESCONS", title:"Construction Spending: Residential (Coincident)", units:"$M", fmt:"int"},
+    {section:"housingCycle", id:"USCONS",    title:"Construction Employment, National (Lagging)", units:"thousands", fmt:"int"},
+
     // Finance (cached + SOFR in registry, hidden until cache populated)
     {section:"finance", id:"DGS10", title:"10-Year Treasury Yield", units:"%", fmt:"pct"},
     {section:"finance", id:"DGS2", title:"2-Year Treasury Yield", units:"%", fmt:"pct"},
@@ -549,6 +566,7 @@ document.addEventListener('DOMContentLoaded', function () {
     sec: {
       construction: document.getElementById("sec-construction"),
       housing: document.getElementById("sec-housing"),
+      housingCycle: document.getElementById("sec-housing-cycle"),
       finance: document.getElementById("sec-finance"),
       labor: document.getElementById("sec-labor"),
     }


### PR DESCRIPTION
## Summary

Adds the **leading / coincident / lagging triplet** for reading the housing cycle, completing the framework analysts use when timing LIHTC applications and pricing-locked debt:

| Series | Role | Why it matters |
|---|---|---|
| **HSN1F** — New One-Family Houses Sold | Leading | ~3-6 mo lead on starts; demand-side cycle signal |
| **TLRESCONS** — Total Residential Construction Spending | Coincident-to-lagging | Spending follows permits/starts ~6-12 mo |
| **USCONS** — Construction Employment, National | Lagging | Employment trails spending by quarters |

Together with `PERMIT`, `HOUST`, `MSACSR`, `CSUSHPISA`, `RRVRUSQ156N` already in the Housing Market section, the dashboard now exposes the full cycle stack — useful for figuring out where the cycle is, not just where prices/rates are right now.

## Files

- **`.github/workflows/fetch-fred-data.yml`** — adds 3 entries to `SERIES` dict (54 total, up from 51).
- **`economic-dashboard.html`** —
  - New collapsible "Housing Cycle Indicators" section.
  - 3 entries in `INDICATORS` array under new `housingCycle` section key.
  - `els.sec.housingCycle` wired to new `#sec-housing-cycle` div.
  - Updates the data-source-inventory coverage note from "30+ series" to "50+ series".

## Backfill timing

The 3 new series will populate in `data/fred-data.json` on the **next FRED CI cron run (every 6h)**. The frontend renderer handles missing series gracefully (existing behavior — no broken cards render meanwhile).

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Inline JS in dashboard parses (`new Function(combined)` smoke check)
- [x] FRED metadata pytest passes (`test_series_count_meets_baseline` switched to `>= 45` floor in PR #784, so 54 series is fine)
- [ ] After merge: confirm next FRED CI cron populates the 3 series and they render on `economic-dashboard.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)