### PR TITLE
fix(tiger): phantom→canonical alias map (PR-C4) — close place-CHAS gap

### DIFF
--- a/.github/workflows/site-audit.yml
+++ b/.github/workflows/site-audit.yml
@@ -55,6 +55,9 @@ jobs:
             data/co_ami_gap_by_county.json \
             data/census-acs-state.json \
             data/hna/ranking-index.json \
+            data/hna/place-chas.json \
+            data/hna/place-phantom-aliases.json \
+            data/hna/cross-county-places.json \
             data/boundaries/counties_co.geojson; do
             status=$(curl -sf -o /dev/null -w "%{http_code}" "http://127.0.0.1:8080/${path}" 2>/dev/null || echo "FAIL")
             if [ "$status" = "200" ]; then

--- a/data/hna/place-phantom-aliases.json
+++ b/data/hna/place-phantom-aliases.json
@@ -1,0 +1,42 @@
+{
+  "aliases": {
+    "0800775": "0801090",
+    "0803875": "0809555",
+    "0817320": "0817760",
+    "0820730": "0820440",
+    "0821735": "0819850",
+    "0822465": "0824785",
+    "0823680": "0822035",
+    "0824640": "0822200",
+    "0826145": "0827040",
+    "0827290": "0827810",
+    "0827565": "0828690",
+    "0830475": "0830780",
+    "0831400": "0843110",
+    "0832515": "0833640",
+    "0835250": "0833695",
+    "0841930": "0851635",
+    "0844380": "0851745",
+    "0852290": "0857630",
+    "0855745": "0862000",
+    "0857330": "0857400",
+    "0866500": "0864255",
+    "0866955": "0870195",
+    "0869985": "0873935",
+    "0873220": "0873825",
+    "0875140": "0816495",
+    "0875415": "0878610",
+    "0877580": "0876795",
+    "0882870": "0880040",
+    "0884330": "0882350"
+  },
+  "meta": {
+    "count_aliases": 29,
+    "count_duplicates": 29,
+    "count_unresolvable": 0,
+    "generated_at": "2026-05-10T04:33:27Z",
+    "method": "Match duplicate (name, containingCounty) pairs in geography-registry.json; identify canonical = the GEOID that exists in TIGER 2024 PLACE shapefile.",
+    "note": "Consumers should resolve phantom geoids via this map before looking up place data. See js/place-chas-lookup.js for an example consumer.",
+    "tiger_vintage": 2024
+  }
+}

--- a/data/hna/place-tract-membership.json
+++ b/data/hna/place-tract-membership.json
@@ -1,0 +1,14865 @@
+{
+  "meta": {
+    "generated_at": "2026-05-10T03:20:54Z",
+    "source_place": "TIGER 2024 PLACE shapefile (tl_2024_08_place)",
+    "source_tract": "TIGER 2024 TRACT shapefile (tl_2024_08_tract)",
+    "vintage": 2024,
+    "method": "shapely intersection + area-weighted apportionment",
+    "projection": "EPSG:26913 (NAD83 / UTM zone 13N)",
+    "count_places": 464,
+    "count_tracts": 1447,
+    "count_memberships": 2011
+  },
+  "places": {
+    "0833640": {
+      "name": "Gunnison",
+      "place_area_sqm": 12556382.2,
+      "tracts": [
+        {
+          "tract_geoid": "08051963702",
+          "overlap_area_sqm": 6364888.7,
+          "share_of_place_area": 0.5069,
+          "share_of_tract_area": 0.6973
+        },
+        {
+          "tract_geoid": "08051963701",
+          "overlap_area_sqm": 3631208.0,
+          "share_of_place_area": 0.2892,
+          "share_of_tract_area": 0.6991
+        },
+        {
+          "tract_geoid": "08051963602",
+          "overlap_area_sqm": 2097718.8,
+          "share_of_place_area": 0.1671,
+          "share_of_tract_area": 0.0009
+        },
+        {
+          "tract_geoid": "08051963601",
+          "overlap_area_sqm": 462566.6,
+          "share_of_place_area": 0.0368,
+          "share_of_tract_area": 0.0005
+        }
+      ]
+    },
+    "0848555": {
+      "name": "Marble",
+      "place_area_sqm": 931813.7,
+      "tracts": [
+        {
+          "tract_geoid": "08051963900",
+          "overlap_area_sqm": 931813.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0852570": {
+      "name": "Mount Crested Butte",
+      "place_area_sqm": 5354743.9,
+      "tracts": [
+        {
+          "tract_geoid": "08051963800",
+          "overlap_area_sqm": 5354743.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0063
+        }
+      ]
+    },
+    "0831550": {
+      "name": "Granada",
+      "place_area_sqm": 1775947.7,
+      "tracts": [
+        {
+          "tract_geoid": "08099000700",
+          "overlap_area_sqm": 1775947.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0007
+        }
+      ]
+    },
+    "0837215": {
+      "name": "Holly",
+      "place_area_sqm": 1894552.5,
+      "tracts": [
+        {
+          "tract_geoid": "08099000600",
+          "overlap_area_sqm": 1894552.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0015
+        }
+      ]
+    },
+    "0843110": {
+      "name": "Lamar",
+      "place_area_sqm": 13568587.9,
+      "tracts": [
+        {
+          "tract_geoid": "08099000300",
+          "overlap_area_sqm": 5267778.1,
+          "share_of_place_area": 0.3882,
+          "share_of_tract_area": 0.9154
+        },
+        {
+          "tract_geoid": "08099000200",
+          "overlap_area_sqm": 4292482.5,
+          "share_of_place_area": 0.3164,
+          "share_of_tract_area": 0.6884
+        },
+        {
+          "tract_geoid": "08099000700",
+          "overlap_area_sqm": 3885681.7,
+          "share_of_place_area": 0.2864,
+          "share_of_tract_area": 0.0015
+        },
+        {
+          "tract_geoid": "08099000100",
+          "overlap_area_sqm": 122645.7,
+          "share_of_place_area": 0.009,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0885045": {
+      "name": "Wiley",
+      "place_area_sqm": 868245.6,
+      "tracts": [
+        {
+          "tract_geoid": "08099000100",
+          "overlap_area_sqm": 868245.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0021
+        }
+      ]
+    },
+    "0812855": {
+      "name": "Center",
+      "place_area_sqm": 2236238.2,
+      "tracts": [
+        {
+          "tract_geoid": "08109977700",
+          "overlap_area_sqm": 1806813.0,
+          "share_of_place_area": 0.808,
+          "share_of_tract_area": 0.0018
+        },
+        {
+          "tract_geoid": "08105977002",
+          "overlap_area_sqm": 429425.2,
+          "share_of_place_area": 0.192,
+          "share_of_tract_area": 0.0008
+        }
+      ]
+    },
+    "0812387": {
+      "name": "Castle Pines",
+      "place_area_sqm": 24826988.4,
+      "tracts": [
+        {
+          "tract_geoid": "08035014016",
+          "overlap_area_sqm": 10946041.4,
+          "share_of_place_area": 0.4409,
+          "share_of_tract_area": 0.2775
+        },
+        {
+          "tract_geoid": "08035014141",
+          "overlap_area_sqm": 5292078.2,
+          "share_of_place_area": 0.2132,
+          "share_of_tract_area": 0.7072
+        },
+        {
+          "tract_geoid": "08035014127",
+          "overlap_area_sqm": 4693692.2,
+          "share_of_place_area": 0.1891,
+          "share_of_tract_area": 0.7674
+        },
+        {
+          "tract_geoid": "08035014011",
+          "overlap_area_sqm": 2204213.1,
+          "share_of_place_area": 0.0888,
+          "share_of_tract_area": 0.0733
+        },
+        {
+          "tract_geoid": "08035014125",
+          "overlap_area_sqm": 1293940.4,
+          "share_of_place_area": 0.0521,
+          "share_of_tract_area": 0.0748
+        },
+        {
+          "tract_geoid": "08035014017",
+          "overlap_area_sqm": 366475.5,
+          "share_of_place_area": 0.0148,
+          "share_of_tract_area": 0.0393
+        },
+        {
+          "tract_geoid": "08035014142",
+          "overlap_area_sqm": 30547.5,
+          "share_of_place_area": 0.0012,
+          "share_of_tract_area": 0.0049
+        }
+      ]
+    },
+    "0869040": {
+      "name": "Seibert",
+      "place_area_sqm": 887982.9,
+      "tracts": [
+        {
+          "tract_geoid": "08063962400",
+          "overlap_area_sqm": 887982.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0829680": {
+      "name": "Genoa",
+      "place_area_sqm": 803206.4,
+      "tracts": [
+        {
+          "tract_geoid": "08073961700",
+          "overlap_area_sqm": 803206.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0009
+        }
+      ]
+    },
+    "0837875": {
+      "name": "Hugo",
+      "place_area_sqm": 2360787.8,
+      "tracts": [
+        {
+          "tract_geoid": "08073961800",
+          "overlap_area_sqm": 2360787.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0004
+        }
+      ]
+    },
+    "0804000": {
+      "name": "Aurora",
+      "place_area_sqm": 426075261.2,
+      "tracts": [
+        {
+          "tract_geoid": "08001008354",
+          "overlap_area_sqm": 92089862.9,
+          "share_of_place_area": 0.2161,
+          "share_of_tract_area": 0.8487
+        },
+        {
+          "tract_geoid": "08001008401",
+          "overlap_area_sqm": 42296155.5,
+          "share_of_place_area": 0.0993,
+          "share_of_tract_area": 0.0844
+        },
+        {
+          "tract_geoid": "08005007111",
+          "overlap_area_sqm": 25905786.5,
+          "share_of_place_area": 0.0608,
+          "share_of_tract_area": 0.4101
+        },
+        {
+          "tract_geoid": "08005007108",
+          "overlap_area_sqm": 24395911.9,
+          "share_of_place_area": 0.0573,
+          "share_of_tract_area": 0.9169
+        },
+        {
+          "tract_geoid": "08005007110",
+          "overlap_area_sqm": 20134447.1,
+          "share_of_place_area": 0.0473,
+          "share_of_tract_area": 0.8322
+        },
+        {
+          "tract_geoid": "08005007106",
+          "overlap_area_sqm": 14170536.3,
+          "share_of_place_area": 0.0333,
+          "share_of_tract_area": 0.085
+        },
+        {
+          "tract_geoid": "08005007109",
+          "overlap_area_sqm": 12919127.0,
+          "share_of_place_area": 0.0303,
+          "share_of_tract_area": 0.4438
+        },
+        {
+          "tract_geoid": "08001008309",
+          "overlap_area_sqm": 12022034.1,
+          "share_of_place_area": 0.0282,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005083000",
+          "overlap_area_sqm": 8992482.3,
+          "share_of_place_area": 0.0211,
+          "share_of_tract_area": 0.8736
+        },
+        {
+          "tract_geoid": "08005007113",
+          "overlap_area_sqm": 8553353.7,
+          "share_of_place_area": 0.0201,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005086600",
+          "overlap_area_sqm": 6777195.2,
+          "share_of_place_area": 0.0159,
+          "share_of_tract_area": 0.9111
+        },
+        {
+          "tract_geoid": "08005007103",
+          "overlap_area_sqm": 5997654.7,
+          "share_of_place_area": 0.0141,
+          "share_of_tract_area": 0.0362
+        },
+        {
+          "tract_geoid": "08005086500",
+          "overlap_area_sqm": 5904972.7,
+          "share_of_place_area": 0.0139,
+          "share_of_tract_area": 0.9679
+        },
+        {
+          "tract_geoid": "08005007112",
+          "overlap_area_sqm": 5562604.4,
+          "share_of_place_area": 0.0131,
+          "share_of_tract_area": 0.9985
+        },
+        {
+          "tract_geoid": "08005086700",
+          "overlap_area_sqm": 4534715.8,
+          "share_of_place_area": 0.0106,
+          "share_of_tract_area": 0.7411
+        },
+        {
+          "tract_geoid": "08035013912",
+          "overlap_area_sqm": 4495432.8,
+          "share_of_place_area": 0.0106,
+          "share_of_tract_area": 0.164
+        },
+        {
+          "tract_geoid": "08001008200",
+          "overlap_area_sqm": 4496082.2,
+          "share_of_place_area": 0.0106,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001008308",
+          "overlap_area_sqm": 4308492.0,
+          "share_of_place_area": 0.0101,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001008355",
+          "overlap_area_sqm": 3559018.4,
+          "share_of_place_area": 0.0084,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005082000",
+          "overlap_area_sqm": 3257182.0,
+          "share_of_place_area": 0.0076,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005081600",
+          "overlap_area_sqm": 3117592.2,
+          "share_of_place_area": 0.0073,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005007702",
+          "overlap_area_sqm": 2768038.0,
+          "share_of_place_area": 0.0065,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001008100",
+          "overlap_area_sqm": 2717672.2,
+          "share_of_place_area": 0.0064,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005081400",
+          "overlap_area_sqm": 2651137.4,
+          "share_of_place_area": 0.0062,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005081900",
+          "overlap_area_sqm": 2621631.5,
+          "share_of_place_area": 0.0062,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005080200",
+          "overlap_area_sqm": 2594875.4,
+          "share_of_place_area": 0.0061,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005083400",
+          "overlap_area_sqm": 2558606.4,
+          "share_of_place_area": 0.006,
+          "share_of_tract_area": 0.9718
+        },
+        {
+          "tract_geoid": "08005083100",
+          "overlap_area_sqm": 2552606.3,
+          "share_of_place_area": 0.006,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005082900",
+          "overlap_area_sqm": 2577415.7,
+          "share_of_place_area": 0.006,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005080300",
+          "overlap_area_sqm": 2524538.2,
+          "share_of_place_area": 0.0059,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005080700",
+          "overlap_area_sqm": 2521847.9,
+          "share_of_place_area": 0.0059,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005080400",
+          "overlap_area_sqm": 2414608.4,
+          "share_of_place_area": 0.0057,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005082600",
+          "overlap_area_sqm": 2428873.8,
+          "share_of_place_area": 0.0057,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005081800",
+          "overlap_area_sqm": 2117460.8,
+          "share_of_place_area": 0.005,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005082400",
+          "overlap_area_sqm": 2077021.2,
+          "share_of_place_area": 0.0049,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005081101",
+          "overlap_area_sqm": 2083242.6,
+          "share_of_place_area": 0.0049,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005084600",
+          "overlap_area_sqm": 2058106.5,
+          "share_of_place_area": 0.0048,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005082200",
+          "overlap_area_sqm": 1953094.4,
+          "share_of_place_area": 0.0046,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005082100",
+          "overlap_area_sqm": 1945824.7,
+          "share_of_place_area": 0.0046,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005082800",
+          "overlap_area_sqm": 1967653.3,
+          "share_of_place_area": 0.0046,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001008000",
+          "overlap_area_sqm": 1954590.8,
+          "share_of_place_area": 0.0046,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005083300",
+          "overlap_area_sqm": 1920573.8,
+          "share_of_place_area": 0.0045,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005007400",
+          "overlap_area_sqm": 1933019.5,
+          "share_of_place_area": 0.0045,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005083500",
+          "overlap_area_sqm": 1881913.2,
+          "share_of_place_area": 0.0044,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005083700",
+          "overlap_area_sqm": 1823396.8,
+          "share_of_place_area": 0.0043,
+          "share_of_tract_area": 0.8949
+        },
+        {
+          "tract_geoid": "08005007703",
+          "overlap_area_sqm": 1838429.8,
+          "share_of_place_area": 0.0043,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005081500",
+          "overlap_area_sqm": 1807268.6,
+          "share_of_place_area": 0.0042,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005084700",
+          "overlap_area_sqm": 1737021.7,
+          "share_of_place_area": 0.0041,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005085300",
+          "overlap_area_sqm": 1730817.5,
+          "share_of_place_area": 0.0041,
+          "share_of_tract_area": 0.9524
+        },
+        {
+          "tract_geoid": "08005080900",
+          "overlap_area_sqm": 1676099.6,
+          "share_of_place_area": 0.0039,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005085700",
+          "overlap_area_sqm": 1677965.1,
+          "share_of_place_area": 0.0039,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005007202",
+          "overlap_area_sqm": 1662106.1,
+          "share_of_place_area": 0.0039,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001007900",
+          "overlap_area_sqm": 1636919.4,
+          "share_of_place_area": 0.0038,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035013913",
+          "overlap_area_sqm": 1523791.2,
+          "share_of_place_area": 0.0036,
+          "share_of_tract_area": 0.0811
+        },
+        {
+          "tract_geoid": "08005084100",
+          "overlap_area_sqm": 1539697.0,
+          "share_of_place_area": 0.0036,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005084200",
+          "overlap_area_sqm": 1481226.9,
+          "share_of_place_area": 0.0035,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005081002",
+          "overlap_area_sqm": 1431635.4,
+          "share_of_place_area": 0.0034,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005080100",
+          "overlap_area_sqm": 1419927.6,
+          "share_of_place_area": 0.0033,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005083900",
+          "overlap_area_sqm": 1375122.1,
+          "share_of_place_area": 0.0032,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005081200",
+          "overlap_area_sqm": 1335956.9,
+          "share_of_place_area": 0.0031,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005080000",
+          "overlap_area_sqm": 1330428.4,
+          "share_of_place_area": 0.0031,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005007201",
+          "overlap_area_sqm": 1321256.8,
+          "share_of_place_area": 0.0031,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005007302",
+          "overlap_area_sqm": 1304020.8,
+          "share_of_place_area": 0.0031,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005007600",
+          "overlap_area_sqm": 1325824.0,
+          "share_of_place_area": 0.0031,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005083800",
+          "overlap_area_sqm": 1292743.4,
+          "share_of_place_area": 0.003,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005082500",
+          "overlap_area_sqm": 1257133.0,
+          "share_of_place_area": 0.003,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005080500",
+          "overlap_area_sqm": 1263535.5,
+          "share_of_place_area": 0.003,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005083202",
+          "overlap_area_sqm": 1279838.0,
+          "share_of_place_area": 0.003,
+          "share_of_tract_area": 0.4573
+        },
+        {
+          "tract_geoid": "08005080600",
+          "overlap_area_sqm": 1253780.9,
+          "share_of_place_area": 0.0029,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005082300",
+          "overlap_area_sqm": 1227070.5,
+          "share_of_place_area": 0.0029,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005082700",
+          "overlap_area_sqm": 1217128.5,
+          "share_of_place_area": 0.0029,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005081300",
+          "overlap_area_sqm": 1174039.6,
+          "share_of_place_area": 0.0028,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005085800",
+          "overlap_area_sqm": 1211809.2,
+          "share_of_place_area": 0.0028,
+          "share_of_tract_area": 0.812
+        },
+        {
+          "tract_geoid": "08005084300",
+          "overlap_area_sqm": 1191591.8,
+          "share_of_place_area": 0.0028,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005087100",
+          "overlap_area_sqm": 981572.0,
+          "share_of_place_area": 0.0023,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005087000",
+          "overlap_area_sqm": 963527.4,
+          "share_of_place_area": 0.0023,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005081001",
+          "overlap_area_sqm": 966560.5,
+          "share_of_place_area": 0.0023,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005083600",
+          "overlap_area_sqm": 952557.1,
+          "share_of_place_area": 0.0022,
+          "share_of_tract_area": 0.9998
+        },
+        {
+          "tract_geoid": "08005084800",
+          "overlap_area_sqm": 958058.6,
+          "share_of_place_area": 0.0022,
+          "share_of_tract_area": 0.6424
+        },
+        {
+          "tract_geoid": "08005084400",
+          "overlap_area_sqm": 928121.9,
+          "share_of_place_area": 0.0022,
+          "share_of_tract_area": 0.9344
+        },
+        {
+          "tract_geoid": "08005084000",
+          "overlap_area_sqm": 883075.3,
+          "share_of_place_area": 0.0021,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005080800",
+          "overlap_area_sqm": 913775.6,
+          "share_of_place_area": 0.0021,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005007704",
+          "overlap_area_sqm": 842916.2,
+          "share_of_place_area": 0.002,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005007500",
+          "overlap_area_sqm": 855957.2,
+          "share_of_place_area": 0.002,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005007301",
+          "overlap_area_sqm": 858266.4,
+          "share_of_place_area": 0.002,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005086300",
+          "overlap_area_sqm": 826195.9,
+          "share_of_place_area": 0.0019,
+          "share_of_tract_area": 0.1672
+        },
+        {
+          "tract_geoid": "08005081700",
+          "overlap_area_sqm": 756903.9,
+          "share_of_place_area": 0.0018,
+          "share_of_tract_area": 0.4094
+        },
+        {
+          "tract_geoid": "08005084500",
+          "overlap_area_sqm": 726248.8,
+          "share_of_place_area": 0.0017,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001007801",
+          "overlap_area_sqm": 641023.1,
+          "share_of_place_area": 0.0015,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001007802",
+          "overlap_area_sqm": 636863.7,
+          "share_of_place_area": 0.0015,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005085000",
+          "overlap_area_sqm": 597660.5,
+          "share_of_place_area": 0.0014,
+          "share_of_tract_area": 0.1651
+        },
+        {
+          "tract_geoid": "08005081102",
+          "overlap_area_sqm": 353367.8,
+          "share_of_place_area": 0.0008,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005086400",
+          "overlap_area_sqm": 326805.2,
+          "share_of_place_area": 0.0008,
+          "share_of_tract_area": 0.0402
+        },
+        {
+          "tract_geoid": "08005006862",
+          "overlap_area_sqm": 309343.6,
+          "share_of_place_area": 0.0007,
+          "share_of_tract_area": 0.0555
+        },
+        {
+          "tract_geoid": "08005006854",
+          "overlap_area_sqm": 313446.3,
+          "share_of_place_area": 0.0007,
+          "share_of_tract_area": 0.1539
+        },
+        {
+          "tract_geoid": "08005006863",
+          "overlap_area_sqm": 198008.7,
+          "share_of_place_area": 0.0005,
+          "share_of_tract_area": 0.0292
+        },
+        {
+          "tract_geoid": "08005084900",
+          "overlap_area_sqm": 231284.9,
+          "share_of_place_area": 0.0005,
+          "share_of_tract_area": 0.1378
+        },
+        {
+          "tract_geoid": "08005085900",
+          "overlap_area_sqm": 137712.3,
+          "share_of_place_area": 0.0003,
+          "share_of_tract_area": 0.0292
+        },
+        {
+          "tract_geoid": "08005980000",
+          "overlap_area_sqm": 104860.8,
+          "share_of_place_area": 0.0002,
+          "share_of_tract_area": 0.0066
+        },
+        {
+          "tract_geoid": "08005086802",
+          "overlap_area_sqm": 44321.2,
+          "share_of_place_area": 0.0001,
+          "share_of_tract_area": 0.0578
+        },
+        {
+          "tract_geoid": "08005086100",
+          "overlap_area_sqm": 27464.7,
+          "share_of_place_area": 0.0001,
+          "share_of_tract_area": 0.0145
+        },
+        {
+          "tract_geoid": "08005086002",
+          "overlap_area_sqm": 25856.5,
+          "share_of_place_area": 0.0001,
+          "share_of_tract_area": 0.015
+        },
+        {
+          "tract_geoid": "08005085200",
+          "overlap_area_sqm": 32934.4,
+          "share_of_place_area": 0.0001,
+          "share_of_tract_area": 0.0091
+        },
+        {
+          "tract_geoid": "08005083201",
+          "overlap_area_sqm": 17997.0,
+          "share_of_place_area": 0.0,
+          "share_of_tract_area": 0.0075
+        }
+      ]
+    },
+    "0816495": {
+      "name": "Commerce City",
+      "place_area_sqm": 95630090.5,
+      "tracts": [
+        {
+          "tract_geoid": "08001008553",
+          "overlap_area_sqm": 20249680.5,
+          "share_of_place_area": 0.2118,
+          "share_of_tract_area": 0.1219
+        },
+        {
+          "tract_geoid": "08001008538",
+          "overlap_area_sqm": 11150926.4,
+          "share_of_place_area": 0.1166,
+          "share_of_tract_area": 0.9686
+        },
+        {
+          "tract_geoid": "08001008535",
+          "overlap_area_sqm": 8489528.3,
+          "share_of_place_area": 0.0888,
+          "share_of_tract_area": 0.5292
+        },
+        {
+          "tract_geoid": "08001008559",
+          "overlap_area_sqm": 7931447.7,
+          "share_of_place_area": 0.0829,
+          "share_of_tract_area": 0.9226
+        },
+        {
+          "tract_geoid": "08001008709",
+          "overlap_area_sqm": 7906960.9,
+          "share_of_place_area": 0.0827,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001008901",
+          "overlap_area_sqm": 7507143.0,
+          "share_of_place_area": 0.0785,
+          "share_of_tract_area": 0.8823
+        },
+        {
+          "tract_geoid": "08001008536",
+          "overlap_area_sqm": 5617824.8,
+          "share_of_place_area": 0.0587,
+          "share_of_tract_area": 0.7693
+        },
+        {
+          "tract_geoid": "08001008802",
+          "overlap_area_sqm": 5298699.2,
+          "share_of_place_area": 0.0554,
+          "share_of_tract_area": 0.3491
+        },
+        {
+          "tract_geoid": "08001988700",
+          "overlap_area_sqm": 4075044.2,
+          "share_of_place_area": 0.0426,
+          "share_of_tract_area": 0.0593
+        },
+        {
+          "tract_geoid": "08001008558",
+          "overlap_area_sqm": 3820484.7,
+          "share_of_place_area": 0.04,
+          "share_of_tract_area": 0.9807
+        },
+        {
+          "tract_geoid": "08001008557",
+          "overlap_area_sqm": 3491516.4,
+          "share_of_place_area": 0.0365,
+          "share_of_tract_area": 0.4018
+        },
+        {
+          "tract_geoid": "08001008556",
+          "overlap_area_sqm": 3355553.0,
+          "share_of_place_area": 0.0351,
+          "share_of_tract_area": 0.9879
+        },
+        {
+          "tract_geoid": "08001008705",
+          "overlap_area_sqm": 2424186.0,
+          "share_of_place_area": 0.0253,
+          "share_of_tract_area": 0.9935
+        },
+        {
+          "tract_geoid": "08001008801",
+          "overlap_area_sqm": 2415626.2,
+          "share_of_place_area": 0.0253,
+          "share_of_tract_area": 0.6212
+        },
+        {
+          "tract_geoid": "08001008706",
+          "overlap_area_sqm": 1885272.0,
+          "share_of_place_area": 0.0197,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001009103",
+          "overlap_area_sqm": 6545.0,
+          "share_of_place_area": 0.0001,
+          "share_of_tract_area": 0.0013
+        },
+        {
+          "tract_geoid": "08001015000",
+          "overlap_area_sqm": 1794.7,
+          "share_of_place_area": 0.0,
+          "share_of_tract_area": 0.0001
+        },
+        {
+          "tract_geoid": "08001008552",
+          "overlap_area_sqm": 1857.3,
+          "share_of_place_area": 0.0,
+          "share_of_tract_area": 0.0
+        }
+      ]
+    },
+    "0826270": {
+      "name": "Federal Heights",
+      "place_area_sqm": 4597900.9,
+      "tracts": [
+        {
+          "tract_geoid": "08001009321",
+          "overlap_area_sqm": 1297438.1,
+          "share_of_place_area": 0.2822,
+          "share_of_tract_area": 0.9919
+        },
+        {
+          "tract_geoid": "08001009320",
+          "overlap_area_sqm": 1228650.9,
+          "share_of_place_area": 0.2672,
+          "share_of_tract_area": 0.6415
+        },
+        {
+          "tract_geoid": "08001009316",
+          "overlap_area_sqm": 1073512.2,
+          "share_of_place_area": 0.2335,
+          "share_of_tract_area": 0.4761
+        },
+        {
+          "tract_geoid": "08001009319",
+          "overlap_area_sqm": 680936.2,
+          "share_of_place_area": 0.1481,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001009318",
+          "overlap_area_sqm": 317363.6,
+          "share_of_place_area": 0.069,
+          "share_of_tract_area": 0.2453
+        }
+      ]
+    },
+    "0883835": {
+      "name": "Westminster",
+      "place_area_sqm": 87814987.4,
+      "tracts": [
+        {
+          "tract_geoid": "08059060501",
+          "overlap_area_sqm": 9735935.7,
+          "share_of_place_area": 0.1109,
+          "share_of_tract_area": 0.345
+        },
+        {
+          "tract_geoid": "08059009829",
+          "overlap_area_sqm": 8345040.9,
+          "share_of_place_area": 0.095,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001060100",
+          "overlap_area_sqm": 6623621.6,
+          "share_of_place_area": 0.0754,
+          "share_of_tract_area": 0.9937
+        },
+        {
+          "tract_geoid": "08059060400",
+          "overlap_area_sqm": 5252506.9,
+          "share_of_place_area": 0.0598,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001060200",
+          "overlap_area_sqm": 4945986.1,
+          "share_of_place_area": 0.0563,
+          "share_of_tract_area": 0.9892
+        },
+        {
+          "tract_geoid": "08059009827",
+          "overlap_area_sqm": 4221920.7,
+          "share_of_place_area": 0.0481,
+          "share_of_tract_area": 0.9291
+        },
+        {
+          "tract_geoid": "08001009408",
+          "overlap_area_sqm": 3863033.6,
+          "share_of_place_area": 0.044,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001009325",
+          "overlap_area_sqm": 3849324.3,
+          "share_of_place_area": 0.0438,
+          "share_of_tract_area": 0.9955
+        },
+        {
+          "tract_geoid": "08001009409",
+          "overlap_area_sqm": 3841356.4,
+          "share_of_place_area": 0.0437,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059009828",
+          "overlap_area_sqm": 3321926.6,
+          "share_of_place_area": 0.0378,
+          "share_of_tract_area": 0.797
+        },
+        {
+          "tract_geoid": "08001009410",
+          "overlap_area_sqm": 2783015.3,
+          "share_of_place_area": 0.0317,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059009824",
+          "overlap_area_sqm": 2688142.9,
+          "share_of_place_area": 0.0306,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001009401",
+          "overlap_area_sqm": 2588041.8,
+          "share_of_place_area": 0.0295,
+          "share_of_tract_area": 0.7372
+        },
+        {
+          "tract_geoid": "08001009604",
+          "overlap_area_sqm": 2213408.7,
+          "share_of_place_area": 0.0252,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001009603",
+          "overlap_area_sqm": 2139367.3,
+          "share_of_place_area": 0.0244,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059009831",
+          "overlap_area_sqm": 1812035.6,
+          "share_of_place_area": 0.0206,
+          "share_of_tract_area": 0.9809
+        },
+        {
+          "tract_geoid": "08059060300",
+          "overlap_area_sqm": 1797759.0,
+          "share_of_place_area": 0.0205,
+          "share_of_tract_area": 0.9744
+        },
+        {
+          "tract_geoid": "08059009823",
+          "overlap_area_sqm": 1792968.8,
+          "share_of_place_area": 0.0204,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001009406",
+          "overlap_area_sqm": 1737750.9,
+          "share_of_place_area": 0.0198,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001060001",
+          "overlap_area_sqm": 1566382.3,
+          "share_of_place_area": 0.0178,
+          "share_of_tract_area": 0.3146
+        },
+        {
+          "tract_geoid": "08059009815",
+          "overlap_area_sqm": 1412317.2,
+          "share_of_place_area": 0.0161,
+          "share_of_tract_area": 0.2575
+        },
+        {
+          "tract_geoid": "08059010209",
+          "overlap_area_sqm": 1335642.1,
+          "share_of_place_area": 0.0152,
+          "share_of_tract_area": 0.5217
+        },
+        {
+          "tract_geoid": "08001009607",
+          "overlap_area_sqm": 1297980.2,
+          "share_of_place_area": 0.0148,
+          "share_of_tract_area": 0.4874
+        },
+        {
+          "tract_geoid": "08001009326",
+          "overlap_area_sqm": 1293311.8,
+          "share_of_place_area": 0.0147,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001009411",
+          "overlap_area_sqm": 1281217.4,
+          "share_of_place_area": 0.0146,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001009407",
+          "overlap_area_sqm": 883242.7,
+          "share_of_place_area": 0.0101,
+          "share_of_tract_area": 0.4659
+        },
+        {
+          "tract_geoid": "08059009830",
+          "overlap_area_sqm": 850051.2,
+          "share_of_place_area": 0.0097,
+          "share_of_tract_area": 0.9614
+        },
+        {
+          "tract_geoid": "08059009834",
+          "overlap_area_sqm": 764816.3,
+          "share_of_place_area": 0.0087,
+          "share_of_tract_area": 0.4155
+        },
+        {
+          "tract_geoid": "08001009501",
+          "overlap_area_sqm": 650750.1,
+          "share_of_place_area": 0.0074,
+          "share_of_tract_area": 0.5988
+        },
+        {
+          "tract_geoid": "08001009320",
+          "overlap_area_sqm": 640050.0,
+          "share_of_place_area": 0.0073,
+          "share_of_tract_area": 0.3342
+        },
+        {
+          "tract_geoid": "08001009309",
+          "overlap_area_sqm": 580813.7,
+          "share_of_place_area": 0.0066,
+          "share_of_tract_area": 0.4539
+        },
+        {
+          "tract_geoid": "08001009606",
+          "overlap_area_sqm": 546176.5,
+          "share_of_place_area": 0.0062,
+          "share_of_tract_area": 0.2612
+        },
+        {
+          "tract_geoid": "08001009502",
+          "overlap_area_sqm": 469500.8,
+          "share_of_place_area": 0.0053,
+          "share_of_tract_area": 0.1077
+        },
+        {
+          "tract_geoid": "08059010208",
+          "overlap_area_sqm": 299651.7,
+          "share_of_place_area": 0.0034,
+          "share_of_tract_area": 0.1004
+        },
+        {
+          "tract_geoid": "08059009832",
+          "overlap_area_sqm": 232267.6,
+          "share_of_place_area": 0.0026,
+          "share_of_tract_area": 0.1744
+        },
+        {
+          "tract_geoid": "08001009323",
+          "overlap_area_sqm": 96513.3,
+          "share_of_place_area": 0.0011,
+          "share_of_tract_area": 0.0441
+        },
+        {
+          "tract_geoid": "08001009608",
+          "overlap_area_sqm": 50575.0,
+          "share_of_place_area": 0.0006,
+          "share_of_tract_area": 0.0344
+        },
+        {
+          "tract_geoid": "08001009321",
+          "overlap_area_sqm": 10584.6,
+          "share_of_place_area": 0.0001,
+          "share_of_tract_area": 0.0081
+        }
+      ]
+    },
+    "0844980": {
+      "name": "Limon",
+      "place_area_sqm": 8264371.8,
+      "tracts": [
+        {
+          "tract_geoid": "08073961700",
+          "overlap_area_sqm": 8264371.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0088
+        }
+      ]
+    },
+    "0814765": {
+      "name": "City of Creede",
+      "place_area_sqm": 2452782.2,
+      "tracts": [
+        {
+          "tract_geoid": "08079973600",
+          "overlap_area_sqm": 2452782.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0011
+        }
+      ]
+    },
+    "0844100": {
+      "name": "La Veta",
+      "place_area_sqm": 3536406.2,
+      "tracts": [
+        {
+          "tract_geoid": "08055960902",
+          "overlap_area_sqm": 3536406.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0039
+        }
+      ]
+    },
+    "0820000": {
+      "name": "Denver",
+      "place_area_sqm": 400417627.2,
+      "tracts": [
+        {
+          "tract_geoid": "08031980001",
+          "overlap_area_sqm": 103456356.4,
+          "share_of_place_area": 0.2584,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031008388",
+          "overlap_area_sqm": 8806357.2,
+          "share_of_place_area": 0.022,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004110",
+          "overlap_area_sqm": 6492877.6,
+          "share_of_place_area": 0.0162,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031015800",
+          "overlap_area_sqm": 6170475.9,
+          "share_of_place_area": 0.0154,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031008389",
+          "overlap_area_sqm": 5684368.7,
+          "share_of_place_area": 0.0142,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031012010",
+          "overlap_area_sqm": 5700001.6,
+          "share_of_place_area": 0.0142,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004111",
+          "overlap_area_sqm": 5441629.0,
+          "share_of_place_area": 0.0136,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031001500",
+          "overlap_area_sqm": 5300596.9,
+          "share_of_place_area": 0.0132,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004101",
+          "overlap_area_sqm": 4689835.2,
+          "share_of_place_area": 0.0117,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004109",
+          "overlap_area_sqm": 4640552.6,
+          "share_of_place_area": 0.0116,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003501",
+          "overlap_area_sqm": 4661766.2,
+          "share_of_place_area": 0.0116,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004407",
+          "overlap_area_sqm": 4304338.5,
+          "share_of_place_area": 0.0107,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031980100",
+          "overlap_area_sqm": 4222193.4,
+          "share_of_place_area": 0.0105,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004102",
+          "overlap_area_sqm": 3922601.5,
+          "share_of_place_area": 0.0098,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031015600",
+          "overlap_area_sqm": 3736265.9,
+          "share_of_place_area": 0.0093,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003901",
+          "overlap_area_sqm": 3000660.3,
+          "share_of_place_area": 0.0075,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002102",
+          "overlap_area_sqm": 2974880.1,
+          "share_of_place_area": 0.0074,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031001403",
+          "overlap_area_sqm": 2939519.3,
+          "share_of_place_area": 0.0073,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031005502",
+          "overlap_area_sqm": 2896421.6,
+          "share_of_place_area": 0.0072,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003402",
+          "overlap_area_sqm": 2787766.0,
+          "share_of_place_area": 0.007,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004113",
+          "overlap_area_sqm": 2716666.4,
+          "share_of_place_area": 0.0068,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031015400",
+          "overlap_area_sqm": 2646734.1,
+          "share_of_place_area": 0.0066,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004003",
+          "overlap_area_sqm": 2612969.7,
+          "share_of_place_area": 0.0065,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004306",
+          "overlap_area_sqm": 2555942.7,
+          "share_of_place_area": 0.0064,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031008312",
+          "overlap_area_sqm": 2570266.5,
+          "share_of_place_area": 0.0064,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004303",
+          "overlap_area_sqm": 2493208.0,
+          "share_of_place_area": 0.0062,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004700",
+          "overlap_area_sqm": 2498075.9,
+          "share_of_place_area": 0.0062,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031001000",
+          "overlap_area_sqm": 2484731.1,
+          "share_of_place_area": 0.0062,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031007088",
+          "overlap_area_sqm": 2440526.2,
+          "share_of_place_area": 0.0061,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031011902",
+          "overlap_area_sqm": 2444046.3,
+          "share_of_place_area": 0.0061,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004002",
+          "overlap_area_sqm": 2417047.6,
+          "share_of_place_area": 0.006,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031001901",
+          "overlap_area_sqm": 2333280.8,
+          "share_of_place_area": 0.0058,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031008391",
+          "overlap_area_sqm": 2302326.1,
+          "share_of_place_area": 0.0057,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031008390",
+          "overlap_area_sqm": 2286931.6,
+          "share_of_place_area": 0.0057,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004108",
+          "overlap_area_sqm": 2300664.0,
+          "share_of_place_area": 0.0057,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031006810",
+          "overlap_area_sqm": 2250184.0,
+          "share_of_place_area": 0.0056,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031006804",
+          "overlap_area_sqm": 2221550.5,
+          "share_of_place_area": 0.0055,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003902",
+          "overlap_area_sqm": 2191248.9,
+          "share_of_place_area": 0.0055,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003004",
+          "overlap_area_sqm": 2159045.0,
+          "share_of_place_area": 0.0054,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031001302",
+          "overlap_area_sqm": 2113566.0,
+          "share_of_place_area": 0.0053,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031006814",
+          "overlap_area_sqm": 2075777.0,
+          "share_of_place_area": 0.0052,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003502",
+          "overlap_area_sqm": 2077264.4,
+          "share_of_place_area": 0.0052,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031015700",
+          "overlap_area_sqm": 2101670.4,
+          "share_of_place_area": 0.0052,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031001401",
+          "overlap_area_sqm": 2087069.7,
+          "share_of_place_area": 0.0052,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000201",
+          "overlap_area_sqm": 2077808.3,
+          "share_of_place_area": 0.0052,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031005200",
+          "overlap_area_sqm": 2050042.4,
+          "share_of_place_area": 0.0051,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000501",
+          "overlap_area_sqm": 2028754.8,
+          "share_of_place_area": 0.0051,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031006812",
+          "overlap_area_sqm": 1986006.1,
+          "share_of_place_area": 0.005,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003701",
+          "overlap_area_sqm": 1992052.6,
+          "share_of_place_area": 0.005,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003603",
+          "overlap_area_sqm": 1983103.6,
+          "share_of_place_area": 0.005,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003602",
+          "overlap_area_sqm": 1997749.8,
+          "share_of_place_area": 0.005,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031005503",
+          "overlap_area_sqm": 2018640.8,
+          "share_of_place_area": 0.005,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000903",
+          "overlap_area_sqm": 1996604.8,
+          "share_of_place_area": 0.005,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004006",
+          "overlap_area_sqm": 1951480.8,
+          "share_of_place_area": 0.0049,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004202",
+          "overlap_area_sqm": 1951036.6,
+          "share_of_place_area": 0.0049,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004104",
+          "overlap_area_sqm": 1961844.8,
+          "share_of_place_area": 0.0049,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031012001",
+          "overlap_area_sqm": 1971981.5,
+          "share_of_place_area": 0.0049,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004601",
+          "overlap_area_sqm": 1961572.1,
+          "share_of_place_area": 0.0049,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000102",
+          "overlap_area_sqm": 1948814.2,
+          "share_of_place_area": 0.0049,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004201",
+          "overlap_area_sqm": 1902980.8,
+          "share_of_place_area": 0.0048,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004602",
+          "overlap_area_sqm": 1937004.4,
+          "share_of_place_area": 0.0048,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000301",
+          "overlap_area_sqm": 1925248.6,
+          "share_of_place_area": 0.0048,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031006816",
+          "overlap_area_sqm": 1864197.4,
+          "share_of_place_area": 0.0047,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004103",
+          "overlap_area_sqm": 1898049.4,
+          "share_of_place_area": 0.0047,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004603",
+          "overlap_area_sqm": 1866255.7,
+          "share_of_place_area": 0.0047,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031001301",
+          "overlap_area_sqm": 1886413.0,
+          "share_of_place_area": 0.0047,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000902",
+          "overlap_area_sqm": 1872744.8,
+          "share_of_place_area": 0.0047,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031007006",
+          "overlap_area_sqm": 1836884.2,
+          "share_of_place_area": 0.0046,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000202",
+          "overlap_area_sqm": 1784262.0,
+          "share_of_place_area": 0.0045,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031008387",
+          "overlap_area_sqm": 1736605.5,
+          "share_of_place_area": 0.0043,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004406",
+          "overlap_area_sqm": 1699108.4,
+          "share_of_place_area": 0.0042,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031001402",
+          "overlap_area_sqm": 1670163.7,
+          "share_of_place_area": 0.0042,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003203",
+          "overlap_area_sqm": 1681803.0,
+          "share_of_place_area": 0.0042,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031980200",
+          "overlap_area_sqm": 1669939.0,
+          "share_of_place_area": 0.0042,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031005102",
+          "overlap_area_sqm": 1623612.1,
+          "share_of_place_area": 0.0041,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000800",
+          "overlap_area_sqm": 1653777.2,
+          "share_of_place_area": 0.0041,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004112",
+          "overlap_area_sqm": 1568322.4,
+          "share_of_place_area": 0.0039,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031005001",
+          "overlap_area_sqm": 1540839.3,
+          "share_of_place_area": 0.0038,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031012015",
+          "overlap_area_sqm": 1521237.1,
+          "share_of_place_area": 0.0038,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004403",
+          "overlap_area_sqm": 1464220.7,
+          "share_of_place_area": 0.0037,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000303",
+          "overlap_area_sqm": 1462333.2,
+          "share_of_place_area": 0.0037,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004004",
+          "overlap_area_sqm": 1426976.4,
+          "share_of_place_area": 0.0036,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003002",
+          "overlap_area_sqm": 1439997.1,
+          "share_of_place_area": 0.0036,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002300",
+          "overlap_area_sqm": 1457321.8,
+          "share_of_place_area": 0.0036,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000302",
+          "overlap_area_sqm": 1442892.3,
+          "share_of_place_area": 0.0036,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004801",
+          "overlap_area_sqm": 1400357.5,
+          "share_of_place_area": 0.0035,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031008306",
+          "overlap_area_sqm": 1365850.5,
+          "share_of_place_area": 0.0034,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004404",
+          "overlap_area_sqm": 1303168.7,
+          "share_of_place_area": 0.0033,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004309",
+          "overlap_area_sqm": 1331661.8,
+          "share_of_place_area": 0.0033,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003601",
+          "overlap_area_sqm": 1325279.8,
+          "share_of_place_area": 0.0033,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000905",
+          "overlap_area_sqm": 1311883.0,
+          "share_of_place_area": 0.0033,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031001102",
+          "overlap_area_sqm": 1327879.9,
+          "share_of_place_area": 0.0033,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003300",
+          "overlap_area_sqm": 1287686.6,
+          "share_of_place_area": 0.0032,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004310",
+          "overlap_area_sqm": 1288511.2,
+          "share_of_place_area": 0.0032,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031001601",
+          "overlap_area_sqm": 1277814.3,
+          "share_of_place_area": 0.0032,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031008386",
+          "overlap_area_sqm": 1291120.9,
+          "share_of_place_area": 0.0032,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002902",
+          "overlap_area_sqm": 1262460.4,
+          "share_of_place_area": 0.0032,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000600",
+          "overlap_area_sqm": 1277923.6,
+          "share_of_place_area": 0.0032,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031006818",
+          "overlap_area_sqm": 1258082.7,
+          "share_of_place_area": 0.0031,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031007013",
+          "overlap_area_sqm": 1253008.4,
+          "share_of_place_area": 0.0031,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000904",
+          "overlap_area_sqm": 1240252.0,
+          "share_of_place_area": 0.0031,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003006",
+          "overlap_area_sqm": 1213992.7,
+          "share_of_place_area": 0.003,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031006815",
+          "overlap_area_sqm": 1153714.6,
+          "share_of_place_area": 0.0029,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003801",
+          "overlap_area_sqm": 1175761.1,
+          "share_of_place_area": 0.0029,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031005300",
+          "overlap_area_sqm": 1135542.4,
+          "share_of_place_area": 0.0028,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031005004",
+          "overlap_area_sqm": 1130533.4,
+          "share_of_place_area": 0.0028,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031015300",
+          "overlap_area_sqm": 1136532.8,
+          "share_of_place_area": 0.0028,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004302",
+          "overlap_area_sqm": 1103166.8,
+          "share_of_place_area": 0.0028,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003401",
+          "overlap_area_sqm": 1127150.5,
+          "share_of_place_area": 0.0028,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003003",
+          "overlap_area_sqm": 1086918.2,
+          "share_of_place_area": 0.0027,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000504",
+          "overlap_area_sqm": 1078587.8,
+          "share_of_place_area": 0.0027,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031006813",
+          "overlap_area_sqm": 1041298.9,
+          "share_of_place_area": 0.0026,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031006902",
+          "overlap_area_sqm": 1052253.2,
+          "share_of_place_area": 0.0026,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004005",
+          "overlap_area_sqm": 1055424.6,
+          "share_of_place_area": 0.0026,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031007037",
+          "overlap_area_sqm": 1057905.6,
+          "share_of_place_area": 0.0026,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031008305",
+          "overlap_area_sqm": 1025364.2,
+          "share_of_place_area": 0.0026,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031011903",
+          "overlap_area_sqm": 1051237.7,
+          "share_of_place_area": 0.0026,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031006701",
+          "overlap_area_sqm": 1017354.6,
+          "share_of_place_area": 0.0025,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003802",
+          "overlap_area_sqm": 1011329.6,
+          "share_of_place_area": 0.0025,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031012016",
+          "overlap_area_sqm": 993429.2,
+          "share_of_place_area": 0.0025,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004503",
+          "overlap_area_sqm": 1017020.0,
+          "share_of_place_area": 0.0025,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002901",
+          "overlap_area_sqm": 994667.7,
+          "share_of_place_area": 0.0025,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004505",
+          "overlap_area_sqm": 999767.4,
+          "share_of_place_area": 0.0025,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031005003",
+          "overlap_area_sqm": 977327.3,
+          "share_of_place_area": 0.0024,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031001602",
+          "overlap_area_sqm": 969606.7,
+          "share_of_place_area": 0.0024,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004506",
+          "overlap_area_sqm": 957874.1,
+          "share_of_place_area": 0.0024,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031001800",
+          "overlap_area_sqm": 974343.7,
+          "share_of_place_area": 0.0024,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031001603",
+          "overlap_area_sqm": 948583.5,
+          "share_of_place_area": 0.0024,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000403",
+          "overlap_area_sqm": 971030.1,
+          "share_of_place_area": 0.0024,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000401",
+          "overlap_area_sqm": 977610.8,
+          "share_of_place_area": 0.0024,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031006817",
+          "overlap_area_sqm": 911514.9,
+          "share_of_place_area": 0.0023,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031006903",
+          "overlap_area_sqm": 935580.7,
+          "share_of_place_area": 0.0023,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031008304",
+          "overlap_area_sqm": 933749.1,
+          "share_of_place_area": 0.0023,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003005",
+          "overlap_area_sqm": 905192.6,
+          "share_of_place_area": 0.0023,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004504",
+          "overlap_area_sqm": 898567.5,
+          "share_of_place_area": 0.0022,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002802",
+          "overlap_area_sqm": 886082.4,
+          "share_of_place_area": 0.0022,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002101",
+          "overlap_area_sqm": 880224.3,
+          "share_of_place_area": 0.0022,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003102",
+          "overlap_area_sqm": 868100.2,
+          "share_of_place_area": 0.0022,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031001101",
+          "overlap_area_sqm": 898166.4,
+          "share_of_place_area": 0.0022,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004308",
+          "overlap_area_sqm": 790581.0,
+          "share_of_place_area": 0.002,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002000",
+          "overlap_area_sqm": 786674.3,
+          "share_of_place_area": 0.002,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031005104",
+          "overlap_area_sqm": 741445.8,
+          "share_of_place_area": 0.0019,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031007091",
+          "overlap_area_sqm": 756790.2,
+          "share_of_place_area": 0.0019,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002801",
+          "overlap_area_sqm": 752657.3,
+          "share_of_place_area": 0.0019,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000704",
+          "overlap_area_sqm": 720090.7,
+          "share_of_place_area": 0.0018,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003702",
+          "overlap_area_sqm": 705633.5,
+          "share_of_place_area": 0.0018,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000705",
+          "overlap_area_sqm": 735591.6,
+          "share_of_place_area": 0.0018,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003703",
+          "overlap_area_sqm": 680957.5,
+          "share_of_place_area": 0.0017,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000706",
+          "overlap_area_sqm": 674558.4,
+          "share_of_place_area": 0.0017,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000404",
+          "overlap_area_sqm": 682884.1,
+          "share_of_place_area": 0.0017,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031001707",
+          "overlap_area_sqm": 638384.5,
+          "share_of_place_area": 0.0016,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031015500",
+          "overlap_area_sqm": 591265.6,
+          "share_of_place_area": 0.0015,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031004307",
+          "overlap_area_sqm": 614050.0,
+          "share_of_place_area": 0.0015,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003205",
+          "overlap_area_sqm": 607438.8,
+          "share_of_place_area": 0.0015,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002405",
+          "overlap_area_sqm": 569440.1,
+          "share_of_place_area": 0.0014,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003202",
+          "overlap_area_sqm": 507233.0,
+          "share_of_place_area": 0.0013,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000503",
+          "overlap_area_sqm": 514037.9,
+          "share_of_place_area": 0.0013,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003101",
+          "overlap_area_sqm": 516429.5,
+          "share_of_place_area": 0.0013,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031000703",
+          "overlap_area_sqm": 477389.2,
+          "share_of_place_area": 0.0012,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031001706",
+          "overlap_area_sqm": 477190.3,
+          "share_of_place_area": 0.0012,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031001704",
+          "overlap_area_sqm": 489373.8,
+          "share_of_place_area": 0.0012,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002602",
+          "overlap_area_sqm": 392968.3,
+          "share_of_place_area": 0.001,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002402",
+          "overlap_area_sqm": 410925.5,
+          "share_of_place_area": 0.001,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002805",
+          "overlap_area_sqm": 359466.1,
+          "share_of_place_area": 0.0009,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002704",
+          "overlap_area_sqm": 344645.5,
+          "share_of_place_area": 0.0009,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031001705",
+          "overlap_area_sqm": 376838.7,
+          "share_of_place_area": 0.0009,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002404",
+          "overlap_area_sqm": 371389.6,
+          "share_of_place_area": 0.0009,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002706",
+          "overlap_area_sqm": 339967.5,
+          "share_of_place_area": 0.0008,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002707",
+          "overlap_area_sqm": 315009.0,
+          "share_of_place_area": 0.0008,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002708",
+          "overlap_area_sqm": 318608.1,
+          "share_of_place_area": 0.0008,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031001703",
+          "overlap_area_sqm": 272270.5,
+          "share_of_place_area": 0.0007,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002603",
+          "overlap_area_sqm": 289559.4,
+          "share_of_place_area": 0.0007,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002705",
+          "overlap_area_sqm": 228992.6,
+          "share_of_place_area": 0.0006,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031003204",
+          "overlap_area_sqm": 248327.9,
+          "share_of_place_area": 0.0006,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002604",
+          "overlap_area_sqm": 229897.0,
+          "share_of_place_area": 0.0006,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031007090",
+          "overlap_area_sqm": 204741.5,
+          "share_of_place_area": 0.0005,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002804",
+          "overlap_area_sqm": 204190.1,
+          "share_of_place_area": 0.0005,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08031002709",
+          "overlap_area_sqm": 203344.6,
+          "share_of_place_area": 0.0005,
+          "share_of_tract_area": 1.0
+        }
+      ]
+    },
+    "0870250": {
+      "name": "Silver Cliff",
+      "place_area_sqm": 40008441.8,
+      "tracts": [
+        {
+          "tract_geoid": "08027970102",
+          "overlap_area_sqm": 38271440.4,
+          "share_of_place_area": 0.9566,
+          "share_of_tract_area": 0.0439
+        },
+        {
+          "tract_geoid": "08027970101",
+          "overlap_area_sqm": 1737001.4,
+          "share_of_place_area": 0.0434,
+          "share_of_tract_area": 0.0017
+        }
+      ]
+    },
+    "0883450": {
+      "name": "Westcliffe",
+      "place_area_sqm": 3199599.9,
+      "tracts": [
+        {
+          "tract_geoid": "08027970101",
+          "overlap_area_sqm": 2510289.9,
+          "share_of_place_area": 0.7846,
+          "share_of_tract_area": 0.0024
+        },
+        {
+          "tract_geoid": "08027970102",
+          "overlap_area_sqm": 689310.0,
+          "share_of_place_area": 0.2154,
+          "share_of_tract_area": 0.0008
+        }
+      ]
+    },
+    "0819795": {
+      "name": "Del Norte",
+      "place_area_sqm": 2788561.6,
+      "tracts": [
+        {
+          "tract_geoid": "08105976800",
+          "overlap_area_sqm": 2758937.8,
+          "share_of_place_area": 0.9894,
+          "share_of_tract_area": 0.2537
+        },
+        {
+          "tract_geoid": "08105977001",
+          "overlap_area_sqm": 29623.8,
+          "share_of_place_area": 0.0106,
+          "share_of_tract_area": 0.0
+        }
+      ]
+    },
+    "0851635": {
+      "name": "Monte Vista",
+      "place_area_sqm": 6873996.2,
+      "tracts": [
+        {
+          "tract_geoid": "08105976700",
+          "overlap_area_sqm": 6873996.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.1502
+        }
+      ]
+    },
+    "0825280": {
+      "name": "Evans",
+      "place_area_sqm": 28450522.8,
+      "tracts": [
+        {
+          "tract_geoid": "08123001700",
+          "overlap_area_sqm": 6584010.5,
+          "share_of_place_area": 0.2314,
+          "share_of_tract_area": 0.0384
+        },
+        {
+          "tract_geoid": "08123001404",
+          "overlap_area_sqm": 6169578.1,
+          "share_of_place_area": 0.2169,
+          "share_of_tract_area": 0.3444
+        },
+        {
+          "tract_geoid": "08123001005",
+          "overlap_area_sqm": 5200323.4,
+          "share_of_place_area": 0.1828,
+          "share_of_tract_area": 0.6355
+        },
+        {
+          "tract_geoid": "08123001004",
+          "overlap_area_sqm": 3491407.7,
+          "share_of_place_area": 0.1227,
+          "share_of_tract_area": 0.7901
+        },
+        {
+          "tract_geoid": "08123001405",
+          "overlap_area_sqm": 2877793.8,
+          "share_of_place_area": 0.1012,
+          "share_of_tract_area": 0.7485
+        },
+        {
+          "tract_geoid": "08123001006",
+          "overlap_area_sqm": 2481673.9,
+          "share_of_place_area": 0.0872,
+          "share_of_tract_area": 0.8906
+        },
+        {
+          "tract_geoid": "08123002101",
+          "overlap_area_sqm": 1553015.8,
+          "share_of_place_area": 0.0546,
+          "share_of_tract_area": 0.0138
+        },
+        {
+          "tract_geoid": "08123001003",
+          "overlap_area_sqm": 85289.6,
+          "share_of_place_area": 0.003,
+          "share_of_tract_area": 0.0684
+        },
+        {
+          "tract_geoid": "08123000704",
+          "overlap_area_sqm": 7429.9,
+          "share_of_place_area": 0.0003,
+          "share_of_tract_area": 0.0039
+        }
+      ]
+    },
+    "0850480": {
+      "name": "Milliken",
+      "place_area_sqm": 33979085.8,
+      "tracts": [
+        {
+          "tract_geoid": "08123002101",
+          "overlap_area_sqm": 26668903.8,
+          "share_of_place_area": 0.7849,
+          "share_of_tract_area": 0.2369
+        },
+        {
+          "tract_geoid": "08123001700",
+          "overlap_area_sqm": 3432314.5,
+          "share_of_place_area": 0.101,
+          "share_of_tract_area": 0.02
+        },
+        {
+          "tract_geoid": "08123001800",
+          "overlap_area_sqm": 1954847.1,
+          "share_of_place_area": 0.0575,
+          "share_of_tract_area": 0.0059
+        },
+        {
+          "tract_geoid": "08123001404",
+          "overlap_area_sqm": 1923020.5,
+          "share_of_place_area": 0.0566,
+          "share_of_tract_area": 0.1073
+        }
+      ]
+    },
+    "0860160": {
+      "name": "Platteville",
+      "place_area_sqm": 8726989.6,
+      "tracts": [
+        {
+          "tract_geoid": "08123001800",
+          "overlap_area_sqm": 8109548.3,
+          "share_of_place_area": 0.9292,
+          "share_of_tract_area": 0.0245
+        },
+        {
+          "tract_geoid": "08123001700",
+          "overlap_area_sqm": 617441.3,
+          "share_of_place_area": 0.0708,
+          "share_of_tract_area": 0.0036
+        }
+      ]
+    },
+    "0880040": {
+      "name": "Vail",
+      "place_area_sqm": 12221377.8,
+      "tracts": [
+        {
+          "tract_geoid": "08037000702",
+          "overlap_area_sqm": 5379582.0,
+          "share_of_place_area": 0.4402,
+          "share_of_tract_area": 0.118
+        },
+        {
+          "tract_geoid": "08037000703",
+          "overlap_area_sqm": 5297187.1,
+          "share_of_place_area": 0.4334,
+          "share_of_tract_area": 0.0238
+        },
+        {
+          "tract_geoid": "08037000701",
+          "overlap_area_sqm": 1544608.7,
+          "share_of_place_area": 0.1264,
+          "share_of_tract_area": 0.0768
+        }
+      ]
+    },
+    "0826600": {
+      "name": "Firestone",
+      "place_area_sqm": 37692138.2,
+      "tracts": [
+        {
+          "tract_geoid": "08123002019",
+          "overlap_area_sqm": 9666329.5,
+          "share_of_place_area": 0.2565,
+          "share_of_tract_area": 0.6673
+        },
+        {
+          "tract_geoid": "08123002105",
+          "overlap_area_sqm": 7820686.2,
+          "share_of_place_area": 0.2075,
+          "share_of_tract_area": 0.1728
+        },
+        {
+          "tract_geoid": "08123002016",
+          "overlap_area_sqm": 6482650.8,
+          "share_of_place_area": 0.172,
+          "share_of_tract_area": 0.4228
+        },
+        {
+          "tract_geoid": "08123002021",
+          "overlap_area_sqm": 5736114.9,
+          "share_of_place_area": 0.1522,
+          "share_of_tract_area": 0.315
+        },
+        {
+          "tract_geoid": "08123002020",
+          "overlap_area_sqm": 4340225.0,
+          "share_of_place_area": 0.1151,
+          "share_of_tract_area": 0.8531
+        },
+        {
+          "tract_geoid": "08123002010",
+          "overlap_area_sqm": 2617239.5,
+          "share_of_place_area": 0.0694,
+          "share_of_tract_area": 0.0638
+        },
+        {
+          "tract_geoid": "08123001800",
+          "overlap_area_sqm": 846572.7,
+          "share_of_place_area": 0.0225,
+          "share_of_tract_area": 0.0026
+        },
+        {
+          "tract_geoid": "08123002013",
+          "overlap_area_sqm": 173111.1,
+          "share_of_place_area": 0.0046,
+          "share_of_tract_area": 0.0217
+        },
+        {
+          "tract_geoid": "08123002018",
+          "overlap_area_sqm": 9208.6,
+          "share_of_place_area": 0.0002,
+          "share_of_tract_area": 0.0035
+        }
+      ]
+    },
+    "0828360": {
+      "name": "Frederick",
+      "place_area_sqm": 39681741.7,
+      "tracts": [
+        {
+          "tract_geoid": "08123002010",
+          "overlap_area_sqm": 7569254.6,
+          "share_of_place_area": 0.1907,
+          "share_of_tract_area": 0.1844
+        },
+        {
+          "tract_geoid": "08123002012",
+          "overlap_area_sqm": 7097720.9,
+          "share_of_place_area": 0.1789,
+          "share_of_tract_area": 0.8765
+        },
+        {
+          "tract_geoid": "08123002013",
+          "overlap_area_sqm": 6363461.0,
+          "share_of_place_area": 0.1604,
+          "share_of_tract_area": 0.7975
+        },
+        {
+          "tract_geoid": "08123002017",
+          "overlap_area_sqm": 4598709.2,
+          "share_of_place_area": 0.1159,
+          "share_of_tract_area": 0.7239
+        },
+        {
+          "tract_geoid": "08123002015",
+          "overlap_area_sqm": 3657343.0,
+          "share_of_place_area": 0.0922,
+          "share_of_tract_area": 0.5656
+        },
+        {
+          "tract_geoid": "08123002011",
+          "overlap_area_sqm": 2975109.1,
+          "share_of_place_area": 0.075,
+          "share_of_tract_area": 0.7703
+        },
+        {
+          "tract_geoid": "08123002018",
+          "overlap_area_sqm": 2565142.6,
+          "share_of_place_area": 0.0646,
+          "share_of_tract_area": 0.9737
+        },
+        {
+          "tract_geoid": "08123002014",
+          "overlap_area_sqm": 2350241.9,
+          "share_of_place_area": 0.0592,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123002016",
+          "overlap_area_sqm": 1573715.0,
+          "share_of_place_area": 0.0397,
+          "share_of_tract_area": 0.1026
+        },
+        {
+          "tract_geoid": "08123002009",
+          "overlap_area_sqm": 909099.0,
+          "share_of_place_area": 0.0229,
+          "share_of_tract_area": 0.0213
+        },
+        {
+          "tract_geoid": "08123002004",
+          "overlap_area_sqm": 21945.4,
+          "share_of_place_area": 0.0006,
+          "share_of_tract_area": 0.0022
+        }
+      ]
+    },
+    "0862000": {
+      "name": "Pueblo",
+      "place_area_sqm": 148317739.3,
+      "tracts": [
+        {
+          "tract_geoid": "08101003600",
+          "overlap_area_sqm": 23197978.0,
+          "share_of_place_area": 0.1564,
+          "share_of_tract_area": 0.0154
+        },
+        {
+          "tract_geoid": "08101002806",
+          "overlap_area_sqm": 16908210.9,
+          "share_of_place_area": 0.114,
+          "share_of_tract_area": 0.0191
+        },
+        {
+          "tract_geoid": "08101003004",
+          "overlap_area_sqm": 8715158.2,
+          "share_of_place_area": 0.0588,
+          "share_of_tract_area": 0.827
+        },
+        {
+          "tract_geoid": "08101002920",
+          "overlap_area_sqm": 7357853.0,
+          "share_of_place_area": 0.0496,
+          "share_of_tract_area": 0.3215
+        },
+        {
+          "tract_geoid": "08101002901",
+          "overlap_area_sqm": 6437898.6,
+          "share_of_place_area": 0.0434,
+          "share_of_tract_area": 0.6626
+        },
+        {
+          "tract_geoid": "08101003500",
+          "overlap_area_sqm": 5320935.4,
+          "share_of_place_area": 0.0359,
+          "share_of_tract_area": 0.999
+        },
+        {
+          "tract_geoid": "08101003106",
+          "overlap_area_sqm": 5268086.4,
+          "share_of_place_area": 0.0355,
+          "share_of_tract_area": 0.1369
+        },
+        {
+          "tract_geoid": "08101002917",
+          "overlap_area_sqm": 4412431.8,
+          "share_of_place_area": 0.0297,
+          "share_of_tract_area": 0.0984
+        },
+        {
+          "tract_geoid": "08101000902",
+          "overlap_area_sqm": 3601987.5,
+          "share_of_place_area": 0.0243,
+          "share_of_tract_area": 0.9818
+        },
+        {
+          "tract_geoid": "08101002300",
+          "overlap_area_sqm": 3555664.0,
+          "share_of_place_area": 0.024,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101000500",
+          "overlap_area_sqm": 3550626.1,
+          "share_of_place_area": 0.0239,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101002919",
+          "overlap_area_sqm": 3508682.4,
+          "share_of_place_area": 0.0237,
+          "share_of_tract_area": 0.989
+        },
+        {
+          "tract_geoid": "08101002808",
+          "overlap_area_sqm": 3437210.4,
+          "share_of_place_area": 0.0232,
+          "share_of_tract_area": 0.5296
+        },
+        {
+          "tract_geoid": "08101000100",
+          "overlap_area_sqm": 3390134.5,
+          "share_of_place_area": 0.0229,
+          "share_of_tract_area": 0.9859
+        },
+        {
+          "tract_geoid": "08101001700",
+          "overlap_area_sqm": 3116339.6,
+          "share_of_place_area": 0.021,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101000200",
+          "overlap_area_sqm": 3056060.6,
+          "share_of_place_area": 0.0206,
+          "share_of_tract_area": 0.9692
+        },
+        {
+          "tract_geoid": "08101002700",
+          "overlap_area_sqm": 2820844.8,
+          "share_of_place_area": 0.019,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101002807",
+          "overlap_area_sqm": 2804315.2,
+          "share_of_place_area": 0.0189,
+          "share_of_tract_area": 0.8859
+        },
+        {
+          "tract_geoid": "08101001600",
+          "overlap_area_sqm": 2689968.2,
+          "share_of_place_area": 0.0181,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101000904",
+          "overlap_area_sqm": 2487626.0,
+          "share_of_place_area": 0.0168,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101002000",
+          "overlap_area_sqm": 2359701.8,
+          "share_of_place_area": 0.0159,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101002600",
+          "overlap_area_sqm": 2343648.5,
+          "share_of_place_area": 0.0158,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101002801",
+          "overlap_area_sqm": 2169080.3,
+          "share_of_place_area": 0.0146,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101000800",
+          "overlap_area_sqm": 2115295.4,
+          "share_of_place_area": 0.0143,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101001200",
+          "overlap_area_sqm": 2047744.9,
+          "share_of_place_area": 0.0138,
+          "share_of_tract_area": 0.7608
+        },
+        {
+          "tract_geoid": "08101001000",
+          "overlap_area_sqm": 1999737.3,
+          "share_of_place_area": 0.0135,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101002802",
+          "overlap_area_sqm": 1992905.1,
+          "share_of_place_area": 0.0134,
+          "share_of_tract_area": 0.4839
+        },
+        {
+          "tract_geoid": "08101000400",
+          "overlap_area_sqm": 1664723.8,
+          "share_of_place_area": 0.0112,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101000903",
+          "overlap_area_sqm": 1515930.9,
+          "share_of_place_area": 0.0102,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101001100",
+          "overlap_area_sqm": 1394343.8,
+          "share_of_place_area": 0.0094,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101001500",
+          "overlap_area_sqm": 1286600.3,
+          "share_of_place_area": 0.0087,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101000300",
+          "overlap_area_sqm": 1249522.7,
+          "share_of_place_area": 0.0084,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101002500",
+          "overlap_area_sqm": 1199354.5,
+          "share_of_place_area": 0.0081,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101001800",
+          "overlap_area_sqm": 1120873.3,
+          "share_of_place_area": 0.0076,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101001400",
+          "overlap_area_sqm": 1118061.3,
+          "share_of_place_area": 0.0075,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101003001",
+          "overlap_area_sqm": 1013335.0,
+          "share_of_place_area": 0.0068,
+          "share_of_tract_area": 0.0724
+        },
+        {
+          "tract_geoid": "08101001900",
+          "overlap_area_sqm": 930540.5,
+          "share_of_place_area": 0.0063,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101000600",
+          "overlap_area_sqm": 903560.9,
+          "share_of_place_area": 0.0061,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101002400",
+          "overlap_area_sqm": 850005.7,
+          "share_of_place_area": 0.0057,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101002200",
+          "overlap_area_sqm": 794448.4,
+          "share_of_place_area": 0.0054,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101002100",
+          "overlap_area_sqm": 782029.8,
+          "share_of_place_area": 0.0053,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101002921",
+          "overlap_area_sqm": 751380.7,
+          "share_of_place_area": 0.0051,
+          "share_of_tract_area": 0.0213
+        },
+        {
+          "tract_geoid": "08101000905",
+          "overlap_area_sqm": 704080.5,
+          "share_of_place_area": 0.0047,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101003103",
+          "overlap_area_sqm": 372822.2,
+          "share_of_place_area": 0.0025,
+          "share_of_tract_area": 0.028
+        }
+      ]
+    },
+    "0841010": {
+      "name": "Kit Carson",
+      "place_area_sqm": 1530191.1,
+      "tracts": [
+        {
+          "tract_geoid": "08017960600",
+          "overlap_area_sqm": 1530191.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0803235": {
+      "name": "Arriba",
+      "place_area_sqm": 1291915.1,
+      "tracts": [
+        {
+          "tract_geoid": "08073961800",
+          "overlap_area_sqm": 1291915.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0815550": {
+      "name": "Cokedale",
+      "place_area_sqm": 530361.7,
+      "tracts": [
+        {
+          "tract_geoid": "08071000300",
+          "overlap_area_sqm": 530361.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0807190": {
+      "name": "Blanca",
+      "place_area_sqm": 4743450.1,
+      "tracts": [
+        {
+          "tract_geoid": "08023972600",
+          "overlap_area_sqm": 4743450.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.003
+        }
+      ]
+    },
+    "0824785": {
+      "name": "Englewood",
+      "place_area_sqm": 17206155.7,
+      "tracts": [
+        {
+          "tract_geoid": "08005006400",
+          "overlap_area_sqm": 1936343.9,
+          "share_of_place_area": 0.1125,
+          "share_of_tract_area": 0.8075
+        },
+        {
+          "tract_geoid": "08005005551",
+          "overlap_area_sqm": 1876380.9,
+          "share_of_place_area": 0.1091,
+          "share_of_tract_area": 0.6032
+        },
+        {
+          "tract_geoid": "08005006200",
+          "overlap_area_sqm": 1689692.1,
+          "share_of_place_area": 0.0982,
+          "share_of_tract_area": 0.6699
+        },
+        {
+          "tract_geoid": "08005006000",
+          "overlap_area_sqm": 1564742.8,
+          "share_of_place_area": 0.0909,
+          "share_of_tract_area": 0.5954
+        },
+        {
+          "tract_geoid": "08005005951",
+          "overlap_area_sqm": 1433905.6,
+          "share_of_place_area": 0.0833,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005005553",
+          "overlap_area_sqm": 1311129.9,
+          "share_of_place_area": 0.0762,
+          "share_of_tract_area": 0.5023
+        },
+        {
+          "tract_geoid": "08005006300",
+          "overlap_area_sqm": 1292131.4,
+          "share_of_place_area": 0.0751,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005005800",
+          "overlap_area_sqm": 1209961.3,
+          "share_of_place_area": 0.0703,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005005701",
+          "overlap_area_sqm": 1138524.8,
+          "share_of_place_area": 0.0662,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005006100",
+          "overlap_area_sqm": 1130675.2,
+          "share_of_place_area": 0.0657,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005005702",
+          "overlap_area_sqm": 1084592.8,
+          "share_of_place_area": 0.063,
+          "share_of_tract_area": 0.9204
+        },
+        {
+          "tract_geoid": "08005005952",
+          "overlap_area_sqm": 844400.9,
+          "share_of_place_area": 0.0491,
+          "share_of_tract_area": 0.8286
+        },
+        {
+          "tract_geoid": "08005006601",
+          "overlap_area_sqm": 430203.0,
+          "share_of_place_area": 0.025,
+          "share_of_tract_area": 0.2214
+        },
+        {
+          "tract_geoid": "08005005612",
+          "overlap_area_sqm": 259709.9,
+          "share_of_place_area": 0.0151,
+          "share_of_tract_area": 0.0669
+        },
+        {
+          "tract_geoid": "08005006705",
+          "overlap_area_sqm": 3761.2,
+          "share_of_place_area": 0.0002,
+          "share_of_tract_area": 0.0007
+        }
+      ]
+    },
+    "0833035": {
+      "name": "Greenwood Village",
+      "place_area_sqm": 21419402.0,
+      "tracts": [
+        {
+          "tract_geoid": "08005005636",
+          "overlap_area_sqm": 5119866.8,
+          "share_of_place_area": 0.239,
+          "share_of_tract_area": 0.9991
+        },
+        {
+          "tract_geoid": "08005006712",
+          "overlap_area_sqm": 4998423.3,
+          "share_of_place_area": 0.2334,
+          "share_of_tract_area": 0.9958
+        },
+        {
+          "tract_geoid": "08005005612",
+          "overlap_area_sqm": 2689510.7,
+          "share_of_place_area": 0.1256,
+          "share_of_tract_area": 0.6932
+        },
+        {
+          "tract_geoid": "08005006857",
+          "overlap_area_sqm": 1894102.2,
+          "share_of_place_area": 0.0884,
+          "share_of_tract_area": 0.9482
+        },
+        {
+          "tract_geoid": "08005006859",
+          "overlap_area_sqm": 1671957.3,
+          "share_of_place_area": 0.0781,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005006854",
+          "overlap_area_sqm": 1665656.0,
+          "share_of_place_area": 0.0778,
+          "share_of_tract_area": 0.8176
+        },
+        {
+          "tract_geoid": "08005006808",
+          "overlap_area_sqm": 1055815.3,
+          "share_of_place_area": 0.0493,
+          "share_of_tract_area": 0.2775
+        },
+        {
+          "tract_geoid": "08005006860",
+          "overlap_area_sqm": 1045601.9,
+          "share_of_place_area": 0.0488,
+          "share_of_tract_area": 0.8909
+        },
+        {
+          "tract_geoid": "08005006815",
+          "overlap_area_sqm": 503344.3,
+          "share_of_place_area": 0.0235,
+          "share_of_tract_area": 0.1569
+        },
+        {
+          "tract_geoid": "08005006861",
+          "overlap_area_sqm": 346688.0,
+          "share_of_place_area": 0.0162,
+          "share_of_tract_area": 0.1313
+        },
+        {
+          "tract_geoid": "08005005611",
+          "overlap_area_sqm": 135676.0,
+          "share_of_place_area": 0.0063,
+          "share_of_tract_area": 0.0338
+        },
+        {
+          "tract_geoid": "08005980000",
+          "overlap_area_sqm": 93459.7,
+          "share_of_place_area": 0.0044,
+          "share_of_tract_area": 0.0059
+        },
+        {
+          "tract_geoid": "08005005614",
+          "overlap_area_sqm": 83135.1,
+          "share_of_place_area": 0.0039,
+          "share_of_tract_area": 0.0357
+        },
+        {
+          "tract_geoid": "08005006711",
+          "overlap_area_sqm": 77131.7,
+          "share_of_place_area": 0.0036,
+          "share_of_tract_area": 0.0298
+        },
+        {
+          "tract_geoid": "08005006862",
+          "overlap_area_sqm": 23620.2,
+          "share_of_place_area": 0.0011,
+          "share_of_tract_area": 0.0042
+        },
+        {
+          "tract_geoid": "08005006707",
+          "overlap_area_sqm": 10856.5,
+          "share_of_place_area": 0.0005,
+          "share_of_tract_area": 0.0034
+        },
+        {
+          "tract_geoid": "08005005635",
+          "overlap_area_sqm": 4557.0,
+          "share_of_place_area": 0.0002,
+          "share_of_tract_area": 0.0017
+        }
+      ]
+    },
+    "0819630": {
+      "name": "Deer Trail",
+      "place_area_sqm": 3303318.5,
+      "tracts": [
+        {
+          "tract_geoid": "08005007101",
+          "overlap_area_sqm": 3303318.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0027
+        }
+      ]
+    },
+    "0843000": {
+      "name": "Lakewood",
+      "place_area_sqm": 115559451.2,
+      "tracts": [
+        {
+          "tract_geoid": "08059011731",
+          "overlap_area_sqm": 12135179.4,
+          "share_of_place_area": 0.105,
+          "share_of_tract_area": 0.8624
+        },
+        {
+          "tract_geoid": "08059011720",
+          "overlap_area_sqm": 11123800.3,
+          "share_of_place_area": 0.0963,
+          "share_of_tract_area": 0.7193
+        },
+        {
+          "tract_geoid": "08059011724",
+          "overlap_area_sqm": 5902053.0,
+          "share_of_place_area": 0.0511,
+          "share_of_tract_area": 0.636
+        },
+        {
+          "tract_geoid": "08059011701",
+          "overlap_area_sqm": 3931895.7,
+          "share_of_place_area": 0.034,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011202",
+          "overlap_area_sqm": 3905648.7,
+          "share_of_place_area": 0.0338,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011000",
+          "overlap_area_sqm": 3911345.1,
+          "share_of_place_area": 0.0338,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011726",
+          "overlap_area_sqm": 3243098.5,
+          "share_of_place_area": 0.0281,
+          "share_of_tract_area": 0.569
+        },
+        {
+          "tract_geoid": "08059011806",
+          "overlap_area_sqm": 2953488.1,
+          "share_of_place_area": 0.0256,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059980000",
+          "overlap_area_sqm": 2881233.7,
+          "share_of_place_area": 0.0249,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059010901",
+          "overlap_area_sqm": 2769352.8,
+          "share_of_place_area": 0.024,
+          "share_of_tract_area": 0.6103
+        },
+        {
+          "tract_geoid": "08059010902",
+          "overlap_area_sqm": 2652096.0,
+          "share_of_place_area": 0.023,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011101",
+          "overlap_area_sqm": 2629652.5,
+          "share_of_place_area": 0.0228,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011727",
+          "overlap_area_sqm": 2578281.2,
+          "share_of_place_area": 0.0223,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011702",
+          "overlap_area_sqm": 2574719.5,
+          "share_of_place_area": 0.0223,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011951",
+          "overlap_area_sqm": 2581216.2,
+          "share_of_place_area": 0.0223,
+          "share_of_tract_area": 0.7991
+        },
+        {
+          "tract_geoid": "08059011708",
+          "overlap_area_sqm": 2505804.0,
+          "share_of_place_area": 0.0217,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011712",
+          "overlap_area_sqm": 2425699.3,
+          "share_of_place_area": 0.021,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011904",
+          "overlap_area_sqm": 2394159.9,
+          "share_of_place_area": 0.0207,
+          "share_of_tract_area": 0.8923
+        },
+        {
+          "tract_geoid": "08059011710",
+          "overlap_area_sqm": 2322831.1,
+          "share_of_place_area": 0.0201,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059010801",
+          "overlap_area_sqm": 2326817.6,
+          "share_of_place_area": 0.0201,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059015800",
+          "overlap_area_sqm": 2308605.0,
+          "share_of_place_area": 0.02,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011711",
+          "overlap_area_sqm": 2168202.4,
+          "share_of_place_area": 0.0188,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011551",
+          "overlap_area_sqm": 2168813.5,
+          "share_of_place_area": 0.0188,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011602",
+          "overlap_area_sqm": 1983067.1,
+          "share_of_place_area": 0.0172,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011804",
+          "overlap_area_sqm": 1947813.5,
+          "share_of_place_area": 0.0169,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011729",
+          "overlap_area_sqm": 1933898.1,
+          "share_of_place_area": 0.0167,
+          "share_of_tract_area": 0.9842
+        },
+        {
+          "tract_geoid": "08059011803",
+          "overlap_area_sqm": 1926925.9,
+          "share_of_place_area": 0.0167,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011601",
+          "overlap_area_sqm": 1928238.9,
+          "share_of_place_area": 0.0167,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011730",
+          "overlap_area_sqm": 1907850.5,
+          "share_of_place_area": 0.0165,
+          "share_of_tract_area": 0.993
+        },
+        {
+          "tract_geoid": "08059011552",
+          "overlap_area_sqm": 1701972.6,
+          "share_of_place_area": 0.0147,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059012050",
+          "overlap_area_sqm": 1607852.6,
+          "share_of_place_area": 0.0139,
+          "share_of_tract_area": 0.3903
+        },
+        {
+          "tract_geoid": "08059011402",
+          "overlap_area_sqm": 1590912.7,
+          "share_of_place_area": 0.0138,
+          "share_of_tract_area": 0.9313
+        },
+        {
+          "tract_geoid": "08059011723",
+          "overlap_area_sqm": 1399142.8,
+          "share_of_place_area": 0.0121,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059010504",
+          "overlap_area_sqm": 1328987.4,
+          "share_of_place_area": 0.0115,
+          "share_of_tract_area": 0.5738
+        },
+        {
+          "tract_geoid": "08059011732",
+          "overlap_area_sqm": 1323782.0,
+          "share_of_place_area": 0.0115,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011102",
+          "overlap_area_sqm": 1301866.8,
+          "share_of_place_area": 0.0113,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011728",
+          "overlap_area_sqm": 1276488.8,
+          "share_of_place_area": 0.011,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011733",
+          "overlap_area_sqm": 1125932.7,
+          "share_of_place_area": 0.0097,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011725",
+          "overlap_area_sqm": 1003343.7,
+          "share_of_place_area": 0.0087,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011721",
+          "overlap_area_sqm": 950005.3,
+          "share_of_place_area": 0.0082,
+          "share_of_tract_area": 0.3732
+        },
+        {
+          "tract_geoid": "08059011709",
+          "overlap_area_sqm": 794040.4,
+          "share_of_place_area": 0.0069,
+          "share_of_tract_area": 0.4077
+        },
+        {
+          "tract_geoid": "08059015900",
+          "overlap_area_sqm": 685042.4,
+          "share_of_place_area": 0.0059,
+          "share_of_tract_area": 0.1249
+        },
+        {
+          "tract_geoid": "08059011401",
+          "overlap_area_sqm": 653693.7,
+          "share_of_place_area": 0.0057,
+          "share_of_tract_area": 0.7249
+        },
+        {
+          "tract_geoid": "08059009807",
+          "overlap_area_sqm": 659165.4,
+          "share_of_place_area": 0.0057,
+          "share_of_tract_area": 0.376
+        },
+        {
+          "tract_geoid": "08059011807",
+          "overlap_area_sqm": 588985.4,
+          "share_of_place_area": 0.0051,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059010100",
+          "overlap_area_sqm": 442906.3,
+          "share_of_place_area": 0.0038,
+          "share_of_tract_area": 0.0632
+        },
+        {
+          "tract_geoid": "08059011808",
+          "overlap_area_sqm": 353966.2,
+          "share_of_place_area": 0.0031,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059009806",
+          "overlap_area_sqm": 275420.3,
+          "share_of_place_area": 0.0024,
+          "share_of_tract_area": 0.0393
+        },
+        {
+          "tract_geoid": "08059012038",
+          "overlap_area_sqm": 199438.3,
+          "share_of_place_area": 0.0017,
+          "share_of_tract_area": 0.061
+        },
+        {
+          "tract_geoid": "08059012054",
+          "overlap_area_sqm": 110041.7,
+          "share_of_place_area": 0.001,
+          "share_of_tract_area": 0.0469
+        },
+        {
+          "tract_geoid": "08059012041",
+          "overlap_area_sqm": 65192.9,
+          "share_of_place_area": 0.0006,
+          "share_of_tract_area": 0.0196
+        },
+        {
+          "tract_geoid": "08059012039",
+          "overlap_area_sqm": 73641.4,
+          "share_of_place_area": 0.0006,
+          "share_of_tract_area": 0.0291
+        },
+        {
+          "tract_geoid": "08059980400",
+          "overlap_area_sqm": 25841.9,
+          "share_of_place_area": 0.0002,
+          "share_of_tract_area": 0.0323
+        }
+      ]
+    },
+    "0830835": {
+      "name": "Golden",
+      "place_area_sqm": 25191778.1,
+      "tracts": [
+        {
+          "tract_geoid": "08059009855",
+          "overlap_area_sqm": 4597309.1,
+          "share_of_place_area": 0.1825,
+          "share_of_tract_area": 0.6391
+        },
+        {
+          "tract_geoid": "08059010001",
+          "overlap_area_sqm": 4441415.5,
+          "share_of_place_area": 0.1763,
+          "share_of_tract_area": 0.875
+        },
+        {
+          "tract_geoid": "08059009856",
+          "overlap_area_sqm": 2964639.9,
+          "share_of_place_area": 0.1177,
+          "share_of_tract_area": 0.8702
+        },
+        {
+          "tract_geoid": "08059009854",
+          "overlap_area_sqm": 2770332.2,
+          "share_of_place_area": 0.11,
+          "share_of_tract_area": 0.1821
+        },
+        {
+          "tract_geoid": "08059009850",
+          "overlap_area_sqm": 2278787.7,
+          "share_of_place_area": 0.0905,
+          "share_of_tract_area": 0.0414
+        },
+        {
+          "tract_geoid": "08059009901",
+          "overlap_area_sqm": 2102014.2,
+          "share_of_place_area": 0.0834,
+          "share_of_tract_area": 0.5437
+        },
+        {
+          "tract_geoid": "08059009857",
+          "overlap_area_sqm": 1895302.8,
+          "share_of_place_area": 0.0752,
+          "share_of_tract_area": 0.2123
+        },
+        {
+          "tract_geoid": "08059009842",
+          "overlap_area_sqm": 1645558.5,
+          "share_of_place_area": 0.0653,
+          "share_of_tract_area": 0.2436
+        },
+        {
+          "tract_geoid": "08059011720",
+          "overlap_area_sqm": 835439.6,
+          "share_of_place_area": 0.0332,
+          "share_of_tract_area": 0.054
+        },
+        {
+          "tract_geoid": "08059009858",
+          "overlap_area_sqm": 689044.6,
+          "share_of_place_area": 0.0274,
+          "share_of_tract_area": 0.0026
+        },
+        {
+          "tract_geoid": "08059010100",
+          "overlap_area_sqm": 458240.1,
+          "share_of_place_area": 0.0182,
+          "share_of_tract_area": 0.0653
+        },
+        {
+          "tract_geoid": "08059980800",
+          "overlap_area_sqm": 437078.9,
+          "share_of_place_area": 0.0174,
+          "share_of_tract_area": 0.0954
+        },
+        {
+          "tract_geoid": "08059011721",
+          "overlap_area_sqm": 76615.1,
+          "share_of_place_area": 0.003,
+          "share_of_tract_area": 0.0301
+        }
+      ]
+    },
+    "0884440": {
+      "name": "Wheat Ridge",
+      "place_area_sqm": 24804144.8,
+      "tracts": [
+        {
+          "tract_geoid": "08059010502",
+          "overlap_area_sqm": 4292494.3,
+          "share_of_place_area": 0.1731,
+          "share_of_tract_area": 0.6883
+        },
+        {
+          "tract_geoid": "08059010403",
+          "overlap_area_sqm": 4184278.4,
+          "share_of_place_area": 0.1687,
+          "share_of_tract_area": 0.9907
+        },
+        {
+          "tract_geoid": "08059010503",
+          "overlap_area_sqm": 4072502.7,
+          "share_of_place_area": 0.1642,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059010701",
+          "overlap_area_sqm": 2206754.1,
+          "share_of_place_area": 0.089,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059010402",
+          "overlap_area_sqm": 1947418.4,
+          "share_of_place_area": 0.0785,
+          "share_of_tract_area": 0.4667
+        },
+        {
+          "tract_geoid": "08059010603",
+          "overlap_area_sqm": 1701672.7,
+          "share_of_place_area": 0.0686,
+          "share_of_tract_area": 0.8761
+        },
+        {
+          "tract_geoid": "08059010702",
+          "overlap_area_sqm": 1546819.8,
+          "share_of_place_area": 0.0624,
+          "share_of_tract_area": 0.9124
+        },
+        {
+          "tract_geoid": "08059010604",
+          "overlap_area_sqm": 1355261.7,
+          "share_of_place_area": 0.0546,
+          "share_of_tract_area": 0.6673
+        },
+        {
+          "tract_geoid": "08059009852",
+          "overlap_area_sqm": 940936.5,
+          "share_of_place_area": 0.0379,
+          "share_of_tract_area": 0.098
+        },
+        {
+          "tract_geoid": "08059010504",
+          "overlap_area_sqm": 882163.5,
+          "share_of_place_area": 0.0356,
+          "share_of_tract_area": 0.3809
+        },
+        {
+          "tract_geoid": "08059009806",
+          "overlap_area_sqm": 731381.6,
+          "share_of_place_area": 0.0295,
+          "share_of_tract_area": 0.1043
+        },
+        {
+          "tract_geoid": "08059010308",
+          "overlap_area_sqm": 544533.9,
+          "share_of_place_area": 0.022,
+          "share_of_tract_area": 0.111
+        },
+        {
+          "tract_geoid": "08059010406",
+          "overlap_area_sqm": 367223.4,
+          "share_of_place_area": 0.0148,
+          "share_of_tract_area": 0.1307
+        },
+        {
+          "tract_geoid": "08059010405",
+          "overlap_area_sqm": 30703.9,
+          "share_of_place_area": 0.0012,
+          "share_of_tract_area": 0.0188
+        }
+      ]
+    },
+    "0845255": {
+      "name": "Littleton",
+      "place_area_sqm": 35589625.9,
+      "tracts": [
+        {
+          "tract_geoid": "08005005634",
+          "overlap_area_sqm": 4778176.7,
+          "share_of_place_area": 0.1343,
+          "share_of_tract_area": 0.9996
+        },
+        {
+          "tract_geoid": "08005005623",
+          "overlap_area_sqm": 4077592.9,
+          "share_of_place_area": 0.1146,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005005622",
+          "overlap_area_sqm": 3967077.7,
+          "share_of_place_area": 0.1115,
+          "share_of_tract_area": 0.564
+        },
+        {
+          "tract_geoid": "08005005619",
+          "overlap_area_sqm": 2870379.3,
+          "share_of_place_area": 0.0807,
+          "share_of_tract_area": 0.6731
+        },
+        {
+          "tract_geoid": "08005005624",
+          "overlap_area_sqm": 1999745.6,
+          "share_of_place_area": 0.0562,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005005633",
+          "overlap_area_sqm": 1953071.0,
+          "share_of_place_area": 0.0549,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005006604",
+          "overlap_area_sqm": 1942013.9,
+          "share_of_place_area": 0.0546,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005006502",
+          "overlap_area_sqm": 1941754.6,
+          "share_of_place_area": 0.0546,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005006603",
+          "overlap_area_sqm": 1852954.1,
+          "share_of_place_area": 0.0521,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005006501",
+          "overlap_area_sqm": 1736242.2,
+          "share_of_place_area": 0.0488,
+          "share_of_tract_area": 0.9995
+        },
+        {
+          "tract_geoid": "08005006601",
+          "overlap_area_sqm": 1513330.1,
+          "share_of_place_area": 0.0425,
+          "share_of_tract_area": 0.7786
+        },
+        {
+          "tract_geoid": "08005005632",
+          "overlap_area_sqm": 1425205.6,
+          "share_of_place_area": 0.04,
+          "share_of_tract_area": 0.6456
+        },
+        {
+          "tract_geoid": "08059012036",
+          "overlap_area_sqm": 1398122.3,
+          "share_of_place_area": 0.0393,
+          "share_of_tract_area": 0.0093
+        },
+        {
+          "tract_geoid": "08005005620",
+          "overlap_area_sqm": 1037305.3,
+          "share_of_place_area": 0.0291,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005005621",
+          "overlap_area_sqm": 727151.1,
+          "share_of_place_area": 0.0204,
+          "share_of_tract_area": 0.2784
+        },
+        {
+          "tract_geoid": "08035014131",
+          "overlap_area_sqm": 654090.4,
+          "share_of_place_area": 0.0184,
+          "share_of_tract_area": 0.0454
+        },
+        {
+          "tract_geoid": "08005006400",
+          "overlap_area_sqm": 461522.8,
+          "share_of_place_area": 0.013,
+          "share_of_tract_area": 0.1925
+        },
+        {
+          "tract_geoid": "08005005612",
+          "overlap_area_sqm": 426018.5,
+          "share_of_place_area": 0.012,
+          "share_of_tract_area": 0.1098
+        },
+        {
+          "tract_geoid": "08005005625",
+          "overlap_area_sqm": 344017.5,
+          "share_of_place_area": 0.0097,
+          "share_of_tract_area": 0.1829
+        },
+        {
+          "tract_geoid": "08005005553",
+          "overlap_area_sqm": 163199.2,
+          "share_of_place_area": 0.0046,
+          "share_of_tract_area": 0.0625
+        },
+        {
+          "tract_geoid": "08059012053",
+          "overlap_area_sqm": 158833.6,
+          "share_of_place_area": 0.0045,
+          "share_of_tract_area": 0.0625
+        },
+        {
+          "tract_geoid": "08005005611",
+          "overlap_area_sqm": 161821.6,
+          "share_of_place_area": 0.0045,
+          "share_of_tract_area": 0.0403
+        }
+      ]
+    },
+    "0842495": {
+      "name": "Lakeside",
+      "place_area_sqm": 642720.6,
+      "tracts": [
+        {
+          "tract_geoid": "08059010604",
+          "overlap_area_sqm": 642720.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.3164
+        }
+      ]
+    },
+    "0875640": {
+      "name": "Superior",
+      "place_area_sqm": 10279098.6,
+      "tracts": [
+        {
+          "tract_geoid": "08013060601",
+          "overlap_area_sqm": 2733732.3,
+          "share_of_place_area": 0.266,
+          "share_of_tract_area": 0.9139
+        },
+        {
+          "tract_geoid": "08013061400",
+          "overlap_area_sqm": 2559463.5,
+          "share_of_place_area": 0.249,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013060602",
+          "overlap_area_sqm": 2386792.6,
+          "share_of_place_area": 0.2322,
+          "share_of_tract_area": 0.0659
+        },
+        {
+          "tract_geoid": "08013061300",
+          "overlap_area_sqm": 2074396.7,
+          "share_of_place_area": 0.2018,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059980700",
+          "overlap_area_sqm": 524713.5,
+          "share_of_place_area": 0.051,
+          "share_of_tract_area": 0.0167
+        }
+      ]
+    },
+    "0801090": {
+      "name": "Alamosa",
+      "place_area_sqm": 20806817.8,
+      "tracts": [
+        {
+          "tract_geoid": "08003960300",
+          "overlap_area_sqm": 7001951.1,
+          "share_of_place_area": 0.3365,
+          "share_of_tract_area": 0.1913
+        },
+        {
+          "tract_geoid": "08003960100",
+          "overlap_area_sqm": 6289136.5,
+          "share_of_place_area": 0.3023,
+          "share_of_tract_area": 0.0149
+        },
+        {
+          "tract_geoid": "08003960202",
+          "overlap_area_sqm": 5057579.4,
+          "share_of_place_area": 0.2431,
+          "share_of_tract_area": 0.4174
+        },
+        {
+          "tract_geoid": "08003960201",
+          "overlap_area_sqm": 2458150.8,
+          "share_of_place_area": 0.1181,
+          "share_of_tract_area": 0.2259
+        }
+      ]
+    },
+    "0841835": {
+      "name": "Lafayette",
+      "place_area_sqm": 24482189.8,
+      "tracts": [
+        {
+          "tract_geoid": "08013060900",
+          "overlap_area_sqm": 3739850.4,
+          "share_of_place_area": 0.1528,
+          "share_of_tract_area": 0.4799
+        },
+        {
+          "tract_geoid": "08013060802",
+          "overlap_area_sqm": 3694193.3,
+          "share_of_place_area": 0.1509,
+          "share_of_tract_area": 0.5132
+        },
+        {
+          "tract_geoid": "08013060801",
+          "overlap_area_sqm": 3250901.2,
+          "share_of_place_area": 0.1328,
+          "share_of_tract_area": 0.2251
+        },
+        {
+          "tract_geoid": "08013012907",
+          "overlap_area_sqm": 3018670.1,
+          "share_of_place_area": 0.1233,
+          "share_of_tract_area": 0.4611
+        },
+        {
+          "tract_geoid": "08013012903",
+          "overlap_area_sqm": 2950298.6,
+          "share_of_place_area": 0.1205,
+          "share_of_tract_area": 0.7606
+        },
+        {
+          "tract_geoid": "08013012904",
+          "overlap_area_sqm": 2677785.6,
+          "share_of_place_area": 0.1094,
+          "share_of_tract_area": 0.7881
+        },
+        {
+          "tract_geoid": "08013013003",
+          "overlap_area_sqm": 1627051.2,
+          "share_of_place_area": 0.0665,
+          "share_of_tract_area": 0.132
+        },
+        {
+          "tract_geoid": "08013012905",
+          "overlap_area_sqm": 1342319.0,
+          "share_of_place_area": 0.0548,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013012801",
+          "overlap_area_sqm": 1057474.5,
+          "share_of_place_area": 0.0432,
+          "share_of_tract_area": 0.0676
+        },
+        {
+          "tract_geoid": "08013012802",
+          "overlap_area_sqm": 959772.4,
+          "share_of_place_area": 0.0392,
+          "share_of_tract_area": 0.0383
+        },
+        {
+          "tract_geoid": "08013012707",
+          "overlap_area_sqm": 163873.4,
+          "share_of_place_area": 0.0067,
+          "share_of_tract_area": 0.0047
+        }
+      ]
+    },
+    "0882735": {
+      "name": "Ward",
+      "place_area_sqm": 1389503.4,
+      "tracts": [
+        {
+          "tract_geoid": "08013013703",
+          "overlap_area_sqm": 1389503.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0077
+        }
+      ]
+    },
+    "0822035": {
+      "name": "Durango",
+      "place_area_sqm": 52002494.6,
+      "tracts": [
+        {
+          "tract_geoid": "08067970703",
+          "overlap_area_sqm": 14176751.3,
+          "share_of_place_area": 0.2726,
+          "share_of_tract_area": 0.0962
+        },
+        {
+          "tract_geoid": "08067970701",
+          "overlap_area_sqm": 11343436.7,
+          "share_of_place_area": 0.2181,
+          "share_of_tract_area": 0.0126
+        },
+        {
+          "tract_geoid": "08067971100",
+          "overlap_area_sqm": 10896524.6,
+          "share_of_place_area": 0.2095,
+          "share_of_tract_area": 0.4527
+        },
+        {
+          "tract_geoid": "08067970800",
+          "overlap_area_sqm": 6949402.5,
+          "share_of_place_area": 0.1336,
+          "share_of_tract_area": 0.611
+        },
+        {
+          "tract_geoid": "08067970900",
+          "overlap_area_sqm": 4902254.1,
+          "share_of_place_area": 0.0943,
+          "share_of_tract_area": 0.5869
+        },
+        {
+          "tract_geoid": "08067971000",
+          "overlap_area_sqm": 3734125.5,
+          "share_of_place_area": 0.0718,
+          "share_of_tract_area": 0.72
+        }
+      ]
+    },
+    "0864090": {
+      "name": "Rico",
+      "place_area_sqm": 1758282.1,
+      "tracts": [
+        {
+          "tract_geoid": "08033000100",
+          "overlap_area_sqm": 1758282.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0006
+        }
+      ]
+    },
+    "0822145": {
+      "name": "Eads",
+      "place_area_sqm": 1280889.4,
+      "tracts": [
+        {
+          "tract_geoid": "08061960100",
+          "overlap_area_sqm": 1280889.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0869700": {
+      "name": "Sheridan Lake",
+      "place_area_sqm": 804741.7,
+      "tracts": [
+        {
+          "tract_geoid": "08061960100",
+          "overlap_area_sqm": 804741.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0807025": {
+      "name": "Black Hawk",
+      "place_area_sqm": 8073489.0,
+      "tracts": [
+        {
+          "tract_geoid": "08047013802",
+          "overlap_area_sqm": 8073489.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0451
+        }
+      ]
+    },
+    "0867830": {
+      "name": "Sanford",
+      "place_area_sqm": 3780066.1,
+      "tracts": [
+        {
+          "tract_geoid": "08021974900",
+          "overlap_area_sqm": 3780066.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0014
+        }
+      ]
+    },
+    "0822200": {
+      "name": "Eagle",
+      "place_area_sqm": 15236095.5,
+      "tracts": [
+        {
+          "tract_geoid": "08037000405",
+          "overlap_area_sqm": 12443940.8,
+          "share_of_place_area": 0.8167,
+          "share_of_tract_area": 0.0851
+        },
+        {
+          "tract_geoid": "08037000404",
+          "overlap_area_sqm": 2792154.8,
+          "share_of_place_area": 0.1833,
+          "share_of_tract_area": 0.0075
+        }
+      ]
+    },
+    "0833695": {
+      "name": "Gypsum",
+      "place_area_sqm": 23194864.9,
+      "tracts": [
+        {
+          "tract_geoid": "08037000200",
+          "overlap_area_sqm": 20379952.0,
+          "share_of_place_area": 0.8786,
+          "share_of_tract_area": 0.0541
+        },
+        {
+          "tract_geoid": "08037000405",
+          "overlap_area_sqm": 2228280.9,
+          "share_of_place_area": 0.0961,
+          "share_of_tract_area": 0.0152
+        },
+        {
+          "tract_geoid": "08037000100",
+          "overlap_area_sqm": 364504.6,
+          "share_of_place_area": 0.0157,
+          "share_of_tract_area": 0.0003
+        },
+        {
+          "tract_geoid": "08037000404",
+          "overlap_area_sqm": 222127.4,
+          "share_of_place_area": 0.0096,
+          "share_of_tract_area": 0.0006
+        }
+      ]
+    },
+    "0859830": {
+      "name": "Pitkin",
+      "place_area_sqm": 667830.4,
+      "tracts": [
+        {
+          "tract_geoid": "08051963602",
+          "overlap_area_sqm": 667830.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0856365": {
+      "name": "Otis",
+      "place_area_sqm": 1070131.4,
+      "tracts": [
+        {
+          "tract_geoid": "08121924100",
+          "overlap_area_sqm": 1070131.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0809555": {
+      "name": "Brush",
+      "place_area_sqm": 7336283.7,
+      "tracts": [
+        {
+          "tract_geoid": "08087000700",
+          "overlap_area_sqm": 6951323.8,
+          "share_of_place_area": 0.9475,
+          "share_of_tract_area": 0.252
+        },
+        {
+          "tract_geoid": "08087000800",
+          "overlap_area_sqm": 384959.9,
+          "share_of_place_area": 0.0525,
+          "share_of_tract_area": 0.0004
+        }
+      ]
+    },
+    "0836610": {
+      "name": "Hillrose",
+      "place_area_sqm": 488140.0,
+      "tracts": [
+        {
+          "tract_geoid": "08087000800",
+          "overlap_area_sqm": 488140.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0006
+        }
+      ]
+    },
+    "0845695": {
+      "name": "Log Lane Village",
+      "place_area_sqm": 507289.4,
+      "tracts": [
+        {
+          "tract_geoid": "08087000300",
+          "overlap_area_sqm": 507289.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0119
+        }
+      ]
+    },
+    "0884770": {
+      "name": "Wiggins",
+      "place_area_sqm": 3434735.0,
+      "tracts": [
+        {
+          "tract_geoid": "08087000200",
+          "overlap_area_sqm": 3434735.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0045
+        }
+      ]
+    },
+    "0833310": {
+      "name": "Grover",
+      "place_area_sqm": 1541114.7,
+      "tracts": [
+        {
+          "tract_geoid": "08123002501",
+          "overlap_area_sqm": 1541114.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0813460": {
+      "name": "Cheraw",
+      "place_area_sqm": 473961.9,
+      "tracts": [
+        {
+          "tract_geoid": "08089968500",
+          "overlap_area_sqm": 473961.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.001
+        }
+      ]
+    },
+    "0848500": {
+      "name": "Manzanola",
+      "place_area_sqm": 735981.6,
+      "tracts": [
+        {
+          "tract_geoid": "08089968400",
+          "overlap_area_sqm": 735981.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0808345": {
+      "name": "Branson",
+      "place_area_sqm": 633651.4,
+      "tracts": [
+        {
+          "tract_geoid": "08071000800",
+          "overlap_area_sqm": 633651.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0878610": {
+      "name": "Trinidad",
+      "place_area_sqm": 24288772.4,
+      "tracts": [
+        {
+          "tract_geoid": "08071000800",
+          "overlap_area_sqm": 10665999.6,
+          "share_of_place_area": 0.4391,
+          "share_of_tract_area": 0.0011
+        },
+        {
+          "tract_geoid": "08071000400",
+          "overlap_area_sqm": 5822555.4,
+          "share_of_place_area": 0.2397,
+          "share_of_tract_area": 0.0575
+        },
+        {
+          "tract_geoid": "08071000500",
+          "overlap_area_sqm": 2295453.4,
+          "share_of_place_area": 0.0945,
+          "share_of_tract_area": 0.0316
+        },
+        {
+          "tract_geoid": "08071000200",
+          "overlap_area_sqm": 1988959.5,
+          "share_of_place_area": 0.0819,
+          "share_of_tract_area": 0.4957
+        },
+        {
+          "tract_geoid": "08071000300",
+          "overlap_area_sqm": 1796366.9,
+          "share_of_place_area": 0.074,
+          "share_of_tract_area": 0.0011
+        },
+        {
+          "tract_geoid": "08071000100",
+          "overlap_area_sqm": 1719437.6,
+          "share_of_place_area": 0.0708,
+          "share_of_tract_area": 0.0021
+        }
+      ]
+    },
+    "0840570": {
+      "name": "Kim",
+      "place_area_sqm": 980655.0,
+      "tracts": [
+        {
+          "tract_geoid": "08071000800",
+          "overlap_area_sqm": 980655.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0826875": {
+      "name": "Fleming",
+      "place_area_sqm": 1267211.3,
+      "tracts": [
+        {
+          "tract_geoid": "08075966400",
+          "overlap_area_sqm": 1267211.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0007
+        }
+      ]
+    },
+    "0858235": {
+      "name": "Peetz",
+      "place_area_sqm": 578359.7,
+      "tracts": [
+        {
+          "tract_geoid": "08075965900",
+          "overlap_area_sqm": 578359.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0004
+        }
+      ]
+    },
+    "0843660": {
+      "name": "Las Animas",
+      "place_area_sqm": 4330024.5,
+      "tracts": [
+        {
+          "tract_geoid": "08011966702",
+          "overlap_area_sqm": 2592533.3,
+          "share_of_place_area": 0.5987,
+          "share_of_tract_area": 0.0007
+        },
+        {
+          "tract_geoid": "08011966701",
+          "overlap_area_sqm": 1737491.2,
+          "share_of_place_area": 0.4013,
+          "share_of_tract_area": 0.1451
+        }
+      ]
+    },
+    "0828690": {
+      "name": "Frisco",
+      "place_area_sqm": 4600510.1,
+      "tracts": [
+        {
+          "tract_geoid": "08117000301",
+          "overlap_area_sqm": 3690510.7,
+          "share_of_place_area": 0.8022,
+          "share_of_tract_area": 0.2152
+        },
+        {
+          "tract_geoid": "08117000302",
+          "overlap_area_sqm": 909999.4,
+          "share_of_place_area": 0.1978,
+          "share_of_tract_area": 0.0035
+        }
+      ]
+    },
+    "0853120": {
+      "name": "Naturita",
+      "place_area_sqm": 1596613.5,
+      "tracts": [
+        {
+          "tract_geoid": "08085966100",
+          "overlap_area_sqm": 1596613.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0006
+        }
+      ]
+    },
+    "0854935": {
+      "name": "Nucla",
+      "place_area_sqm": 1799429.1,
+      "tracts": [
+        {
+          "tract_geoid": "08085966100",
+          "overlap_area_sqm": 1799429.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0006
+        }
+      ]
+    },
+    "0855540": {
+      "name": "Olathe",
+      "place_area_sqm": 3908513.8,
+      "tracts": [
+        {
+          "tract_geoid": "08085966202",
+          "overlap_area_sqm": 3570584.0,
+          "share_of_place_area": 0.9135,
+          "share_of_tract_area": 0.0054
+        },
+        {
+          "tract_geoid": "08085966201",
+          "overlap_area_sqm": 337929.8,
+          "share_of_place_area": 0.0865,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0817375": {
+      "name": "Cortez",
+      "place_area_sqm": 16275347.2,
+      "tracts": [
+        {
+          "tract_geoid": "08083969400",
+          "overlap_area_sqm": 6683464.2,
+          "share_of_place_area": 0.4106,
+          "share_of_tract_area": 0.7535
+        },
+        {
+          "tract_geoid": "08083969302",
+          "overlap_area_sqm": 5019250.6,
+          "share_of_place_area": 0.3084,
+          "share_of_tract_area": 0.2399
+        },
+        {
+          "tract_geoid": "08083969301",
+          "overlap_area_sqm": 4521996.4,
+          "share_of_place_area": 0.2778,
+          "share_of_tract_area": 0.1198
+        },
+        {
+          "tract_geoid": "08083969600",
+          "overlap_area_sqm": 50636.0,
+          "share_of_place_area": 0.0031,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0866895": {
+      "name": "Rye",
+      "place_area_sqm": 243327.6,
+      "tracts": [
+        {
+          "tract_geoid": "08101002804",
+          "overlap_area_sqm": 243327.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0828305": {
+      "name": "Fraser",
+      "place_area_sqm": 8960228.7,
+      "tracts": [
+        {
+          "tract_geoid": "08049000204",
+          "overlap_area_sqm": 6053900.1,
+          "share_of_place_area": 0.6756,
+          "share_of_tract_area": 0.0232
+        },
+        {
+          "tract_geoid": "08049000203",
+          "overlap_area_sqm": 2906328.6,
+          "share_of_place_area": 0.3244,
+          "share_of_tract_area": 0.0277
+        }
+      ]
+    },
+    "0831715": {
+      "name": "Grand Lake",
+      "place_area_sqm": 2677591.7,
+      "tracts": [
+        {
+          "tract_geoid": "08049000206",
+          "overlap_area_sqm": 2298479.4,
+          "share_of_place_area": 0.8584,
+          "share_of_tract_area": 0.0415
+        },
+        {
+          "tract_geoid": "08049000207",
+          "overlap_area_sqm": 379112.2,
+          "share_of_place_area": 0.1416,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0837600": {
+      "name": "Hot Sulphur Springs",
+      "place_area_sqm": 1990908.8,
+      "tracts": [
+        {
+          "tract_geoid": "08049000205",
+          "overlap_area_sqm": 1491959.6,
+          "share_of_place_area": 0.7494,
+          "share_of_tract_area": 0.0052
+        },
+        {
+          "tract_geoid": "08049000100",
+          "overlap_area_sqm": 498949.3,
+          "share_of_place_area": 0.2506,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0841560": {
+      "name": "Kremmling",
+      "place_area_sqm": 3391440.7,
+      "tracts": [
+        {
+          "tract_geoid": "08049000100",
+          "overlap_area_sqm": 3391440.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0012
+        }
+      ]
+    },
+    "0885705": {
+      "name": "Winter Park",
+      "place_area_sqm": 44048357.3,
+      "tracts": [
+        {
+          "tract_geoid": "08049000204",
+          "overlap_area_sqm": 37406457.3,
+          "share_of_place_area": 0.8492,
+          "share_of_tract_area": 0.1436
+        },
+        {
+          "tract_geoid": "08049000203",
+          "overlap_area_sqm": 6641900.0,
+          "share_of_place_area": 0.1508,
+          "share_of_tract_area": 0.0634
+        }
+      ]
+    },
+    "0818310": {
+      "name": "Crested Butte",
+      "place_area_sqm": 2244448.3,
+      "tracts": [
+        {
+          "tract_geoid": "08051963800",
+          "overlap_area_sqm": 2244448.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0027
+        }
+      ]
+    },
+    "0823740": {
+      "name": "Elizabeth",
+      "place_area_sqm": 5530926.0,
+      "tracts": [
+        {
+          "tract_geoid": "08039961208",
+          "overlap_area_sqm": 4261035.1,
+          "share_of_place_area": 0.7704,
+          "share_of_tract_area": 0.0237
+        },
+        {
+          "tract_geoid": "08039961207",
+          "overlap_area_sqm": 715351.5,
+          "share_of_place_area": 0.1293,
+          "share_of_tract_area": 0.0052
+        },
+        {
+          "tract_geoid": "08039961206",
+          "overlap_area_sqm": 554539.4,
+          "share_of_place_area": 0.1003,
+          "share_of_tract_area": 0.0104
+        }
+      ]
+    },
+    "0840790": {
+      "name": "Kiowa",
+      "place_area_sqm": 2213584.1,
+      "tracts": [
+        {
+          "tract_geoid": "08039961209",
+          "overlap_area_sqm": 1225649.9,
+          "share_of_place_area": 0.5537,
+          "share_of_tract_area": 0.0044
+        },
+        {
+          "tract_geoid": "08039961205",
+          "overlap_area_sqm": 646799.3,
+          "share_of_place_area": 0.2922,
+          "share_of_tract_area": 0.0007
+        },
+        {
+          "tract_geoid": "08039961207",
+          "overlap_area_sqm": 341134.9,
+          "share_of_place_area": 0.1541,
+          "share_of_tract_area": 0.0025
+        }
+      ]
+    },
+    "0827425": {
+      "name": "Fort Collins",
+      "place_area_sqm": 151395441.2,
+      "tracts": [
+        {
+          "tract_geoid": "08069001605",
+          "overlap_area_sqm": 12199554.2,
+          "share_of_place_area": 0.0806,
+          "share_of_tract_area": 0.7444
+        },
+        {
+          "tract_geoid": "08069001114",
+          "overlap_area_sqm": 8616658.1,
+          "share_of_place_area": 0.0569,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069001308",
+          "overlap_area_sqm": 7311146.1,
+          "share_of_place_area": 0.0483,
+          "share_of_tract_area": 0.2346
+        },
+        {
+          "tract_geoid": "08069001009",
+          "overlap_area_sqm": 6985516.5,
+          "share_of_place_area": 0.0461,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069001608",
+          "overlap_area_sqm": 6692839.8,
+          "share_of_place_area": 0.0442,
+          "share_of_tract_area": 0.3509
+        },
+        {
+          "tract_geoid": "08069001307",
+          "overlap_area_sqm": 5639210.4,
+          "share_of_place_area": 0.0372,
+          "share_of_tract_area": 0.5882
+        },
+        {
+          "tract_geoid": "08069001306",
+          "overlap_area_sqm": 5567979.9,
+          "share_of_place_area": 0.0368,
+          "share_of_tract_area": 0.5831
+        },
+        {
+          "tract_geoid": "08069001812",
+          "overlap_area_sqm": 4935232.8,
+          "share_of_place_area": 0.0326,
+          "share_of_tract_area": 0.0648
+        },
+        {
+          "tract_geoid": "08069001112",
+          "overlap_area_sqm": 4930635.7,
+          "share_of_place_area": 0.0326,
+          "share_of_tract_area": 0.7321
+        },
+        {
+          "tract_geoid": "08069001813",
+          "overlap_area_sqm": 4883918.9,
+          "share_of_place_area": 0.0323,
+          "share_of_tract_area": 0.3124
+        },
+        {
+          "tract_geoid": "08069001601",
+          "overlap_area_sqm": 3780523.9,
+          "share_of_place_area": 0.025,
+          "share_of_tract_area": 0.575
+        },
+        {
+          "tract_geoid": "08069001708",
+          "overlap_area_sqm": 3741552.3,
+          "share_of_place_area": 0.0247,
+          "share_of_tract_area": 0.9015
+        },
+        {
+          "tract_geoid": "08069001007",
+          "overlap_area_sqm": 3429820.5,
+          "share_of_place_area": 0.0227,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069002300",
+          "overlap_area_sqm": 3265590.4,
+          "share_of_place_area": 0.0216,
+          "share_of_tract_area": 0.0299
+        },
+        {
+          "tract_geoid": "08069001603",
+          "overlap_area_sqm": 3202203.3,
+          "share_of_place_area": 0.0212,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069001602",
+          "overlap_area_sqm": 3045808.4,
+          "share_of_place_area": 0.0201,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069001003",
+          "overlap_area_sqm": 3032346.0,
+          "share_of_place_area": 0.02,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069000901",
+          "overlap_area_sqm": 2946827.1,
+          "share_of_place_area": 0.0195,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069001010",
+          "overlap_area_sqm": 2897580.3,
+          "share_of_place_area": 0.0191,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069001606",
+          "overlap_area_sqm": 2848113.5,
+          "share_of_place_area": 0.0188,
+          "share_of_tract_area": 0.8653
+        },
+        {
+          "tract_geoid": "08069001305",
+          "overlap_area_sqm": 2839209.5,
+          "share_of_place_area": 0.0188,
+          "share_of_tract_area": 0.9909
+        },
+        {
+          "tract_geoid": "08069001110",
+          "overlap_area_sqm": 2613805.6,
+          "share_of_place_area": 0.0173,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069001107",
+          "overlap_area_sqm": 2607840.9,
+          "share_of_place_area": 0.0172,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069001104",
+          "overlap_area_sqm": 2564352.7,
+          "share_of_place_area": 0.0169,
+          "share_of_tract_area": 0.9687
+        },
+        {
+          "tract_geoid": "08069001607",
+          "overlap_area_sqm": 2532637.3,
+          "share_of_place_area": 0.0167,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069001111",
+          "overlap_area_sqm": 2252438.9,
+          "share_of_place_area": 0.0149,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069001106",
+          "overlap_area_sqm": 2163887.0,
+          "share_of_place_area": 0.0143,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069001109",
+          "overlap_area_sqm": 2114057.9,
+          "share_of_place_area": 0.014,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069000902",
+          "overlap_area_sqm": 2030864.7,
+          "share_of_place_area": 0.0134,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069001004",
+          "overlap_area_sqm": 1986289.9,
+          "share_of_place_area": 0.0131,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069000402",
+          "overlap_area_sqm": 1983739.4,
+          "share_of_place_area": 0.0131,
+          "share_of_tract_area": 0.7603
+        },
+        {
+          "tract_geoid": "08069000600",
+          "overlap_area_sqm": 1967185.2,
+          "share_of_place_area": 0.013,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069001113",
+          "overlap_area_sqm": 1952310.0,
+          "share_of_place_area": 0.0129,
+          "share_of_tract_area": 0.7491
+        },
+        {
+          "tract_geoid": "08069000100",
+          "overlap_area_sqm": 1856915.4,
+          "share_of_place_area": 0.0123,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069000202",
+          "overlap_area_sqm": 1849605.1,
+          "share_of_place_area": 0.0122,
+          "share_of_tract_area": 0.928
+        },
+        {
+          "tract_geoid": "08069002506",
+          "overlap_area_sqm": 1766580.0,
+          "share_of_place_area": 0.0117,
+          "share_of_tract_area": 0.0596
+        },
+        {
+          "tract_geoid": "08069002504",
+          "overlap_area_sqm": 1747253.8,
+          "share_of_place_area": 0.0115,
+          "share_of_tract_area": 0.0448
+        },
+        {
+          "tract_geoid": "08069001008",
+          "overlap_area_sqm": 1662426.5,
+          "share_of_place_area": 0.011,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069001304",
+          "overlap_area_sqm": 1533171.4,
+          "share_of_place_area": 0.0101,
+          "share_of_tract_area": 0.3812
+        },
+        {
+          "tract_geoid": "08069000700",
+          "overlap_area_sqm": 1298871.9,
+          "share_of_place_area": 0.0086,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069000504",
+          "overlap_area_sqm": 1299540.5,
+          "share_of_place_area": 0.0086,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069000503",
+          "overlap_area_sqm": 1291418.2,
+          "share_of_place_area": 0.0085,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069000506",
+          "overlap_area_sqm": 1276410.9,
+          "share_of_place_area": 0.0084,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069000505",
+          "overlap_area_sqm": 1219073.1,
+          "share_of_place_area": 0.0081,
+          "share_of_tract_area": 0.9595
+        },
+        {
+          "tract_geoid": "08069000801",
+          "overlap_area_sqm": 1099423.3,
+          "share_of_place_area": 0.0073,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069000802",
+          "overlap_area_sqm": 1041035.7,
+          "share_of_place_area": 0.0069,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069000201",
+          "overlap_area_sqm": 983085.0,
+          "share_of_place_area": 0.0065,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069000401",
+          "overlap_area_sqm": 815289.6,
+          "share_of_place_area": 0.0054,
+          "share_of_tract_area": 0.6218
+        },
+        {
+          "tract_geoid": "08069000300",
+          "overlap_area_sqm": 727505.0,
+          "share_of_place_area": 0.0048,
+          "share_of_tract_area": 0.0973
+        },
+        {
+          "tract_geoid": "08069002505",
+          "overlap_area_sqm": 366158.6,
+          "share_of_place_area": 0.0024,
+          "share_of_tract_area": 0.0153
+        }
+      ]
+    },
+    "0886310": {
+      "name": "Wray",
+      "place_area_sqm": 8967780.3,
+      "tracts": [
+        {
+          "tract_geoid": "08125963100",
+          "overlap_area_sqm": 8967780.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0026
+        }
+      ]
+    },
+    "0849875": {
+      "name": "Meeker",
+      "place_area_sqm": 9301757.3,
+      "tracts": [
+        {
+          "tract_geoid": "08103951100",
+          "overlap_area_sqm": 9301757.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0018
+        }
+      ]
+    },
+    "0800925": {
+      "name": "Akron",
+      "place_area_sqm": 7178448.2,
+      "tracts": [
+        {
+          "tract_geoid": "08121924200",
+          "overlap_area_sqm": 7178448.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0038
+        }
+      ]
+    },
+    "0862880": {
+      "name": "Rangely",
+      "place_area_sqm": 11372888.2,
+      "tracts": [
+        {
+          "tract_geoid": "08103951200",
+          "overlap_area_sqm": 11372888.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0036
+        }
+      ]
+    },
+    "0817760": {
+      "name": "Craig",
+      "place_area_sqm": 13142495.6,
+      "tracts": [
+        {
+          "tract_geoid": "08081000500",
+          "overlap_area_sqm": 5219459.4,
+          "share_of_place_area": 0.3971,
+          "share_of_tract_area": 0.5488
+        },
+        {
+          "tract_geoid": "08081000300",
+          "overlap_area_sqm": 4118138.1,
+          "share_of_place_area": 0.3133,
+          "share_of_tract_area": 0.0097
+        },
+        {
+          "tract_geoid": "08081000400",
+          "overlap_area_sqm": 3804898.2,
+          "share_of_place_area": 0.2895,
+          "share_of_tract_area": 0.5124
+        }
+      ]
+    },
+    "0820495": {
+      "name": "Dinosaur",
+      "place_area_sqm": 2413210.8,
+      "tracts": [
+        {
+          "tract_geoid": "08081000600",
+          "overlap_area_sqm": 2413210.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0868655": {
+      "name": "Sawpit",
+      "place_area_sqm": 77862.9,
+      "tracts": [
+        {
+          "tract_geoid": "08113968103",
+          "overlap_area_sqm": 77862.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0819080": {
+      "name": "Dacono",
+      "place_area_sqm": 24028644.7,
+      "tracts": [
+        {
+          "tract_geoid": "08123002006",
+          "overlap_area_sqm": 7830989.9,
+          "share_of_place_area": 0.3259,
+          "share_of_tract_area": 0.1962
+        },
+        {
+          "tract_geoid": "08123002005",
+          "overlap_area_sqm": 7782946.7,
+          "share_of_place_area": 0.3239,
+          "share_of_tract_area": 0.4224
+        },
+        {
+          "tract_geoid": "08123002004",
+          "overlap_area_sqm": 7475962.7,
+          "share_of_place_area": 0.3111,
+          "share_of_tract_area": 0.7345
+        },
+        {
+          "tract_geoid": "08123002009",
+          "overlap_area_sqm": 518913.4,
+          "share_of_place_area": 0.0216,
+          "share_of_tract_area": 0.0121
+        },
+        {
+          "tract_geoid": "08123001909",
+          "overlap_area_sqm": 355493.7,
+          "share_of_place_area": 0.0148,
+          "share_of_tract_area": 0.0104
+        },
+        {
+          "tract_geoid": "08123002015",
+          "overlap_area_sqm": 64219.5,
+          "share_of_place_area": 0.0027,
+          "share_of_tract_area": 0.0099
+        },
+        {
+          "tract_geoid": "08123001910",
+          "overlap_area_sqm": 118.8,
+          "share_of_place_area": 0.0,
+          "share_of_tract_area": 0.0
+        }
+      ]
+    },
+    "0885485": {
+      "name": "Windsor",
+      "place_area_sqm": 71128415.3,
+      "tracts": [
+        {
+          "tract_geoid": "08123002203",
+          "overlap_area_sqm": 13292437.7,
+          "share_of_place_area": 0.1869,
+          "share_of_tract_area": 0.6495
+        },
+        {
+          "tract_geoid": "08123002210",
+          "overlap_area_sqm": 12436650.5,
+          "share_of_place_area": 0.1748,
+          "share_of_tract_area": 0.6133
+        },
+        {
+          "tract_geoid": "08069001714",
+          "overlap_area_sqm": 10822294.6,
+          "share_of_place_area": 0.1522,
+          "share_of_tract_area": 0.343
+        },
+        {
+          "tract_geoid": "08123002207",
+          "overlap_area_sqm": 8268726.4,
+          "share_of_place_area": 0.1163,
+          "share_of_tract_area": 0.5567
+        },
+        {
+          "tract_geoid": "08123002209",
+          "overlap_area_sqm": 8089727.8,
+          "share_of_place_area": 0.1137,
+          "share_of_tract_area": 0.197
+        },
+        {
+          "tract_geoid": "08123002208",
+          "overlap_area_sqm": 5358619.8,
+          "share_of_place_area": 0.0753,
+          "share_of_tract_area": 0.0499
+        },
+        {
+          "tract_geoid": "08069002505",
+          "overlap_area_sqm": 4740781.2,
+          "share_of_place_area": 0.0667,
+          "share_of_tract_area": 0.1985
+        },
+        {
+          "tract_geoid": "08123002206",
+          "overlap_area_sqm": 3637803.7,
+          "share_of_place_area": 0.0511,
+          "share_of_tract_area": 0.8563
+        },
+        {
+          "tract_geoid": "08123002205",
+          "overlap_area_sqm": 2518850.6,
+          "share_of_place_area": 0.0354,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123002204",
+          "overlap_area_sqm": 1962523.0,
+          "share_of_place_area": 0.0276,
+          "share_of_tract_area": 1.0
+        }
+      ]
+    },
+    "0839855": {
+      "name": "Johnstown",
+      "place_area_sqm": 40546056.6,
+      "tracts": [
+        {
+          "tract_geoid": "08123002108",
+          "overlap_area_sqm": 11517892.6,
+          "share_of_place_area": 0.2841,
+          "share_of_tract_area": 0.3055
+        },
+        {
+          "tract_geoid": "08123002107",
+          "overlap_area_sqm": 10448723.8,
+          "share_of_place_area": 0.2577,
+          "share_of_tract_area": 0.2937
+        },
+        {
+          "tract_geoid": "08069001713",
+          "overlap_area_sqm": 10216206.2,
+          "share_of_place_area": 0.252,
+          "share_of_tract_area": 0.1818
+        },
+        {
+          "tract_geoid": "08069001714",
+          "overlap_area_sqm": 4493637.8,
+          "share_of_place_area": 0.1108,
+          "share_of_tract_area": 0.1424
+        },
+        {
+          "tract_geoid": "08123002104",
+          "overlap_area_sqm": 3083676.4,
+          "share_of_place_area": 0.0761,
+          "share_of_tract_area": 0.0371
+        },
+        {
+          "tract_geoid": "08123002101",
+          "overlap_area_sqm": 785919.7,
+          "share_of_place_area": 0.0194,
+          "share_of_tract_area": 0.007
+        }
+      ]
+    },
+    "0845530": {
+      "name": "Lochbuie",
+      "place_area_sqm": 9594783.8,
+      "tracts": [
+        {
+          "tract_geoid": "08123001913",
+          "overlap_area_sqm": 8665722.4,
+          "share_of_place_area": 0.9032,
+          "share_of_tract_area": 0.2708
+        },
+        {
+          "tract_geoid": "08001008562",
+          "overlap_area_sqm": 416071.3,
+          "share_of_place_area": 0.0434,
+          "share_of_tract_area": 0.071
+        },
+        {
+          "tract_geoid": "08123002502",
+          "overlap_area_sqm": 382869.5,
+          "share_of_place_area": 0.0399,
+          "share_of_tract_area": 0.0003
+        },
+        {
+          "tract_geoid": "08001008553",
+          "overlap_area_sqm": 130120.7,
+          "share_of_place_area": 0.0136,
+          "share_of_tract_area": 0.0008
+        }
+      ]
+    },
+    "0863045": {
+      "name": "Raymer (New Raymer)",
+      "place_area_sqm": 2030075.9,
+      "tracts": [
+        {
+          "tract_geoid": "08123002501",
+          "overlap_area_sqm": 2030075.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0837820": {
+      "name": "Hudson",
+      "place_area_sqm": 15480865.1,
+      "tracts": [
+        {
+          "tract_geoid": "08123002502",
+          "overlap_area_sqm": 9813291.0,
+          "share_of_place_area": 0.6339,
+          "share_of_tract_area": 0.0071
+        },
+        {
+          "tract_geoid": "08123001914",
+          "overlap_area_sqm": 5493946.9,
+          "share_of_place_area": 0.3549,
+          "share_of_tract_area": 0.0451
+        },
+        {
+          "tract_geoid": "08123001913",
+          "overlap_area_sqm": 173627.3,
+          "share_of_place_area": 0.0112,
+          "share_of_tract_area": 0.0054
+        }
+      ]
+    },
+    "0845970": {
+      "name": "Longmont",
+      "place_area_sqm": 80977024.9,
+      "tracts": [
+        {
+          "tract_geoid": "08123002105",
+          "overlap_area_sqm": 10825390.0,
+          "share_of_place_area": 0.1337,
+          "share_of_tract_area": 0.2392
+        },
+        {
+          "tract_geoid": "08013013212",
+          "overlap_area_sqm": 7136982.8,
+          "share_of_place_area": 0.0881,
+          "share_of_tract_area": 0.7873
+        },
+        {
+          "tract_geoid": "08013013215",
+          "overlap_area_sqm": 6452485.3,
+          "share_of_place_area": 0.0797,
+          "share_of_tract_area": 0.5952
+        },
+        {
+          "tract_geoid": "08013013210",
+          "overlap_area_sqm": 5369035.1,
+          "share_of_place_area": 0.0663,
+          "share_of_tract_area": 0.9241
+        },
+        {
+          "tract_geoid": "08013013211",
+          "overlap_area_sqm": 5192255.7,
+          "share_of_place_area": 0.0641,
+          "share_of_tract_area": 0.0949
+        },
+        {
+          "tract_geoid": "08013013402",
+          "overlap_area_sqm": 4759129.6,
+          "share_of_place_area": 0.0588,
+          "share_of_tract_area": 0.84
+        },
+        {
+          "tract_geoid": "08013013508",
+          "overlap_area_sqm": 4652090.5,
+          "share_of_place_area": 0.0574,
+          "share_of_tract_area": 0.8897
+        },
+        {
+          "tract_geoid": "08123002010",
+          "overlap_area_sqm": 4234012.8,
+          "share_of_place_area": 0.0523,
+          "share_of_tract_area": 0.1032
+        },
+        {
+          "tract_geoid": "08013013302",
+          "overlap_area_sqm": 3764985.7,
+          "share_of_place_area": 0.0465,
+          "share_of_tract_area": 0.9844
+        },
+        {
+          "tract_geoid": "08013013207",
+          "overlap_area_sqm": 3759943.0,
+          "share_of_place_area": 0.0464,
+          "share_of_tract_area": 0.5771
+        },
+        {
+          "tract_geoid": "08013013208",
+          "overlap_area_sqm": 3236825.5,
+          "share_of_place_area": 0.04,
+          "share_of_tract_area": 0.9927
+        },
+        {
+          "tract_geoid": "08013013401",
+          "overlap_area_sqm": 2785984.6,
+          "share_of_place_area": 0.0344,
+          "share_of_tract_area": 0.8424
+        },
+        {
+          "tract_geoid": "08013013506",
+          "overlap_area_sqm": 2590892.3,
+          "share_of_place_area": 0.032,
+          "share_of_tract_area": 0.9981
+        },
+        {
+          "tract_geoid": "08013013214",
+          "overlap_area_sqm": 2095608.6,
+          "share_of_place_area": 0.0259,
+          "share_of_tract_area": 0.2154
+        },
+        {
+          "tract_geoid": "08013013306",
+          "overlap_area_sqm": 1987914.7,
+          "share_of_place_area": 0.0245,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013013307",
+          "overlap_area_sqm": 1964523.8,
+          "share_of_place_area": 0.0243,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013013308",
+          "overlap_area_sqm": 1962400.8,
+          "share_of_place_area": 0.0242,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013013507",
+          "overlap_area_sqm": 1952678.1,
+          "share_of_place_area": 0.0241,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013013503",
+          "overlap_area_sqm": 1948841.9,
+          "share_of_place_area": 0.0241,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013013305",
+          "overlap_area_sqm": 1841634.4,
+          "share_of_place_area": 0.0227,
+          "share_of_tract_area": 0.9376
+        },
+        {
+          "tract_geoid": "08013013505",
+          "overlap_area_sqm": 1290617.0,
+          "share_of_place_area": 0.0159,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013013201",
+          "overlap_area_sqm": 1032025.9,
+          "share_of_place_area": 0.0127,
+          "share_of_tract_area": 0.0165
+        },
+        {
+          "tract_geoid": "08013013205",
+          "overlap_area_sqm": 140767.0,
+          "share_of_place_area": 0.0017,
+          "share_of_tract_area": 0.0062
+        }
+      ]
+    },
+    "0822860": {
+      "name": "Eaton",
+      "place_area_sqm": 8178579.1,
+      "tracts": [
+        {
+          "tract_geoid": "08123001500",
+          "overlap_area_sqm": 8178579.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0479
+        }
+      ]
+    },
+    "0840515": {
+      "name": "Kersey",
+      "place_area_sqm": 6137330.6,
+      "tracts": [
+        {
+          "tract_geoid": "08123001600",
+          "overlap_area_sqm": 4118203.4,
+          "share_of_place_area": 0.671,
+          "share_of_tract_area": 0.017
+        },
+        {
+          "tract_geoid": "08123000705",
+          "overlap_area_sqm": 2019127.1,
+          "share_of_place_area": 0.329,
+          "share_of_tract_area": 0.0227
+        }
+      ]
+    },
+    "0882350": {
+      "name": "Walsenburg",
+      "place_area_sqm": 7737366.2,
+      "tracts": [
+        {
+          "tract_geoid": "08055960600",
+          "overlap_area_sqm": 7737366.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0666
+        }
+      ]
+    },
+    "0819355": {
+      "name": "De Beque",
+      "place_area_sqm": 7333266.0,
+      "tracts": [
+        {
+          "tract_geoid": "08077001800",
+          "overlap_area_sqm": 7333266.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0025
+        }
+      ]
+    },
+    "0834520": {
+      "name": "Hartman",
+      "place_area_sqm": 711283.2,
+      "tracts": [
+        {
+          "tract_geoid": "08099000600",
+          "overlap_area_sqm": 711283.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0006
+        }
+      ]
+    },
+    "0873825": {
+      "name": "Steamboat Springs",
+      "place_area_sqm": 25644142.1,
+      "tracts": [
+        {
+          "tract_geoid": "08107000600",
+          "overlap_area_sqm": 6011536.6,
+          "share_of_place_area": 0.2344,
+          "share_of_tract_area": 0.0723
+        },
+        {
+          "tract_geoid": "08107000400",
+          "overlap_area_sqm": 5671090.8,
+          "share_of_place_area": 0.2211,
+          "share_of_tract_area": 0.0566
+        },
+        {
+          "tract_geoid": "08107000500",
+          "overlap_area_sqm": 5456665.8,
+          "share_of_place_area": 0.2128,
+          "share_of_tract_area": 0.0495
+        },
+        {
+          "tract_geoid": "08107000703",
+          "overlap_area_sqm": 4116047.0,
+          "share_of_place_area": 0.1605,
+          "share_of_tract_area": 0.0279
+        },
+        {
+          "tract_geoid": "08107000701",
+          "overlap_area_sqm": 3638817.5,
+          "share_of_place_area": 0.1419,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08107000702",
+          "overlap_area_sqm": 749984.5,
+          "share_of_place_area": 0.0292,
+          "share_of_tract_area": 1.0
+        }
+      ]
+    },
+    "0809115": {
+      "name": "Brookside",
+      "place_area_sqm": 1226476.4,
+      "tracts": [
+        {
+          "tract_geoid": "08043979100",
+          "overlap_area_sqm": 1215014.1,
+          "share_of_place_area": 0.9907,
+          "share_of_tract_area": 0.0751
+        },
+        {
+          "tract_geoid": "08043979200",
+          "overlap_area_sqm": 11462.2,
+          "share_of_place_area": 0.0093,
+          "share_of_tract_area": 0.0
+        }
+      ]
+    },
+    "0811810": {
+      "name": "Ca\u00f1on City",
+      "place_area_sqm": 32154615.2,
+      "tracts": [
+        {
+          "tract_geoid": "08043978300",
+          "overlap_area_sqm": 13193795.0,
+          "share_of_place_area": 0.4103,
+          "share_of_tract_area": 0.0644
+        },
+        {
+          "tract_geoid": "08043979200",
+          "overlap_area_sqm": 6986415.1,
+          "share_of_place_area": 0.2173,
+          "share_of_tract_area": 0.0277
+        },
+        {
+          "tract_geoid": "08043978500",
+          "overlap_area_sqm": 3222374.4,
+          "share_of_place_area": 0.1002,
+          "share_of_tract_area": 0.1403
+        },
+        {
+          "tract_geoid": "08043978800",
+          "overlap_area_sqm": 3160898.3,
+          "share_of_place_area": 0.0983,
+          "share_of_tract_area": 0.615
+        },
+        {
+          "tract_geoid": "08043978600",
+          "overlap_area_sqm": 2433497.6,
+          "share_of_place_area": 0.0757,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08043978400",
+          "overlap_area_sqm": 2354533.1,
+          "share_of_place_area": 0.0732,
+          "share_of_tract_area": 0.2789
+        },
+        {
+          "tract_geoid": "08043980100",
+          "overlap_area_sqm": 739156.6,
+          "share_of_place_area": 0.023,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08043979100",
+          "overlap_area_sqm": 63945.3,
+          "share_of_place_area": 0.002,
+          "share_of_tract_area": 0.004
+        }
+      ]
+    },
+    "0808400": {
+      "name": "Breckenridge",
+      "place_area_sqm": 15641761.7,
+      "tracts": [
+        {
+          "tract_geoid": "08117000406",
+          "overlap_area_sqm": 6306986.6,
+          "share_of_place_area": 0.4032,
+          "share_of_tract_area": 0.1077
+        },
+        {
+          "tract_geoid": "08117000404",
+          "overlap_area_sqm": 5920236.7,
+          "share_of_place_area": 0.3785,
+          "share_of_tract_area": 0.0549
+        },
+        {
+          "tract_geoid": "08117000405",
+          "overlap_area_sqm": 2546317.7,
+          "share_of_place_area": 0.1628,
+          "share_of_tract_area": 0.0379
+        },
+        {
+          "tract_geoid": "08117000403",
+          "overlap_area_sqm": 868220.7,
+          "share_of_place_area": 0.0555,
+          "share_of_tract_area": 0.0094
+        }
+      ]
+    },
+    "0851690": {
+      "name": "Montezuma",
+      "place_area_sqm": 204056.2,
+      "tracts": [
+        {
+          "tract_geoid": "08117000201",
+          "overlap_area_sqm": 204056.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0009
+        }
+      ]
+    },
+    "0882130": {
+      "name": "Walden",
+      "place_area_sqm": 867815.9,
+      "tracts": [
+        {
+          "tract_geoid": "08057955600",
+          "overlap_area_sqm": 867815.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0811645": {
+      "name": "Campo",
+      "place_area_sqm": 373819.7,
+      "tracts": [
+        {
+          "tract_geoid": "08009964600",
+          "overlap_area_sqm": 373819.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0806530": {
+      "name": "Bethune",
+      "place_area_sqm": 419803.7,
+      "tracts": [
+        {
+          "tract_geoid": "08063962100",
+          "overlap_area_sqm": 419803.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0810600": {
+      "name": "Burlington",
+      "place_area_sqm": 5563701.2,
+      "tracts": [
+        {
+          "tract_geoid": "08063962100",
+          "overlap_area_sqm": 5563701.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0029
+        }
+      ]
+    },
+    "0857630": {
+      "name": "Parker",
+      "place_area_sqm": 58119177.0,
+      "tracts": [
+        {
+          "tract_geoid": "08035014016",
+          "overlap_area_sqm": 12084683.7,
+          "share_of_place_area": 0.2079,
+          "share_of_tract_area": 0.3063
+        },
+        {
+          "tract_geoid": "08035013910",
+          "overlap_area_sqm": 5094668.1,
+          "share_of_place_area": 0.0877,
+          "share_of_tract_area": 0.9867
+        },
+        {
+          "tract_geoid": "08035013907",
+          "overlap_area_sqm": 4769883.4,
+          "share_of_place_area": 0.0821,
+          "share_of_tract_area": 0.7537
+        },
+        {
+          "tract_geoid": "08035014006",
+          "overlap_area_sqm": 4255794.9,
+          "share_of_place_area": 0.0732,
+          "share_of_tract_area": 0.7328
+        },
+        {
+          "tract_geoid": "08035013911",
+          "overlap_area_sqm": 3891574.7,
+          "share_of_place_area": 0.067,
+          "share_of_tract_area": 0.1061
+        },
+        {
+          "tract_geoid": "08035014010",
+          "overlap_area_sqm": 3711971.8,
+          "share_of_place_area": 0.0639,
+          "share_of_tract_area": 0.8592
+        },
+        {
+          "tract_geoid": "08035013905",
+          "overlap_area_sqm": 3642750.3,
+          "share_of_place_area": 0.0627,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035013904",
+          "overlap_area_sqm": 3568967.3,
+          "share_of_place_area": 0.0614,
+          "share_of_tract_area": 0.6707
+        },
+        {
+          "tract_geoid": "08035013912",
+          "overlap_area_sqm": 3552123.0,
+          "share_of_place_area": 0.0611,
+          "share_of_tract_area": 0.1296
+        },
+        {
+          "tract_geoid": "08035014009",
+          "overlap_area_sqm": 3291267.6,
+          "share_of_place_area": 0.0566,
+          "share_of_tract_area": 0.8967
+        },
+        {
+          "tract_geoid": "08035014014",
+          "overlap_area_sqm": 2380676.1,
+          "share_of_place_area": 0.041,
+          "share_of_tract_area": 0.2631
+        },
+        {
+          "tract_geoid": "08035014015",
+          "overlap_area_sqm": 2169572.6,
+          "share_of_place_area": 0.0373,
+          "share_of_tract_area": 0.8533
+        },
+        {
+          "tract_geoid": "08035014013",
+          "overlap_area_sqm": 2059747.7,
+          "share_of_place_area": 0.0354,
+          "share_of_tract_area": 0.0498
+        },
+        {
+          "tract_geoid": "08035014008",
+          "overlap_area_sqm": 1321364.8,
+          "share_of_place_area": 0.0227,
+          "share_of_tract_area": 0.2289
+        },
+        {
+          "tract_geoid": "08035014007",
+          "overlap_area_sqm": 964875.3,
+          "share_of_place_area": 0.0166,
+          "share_of_tract_area": 0.0968
+        },
+        {
+          "tract_geoid": "08035013914",
+          "overlap_area_sqm": 706549.1,
+          "share_of_place_area": 0.0122,
+          "share_of_tract_area": 0.0327
+        },
+        {
+          "tract_geoid": "08035014011",
+          "overlap_area_sqm": 464245.4,
+          "share_of_place_area": 0.008,
+          "share_of_tract_area": 0.0154
+        },
+        {
+          "tract_geoid": "08035014005",
+          "overlap_area_sqm": 188461.0,
+          "share_of_place_area": 0.0032,
+          "share_of_tract_area": 0.0724
+        }
+      ]
+    },
+    "0856420": {
+      "name": "Ouray",
+      "place_area_sqm": 2235666.2,
+      "tracts": [
+        {
+          "tract_geoid": "08091967602",
+          "overlap_area_sqm": 2235666.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0022
+        }
+      ]
+    },
+    "0803620": {
+      "name": "Aspen",
+      "place_area_sqm": 10002979.5,
+      "tracts": [
+        {
+          "tract_geoid": "08097000404",
+          "overlap_area_sqm": 3568937.0,
+          "share_of_place_area": 0.3568,
+          "share_of_tract_area": 0.8724
+        },
+        {
+          "tract_geoid": "08097000402",
+          "overlap_area_sqm": 3131197.7,
+          "share_of_place_area": 0.313,
+          "share_of_tract_area": 0.0355
+        },
+        {
+          "tract_geoid": "08097000500",
+          "overlap_area_sqm": 1118983.2,
+          "share_of_place_area": 0.1119,
+          "share_of_tract_area": 0.0009
+        },
+        {
+          "tract_geoid": "08097000101",
+          "overlap_area_sqm": 1096380.8,
+          "share_of_place_area": 0.1096,
+          "share_of_tract_area": 0.0042
+        },
+        {
+          "tract_geoid": "08097000403",
+          "overlap_area_sqm": 1087480.9,
+          "share_of_place_area": 0.1087,
+          "share_of_tract_area": 0.0508
+        }
+      ]
+    },
+    "0871755": {
+      "name": "Snowmass Village",
+      "place_area_sqm": 72184107.7,
+      "tracts": [
+        {
+          "tract_geoid": "08097000101",
+          "overlap_area_sqm": 72100740.7,
+          "share_of_place_area": 0.9988,
+          "share_of_tract_area": 0.2772
+        },
+        {
+          "tract_geoid": "08097000102",
+          "overlap_area_sqm": 83367.1,
+          "share_of_place_area": 0.0012,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0814175": {
+      "name": "Cheyenne Wells",
+      "place_area_sqm": 2771559.6,
+      "tracts": [
+        {
+          "tract_geoid": "08017960600",
+          "overlap_area_sqm": 2771559.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0006
+        }
+      ]
+    },
+    "0811260": {
+      "name": "Calhan",
+      "place_area_sqm": 2354194.4,
+      "tracts": [
+        {
+          "tract_geoid": "08041003911",
+          "overlap_area_sqm": 2189418.0,
+          "share_of_place_area": 0.93,
+          "share_of_tract_area": 0.0062
+        },
+        {
+          "tract_geoid": "08041003910",
+          "overlap_area_sqm": 164776.3,
+          "share_of_place_area": 0.07,
+          "share_of_tract_area": 0.0004
+        }
+      ]
+    },
+    "0816000": {
+      "name": "Colorado Springs",
+      "place_area_sqm": 523929625.6,
+      "tracts": [
+        {
+          "tract_geoid": "08041004008",
+          "overlap_area_sqm": 39208261.5,
+          "share_of_place_area": 0.0748,
+          "share_of_tract_area": 0.9753
+        },
+        {
+          "tract_geoid": "08041004603",
+          "overlap_area_sqm": 36322620.2,
+          "share_of_place_area": 0.0693,
+          "share_of_tract_area": 0.096
+        },
+        {
+          "tract_geoid": "08041005123",
+          "overlap_area_sqm": 32471995.6,
+          "share_of_place_area": 0.062,
+          "share_of_tract_area": 0.3419
+        },
+        {
+          "tract_geoid": "08041005122",
+          "overlap_area_sqm": 28629279.1,
+          "share_of_place_area": 0.0546,
+          "share_of_tract_area": 0.7762
+        },
+        {
+          "tract_geoid": "08041003305",
+          "overlap_area_sqm": 12758484.6,
+          "share_of_place_area": 0.0244,
+          "share_of_tract_area": 0.9574
+        },
+        {
+          "tract_geoid": "08041007105",
+          "overlap_area_sqm": 11590851.5,
+          "share_of_place_area": 0.0221,
+          "share_of_tract_area": 0.9445
+        },
+        {
+          "tract_geoid": "08041002501",
+          "overlap_area_sqm": 10607032.1,
+          "share_of_place_area": 0.0202,
+          "share_of_tract_area": 0.7132
+        },
+        {
+          "tract_geoid": "08041003100",
+          "overlap_area_sqm": 9822395.2,
+          "share_of_place_area": 0.0187,
+          "share_of_tract_area": 0.8622
+        },
+        {
+          "tract_geoid": "08041003713",
+          "overlap_area_sqm": 9201949.2,
+          "share_of_place_area": 0.0176,
+          "share_of_tract_area": 0.0353
+        },
+        {
+          "tract_geoid": "08041003306",
+          "overlap_area_sqm": 8516834.8,
+          "share_of_place_area": 0.0163,
+          "share_of_tract_area": 0.0505
+        },
+        {
+          "tract_geoid": "08041007206",
+          "overlap_area_sqm": 8465548.9,
+          "share_of_place_area": 0.0162,
+          "share_of_tract_area": 0.9665
+        },
+        {
+          "tract_geoid": "08041003401",
+          "overlap_area_sqm": 8238275.2,
+          "share_of_place_area": 0.0157,
+          "share_of_tract_area": 0.0549
+        },
+        {
+          "tract_geoid": "08041007205",
+          "overlap_area_sqm": 8030288.1,
+          "share_of_place_area": 0.0153,
+          "share_of_tract_area": 0.9433
+        },
+        {
+          "tract_geoid": "08041003705",
+          "overlap_area_sqm": 7473372.0,
+          "share_of_place_area": 0.0143,
+          "share_of_tract_area": 0.6389
+        },
+        {
+          "tract_geoid": "08041007502",
+          "overlap_area_sqm": 7275821.7,
+          "share_of_place_area": 0.0139,
+          "share_of_tract_area": 0.0508
+        },
+        {
+          "tract_geoid": "08041005900",
+          "overlap_area_sqm": 6254938.6,
+          "share_of_place_area": 0.0119,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041007900",
+          "overlap_area_sqm": 6152619.8,
+          "share_of_place_area": 0.0117,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041007700",
+          "overlap_area_sqm": 6047218.5,
+          "share_of_place_area": 0.0115,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041003711",
+          "overlap_area_sqm": 5885532.2,
+          "share_of_place_area": 0.0112,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041004518",
+          "overlap_area_sqm": 5647370.0,
+          "share_of_place_area": 0.0108,
+          "share_of_tract_area": 0.3341
+        },
+        {
+          "tract_geoid": "08041000104",
+          "overlap_area_sqm": 5646989.1,
+          "share_of_place_area": 0.0108,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041000302",
+          "overlap_area_sqm": 5588284.9,
+          "share_of_place_area": 0.0107,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041003905",
+          "overlap_area_sqm": 5519601.0,
+          "share_of_place_area": 0.0105,
+          "share_of_tract_area": 0.9948
+        },
+        {
+          "tract_geoid": "08041002802",
+          "overlap_area_sqm": 5098120.7,
+          "share_of_place_area": 0.0097,
+          "share_of_tract_area": 0.8106
+        },
+        {
+          "tract_geoid": "08041003702",
+          "overlap_area_sqm": 4910445.8,
+          "share_of_place_area": 0.0094,
+          "share_of_tract_area": 0.9674
+        },
+        {
+          "tract_geoid": "08041003906",
+          "overlap_area_sqm": 4848704.8,
+          "share_of_place_area": 0.0093,
+          "share_of_tract_area": 0.9887
+        },
+        {
+          "tract_geoid": "08041007000",
+          "overlap_area_sqm": 4615648.7,
+          "share_of_place_area": 0.0088,
+          "share_of_tract_area": 0.8225
+        },
+        {
+          "tract_geoid": "08041003402",
+          "overlap_area_sqm": 4554438.7,
+          "share_of_place_area": 0.0087,
+          "share_of_tract_area": 0.09
+        },
+        {
+          "tract_geoid": "08041004501",
+          "overlap_area_sqm": 4507728.7,
+          "share_of_place_area": 0.0086,
+          "share_of_tract_area": 0.3315
+        },
+        {
+          "tract_geoid": "08041007603",
+          "overlap_area_sqm": 4498831.4,
+          "share_of_place_area": 0.0086,
+          "share_of_tract_area": 0.1203
+        },
+        {
+          "tract_geoid": "08041001104",
+          "overlap_area_sqm": 4240657.5,
+          "share_of_place_area": 0.0081,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041003707",
+          "overlap_area_sqm": 4192736.1,
+          "share_of_place_area": 0.008,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041007104",
+          "overlap_area_sqm": 4013944.8,
+          "share_of_place_area": 0.0077,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041007802",
+          "overlap_area_sqm": 3986872.6,
+          "share_of_place_area": 0.0076,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041006000",
+          "overlap_area_sqm": 3959928.5,
+          "share_of_place_area": 0.0076,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041002502",
+          "overlap_area_sqm": 3918391.9,
+          "share_of_place_area": 0.0075,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041005121",
+          "overlap_area_sqm": 3655728.2,
+          "share_of_place_area": 0.007,
+          "share_of_tract_area": 0.7226
+        },
+        {
+          "tract_geoid": "08041006200",
+          "overlap_area_sqm": 3606812.1,
+          "share_of_place_area": 0.0069,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041002000",
+          "overlap_area_sqm": 3443445.0,
+          "share_of_place_area": 0.0066,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041005501",
+          "overlap_area_sqm": 3327319.5,
+          "share_of_place_area": 0.0064,
+          "share_of_tract_area": 0.8219
+        },
+        {
+          "tract_geoid": "08041006400",
+          "overlap_area_sqm": 3258113.2,
+          "share_of_place_area": 0.0062,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041003708",
+          "overlap_area_sqm": 3159248.5,
+          "share_of_place_area": 0.006,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041002300",
+          "overlap_area_sqm": 3127402.2,
+          "share_of_place_area": 0.006,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041005700",
+          "overlap_area_sqm": 3143699.9,
+          "share_of_place_area": 0.006,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041005125",
+          "overlap_area_sqm": 3080076.5,
+          "share_of_place_area": 0.0059,
+          "share_of_tract_area": 0.9175
+        },
+        {
+          "tract_geoid": "08041001302",
+          "overlap_area_sqm": 3052207.8,
+          "share_of_place_area": 0.0058,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041004706",
+          "overlap_area_sqm": 2876262.3,
+          "share_of_place_area": 0.0055,
+          "share_of_tract_area": 0.9611
+        },
+        {
+          "tract_geoid": "08041007106",
+          "overlap_area_sqm": 2885938.1,
+          "share_of_place_area": 0.0055,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041008000",
+          "overlap_area_sqm": 2827484.6,
+          "share_of_place_area": 0.0054,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041005400",
+          "overlap_area_sqm": 2821822.9,
+          "share_of_place_area": 0.0054,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041006901",
+          "overlap_area_sqm": 2813545.7,
+          "share_of_place_area": 0.0054,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041007103",
+          "overlap_area_sqm": 2804193.4,
+          "share_of_place_area": 0.0054,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041003706",
+          "overlap_area_sqm": 2756761.3,
+          "share_of_place_area": 0.0053,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041002101",
+          "overlap_area_sqm": 2729946.5,
+          "share_of_place_area": 0.0052,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041000202",
+          "overlap_area_sqm": 2655612.4,
+          "share_of_place_area": 0.0051,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041006600",
+          "overlap_area_sqm": 2606620.5,
+          "share_of_place_area": 0.005,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041000203",
+          "overlap_area_sqm": 2629074.9,
+          "share_of_place_area": 0.005,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041002102",
+          "overlap_area_sqm": 2619351.6,
+          "share_of_place_area": 0.005,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041005117",
+          "overlap_area_sqm": 2601161.0,
+          "share_of_place_area": 0.005,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041004902",
+          "overlap_area_sqm": 2632512.3,
+          "share_of_place_area": 0.005,
+          "share_of_tract_area": 0.6441
+        },
+        {
+          "tract_geoid": "08041006502",
+          "overlap_area_sqm": 2589698.4,
+          "share_of_place_area": 0.0049,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041006301",
+          "overlap_area_sqm": 2544038.3,
+          "share_of_place_area": 0.0049,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041002402",
+          "overlap_area_sqm": 2476744.2,
+          "share_of_place_area": 0.0047,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041003303",
+          "overlap_area_sqm": 2473624.6,
+          "share_of_place_area": 0.0047,
+          "share_of_tract_area": 0.466
+        },
+        {
+          "tract_geoid": "08041006902",
+          "overlap_area_sqm": 2467112.1,
+          "share_of_place_area": 0.0047,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041003710",
+          "overlap_area_sqm": 2425238.4,
+          "share_of_place_area": 0.0046,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041004800",
+          "overlap_area_sqm": 2385028.5,
+          "share_of_place_area": 0.0046,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041005118",
+          "overlap_area_sqm": 2360666.4,
+          "share_of_place_area": 0.0045,
+          "share_of_tract_area": 0.8176
+        },
+        {
+          "tract_geoid": "08041002700",
+          "overlap_area_sqm": 2321834.2,
+          "share_of_place_area": 0.0044,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041004703",
+          "overlap_area_sqm": 2329090.9,
+          "share_of_place_area": 0.0044,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041000800",
+          "overlap_area_sqm": 2246018.6,
+          "share_of_place_area": 0.0043,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041005120",
+          "overlap_area_sqm": 2257416.1,
+          "share_of_place_area": 0.0043,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041003001",
+          "overlap_area_sqm": 2182150.2,
+          "share_of_place_area": 0.0042,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041004701",
+          "overlap_area_sqm": 2226579.3,
+          "share_of_place_area": 0.0042,
+          "share_of_tract_area": 0.9969
+        },
+        {
+          "tract_geoid": "08041003307",
+          "overlap_area_sqm": 2154524.1,
+          "share_of_place_area": 0.0041,
+          "share_of_tract_area": 0.9501
+        },
+        {
+          "tract_geoid": "08041004708",
+          "overlap_area_sqm": 2142025.1,
+          "share_of_place_area": 0.0041,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041006802",
+          "overlap_area_sqm": 2125777.6,
+          "share_of_place_area": 0.0041,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041002901",
+          "overlap_area_sqm": 2106809.3,
+          "share_of_place_area": 0.004,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041001400",
+          "overlap_area_sqm": 1971061.9,
+          "share_of_place_area": 0.0038,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041001000",
+          "overlap_area_sqm": 1970441.4,
+          "share_of_place_area": 0.0038,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041000301",
+          "overlap_area_sqm": 1865807.4,
+          "share_of_place_area": 0.0036,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041006801",
+          "overlap_area_sqm": 1905841.1,
+          "share_of_place_area": 0.0036,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041006701",
+          "overlap_area_sqm": 1847879.0,
+          "share_of_place_area": 0.0035,
+          "share_of_tract_area": 0.289
+        },
+        {
+          "tract_geoid": "08041005601",
+          "overlap_area_sqm": 1856926.1,
+          "share_of_place_area": 0.0035,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041001500",
+          "overlap_area_sqm": 1758343.3,
+          "share_of_place_area": 0.0034,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041002200",
+          "overlap_area_sqm": 1728070.7,
+          "share_of_place_area": 0.0033,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041000400",
+          "overlap_area_sqm": 1715542.5,
+          "share_of_place_area": 0.0033,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041006302",
+          "overlap_area_sqm": 1711095.4,
+          "share_of_place_area": 0.0033,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041000600",
+          "overlap_area_sqm": 1712881.2,
+          "share_of_place_area": 0.0033,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041005502",
+          "overlap_area_sqm": 1716234.2,
+          "share_of_place_area": 0.0033,
+          "share_of_tract_area": 0.9281
+        },
+        {
+          "tract_geoid": "08041002401",
+          "overlap_area_sqm": 1670243.6,
+          "share_of_place_area": 0.0032,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041005201",
+          "overlap_area_sqm": 1655516.4,
+          "share_of_place_area": 0.0032,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041004901",
+          "overlap_area_sqm": 1693541.7,
+          "share_of_place_area": 0.0032,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041006501",
+          "overlap_area_sqm": 1599273.6,
+          "share_of_place_area": 0.0031,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041000700",
+          "overlap_area_sqm": 1623652.8,
+          "share_of_place_area": 0.0031,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041000102",
+          "overlap_area_sqm": 1614635.4,
+          "share_of_place_area": 0.0031,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041001600",
+          "overlap_area_sqm": 1586991.7,
+          "share_of_place_area": 0.003,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041005602",
+          "overlap_area_sqm": 1511260.5,
+          "share_of_place_area": 0.0029,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041005112",
+          "overlap_area_sqm": 1518135.2,
+          "share_of_place_area": 0.0029,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041005300",
+          "overlap_area_sqm": 1489717.4,
+          "share_of_place_area": 0.0028,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041003308",
+          "overlap_area_sqm": 1423240.1,
+          "share_of_place_area": 0.0027,
+          "share_of_tract_area": 0.852
+        },
+        {
+          "tract_geoid": "08041005800",
+          "overlap_area_sqm": 1389005.6,
+          "share_of_place_area": 0.0027,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041005113",
+          "overlap_area_sqm": 1397019.2,
+          "share_of_place_area": 0.0027,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041006100",
+          "overlap_area_sqm": 1354589.6,
+          "share_of_place_area": 0.0026,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041000500",
+          "overlap_area_sqm": 1330062.0,
+          "share_of_place_area": 0.0025,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041000103",
+          "overlap_area_sqm": 1294066.4,
+          "share_of_place_area": 0.0025,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041005124",
+          "overlap_area_sqm": 1312696.9,
+          "share_of_place_area": 0.0025,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041001301",
+          "overlap_area_sqm": 1259837.8,
+          "share_of_place_area": 0.0024,
+          "share_of_tract_area": 0.9481
+        },
+        {
+          "tract_geoid": "08041001800",
+          "overlap_area_sqm": 1280842.4,
+          "share_of_place_area": 0.0024,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041001101",
+          "overlap_area_sqm": 1263369.0,
+          "share_of_place_area": 0.0024,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041007204",
+          "overlap_area_sqm": 1245660.1,
+          "share_of_place_area": 0.0024,
+          "share_of_tract_area": 0.1261
+        },
+        {
+          "tract_geoid": "08041007801",
+          "overlap_area_sqm": 1220725.1,
+          "share_of_place_area": 0.0023,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041003002",
+          "overlap_area_sqm": 1138340.2,
+          "share_of_place_area": 0.0022,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041002801",
+          "overlap_area_sqm": 1101389.7,
+          "share_of_place_area": 0.0021,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041000900",
+          "overlap_area_sqm": 1055151.0,
+          "share_of_place_area": 0.002,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041005202",
+          "overlap_area_sqm": 1017605.7,
+          "share_of_place_area": 0.0019,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041001901",
+          "overlap_area_sqm": 1002037.0,
+          "share_of_place_area": 0.0019,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041004702",
+          "overlap_area_sqm": 1014260.5,
+          "share_of_place_area": 0.0019,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041005119",
+          "overlap_area_sqm": 961952.9,
+          "share_of_place_area": 0.0018,
+          "share_of_tract_area": 0.2815
+        },
+        {
+          "tract_geoid": "08041005116",
+          "overlap_area_sqm": 942180.3,
+          "share_of_place_area": 0.0018,
+          "share_of_tract_area": 0.4772
+        },
+        {
+          "tract_geoid": "08041002902",
+          "overlap_area_sqm": 910146.0,
+          "share_of_place_area": 0.0017,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041004707",
+          "overlap_area_sqm": 902817.8,
+          "share_of_place_area": 0.0017,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041003802",
+          "overlap_area_sqm": 822000.2,
+          "share_of_place_area": 0.0016,
+          "share_of_tract_area": 0.0169
+        },
+        {
+          "tract_geoid": "08041001700",
+          "overlap_area_sqm": 784911.9,
+          "share_of_place_area": 0.0015,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041007604",
+          "overlap_area_sqm": 729215.5,
+          "share_of_place_area": 0.0014,
+          "share_of_tract_area": 0.056
+        },
+        {
+          "tract_geoid": "08041001902",
+          "overlap_area_sqm": 706754.5,
+          "share_of_place_area": 0.0013,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041004502",
+          "overlap_area_sqm": 647125.9,
+          "share_of_place_area": 0.0012,
+          "share_of_tract_area": 0.0543
+        },
+        {
+          "tract_geoid": "08041004009",
+          "overlap_area_sqm": 472058.9,
+          "share_of_place_area": 0.0009,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041005114",
+          "overlap_area_sqm": 313284.6,
+          "share_of_place_area": 0.0006,
+          "share_of_tract_area": 0.129
+        },
+        {
+          "tract_geoid": "08041005110",
+          "overlap_area_sqm": 138435.4,
+          "share_of_place_area": 0.0003,
+          "share_of_tract_area": 0.0699
+        },
+        {
+          "tract_geoid": "08041006702",
+          "overlap_area_sqm": 86120.9,
+          "share_of_place_area": 0.0002,
+          "share_of_tract_area": 0.0101
+        },
+        {
+          "tract_geoid": "08041005000",
+          "overlap_area_sqm": 38476.9,
+          "share_of_place_area": 0.0001,
+          "share_of_tract_area": 0.0077
+        },
+        {
+          "tract_geoid": "08041005115",
+          "overlap_area_sqm": 20422.4,
+          "share_of_place_area": 0.0,
+          "share_of_tract_area": 0.0063
+        }
+      ]
+    },
+    "0827975": {
+      "name": "Fowler",
+      "place_area_sqm": 1457619.5,
+      "tracts": [
+        {
+          "tract_geoid": "08089968000",
+          "overlap_area_sqm": 1457619.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0321
+        }
+      ]
+    },
+    "0826765": {
+      "name": "Flagler",
+      "place_area_sqm": 3729493.4,
+      "tracts": [
+        {
+          "tract_geoid": "08063962400",
+          "overlap_area_sqm": 3729493.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.001
+        }
+      ]
+    },
+    "0874485": {
+      "name": "Stratton",
+      "place_area_sqm": 1331755.5,
+      "tracts": [
+        {
+          "tract_geoid": "08063962400",
+          "overlap_area_sqm": 1331755.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0004
+        }
+      ]
+    },
+    "0827810": {
+      "name": "Fort Morgan",
+      "place_area_sqm": 14023312.7,
+      "tracts": [
+        {
+          "tract_geoid": "08087000600",
+          "overlap_area_sqm": 7046079.6,
+          "share_of_place_area": 0.5025,
+          "share_of_tract_area": 0.024
+        },
+        {
+          "tract_geoid": "08087000400",
+          "overlap_area_sqm": 2627059.2,
+          "share_of_place_area": 0.1873,
+          "share_of_tract_area": 0.7967
+        },
+        {
+          "tract_geoid": "08087000500",
+          "overlap_area_sqm": 2494984.9,
+          "share_of_place_area": 0.1779,
+          "share_of_tract_area": 0.7024
+        },
+        {
+          "tract_geoid": "08087000100",
+          "overlap_area_sqm": 1830828.8,
+          "share_of_place_area": 0.1306,
+          "share_of_tract_area": 0.0014
+        },
+        {
+          "tract_geoid": "08087000300",
+          "overlap_area_sqm": 24360.2,
+          "share_of_place_area": 0.0017,
+          "share_of_tract_area": 0.0006
+        }
+      ]
+    },
+    "0819850": {
+      "name": "Delta",
+      "place_area_sqm": 35077247.7,
+      "tracts": [
+        {
+          "tract_geoid": "08029964800",
+          "overlap_area_sqm": 24115496.9,
+          "share_of_place_area": 0.6875,
+          "share_of_tract_area": 0.0397
+        },
+        {
+          "tract_geoid": "08029964900",
+          "overlap_area_sqm": 5794553.5,
+          "share_of_place_area": 0.1652,
+          "share_of_tract_area": 0.03
+        },
+        {
+          "tract_geoid": "08029965100",
+          "overlap_area_sqm": 5167197.3,
+          "share_of_place_area": 0.1473,
+          "share_of_tract_area": 0.1093
+        }
+      ]
+    },
+    "0865190": {
+      "name": "Rocky Ford",
+      "place_area_sqm": 4381345.0,
+      "tracts": [
+        {
+          "tract_geoid": "08089968100",
+          "overlap_area_sqm": 2418801.8,
+          "share_of_place_area": 0.5521,
+          "share_of_tract_area": 0.0665
+        },
+        {
+          "tract_geoid": "08089968200",
+          "overlap_area_sqm": 1962543.2,
+          "share_of_place_area": 0.4479,
+          "share_of_tract_area": 0.0146
+        }
+      ]
+    },
+    "0875970": {
+      "name": "Swink",
+      "place_area_sqm": 724743.7,
+      "tracts": [
+        {
+          "tract_geoid": "08089968300",
+          "overlap_area_sqm": 724743.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0074
+        }
+      ]
+    },
+    "0838590": {
+      "name": "Iliff",
+      "place_area_sqm": 494660.3,
+      "tracts": [
+        {
+          "tract_geoid": "08075966000",
+          "overlap_area_sqm": 494660.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0004
+        }
+      ]
+    },
+    "0873935": {
+      "name": "Sterling",
+      "place_area_sqm": 19727660.9,
+      "tracts": [
+        {
+          "tract_geoid": "08075966400",
+          "overlap_area_sqm": 8037612.0,
+          "share_of_place_area": 0.4074,
+          "share_of_tract_area": 0.0044
+        },
+        {
+          "tract_geoid": "08075966200",
+          "overlap_area_sqm": 3946343.5,
+          "share_of_place_area": 0.2,
+          "share_of_tract_area": 0.1901
+        },
+        {
+          "tract_geoid": "08075966102",
+          "overlap_area_sqm": 3547503.4,
+          "share_of_place_area": 0.1798,
+          "share_of_tract_area": 0.235
+        },
+        {
+          "tract_geoid": "08075966300",
+          "overlap_area_sqm": 3454036.8,
+          "share_of_place_area": 0.1751,
+          "share_of_tract_area": 0.082
+        },
+        {
+          "tract_geoid": "08075966101",
+          "overlap_area_sqm": 742165.3,
+          "share_of_place_area": 0.0376,
+          "share_of_tract_area": 0.0118
+        }
+      ]
+    },
+    "0827865": {
+      "name": "Fountain",
+      "place_area_sqm": 57883394.8,
+      "tracts": [
+        {
+          "tract_geoid": "08041004517",
+          "overlap_area_sqm": 13908081.1,
+          "share_of_place_area": 0.2403,
+          "share_of_tract_area": 0.1959
+        },
+        {
+          "tract_geoid": "08041004516",
+          "overlap_area_sqm": 11485193.0,
+          "share_of_place_area": 0.1984,
+          "share_of_tract_area": 0.1189
+        },
+        {
+          "tract_geoid": "08041004513",
+          "overlap_area_sqm": 6101517.1,
+          "share_of_place_area": 0.1054,
+          "share_of_tract_area": 0.8525
+        },
+        {
+          "tract_geoid": "08041004515",
+          "overlap_area_sqm": 4851908.6,
+          "share_of_place_area": 0.0838,
+          "share_of_tract_area": 0.4332
+        },
+        {
+          "tract_geoid": "08041004518",
+          "overlap_area_sqm": 3835759.4,
+          "share_of_place_area": 0.0663,
+          "share_of_tract_area": 0.2269
+        },
+        {
+          "tract_geoid": "08041004514",
+          "overlap_area_sqm": 2926419.8,
+          "share_of_place_area": 0.0506,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041004512",
+          "overlap_area_sqm": 2473121.1,
+          "share_of_place_area": 0.0427,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041004501",
+          "overlap_area_sqm": 2357003.0,
+          "share_of_place_area": 0.0407,
+          "share_of_tract_area": 0.1733
+        },
+        {
+          "tract_geoid": "08041004602",
+          "overlap_area_sqm": 2240463.0,
+          "share_of_place_area": 0.0387,
+          "share_of_tract_area": 0.0013
+        },
+        {
+          "tract_geoid": "08041004603",
+          "overlap_area_sqm": 2154311.3,
+          "share_of_place_area": 0.0372,
+          "share_of_tract_area": 0.0057
+        },
+        {
+          "tract_geoid": "08041004519",
+          "overlap_area_sqm": 1994730.8,
+          "share_of_place_area": 0.0345,
+          "share_of_tract_area": 0.7926
+        },
+        {
+          "tract_geoid": "08041004403",
+          "overlap_area_sqm": 1025074.8,
+          "share_of_place_area": 0.0177,
+          "share_of_tract_area": 0.0032
+        },
+        {
+          "tract_geoid": "08041004507",
+          "overlap_area_sqm": 877639.9,
+          "share_of_place_area": 0.0152,
+          "share_of_tract_area": 0.3906
+        },
+        {
+          "tract_geoid": "08041004520",
+          "overlap_area_sqm": 614019.8,
+          "share_of_place_area": 0.0106,
+          "share_of_tract_area": 0.7041
+        },
+        {
+          "tract_geoid": "08041003303",
+          "overlap_area_sqm": 439854.3,
+          "share_of_place_area": 0.0076,
+          "share_of_tract_area": 0.0829
+        },
+        {
+          "tract_geoid": "08041004506",
+          "overlap_area_sqm": 309490.4,
+          "share_of_place_area": 0.0053,
+          "share_of_tract_area": 0.1149
+        },
+        {
+          "tract_geoid": "08041004402",
+          "overlap_area_sqm": 288807.6,
+          "share_of_place_area": 0.005,
+          "share_of_tract_area": 0.018
+        }
+      ]
+    },
+    "0851800": {
+      "name": "Monument",
+      "place_area_sqm": 18170281.7,
+      "tracts": [
+        {
+          "tract_geoid": "08041007301",
+          "overlap_area_sqm": 9196925.8,
+          "share_of_place_area": 0.5062,
+          "share_of_tract_area": 0.6088
+        },
+        {
+          "tract_geoid": "08041003712",
+          "overlap_area_sqm": 6493658.8,
+          "share_of_place_area": 0.3574,
+          "share_of_tract_area": 0.2966
+        },
+        {
+          "tract_geoid": "08041007302",
+          "overlap_area_sqm": 1312213.4,
+          "share_of_place_area": 0.0722,
+          "share_of_tract_area": 0.056
+        },
+        {
+          "tract_geoid": "08041003713",
+          "overlap_area_sqm": 721874.0,
+          "share_of_place_area": 0.0397,
+          "share_of_tract_area": 0.0028
+        },
+        {
+          "tract_geoid": "08041007203",
+          "overlap_area_sqm": 425638.4,
+          "share_of_place_area": 0.0234,
+          "share_of_tract_area": 0.0839
+        },
+        {
+          "tract_geoid": "08041003802",
+          "overlap_area_sqm": 19971.3,
+          "share_of_place_area": 0.0011,
+          "share_of_tract_area": 0.0004
+        }
+      ]
+    },
+    "0886090": {
+      "name": "Woodland Park",
+      "place_area_sqm": 17112316.1,
+      "tracts": [
+        {
+          "tract_geoid": "08119010108",
+          "overlap_area_sqm": 7498391.0,
+          "share_of_place_area": 0.4382,
+          "share_of_tract_area": 0.2998
+        },
+        {
+          "tract_geoid": "08119010107",
+          "overlap_area_sqm": 5800591.9,
+          "share_of_place_area": 0.339,
+          "share_of_tract_area": 0.5936
+        },
+        {
+          "tract_geoid": "08119010104",
+          "overlap_area_sqm": 2102104.8,
+          "share_of_place_area": 0.1228,
+          "share_of_tract_area": 0.1623
+        },
+        {
+          "tract_geoid": "08119010111",
+          "overlap_area_sqm": 1711228.3,
+          "share_of_place_area": 0.1,
+          "share_of_tract_area": 0.0045
+        }
+      ]
+    },
+    "0881690": {
+      "name": "Vona",
+      "place_area_sqm": 573323.6,
+      "tracts": [
+        {
+          "tract_geoid": "08063962400",
+          "overlap_area_sqm": 573323.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0874815": {
+      "name": "Sugar City",
+      "place_area_sqm": 996342.1,
+      "tracts": [
+        {
+          "tract_geoid": "08025969601",
+          "overlap_area_sqm": 996342.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0005
+        }
+      ]
+    },
+    "0818750": {
+      "name": "Crowley",
+      "place_area_sqm": 583697.2,
+      "tracts": [
+        {
+          "tract_geoid": "08025969602",
+          "overlap_area_sqm": 583697.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0026
+        }
+      ]
+    },
+    "0855705": {
+      "name": "Olney Springs",
+      "place_area_sqm": 622727.7,
+      "tracts": [
+        {
+          "tract_geoid": "08025969601",
+          "overlap_area_sqm": 622727.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0856145": {
+      "name": "Ordway",
+      "place_area_sqm": 1996830.1,
+      "tracts": [
+        {
+          "tract_geoid": "08025969602",
+          "overlap_area_sqm": 1996830.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0089
+        }
+      ]
+    },
+    "0851745": {
+      "name": "Montrose",
+      "place_area_sqm": 48969462.3,
+      "tracts": [
+        {
+          "tract_geoid": "08085966501",
+          "overlap_area_sqm": 12859037.9,
+          "share_of_place_area": 0.2626,
+          "share_of_tract_area": 0.0211
+        },
+        {
+          "tract_geoid": "08085966601",
+          "overlap_area_sqm": 7923454.9,
+          "share_of_place_area": 0.1618,
+          "share_of_tract_area": 0.4684
+        },
+        {
+          "tract_geoid": "08085966302",
+          "overlap_area_sqm": 7482020.9,
+          "share_of_place_area": 0.1528,
+          "share_of_tract_area": 0.7821
+        },
+        {
+          "tract_geoid": "08085966502",
+          "overlap_area_sqm": 6651495.1,
+          "share_of_place_area": 0.1358,
+          "share_of_tract_area": 0.8433
+        },
+        {
+          "tract_geoid": "08085966402",
+          "overlap_area_sqm": 5293923.9,
+          "share_of_place_area": 0.1081,
+          "share_of_tract_area": 0.9676
+        },
+        {
+          "tract_geoid": "08085966503",
+          "overlap_area_sqm": 4254696.5,
+          "share_of_place_area": 0.0869,
+          "share_of_tract_area": 0.058
+        },
+        {
+          "tract_geoid": "08085966401",
+          "overlap_area_sqm": 2222946.1,
+          "share_of_place_area": 0.0454,
+          "share_of_tract_area": 0.9859
+        },
+        {
+          "tract_geoid": "08085966301",
+          "overlap_area_sqm": 1855105.8,
+          "share_of_place_area": 0.0379,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08085966602",
+          "overlap_area_sqm": 426781.3,
+          "share_of_place_area": 0.0087,
+          "share_of_tract_area": 0.0007
+        }
+      ]
+    },
+    "0870635": {
+      "name": "Simla",
+      "place_area_sqm": 1685930.5,
+      "tracts": [
+        {
+          "tract_geoid": "08039961100",
+          "overlap_area_sqm": 1685930.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0006
+        }
+      ]
+    },
+    "0823025": {
+      "name": "Eckley",
+      "place_area_sqm": 1224888.2,
+      "tracts": [
+        {
+          "tract_geoid": "08125963200",
+          "overlap_area_sqm": 1224888.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0005
+        }
+      ]
+    },
+    "0848445": {
+      "name": "Manitou Springs",
+      "place_area_sqm": 8148988.9,
+      "tracts": [
+        {
+          "tract_geoid": "08041006701",
+          "overlap_area_sqm": 4465874.7,
+          "share_of_place_area": 0.548,
+          "share_of_tract_area": 0.6985
+        },
+        {
+          "tract_geoid": "08041006702",
+          "overlap_area_sqm": 3262114.7,
+          "share_of_place_area": 0.4003,
+          "share_of_tract_area": 0.3818
+        },
+        {
+          "tract_geoid": "08041003401",
+          "overlap_area_sqm": 420999.6,
+          "share_of_place_area": 0.0517,
+          "share_of_tract_area": 0.0028
+        }
+      ]
+    },
+    "0857025": {
+      "name": "Palmer Lake",
+      "place_area_sqm": 8056905.6,
+      "tracts": [
+        {
+          "tract_geoid": "08041003713",
+          "overlap_area_sqm": 7105038.5,
+          "share_of_place_area": 0.8819,
+          "share_of_tract_area": 0.0272
+        },
+        {
+          "tract_geoid": "08041003712",
+          "overlap_area_sqm": 951867.1,
+          "share_of_place_area": 0.1181,
+          "share_of_tract_area": 0.0435
+        }
+      ]
+    },
+    "0862660": {
+      "name": "Ramah",
+      "place_area_sqm": 657546.0,
+      "tracts": [
+        {
+          "tract_geoid": "08041003910",
+          "overlap_area_sqm": 654179.9,
+          "share_of_place_area": 0.9949,
+          "share_of_tract_area": 0.0014
+        },
+        {
+          "tract_geoid": "08041003911",
+          "overlap_area_sqm": 3366.1,
+          "share_of_place_area": 0.0051,
+          "share_of_tract_area": 0.0
+        }
+      ]
+    },
+    "0872395": {
+      "name": "South Fork",
+      "place_area_sqm": 6587899.4,
+      "tracts": [
+        {
+          "tract_geoid": "08105977001",
+          "overlap_area_sqm": 6587899.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0037
+        }
+      ]
+    },
+    "0815330": {
+      "name": "Coal Creek",
+      "place_area_sqm": 3089729.7,
+      "tracts": [
+        {
+          "tract_geoid": "08043979400",
+          "overlap_area_sqm": 3089729.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0085
+        }
+      ]
+    },
+    "0867280": {
+      "name": "Salida",
+      "place_area_sqm": 7285022.9,
+      "tracts": [
+        {
+          "tract_geoid": "08015000200",
+          "overlap_area_sqm": 5163005.1,
+          "share_of_place_area": 0.7087,
+          "share_of_tract_area": 0.0469
+        },
+        {
+          "tract_geoid": "08015000100",
+          "overlap_area_sqm": 2062945.5,
+          "share_of_place_area": 0.2832,
+          "share_of_tract_area": 0.5235
+        },
+        {
+          "tract_geoid": "08015000300",
+          "overlap_area_sqm": 59072.4,
+          "share_of_place_area": 0.0081,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0832650": {
+      "name": "Green Mountain Falls",
+      "place_area_sqm": 3003717.7,
+      "tracts": [
+        {
+          "tract_geoid": "08041003401",
+          "overlap_area_sqm": 2033056.7,
+          "share_of_place_area": 0.6768,
+          "share_of_tract_area": 0.0136
+        },
+        {
+          "tract_geoid": "08119010110",
+          "overlap_area_sqm": 963203.7,
+          "share_of_place_area": 0.3207,
+          "share_of_tract_area": 0.004
+        },
+        {
+          "tract_geoid": "08041003402",
+          "overlap_area_sqm": 7457.2,
+          "share_of_place_area": 0.0025,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0818530": {
+      "name": "Cripple Creek",
+      "place_area_sqm": 3937592.8,
+      "tracts": [
+        {
+          "tract_geoid": "08119010203",
+          "overlap_area_sqm": 3937592.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0067
+        }
+      ]
+    },
+    "0880865": {
+      "name": "Victor",
+      "place_area_sqm": 743185.2,
+      "tracts": [
+        {
+          "tract_geoid": "08119010203",
+          "overlap_area_sqm": 743185.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0013
+        }
+      ]
+    },
+    "0873330": {
+      "name": "Springfield",
+      "place_area_sqm": 2918030.7,
+      "tracts": [
+        {
+          "tract_geoid": "08009964700",
+          "overlap_area_sqm": 2918030.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0022
+        }
+      ]
+    },
+    "0879270": {
+      "name": "Two Buttes",
+      "place_area_sqm": 642510.7,
+      "tracts": [
+        {
+          "tract_geoid": "08009964600",
+          "overlap_area_sqm": 642510.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0881030": {
+      "name": "Vilas",
+      "place_area_sqm": 331258.8,
+      "tracts": [
+        {
+          "tract_geoid": "08009964700",
+          "overlap_area_sqm": 331258.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0827040": {
+      "name": "Florence",
+      "place_area_sqm": 11645342.7,
+      "tracts": [
+        {
+          "tract_geoid": "08043978200",
+          "overlap_area_sqm": 8060634.0,
+          "share_of_place_area": 0.6922,
+          "share_of_tract_area": 0.1968
+        },
+        {
+          "tract_geoid": "08043979400",
+          "overlap_area_sqm": 3584708.7,
+          "share_of_place_area": 0.3078,
+          "share_of_tract_area": 0.0098
+        }
+      ]
+    },
+    "0864970": {
+      "name": "Rockvale",
+      "place_area_sqm": 5313502.9,
+      "tracts": [
+        {
+          "tract_geoid": "08043979400",
+          "overlap_area_sqm": 5313502.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0146
+        }
+      ]
+    },
+    "0885155": {
+      "name": "Williamsburg",
+      "place_area_sqm": 9140471.3,
+      "tracts": [
+        {
+          "tract_geoid": "08043979400",
+          "overlap_area_sqm": 6906474.9,
+          "share_of_place_area": 0.7556,
+          "share_of_tract_area": 0.0189
+        },
+        {
+          "tract_geoid": "08043979200",
+          "overlap_area_sqm": 1826823.1,
+          "share_of_place_area": 0.1999,
+          "share_of_tract_area": 0.0072
+        },
+        {
+          "tract_geoid": "08043979100",
+          "overlap_area_sqm": 284702.9,
+          "share_of_place_area": 0.0311,
+          "share_of_tract_area": 0.0176
+        },
+        {
+          "tract_geoid": "08043978200",
+          "overlap_area_sqm": 122470.3,
+          "share_of_place_area": 0.0134,
+          "share_of_tract_area": 0.003
+        }
+      ]
+    },
+    "0844320": {
+      "name": "Leadville",
+      "place_area_sqm": 3037917.3,
+      "tracts": [
+        {
+          "tract_geoid": "08065961702",
+          "overlap_area_sqm": 2940114.5,
+          "share_of_place_area": 0.9678,
+          "share_of_tract_area": 0.0953
+        },
+        {
+          "tract_geoid": "08065961701",
+          "overlap_area_sqm": 97802.8,
+          "share_of_place_area": 0.0322,
+          "share_of_tract_area": 0.0108
+        }
+      ]
+    },
+    "0857400": {
+      "name": "Parachute",
+      "place_area_sqm": 6172690.5,
+      "tracts": [
+        {
+          "tract_geoid": "08045952100",
+          "overlap_area_sqm": 6172690.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0019
+        }
+      ]
+    },
+    "0842330": {
+      "name": "Lake City",
+      "place_area_sqm": 2169388.3,
+      "tracts": [
+        {
+          "tract_geoid": "08053973100",
+          "overlap_area_sqm": 2169388.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0007
+        }
+      ]
+    },
+    "0810105": {
+      "name": "Buena Vista",
+      "place_area_sqm": 8996327.7,
+      "tracts": [
+        {
+          "tract_geoid": "08015000404",
+          "overlap_area_sqm": 6683079.0,
+          "share_of_place_area": 0.7429,
+          "share_of_tract_area": 0.2519
+        },
+        {
+          "tract_geoid": "08015000402",
+          "overlap_area_sqm": 2313248.7,
+          "share_of_place_area": 0.2571,
+          "share_of_tract_area": 0.005
+        }
+      ]
+    },
+    "0860600": {
+      "name": "Poncha Springs",
+      "place_area_sqm": 7972971.7,
+      "tracts": [
+        {
+          "tract_geoid": "08015000300",
+          "overlap_area_sqm": 6536610.1,
+          "share_of_place_area": 0.8198,
+          "share_of_tract_area": 0.006
+        },
+        {
+          "tract_geoid": "08015000200",
+          "overlap_area_sqm": 1436361.6,
+          "share_of_place_area": 0.1802,
+          "share_of_tract_area": 0.013
+        }
+      ]
+    },
+    "0842110": {
+      "name": "La Junta",
+      "place_area_sqm": 8287709.8,
+      "tracts": [
+        {
+          "tract_geoid": "08089968600",
+          "overlap_area_sqm": 4315566.8,
+          "share_of_place_area": 0.5207,
+          "share_of_tract_area": 0.8375
+        },
+        {
+          "tract_geoid": "08089968300",
+          "overlap_area_sqm": 3972143.0,
+          "share_of_place_area": 0.4793,
+          "share_of_tract_area": 0.0405
+        }
+      ]
+    },
+    "0825115": {
+      "name": "Estes Park",
+      "place_area_sqm": 17520180.2,
+      "tracts": [
+        {
+          "tract_geoid": "08069002801",
+          "overlap_area_sqm": 8118348.9,
+          "share_of_place_area": 0.4634,
+          "share_of_tract_area": 0.2805
+        },
+        {
+          "tract_geoid": "08069002805",
+          "overlap_area_sqm": 4703305.5,
+          "share_of_place_area": 0.2685,
+          "share_of_tract_area": 0.3348
+        },
+        {
+          "tract_geoid": "08069002804",
+          "overlap_area_sqm": 4575984.6,
+          "share_of_place_area": 0.2612,
+          "share_of_tract_area": 0.0488
+        },
+        {
+          "tract_geoid": "08069002803",
+          "overlap_area_sqm": 122541.2,
+          "share_of_place_area": 0.007,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0883230": {
+      "name": "Wellington",
+      "place_area_sqm": 9940222.4,
+      "tracts": [
+        {
+          "tract_geoid": "08069002508",
+          "overlap_area_sqm": 5190032.1,
+          "share_of_place_area": 0.5221,
+          "share_of_tract_area": 0.1334
+        },
+        {
+          "tract_geoid": "08069002507",
+          "overlap_area_sqm": 4750190.3,
+          "share_of_place_area": 0.4779,
+          "share_of_tract_area": 0.0501
+        }
+      ]
+    },
+    "0848115": {
+      "name": "Mancos",
+      "place_area_sqm": 1653681.8,
+      "tracts": [
+        {
+          "tract_geoid": "08083969100",
+          "overlap_area_sqm": 1653681.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.002
+        }
+      ]
+    },
+    "0845955": {
+      "name": "Lone Tree",
+      "place_area_sqm": 25386260.0,
+      "tracts": [
+        {
+          "tract_geoid": "08035014011",
+          "overlap_area_sqm": 9738853.0,
+          "share_of_place_area": 0.3836,
+          "share_of_tract_area": 0.3239
+        },
+        {
+          "tract_geoid": "08035014125",
+          "overlap_area_sqm": 5758583.7,
+          "share_of_place_area": 0.2268,
+          "share_of_tract_area": 0.333
+        },
+        {
+          "tract_geoid": "08035014116",
+          "overlap_area_sqm": 3726420.3,
+          "share_of_place_area": 0.1468,
+          "share_of_tract_area": 0.9379
+        },
+        {
+          "tract_geoid": "08035014115",
+          "overlap_area_sqm": 2583010.6,
+          "share_of_place_area": 0.1017,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014140",
+          "overlap_area_sqm": 1566164.2,
+          "share_of_place_area": 0.0617,
+          "share_of_tract_area": 0.4
+        },
+        {
+          "tract_geoid": "08035014114",
+          "overlap_area_sqm": 1541650.9,
+          "share_of_place_area": 0.0607,
+          "share_of_tract_area": 0.4943
+        },
+        {
+          "tract_geoid": "08035014007",
+          "overlap_area_sqm": 198711.2,
+          "share_of_place_area": 0.0078,
+          "share_of_tract_area": 0.0199
+        },
+        {
+          "tract_geoid": "08035014144",
+          "overlap_area_sqm": 160107.0,
+          "share_of_place_area": 0.0063,
+          "share_of_tract_area": 0.0163
+        },
+        {
+          "tract_geoid": "08035014014",
+          "overlap_area_sqm": 107018.5,
+          "share_of_place_area": 0.0042,
+          "share_of_tract_area": 0.0118
+        },
+        {
+          "tract_geoid": "08035014008",
+          "overlap_area_sqm": 5740.4,
+          "share_of_place_area": 0.0002,
+          "share_of_tract_area": 0.001
+        }
+      ]
+    },
+    "0812415": {
+      "name": "Castle Rock",
+      "place_area_sqm": 89909691.0,
+      "tracts": [
+        {
+          "tract_geoid": "08035014013",
+          "overlap_area_sqm": 13026587.3,
+          "share_of_place_area": 0.1449,
+          "share_of_tract_area": 0.315
+        },
+        {
+          "tract_geoid": "08035014407",
+          "overlap_area_sqm": 13013663.4,
+          "share_of_place_area": 0.1447,
+          "share_of_tract_area": 0.194
+        },
+        {
+          "tract_geoid": "08035014410",
+          "overlap_area_sqm": 10003780.0,
+          "share_of_place_area": 0.1113,
+          "share_of_tract_area": 0.9221
+        },
+        {
+          "tract_geoid": "08035014506",
+          "overlap_area_sqm": 9034997.3,
+          "share_of_place_area": 0.1005,
+          "share_of_tract_area": 0.0452
+        },
+        {
+          "tract_geoid": "08035014505",
+          "overlap_area_sqm": 7083656.5,
+          "share_of_place_area": 0.0788,
+          "share_of_tract_area": 0.4798
+        },
+        {
+          "tract_geoid": "08035014405",
+          "overlap_area_sqm": 6393430.2,
+          "share_of_place_area": 0.0711,
+          "share_of_tract_area": 0.6941
+        },
+        {
+          "tract_geoid": "08035014504",
+          "overlap_area_sqm": 5510433.2,
+          "share_of_place_area": 0.0613,
+          "share_of_tract_area": 0.8559
+        },
+        {
+          "tract_geoid": "08035014503",
+          "overlap_area_sqm": 5371015.8,
+          "share_of_place_area": 0.0597,
+          "share_of_tract_area": 0.5719
+        },
+        {
+          "tract_geoid": "08035014604",
+          "overlap_area_sqm": 5081938.2,
+          "share_of_place_area": 0.0565,
+          "share_of_tract_area": 0.078
+        },
+        {
+          "tract_geoid": "08035014603",
+          "overlap_area_sqm": 4881620.5,
+          "share_of_place_area": 0.0543,
+          "share_of_tract_area": 0.7431
+        },
+        {
+          "tract_geoid": "08035014017",
+          "overlap_area_sqm": 3998028.0,
+          "share_of_place_area": 0.0445,
+          "share_of_tract_area": 0.4289
+        },
+        {
+          "tract_geoid": "08035014409",
+          "overlap_area_sqm": 2994465.7,
+          "share_of_place_area": 0.0333,
+          "share_of_tract_area": 0.1131
+        },
+        {
+          "tract_geoid": "08035014123",
+          "overlap_area_sqm": 2066935.8,
+          "share_of_place_area": 0.023,
+          "share_of_tract_area": 0.3678
+        },
+        {
+          "tract_geoid": "08035014016",
+          "overlap_area_sqm": 1327827.5,
+          "share_of_place_area": 0.0148,
+          "share_of_tract_area": 0.0337
+        },
+        {
+          "tract_geoid": "08035013909",
+          "overlap_area_sqm": 116641.8,
+          "share_of_place_area": 0.0013,
+          "share_of_tract_area": 0.0018
+        },
+        {
+          "tract_geoid": "08035014135",
+          "overlap_area_sqm": 4670.0,
+          "share_of_place_area": 0.0001,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0818640": {
+      "name": "Crook",
+      "place_area_sqm": 350548.4,
+      "tracts": [
+        {
+          "tract_geoid": "08075965900",
+          "overlap_area_sqm": 350548.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0855980": {
+      "name": "Orchard City",
+      "place_area_sqm": 29887712.5,
+      "tracts": [
+        {
+          "tract_geoid": "08029964700",
+          "overlap_area_sqm": 29886988.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.087
+        },
+        {
+          "tract_geoid": "08029965002",
+          "overlap_area_sqm": 724.4,
+          "share_of_place_area": 0.0,
+          "share_of_tract_area": 0.0
+        }
+      ]
+    },
+    "0850040": {
+      "name": "Merino",
+      "place_area_sqm": 392549.2,
+      "tracts": [
+        {
+          "tract_geoid": "08075966000",
+          "overlap_area_sqm": 392549.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0818420": {
+      "name": "Crestone",
+      "place_area_sqm": 995584.5,
+      "tracts": [
+        {
+          "tract_geoid": "08109977600",
+          "overlap_area_sqm": 995584.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0851250": {
+      "name": "Moffat",
+      "place_area_sqm": 5492707.7,
+      "tracts": [
+        {
+          "tract_geoid": "08109977600",
+          "overlap_area_sqm": 5492707.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0008
+        }
+      ]
+    },
+    "0867005": {
+      "name": "Saguache",
+      "place_area_sqm": 1020650.5,
+      "tracts": [
+        {
+          "tract_geoid": "08109977600",
+          "overlap_area_sqm": 1020650.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0824620": {
+      "name": "Empire",
+      "place_area_sqm": 761240.0,
+      "tracts": [
+        {
+          "tract_geoid": "08019014900",
+          "overlap_area_sqm": 761240.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0014
+        }
+      ]
+    },
+    "0829735": {
+      "name": "Georgetown",
+      "place_area_sqm": 2850855.3,
+      "tracts": [
+        {
+          "tract_geoid": "08019014900",
+          "overlap_area_sqm": 2850855.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0054
+        }
+      ]
+    },
+    "0870360": {
+      "name": "Silver Plume",
+      "place_area_sqm": 674816.9,
+      "tracts": [
+        {
+          "tract_geoid": "08019014900",
+          "overlap_area_sqm": 674816.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0013
+        }
+      ]
+    },
+    "0812635": {
+      "name": "Cedaredge",
+      "place_area_sqm": 5082416.7,
+      "tracts": [
+        {
+          "tract_geoid": "08029965201",
+          "overlap_area_sqm": 3144499.3,
+          "share_of_place_area": 0.6187,
+          "share_of_tract_area": 0.3563
+        },
+        {
+          "tract_geoid": "08029965202",
+          "overlap_area_sqm": 1933820.8,
+          "share_of_place_area": 0.3805,
+          "share_of_tract_area": 0.0069
+        },
+        {
+          "tract_geoid": "08029964700",
+          "overlap_area_sqm": 4096.5,
+          "share_of_place_area": 0.0008,
+          "share_of_tract_area": 0.0
+        }
+      ]
+    },
+    "0817925": {
+      "name": "Crawford",
+      "place_area_sqm": 650807.0,
+      "tracts": [
+        {
+          "tract_geoid": "08029965001",
+          "overlap_area_sqm": 650807.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0016
+        }
+      ]
+    },
+    "0857300": {
+      "name": "Paonia",
+      "place_area_sqm": 2147749.2,
+      "tracts": [
+        {
+          "tract_geoid": "08029964600",
+          "overlap_area_sqm": 2147749.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0032
+        }
+      ]
+    },
+    "0815605": {
+      "name": "Collbran",
+      "place_area_sqm": 1447098.2,
+      "tracts": [
+        {
+          "tract_geoid": "08077001800",
+          "overlap_area_sqm": 1447098.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0005
+        }
+      ]
+    },
+    "0828745": {
+      "name": "Fruita",
+      "place_area_sqm": 21535856.7,
+      "tracts": [
+        {
+          "tract_geoid": "08077001504",
+          "overlap_area_sqm": 10019638.8,
+          "share_of_place_area": 0.4653,
+          "share_of_tract_area": 0.7387
+        },
+        {
+          "tract_geoid": "08077001502",
+          "overlap_area_sqm": 5126603.7,
+          "share_of_place_area": 0.238,
+          "share_of_tract_area": 0.0051
+        },
+        {
+          "tract_geoid": "08077001503",
+          "overlap_area_sqm": 4415478.2,
+          "share_of_place_area": 0.205,
+          "share_of_tract_area": 0.7486
+        },
+        {
+          "tract_geoid": "08077001900",
+          "overlap_area_sqm": 1873444.1,
+          "share_of_place_area": 0.087,
+          "share_of_tract_area": 0.0004
+        },
+        {
+          "tract_geoid": "08077001402",
+          "overlap_area_sqm": 100692.0,
+          "share_of_place_area": 0.0047,
+          "share_of_tract_area": 0.004
+        }
+      ]
+    },
+    "0864200": {
+      "name": "Ridgway",
+      "place_area_sqm": 4790447.5,
+      "tracts": [
+        {
+          "tract_geoid": "08091967602",
+          "overlap_area_sqm": 4790447.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0048
+        }
+      ]
+    },
+    "0861315": {
+      "name": "Pritchett",
+      "place_area_sqm": 603646.4,
+      "tracts": [
+        {
+          "tract_geoid": "08009964600",
+          "overlap_area_sqm": 603646.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0882460": {
+      "name": "Walsh",
+      "place_area_sqm": 1159220.5,
+      "tracts": [
+        {
+          "tract_geoid": "08009964600",
+          "overlap_area_sqm": 1159220.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0856970": {
+      "name": "Palisade",
+      "place_area_sqm": 3095815.6,
+      "tracts": [
+        {
+          "tract_geoid": "08077001702",
+          "overlap_area_sqm": 3095815.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0593
+        }
+      ]
+    },
+    "0852075": {
+      "name": "Morrison",
+      "place_area_sqm": 4273356.7,
+      "tracts": [
+        {
+          "tract_geoid": "08059012027",
+          "overlap_area_sqm": 3275076.6,
+          "share_of_place_area": 0.7664,
+          "share_of_tract_area": 0.0597
+        },
+        {
+          "tract_geoid": "08059011724",
+          "overlap_area_sqm": 505586.9,
+          "share_of_place_area": 0.1183,
+          "share_of_tract_area": 0.0545
+        },
+        {
+          "tract_geoid": "08059009845",
+          "overlap_area_sqm": 348458.1,
+          "share_of_place_area": 0.0815,
+          "share_of_tract_area": 0.0081
+        },
+        {
+          "tract_geoid": "08059012034",
+          "overlap_area_sqm": 113593.5,
+          "share_of_place_area": 0.0266,
+          "share_of_tract_area": 0.0051
+        },
+        {
+          "tract_geoid": "08059011731",
+          "overlap_area_sqm": 30641.5,
+          "share_of_place_area": 0.0072,
+          "share_of_tract_area": 0.0022
+        }
+      ]
+    },
+    "0805265": {
+      "name": "Bayfield",
+      "place_area_sqm": 5224333.0,
+      "tracts": [
+        {
+          "tract_geoid": "08067970602",
+          "overlap_area_sqm": 4974394.6,
+          "share_of_place_area": 0.9522,
+          "share_of_tract_area": 0.0093
+        },
+        {
+          "tract_geoid": "08067970601",
+          "overlap_area_sqm": 249938.4,
+          "share_of_place_area": 0.0478,
+          "share_of_tract_area": 0.0012
+        }
+      ]
+    },
+    "0838535": {
+      "name": "Ignacio",
+      "place_area_sqm": 1326161.1,
+      "tracts": [
+        {
+          "tract_geoid": "08067940300",
+          "overlap_area_sqm": 1326161.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0025
+        }
+      ]
+    },
+    "0870580": {
+      "name": "Silverton",
+      "place_area_sqm": 2163601.3,
+      "tracts": [
+        {
+          "tract_geoid": "08111972600",
+          "overlap_area_sqm": 2163601.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0022
+        }
+      ]
+    },
+    "0846355": {
+      "name": "Louisville",
+      "place_area_sqm": 20915116.3,
+      "tracts": [
+        {
+          "tract_geoid": "08013060700",
+          "overlap_area_sqm": 7569876.4,
+          "share_of_place_area": 0.3619,
+          "share_of_tract_area": 0.7546
+        },
+        {
+          "tract_geoid": "08013013006",
+          "overlap_area_sqm": 3182887.6,
+          "share_of_place_area": 0.1522,
+          "share_of_tract_area": 0.9996
+        },
+        {
+          "tract_geoid": "08013012710",
+          "overlap_area_sqm": 2552914.4,
+          "share_of_place_area": 0.1221,
+          "share_of_tract_area": 0.1256
+        },
+        {
+          "tract_geoid": "08013013003",
+          "overlap_area_sqm": 2306630.0,
+          "share_of_place_area": 0.1103,
+          "share_of_tract_area": 0.1872
+        },
+        {
+          "tract_geoid": "08013013004",
+          "overlap_area_sqm": 2108002.3,
+          "share_of_place_area": 0.1008,
+          "share_of_tract_area": 0.9992
+        },
+        {
+          "tract_geoid": "08013013005",
+          "overlap_area_sqm": 1932898.5,
+          "share_of_place_area": 0.0924,
+          "share_of_tract_area": 0.9965
+        },
+        {
+          "tract_geoid": "08013060900",
+          "overlap_area_sqm": 649510.1,
+          "share_of_place_area": 0.0311,
+          "share_of_tract_area": 0.0833
+        },
+        {
+          "tract_geoid": "08013012904",
+          "overlap_area_sqm": 566148.1,
+          "share_of_place_area": 0.0271,
+          "share_of_tract_area": 0.1666
+        },
+        {
+          "tract_geoid": "08013060602",
+          "overlap_area_sqm": 46248.8,
+          "share_of_place_area": 0.0022,
+          "share_of_tract_area": 0.0013
+        }
+      ]
+    },
+    "0831605": {
+      "name": "Granby",
+      "place_area_sqm": 32823474.6,
+      "tracts": [
+        {
+          "tract_geoid": "08049000205",
+          "overlap_area_sqm": 22670417.7,
+          "share_of_place_area": 0.6907,
+          "share_of_tract_area": 0.0785
+        },
+        {
+          "tract_geoid": "08049000207",
+          "overlap_area_sqm": 10153056.9,
+          "share_of_place_area": 0.3093,
+          "share_of_tract_area": 0.008
+        }
+      ]
+    },
+    "0868105": {
+      "name": "San Luis",
+      "place_area_sqm": 1466967.5,
+      "tracts": [
+        {
+          "tract_geoid": "08023972700",
+          "overlap_area_sqm": 1466967.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0009
+        }
+      ]
+    },
+    "0839965": {
+      "name": "Julesburg",
+      "place_area_sqm": 3918460.8,
+      "tracts": [
+        {
+          "tract_geoid": "08115968300",
+          "overlap_area_sqm": 3918460.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0028
+        }
+      ]
+    },
+    "0856475": {
+      "name": "Ovid",
+      "place_area_sqm": 403467.8,
+      "tracts": [
+        {
+          "tract_geoid": "08115968300",
+          "overlap_area_sqm": 403467.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0868930": {
+      "name": "Sedgwick",
+      "place_area_sqm": 1007819.7,
+      "tracts": [
+        {
+          "tract_geoid": "08115968300",
+          "overlap_area_sqm": 1007819.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0007
+        }
+      ]
+    },
+    "0823135": {
+      "name": "Edgewater",
+      "place_area_sqm": 1797658.6,
+      "tracts": [
+        {
+          "tract_geoid": "08059011300",
+          "overlap_area_sqm": 1283624.8,
+          "share_of_place_area": 0.7141,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059011401",
+          "overlap_area_sqm": 248101.4,
+          "share_of_place_area": 0.138,
+          "share_of_tract_area": 0.2751
+        },
+        {
+          "tract_geoid": "08059010702",
+          "overlap_area_sqm": 148506.4,
+          "share_of_place_area": 0.0826,
+          "share_of_tract_area": 0.0876
+        },
+        {
+          "tract_geoid": "08059011402",
+          "overlap_area_sqm": 117425.9,
+          "share_of_place_area": 0.0653,
+          "share_of_tract_area": 0.0687
+        }
+      ]
+    },
+    "0852350": {
+      "name": "Mountain View",
+      "place_area_sqm": 240625.9,
+      "tracts": [
+        {
+          "tract_geoid": "08059010603",
+          "overlap_area_sqm": 240625.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.1239
+        }
+      ]
+    },
+    "0840185": {
+      "name": "Keenesburg",
+      "place_area_sqm": 24271610.7,
+      "tracts": [
+        {
+          "tract_geoid": "08123002502",
+          "overlap_area_sqm": 24213891.6,
+          "share_of_place_area": 0.9976,
+          "share_of_tract_area": 0.0176
+        },
+        {
+          "tract_geoid": "08123001914",
+          "overlap_area_sqm": 57719.1,
+          "share_of_place_area": 0.0024,
+          "share_of_tract_area": 0.0005
+        }
+      ]
+    },
+    "0855045": {
+      "name": "Nunn",
+      "place_area_sqm": 10297528.3,
+      "tracts": [
+        {
+          "tract_geoid": "08123002501",
+          "overlap_area_sqm": 10297528.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0016
+        }
+      ]
+    },
+    "0856860": {
+      "name": "Pagosa Springs",
+      "place_area_sqm": 13180251.3,
+      "tracts": [
+        {
+          "tract_geoid": "08007974300",
+          "overlap_area_sqm": 6468016.0,
+          "share_of_place_area": 0.4907,
+          "share_of_tract_area": 0.0069
+        },
+        {
+          "tract_geoid": "08007974400",
+          "overlap_area_sqm": 6279271.1,
+          "share_of_place_area": 0.4764,
+          "share_of_tract_area": 0.0043
+        },
+        {
+          "tract_geoid": "08007974202",
+          "overlap_area_sqm": 432964.1,
+          "share_of_place_area": 0.0328,
+          "share_of_tract_area": 0.0225
+        }
+      ]
+    },
+    "0807850": {
+      "name": "Boulder",
+      "place_area_sqm": 72279486.9,
+      "tracts": [
+        {
+          "tract_geoid": "08013012701",
+          "overlap_area_sqm": 9725674.6,
+          "share_of_place_area": 0.1346,
+          "share_of_tract_area": 0.1932
+        },
+        {
+          "tract_geoid": "08013012505",
+          "overlap_area_sqm": 5997979.2,
+          "share_of_place_area": 0.083,
+          "share_of_tract_area": 0.3976
+        },
+        {
+          "tract_geoid": "08013012208",
+          "overlap_area_sqm": 4722595.2,
+          "share_of_place_area": 0.0653,
+          "share_of_tract_area": 0.9995
+        },
+        {
+          "tract_geoid": "08013012510",
+          "overlap_area_sqm": 4246170.9,
+          "share_of_place_area": 0.0587,
+          "share_of_tract_area": 0.0837
+        },
+        {
+          "tract_geoid": "08013012707",
+          "overlap_area_sqm": 3235818.7,
+          "share_of_place_area": 0.0448,
+          "share_of_tract_area": 0.0932
+        },
+        {
+          "tract_geoid": "08013013704",
+          "overlap_area_sqm": 3203233.3,
+          "share_of_place_area": 0.0443,
+          "share_of_tract_area": 0.0441
+        },
+        {
+          "tract_geoid": "08013012104",
+          "overlap_area_sqm": 2664016.4,
+          "share_of_place_area": 0.0369,
+          "share_of_tract_area": 0.9531
+        },
+        {
+          "tract_geoid": "08013012101",
+          "overlap_area_sqm": 2455905.3,
+          "share_of_place_area": 0.034,
+          "share_of_tract_area": 0.8266
+        },
+        {
+          "tract_geoid": "08013012105",
+          "overlap_area_sqm": 2429398.0,
+          "share_of_place_area": 0.0336,
+          "share_of_tract_area": 0.9837
+        },
+        {
+          "tract_geoid": "08013012508",
+          "overlap_area_sqm": 2306482.7,
+          "share_of_place_area": 0.0319,
+          "share_of_tract_area": 0.651
+        },
+        {
+          "tract_geoid": "08013012705",
+          "overlap_area_sqm": 2163125.6,
+          "share_of_place_area": 0.0299,
+          "share_of_tract_area": 0.4833
+        },
+        {
+          "tract_geoid": "08013012103",
+          "overlap_area_sqm": 2090108.8,
+          "share_of_place_area": 0.0289,
+          "share_of_tract_area": 0.9062
+        },
+        {
+          "tract_geoid": "08013012501",
+          "overlap_area_sqm": 1938955.3,
+          "share_of_place_area": 0.0268,
+          "share_of_tract_area": 0.5617
+        },
+        {
+          "tract_geoid": "08013012511",
+          "overlap_area_sqm": 1932943.7,
+          "share_of_place_area": 0.0267,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013012710",
+          "overlap_area_sqm": 1892930.5,
+          "share_of_place_area": 0.0262,
+          "share_of_tract_area": 0.0931
+        },
+        {
+          "tract_geoid": "08013012509",
+          "overlap_area_sqm": 1814300.3,
+          "share_of_place_area": 0.0251,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013012603",
+          "overlap_area_sqm": 1694115.9,
+          "share_of_place_area": 0.0234,
+          "share_of_tract_area": 0.9614
+        },
+        {
+          "tract_geoid": "08013012207",
+          "overlap_area_sqm": 1684773.9,
+          "share_of_place_area": 0.0233,
+          "share_of_tract_area": 0.8542
+        },
+        {
+          "tract_geoid": "08013012107",
+          "overlap_area_sqm": 1651057.8,
+          "share_of_place_area": 0.0228,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013012507",
+          "overlap_area_sqm": 1638562.5,
+          "share_of_place_area": 0.0227,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013012201",
+          "overlap_area_sqm": 1574649.6,
+          "share_of_place_area": 0.0218,
+          "share_of_tract_area": 0.2969
+        },
+        {
+          "tract_geoid": "08013012708",
+          "overlap_area_sqm": 1565426.4,
+          "share_of_place_area": 0.0217,
+          "share_of_tract_area": 0.2757
+        },
+        {
+          "tract_geoid": "08013012300",
+          "overlap_area_sqm": 1425881.3,
+          "share_of_place_area": 0.0197,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013012204",
+          "overlap_area_sqm": 1392655.9,
+          "share_of_place_area": 0.0193,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013012106",
+          "overlap_area_sqm": 1228713.0,
+          "share_of_place_area": 0.017,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013012605",
+          "overlap_area_sqm": 1212076.3,
+          "share_of_place_area": 0.0168,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013012401",
+          "overlap_area_sqm": 1117266.5,
+          "share_of_place_area": 0.0155,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013012206",
+          "overlap_area_sqm": 1021086.2,
+          "share_of_place_area": 0.0141,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013012608",
+          "overlap_area_sqm": 879042.0,
+          "share_of_place_area": 0.0122,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013012205",
+          "overlap_area_sqm": 605615.5,
+          "share_of_place_area": 0.0084,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013012610",
+          "overlap_area_sqm": 390304.3,
+          "share_of_place_area": 0.0054,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013012609",
+          "overlap_area_sqm": 332398.7,
+          "share_of_place_area": 0.0046,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08013013205",
+          "overlap_area_sqm": 41517.4,
+          "share_of_place_area": 0.0006,
+          "share_of_tract_area": 0.0018
+        },
+        {
+          "tract_geoid": "08013012709",
+          "overlap_area_sqm": 4704.9,
+          "share_of_place_area": 0.0001,
+          "share_of_tract_area": 0.0005
+        }
+      ]
+    },
+    "0839195": {
+      "name": "Jamestown",
+      "place_area_sqm": 1486848.6,
+      "tracts": [
+        {
+          "tract_geoid": "08013013703",
+          "overlap_area_sqm": 1486848.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0082
+        }
+      ]
+    },
+    "0847070": {
+      "name": "Lyons",
+      "place_area_sqm": 3572997.8,
+      "tracts": [
+        {
+          "tract_geoid": "08013013601",
+          "overlap_area_sqm": 3572997.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0255
+        }
+      ]
+    },
+    "0853175": {
+      "name": "Nederland",
+      "place_area_sqm": 4009191.9,
+      "tracts": [
+        {
+          "tract_geoid": "08013013705",
+          "overlap_area_sqm": 4009191.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0245
+        }
+      ]
+    },
+    "0812900": {
+      "name": "Central",
+      "place_area_sqm": 7191816.9,
+      "tracts": [
+        {
+          "tract_geoid": "08047013802",
+          "overlap_area_sqm": 6277325.3,
+          "share_of_place_area": 0.8728,
+          "share_of_tract_area": 0.0351
+        },
+        {
+          "tract_geoid": "08019014702",
+          "overlap_area_sqm": 914491.6,
+          "share_of_place_area": 0.1272,
+          "share_of_tract_area": 0.0036
+        }
+      ]
+    },
+    "0838370": {
+      "name": "Idaho Springs",
+      "place_area_sqm": 6259120.0,
+      "tracts": [
+        {
+          "tract_geoid": "08019014800",
+          "overlap_area_sqm": 3535520.7,
+          "share_of_place_area": 0.5649,
+          "share_of_tract_area": 0.2322
+        },
+        {
+          "tract_geoid": "08019014702",
+          "overlap_area_sqm": 2723599.3,
+          "share_of_place_area": 0.4351,
+          "share_of_tract_area": 0.0109
+        }
+      ]
+    },
+    "0807795": {
+      "name": "Boone",
+      "place_area_sqm": 1005755.5,
+      "tracts": [
+        {
+          "tract_geoid": "08101003600",
+          "overlap_area_sqm": 1005755.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0007
+        }
+      ]
+    },
+    "0801530": {
+      "name": "Alma",
+      "place_area_sqm": 1129679.0,
+      "tracts": [
+        {
+          "tract_geoid": "08093000300",
+          "overlap_area_sqm": 1129679.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.004
+        }
+      ]
+    },
+    "0825610": {
+      "name": "Fairplay",
+      "place_area_sqm": 2998514.6,
+      "tracts": [
+        {
+          "tract_geoid": "08093000300",
+          "overlap_area_sqm": 2998514.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0106
+        }
+      ]
+    },
+    "0806255": {
+      "name": "Berthoud",
+      "place_area_sqm": 33978670.4,
+      "tracts": [
+        {
+          "tract_geoid": "08123002104",
+          "overlap_area_sqm": 15280241.3,
+          "share_of_place_area": 0.4497,
+          "share_of_tract_area": 0.1841
+        },
+        {
+          "tract_geoid": "08069002602",
+          "overlap_area_sqm": 9397744.3,
+          "share_of_place_area": 0.2766,
+          "share_of_tract_area": 0.1395
+        },
+        {
+          "tract_geoid": "08069002700",
+          "overlap_area_sqm": 9300684.8,
+          "share_of_place_area": 0.2737,
+          "share_of_tract_area": 0.6731
+        }
+      ]
+    },
+    "0803950": {
+      "name": "Ault",
+      "place_area_sqm": 4567758.6,
+      "tracts": [
+        {
+          "tract_geoid": "08123002300",
+          "overlap_area_sqm": 4567758.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0156
+        }
+      ]
+    },
+    "0808675": {
+      "name": "Brighton",
+      "place_area_sqm": 56896165.8,
+      "tracts": [
+        {
+          "tract_geoid": "08001008552",
+          "overlap_area_sqm": 20277793.4,
+          "share_of_place_area": 0.3564,
+          "share_of_tract_area": 0.5304
+        },
+        {
+          "tract_geoid": "08123001911",
+          "overlap_area_sqm": 5961063.3,
+          "share_of_place_area": 0.1048,
+          "share_of_tract_area": 0.1796
+        },
+        {
+          "tract_geoid": "08001008562",
+          "overlap_area_sqm": 5283449.6,
+          "share_of_place_area": 0.0929,
+          "share_of_tract_area": 0.9018
+        },
+        {
+          "tract_geoid": "08001008606",
+          "overlap_area_sqm": 3772294.2,
+          "share_of_place_area": 0.0663,
+          "share_of_tract_area": 0.9396
+        },
+        {
+          "tract_geoid": "08001008563",
+          "overlap_area_sqm": 3741063.0,
+          "share_of_place_area": 0.0658,
+          "share_of_tract_area": 0.9887
+        },
+        {
+          "tract_geoid": "08001008557",
+          "overlap_area_sqm": 3598579.1,
+          "share_of_place_area": 0.0632,
+          "share_of_tract_area": 0.4141
+        },
+        {
+          "tract_geoid": "08001008565",
+          "overlap_area_sqm": 3018978.4,
+          "share_of_place_area": 0.0531,
+          "share_of_tract_area": 0.8153
+        },
+        {
+          "tract_geoid": "08001008553",
+          "overlap_area_sqm": 2953580.2,
+          "share_of_place_area": 0.0519,
+          "share_of_tract_area": 0.0178
+        },
+        {
+          "tract_geoid": "08001008604",
+          "overlap_area_sqm": 2164392.9,
+          "share_of_place_area": 0.038,
+          "share_of_tract_area": 0.9928
+        },
+        {
+          "tract_geoid": "08001008605",
+          "overlap_area_sqm": 1980972.4,
+          "share_of_place_area": 0.0348,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001008564",
+          "overlap_area_sqm": 1644854.3,
+          "share_of_place_area": 0.0289,
+          "share_of_tract_area": 0.5031
+        },
+        {
+          "tract_geoid": "08001008603",
+          "overlap_area_sqm": 1633518.1,
+          "share_of_place_area": 0.0287,
+          "share_of_tract_area": 0.8521
+        },
+        {
+          "tract_geoid": "08123001909",
+          "overlap_area_sqm": 357980.7,
+          "share_of_place_area": 0.0063,
+          "share_of_tract_area": 0.0105
+        },
+        {
+          "tract_geoid": "08001008535",
+          "overlap_area_sqm": 323690.6,
+          "share_of_place_area": 0.0057,
+          "share_of_tract_area": 0.0202
+        },
+        {
+          "tract_geoid": "08001008560",
+          "overlap_area_sqm": 64178.7,
+          "share_of_place_area": 0.0011,
+          "share_of_tract_area": 0.0053
+        },
+        {
+          "tract_geoid": "08001008561",
+          "overlap_area_sqm": 59457.2,
+          "share_of_place_area": 0.001,
+          "share_of_tract_area": 0.0026
+        },
+        {
+          "tract_geoid": "08001008536",
+          "overlap_area_sqm": 47074.9,
+          "share_of_place_area": 0.0008,
+          "share_of_tract_area": 0.0064
+        },
+        {
+          "tract_geoid": "08001008556",
+          "overlap_area_sqm": 11461.3,
+          "share_of_place_area": 0.0002,
+          "share_of_tract_area": 0.0034
+        },
+        {
+          "tract_geoid": "08001008540",
+          "overlap_area_sqm": 1783.7,
+          "share_of_place_area": 0.0,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0824950": {
+      "name": "Erie",
+      "place_area_sqm": 55514663.0,
+      "tracts": [
+        {
+          "tract_geoid": "08123002009",
+          "overlap_area_sqm": 25056210.1,
+          "share_of_place_area": 0.4513,
+          "share_of_tract_area": 0.5865
+        },
+        {
+          "tract_geoid": "08123002007",
+          "overlap_area_sqm": 10568311.6,
+          "share_of_place_area": 0.1904,
+          "share_of_tract_area": 0.9434
+        },
+        {
+          "tract_geoid": "08013012802",
+          "overlap_area_sqm": 7633102.1,
+          "share_of_place_area": 0.1375,
+          "share_of_tract_area": 0.3044
+        },
+        {
+          "tract_geoid": "08013012801",
+          "overlap_area_sqm": 5618234.4,
+          "share_of_place_area": 0.1012,
+          "share_of_tract_area": 0.3589
+        },
+        {
+          "tract_geoid": "08123002008",
+          "overlap_area_sqm": 3821022.7,
+          "share_of_place_area": 0.0688,
+          "share_of_tract_area": 0.9908
+        },
+        {
+          "tract_geoid": "08013012907",
+          "overlap_area_sqm": 2097374.8,
+          "share_of_place_area": 0.0378,
+          "share_of_tract_area": 0.3204
+        },
+        {
+          "tract_geoid": "08123002010",
+          "overlap_area_sqm": 669253.4,
+          "share_of_place_area": 0.0121,
+          "share_of_tract_area": 0.0163
+        },
+        {
+          "tract_geoid": "08013013211",
+          "overlap_area_sqm": 21075.5,
+          "share_of_place_area": 0.0004,
+          "share_of_tract_area": 0.0004
+        },
+        {
+          "tract_geoid": "08123002011",
+          "overlap_area_sqm": 14038.8,
+          "share_of_place_area": 0.0003,
+          "share_of_tract_area": 0.0036
+        },
+        {
+          "tract_geoid": "08013012903",
+          "overlap_area_sqm": 14478.8,
+          "share_of_place_area": 0.0003,
+          "share_of_tract_area": 0.0037
+        },
+        {
+          "tract_geoid": "08123002005",
+          "overlap_area_sqm": 1560.8,
+          "share_of_place_area": 0.0,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0827700": {
+      "name": "Fort Lupton",
+      "place_area_sqm": 34413766.8,
+      "tracts": [
+        {
+          "tract_geoid": "08123001912",
+          "overlap_area_sqm": 9045638.0,
+          "share_of_place_area": 0.2628,
+          "share_of_tract_area": 0.5171
+        },
+        {
+          "tract_geoid": "08123001910",
+          "overlap_area_sqm": 8788104.3,
+          "share_of_place_area": 0.2554,
+          "share_of_tract_area": 0.205
+        },
+        {
+          "tract_geoid": "08123001905",
+          "overlap_area_sqm": 5438566.7,
+          "share_of_place_area": 0.158,
+          "share_of_tract_area": 0.7717
+        },
+        {
+          "tract_geoid": "08123001911",
+          "overlap_area_sqm": 4581913.7,
+          "share_of_place_area": 0.1331,
+          "share_of_tract_area": 0.138
+        },
+        {
+          "tract_geoid": "08123001906",
+          "overlap_area_sqm": 2905521.4,
+          "share_of_place_area": 0.0844,
+          "share_of_tract_area": 0.065
+        },
+        {
+          "tract_geoid": "08123001914",
+          "overlap_area_sqm": 2230671.3,
+          "share_of_place_area": 0.0648,
+          "share_of_tract_area": 0.0183
+        },
+        {
+          "tract_geoid": "08123001909",
+          "overlap_area_sqm": 998649.0,
+          "share_of_place_area": 0.029,
+          "share_of_tract_area": 0.0293
+        },
+        {
+          "tract_geoid": "08123001800",
+          "overlap_area_sqm": 359808.9,
+          "share_of_place_area": 0.0105,
+          "share_of_tract_area": 0.0011
+        },
+        {
+          "tract_geoid": "08123002006",
+          "overlap_area_sqm": 64893.5,
+          "share_of_place_area": 0.0019,
+          "share_of_tract_area": 0.0016
+        }
+      ]
+    },
+    "0829185": {
+      "name": "Garden City",
+      "place_area_sqm": 292182.1,
+      "tracts": [
+        {
+          "tract_geoid": "08123000800",
+          "overlap_area_sqm": 289723.4,
+          "share_of_place_area": 0.9916,
+          "share_of_tract_area": 0.159
+        },
+        {
+          "tract_geoid": "08123001004",
+          "overlap_area_sqm": 2458.7,
+          "share_of_place_area": 0.0084,
+          "share_of_tract_area": 0.0006
+        }
+      ]
+    },
+    "0829955": {
+      "name": "Gilcrest",
+      "place_area_sqm": 2098694.0,
+      "tracts": [
+        {
+          "tract_geoid": "08123001700",
+          "overlap_area_sqm": 2098694.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0122
+        }
+      ]
+    },
+    "0832155": {
+      "name": "Greeley",
+      "place_area_sqm": 130713281.2,
+      "tracts": [
+        {
+          "tract_geoid": "08123002101",
+          "overlap_area_sqm": 25097859.2,
+          "share_of_place_area": 0.192,
+          "share_of_tract_area": 0.2229
+        },
+        {
+          "tract_geoid": "08123002209",
+          "overlap_area_sqm": 14413552.9,
+          "share_of_place_area": 0.1103,
+          "share_of_tract_area": 0.3511
+        },
+        {
+          "tract_geoid": "08123001416",
+          "overlap_area_sqm": 8951373.1,
+          "share_of_place_area": 0.0685,
+          "share_of_tract_area": 0.5688
+        },
+        {
+          "tract_geoid": "08123001500",
+          "overlap_area_sqm": 7354782.3,
+          "share_of_place_area": 0.0563,
+          "share_of_tract_area": 0.0431
+        },
+        {
+          "tract_geoid": "08123001406",
+          "overlap_area_sqm": 7351388.1,
+          "share_of_place_area": 0.0562,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123000705",
+          "overlap_area_sqm": 7083373.5,
+          "share_of_place_area": 0.0542,
+          "share_of_tract_area": 0.0795
+        },
+        {
+          "tract_geoid": "08123001412",
+          "overlap_area_sqm": 5241799.8,
+          "share_of_place_area": 0.0401,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123001300",
+          "overlap_area_sqm": 4227930.7,
+          "share_of_place_area": 0.0323,
+          "share_of_tract_area": 0.8826
+        },
+        {
+          "tract_geoid": "08123001407",
+          "overlap_area_sqm": 4036191.0,
+          "share_of_place_area": 0.0309,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123001408",
+          "overlap_area_sqm": 3245158.3,
+          "share_of_place_area": 0.0248,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123001410",
+          "overlap_area_sqm": 3073349.1,
+          "share_of_place_area": 0.0235,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123001409",
+          "overlap_area_sqm": 2870372.2,
+          "share_of_place_area": 0.022,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123000703",
+          "overlap_area_sqm": 2811684.9,
+          "share_of_place_area": 0.0215,
+          "share_of_tract_area": 0.5098
+        },
+        {
+          "tract_geoid": "08123000701",
+          "overlap_area_sqm": 2676034.7,
+          "share_of_place_area": 0.0205,
+          "share_of_tract_area": 0.8176
+        },
+        {
+          "tract_geoid": "08123000600",
+          "overlap_area_sqm": 2583245.3,
+          "share_of_place_area": 0.0198,
+          "share_of_tract_area": 0.5353
+        },
+        {
+          "tract_geoid": "08123001411",
+          "overlap_area_sqm": 2573067.6,
+          "share_of_place_area": 0.0197,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123001100",
+          "overlap_area_sqm": 2550633.9,
+          "share_of_place_area": 0.0195,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123000401",
+          "overlap_area_sqm": 1808787.0,
+          "share_of_place_area": 0.0138,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123001417",
+          "overlap_area_sqm": 1790599.4,
+          "share_of_place_area": 0.0137,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123000402",
+          "overlap_area_sqm": 1635146.9,
+          "share_of_place_area": 0.0125,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123001201",
+          "overlap_area_sqm": 1502716.9,
+          "share_of_place_area": 0.0115,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123000900",
+          "overlap_area_sqm": 1492937.3,
+          "share_of_place_area": 0.0114,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123000100",
+          "overlap_area_sqm": 1490324.9,
+          "share_of_place_area": 0.0114,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123001202",
+          "overlap_area_sqm": 1476222.2,
+          "share_of_place_area": 0.0113,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123000800",
+          "overlap_area_sqm": 1468861.7,
+          "share_of_place_area": 0.0112,
+          "share_of_tract_area": 0.8059
+        },
+        {
+          "tract_geoid": "08123001415",
+          "overlap_area_sqm": 1434807.0,
+          "share_of_place_area": 0.011,
+          "share_of_tract_area": 0.6487
+        },
+        {
+          "tract_geoid": "08123001413",
+          "overlap_area_sqm": 1418206.8,
+          "share_of_place_area": 0.0108,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123001414",
+          "overlap_area_sqm": 1403269.2,
+          "share_of_place_area": 0.0107,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123000502",
+          "overlap_area_sqm": 1353971.3,
+          "share_of_place_area": 0.0104,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123001005",
+          "overlap_area_sqm": 1327405.3,
+          "share_of_place_area": 0.0102,
+          "share_of_tract_area": 0.1622
+        },
+        {
+          "tract_geoid": "08123001003",
+          "overlap_area_sqm": 1160739.3,
+          "share_of_place_area": 0.0089,
+          "share_of_tract_area": 0.9316
+        },
+        {
+          "tract_geoid": "08123000501",
+          "overlap_area_sqm": 950105.3,
+          "share_of_place_area": 0.0073,
+          "share_of_tract_area": 0.9654
+        },
+        {
+          "tract_geoid": "08123000200",
+          "overlap_area_sqm": 888772.4,
+          "share_of_place_area": 0.0068,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123001004",
+          "overlap_area_sqm": 667382.3,
+          "share_of_place_area": 0.0051,
+          "share_of_tract_area": 0.151
+        },
+        {
+          "tract_geoid": "08123000704",
+          "overlap_area_sqm": 657925.3,
+          "share_of_place_area": 0.005,
+          "share_of_tract_area": 0.348
+        },
+        {
+          "tract_geoid": "08123000300",
+          "overlap_area_sqm": 627269.2,
+          "share_of_place_area": 0.0048,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123002107",
+          "overlap_area_sqm": 16034.8,
+          "share_of_place_area": 0.0001,
+          "share_of_tract_area": 0.0005
+        }
+      ]
+    },
+    "0809280": {
+      "name": "Broomfield",
+      "place_area_sqm": 86820288.1,
+      "tracts": [
+        {
+          "tract_geoid": "08014031402",
+          "overlap_area_sqm": 16591674.9,
+          "share_of_place_area": 0.1911,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014031300",
+          "overlap_area_sqm": 10474229.1,
+          "share_of_place_area": 0.1206,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014031103",
+          "overlap_area_sqm": 5514161.7,
+          "share_of_place_area": 0.0635,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014030900",
+          "overlap_area_sqm": 5457544.2,
+          "share_of_place_area": 0.0629,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014030500",
+          "overlap_area_sqm": 5122615.8,
+          "share_of_place_area": 0.059,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014031104",
+          "overlap_area_sqm": 4072482.1,
+          "share_of_place_area": 0.0469,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014031403",
+          "overlap_area_sqm": 4032208.8,
+          "share_of_place_area": 0.0464,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014031000",
+          "overlap_area_sqm": 3555687.3,
+          "share_of_place_area": 0.041,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014031201",
+          "overlap_area_sqm": 3410982.4,
+          "share_of_place_area": 0.0393,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014031102",
+          "overlap_area_sqm": 3061938.5,
+          "share_of_place_area": 0.0353,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014031401",
+          "overlap_area_sqm": 2956515.8,
+          "share_of_place_area": 0.0341,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014030300",
+          "overlap_area_sqm": 2735935.0,
+          "share_of_place_area": 0.0315,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014031202",
+          "overlap_area_sqm": 2659348.6,
+          "share_of_place_area": 0.0306,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014030200",
+          "overlap_area_sqm": 2607474.3,
+          "share_of_place_area": 0.03,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014030600",
+          "overlap_area_sqm": 2593114.1,
+          "share_of_place_area": 0.0299,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014030800",
+          "overlap_area_sqm": 2556057.3,
+          "share_of_place_area": 0.0294,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014030400",
+          "overlap_area_sqm": 2449441.2,
+          "share_of_place_area": 0.0282,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014031101",
+          "overlap_area_sqm": 2332775.9,
+          "share_of_place_area": 0.0269,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014030000",
+          "overlap_area_sqm": 1616021.9,
+          "share_of_place_area": 0.0186,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014030700",
+          "overlap_area_sqm": 1332592.3,
+          "share_of_place_area": 0.0153,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014030100",
+          "overlap_area_sqm": 1075828.8,
+          "share_of_place_area": 0.0124,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014980200",
+          "overlap_area_sqm": 394621.4,
+          "share_of_place_area": 0.0045,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014980100",
+          "overlap_area_sqm": 111860.6,
+          "share_of_place_area": 0.0013,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08014980300",
+          "overlap_area_sqm": 105175.9,
+          "share_of_place_area": 0.0012,
+          "share_of_tract_area": 1.0
+        }
+      ]
+    },
+    "0830780": {
+      "name": "Glenwood Springs",
+      "place_area_sqm": 15136670.2,
+      "tracts": [
+        {
+          "tract_geoid": "08045951701",
+          "overlap_area_sqm": 7109433.5,
+          "share_of_place_area": 0.4697,
+          "share_of_tract_area": 0.5387
+        },
+        {
+          "tract_geoid": "08045951600",
+          "overlap_area_sqm": 4808507.1,
+          "share_of_place_area": 0.3177,
+          "share_of_tract_area": 0.0032
+        },
+        {
+          "tract_geoid": "08045951702",
+          "overlap_area_sqm": 2762072.0,
+          "share_of_place_area": 0.1825,
+          "share_of_tract_area": 0.2444
+        },
+        {
+          "tract_geoid": "08045951802",
+          "overlap_area_sqm": 456657.5,
+          "share_of_place_area": 0.0302,
+          "share_of_tract_area": 0.0012
+        }
+      ]
+    },
+    "0870195": {
+      "name": "Silt",
+      "place_area_sqm": 4548143.8,
+      "tracts": [
+        {
+          "tract_geoid": "08045951901",
+          "overlap_area_sqm": 4548143.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.012
+        }
+      ]
+    },
+    "0843605": {
+      "name": "La Salle",
+      "place_area_sqm": 2547236.9,
+      "tracts": [
+        {
+          "tract_geoid": "08123001700",
+          "overlap_area_sqm": 2547236.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0149
+        }
+      ]
+    },
+    "0849600": {
+      "name": "Mead",
+      "place_area_sqm": 40285693.7,
+      "tracts": [
+        {
+          "tract_geoid": "08123002106",
+          "overlap_area_sqm": 24667055.2,
+          "share_of_place_area": 0.6123,
+          "share_of_tract_area": 0.2819
+        },
+        {
+          "tract_geoid": "08123002104",
+          "overlap_area_sqm": 7816935.8,
+          "share_of_place_area": 0.194,
+          "share_of_tract_area": 0.0942
+        },
+        {
+          "tract_geoid": "08123002105",
+          "overlap_area_sqm": 7774209.4,
+          "share_of_place_area": 0.193,
+          "share_of_tract_area": 0.1718
+        },
+        {
+          "tract_geoid": "08123002010",
+          "overlap_area_sqm": 25923.4,
+          "share_of_place_area": 0.0006,
+          "share_of_tract_area": 0.0006
+        },
+        {
+          "tract_geoid": "08123002019",
+          "overlap_area_sqm": 1570.0,
+          "share_of_place_area": 0.0,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0854330": {
+      "name": "Northglenn",
+      "place_area_sqm": 19267092.4,
+      "tracts": [
+        {
+          "tract_geoid": "08001008505",
+          "overlap_area_sqm": 3063569.1,
+          "share_of_place_area": 0.159,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001008507",
+          "overlap_area_sqm": 2599968.2,
+          "share_of_place_area": 0.1349,
+          "share_of_tract_area": 0.9876
+        },
+        {
+          "tract_geoid": "08001009327",
+          "overlap_area_sqm": 2591469.1,
+          "share_of_place_area": 0.1345,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08123002005",
+          "overlap_area_sqm": 2555259.9,
+          "share_of_place_area": 0.1326,
+          "share_of_tract_area": 0.1387
+        },
+        {
+          "tract_geoid": "08001009323",
+          "overlap_area_sqm": 2089929.0,
+          "share_of_place_area": 0.1085,
+          "share_of_tract_area": 0.9559
+        },
+        {
+          "tract_geoid": "08001009304",
+          "overlap_area_sqm": 2070032.5,
+          "share_of_place_area": 0.1074,
+          "share_of_tract_area": 0.5921
+        },
+        {
+          "tract_geoid": "08001008533",
+          "overlap_area_sqm": 1921896.7,
+          "share_of_place_area": 0.0998,
+          "share_of_tract_area": 0.5675
+        },
+        {
+          "tract_geoid": "08001008506",
+          "overlap_area_sqm": 1633973.4,
+          "share_of_place_area": 0.0848,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001008555",
+          "overlap_area_sqm": 610399.3,
+          "share_of_place_area": 0.0317,
+          "share_of_tract_area": 0.122
+        },
+        {
+          "tract_geoid": "08001009203",
+          "overlap_area_sqm": 56724.9,
+          "share_of_place_area": 0.0029,
+          "share_of_tract_area": 0.021
+        },
+        {
+          "tract_geoid": "08001009322",
+          "overlap_area_sqm": 51186.6,
+          "share_of_place_area": 0.0027,
+          "share_of_tract_area": 0.0397
+        },
+        {
+          "tract_geoid": "08001009316",
+          "overlap_area_sqm": 22683.5,
+          "share_of_place_area": 0.0012,
+          "share_of_tract_area": 0.0101
+        }
+      ]
+    },
+    "0807410": {
+      "name": "Blue River",
+      "place_area_sqm": 6558357.0,
+      "tracts": [
+        {
+          "tract_geoid": "08117000405",
+          "overlap_area_sqm": 4055819.7,
+          "share_of_place_area": 0.6184,
+          "share_of_tract_area": 0.0604
+        },
+        {
+          "tract_geoid": "08117000403",
+          "overlap_area_sqm": 2502537.4,
+          "share_of_place_area": 0.3816,
+          "share_of_tract_area": 0.027
+        }
+      ]
+    },
+    "0820440": {
+      "name": "Dillon",
+      "place_area_sqm": 5992249.7,
+      "tracts": [
+        {
+          "tract_geoid": "08117000203",
+          "overlap_area_sqm": 5629501.1,
+          "share_of_place_area": 0.9395,
+          "share_of_tract_area": 0.143
+        },
+        {
+          "tract_geoid": "08117000202",
+          "overlap_area_sqm": 346037.6,
+          "share_of_place_area": 0.0577,
+          "share_of_tract_area": 0.1749
+        },
+        {
+          "tract_geoid": "08117000201",
+          "overlap_area_sqm": 16711.0,
+          "share_of_place_area": 0.0028,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0870525": {
+      "name": "Silverthorne",
+      "place_area_sqm": 10679857.4,
+      "tracts": [
+        {
+          "tract_geoid": "08117000102",
+          "overlap_area_sqm": 10326373.3,
+          "share_of_place_area": 0.9669,
+          "share_of_tract_area": 0.1472
+        },
+        {
+          "tract_geoid": "08117000301",
+          "overlap_area_sqm": 157933.2,
+          "share_of_place_area": 0.0148,
+          "share_of_tract_area": 0.0092
+        },
+        {
+          "tract_geoid": "08117000203",
+          "overlap_area_sqm": 138220.4,
+          "share_of_place_area": 0.0129,
+          "share_of_tract_area": 0.0035
+        },
+        {
+          "tract_geoid": "08117000202",
+          "overlap_area_sqm": 57330.5,
+          "share_of_place_area": 0.0054,
+          "share_of_tract_area": 0.029
+        }
+      ]
+    },
+    "0820770": {
+      "name": "Dolores",
+      "place_area_sqm": 1931348.4,
+      "tracts": [
+        {
+          "tract_geoid": "08083969000",
+          "overlap_area_sqm": 1931348.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.002
+        }
+      ]
+    },
+    "0859005": {
+      "name": "Pierce",
+      "place_area_sqm": 4807849.5,
+      "tracts": [
+        {
+          "tract_geoid": "08123002501",
+          "overlap_area_sqm": 2577704.5,
+          "share_of_place_area": 0.5361,
+          "share_of_tract_area": 0.0004
+        },
+        {
+          "tract_geoid": "08123002300",
+          "overlap_area_sqm": 2230144.9,
+          "share_of_place_area": 0.4639,
+          "share_of_tract_area": 0.0076
+        }
+      ]
+    },
+    "0869150": {
+      "name": "Severance",
+      "place_area_sqm": 33903977.1,
+      "tracts": [
+        {
+          "tract_geoid": "08123002208",
+          "overlap_area_sqm": 20970582.0,
+          "share_of_place_area": 0.6185,
+          "share_of_tract_area": 0.1954
+        },
+        {
+          "tract_geoid": "08123002300",
+          "overlap_area_sqm": 9749565.9,
+          "share_of_place_area": 0.2876,
+          "share_of_tract_area": 0.0332
+        },
+        {
+          "tract_geoid": "08123002501",
+          "overlap_area_sqm": 3183829.1,
+          "share_of_place_area": 0.0939,
+          "share_of_tract_area": 0.0005
+        }
+      ]
+    },
+    "0877290": {
+      "name": "Thornton",
+      "place_area_sqm": 99731388.0,
+      "tracts": [
+        {
+          "tract_geoid": "08001060002",
+          "overlap_area_sqm": 10188926.6,
+          "share_of_place_area": 0.1022,
+          "share_of_tract_area": 0.6436
+        },
+        {
+          "tract_geoid": "08001008561",
+          "overlap_area_sqm": 8548391.0,
+          "share_of_place_area": 0.0857,
+          "share_of_tract_area": 0.3779
+        },
+        {
+          "tract_geoid": "08001008540",
+          "overlap_area_sqm": 8378248.5,
+          "share_of_place_area": 0.084,
+          "share_of_tract_area": 0.5285
+        },
+        {
+          "tract_geoid": "08001061200",
+          "overlap_area_sqm": 5847492.2,
+          "share_of_place_area": 0.0586,
+          "share_of_tract_area": 0.5437
+        },
+        {
+          "tract_geoid": "08001008526",
+          "overlap_area_sqm": 4680493.8,
+          "share_of_place_area": 0.0469,
+          "share_of_tract_area": 0.6383
+        },
+        {
+          "tract_geoid": "08001008524",
+          "overlap_area_sqm": 4431106.2,
+          "share_of_place_area": 0.0444,
+          "share_of_tract_area": 0.8822
+        },
+        {
+          "tract_geoid": "08001008555",
+          "overlap_area_sqm": 4373763.4,
+          "share_of_place_area": 0.0439,
+          "share_of_tract_area": 0.8739
+        },
+        {
+          "tract_geoid": "08001009103",
+          "overlap_area_sqm": 3915674.3,
+          "share_of_place_area": 0.0393,
+          "share_of_tract_area": 0.7621
+        },
+        {
+          "tract_geoid": "08001008550",
+          "overlap_area_sqm": 3810907.6,
+          "share_of_place_area": 0.0382,
+          "share_of_tract_area": 0.8596
+        },
+        {
+          "tract_geoid": "08001008802",
+          "overlap_area_sqm": 3553291.1,
+          "share_of_place_area": 0.0356,
+          "share_of_tract_area": 0.2341
+        },
+        {
+          "tract_geoid": "08001008545",
+          "overlap_area_sqm": 3175756.1,
+          "share_of_place_area": 0.0318,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001009203",
+          "overlap_area_sqm": 2647561.0,
+          "share_of_place_area": 0.0265,
+          "share_of_tract_area": 0.979
+        },
+        {
+          "tract_geoid": "08001009204",
+          "overlap_area_sqm": 2570507.9,
+          "share_of_place_area": 0.0258,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001008508",
+          "overlap_area_sqm": 2533009.8,
+          "share_of_place_area": 0.0254,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001009104",
+          "overlap_area_sqm": 2519895.8,
+          "share_of_place_area": 0.0253,
+          "share_of_tract_area": 0.9672
+        },
+        {
+          "tract_geoid": "08001008544",
+          "overlap_area_sqm": 2393280.3,
+          "share_of_place_area": 0.024,
+          "share_of_tract_area": 0.9108
+        },
+        {
+          "tract_geoid": "08001008534",
+          "overlap_area_sqm": 2185338.0,
+          "share_of_place_area": 0.0219,
+          "share_of_tract_area": 0.9231
+        },
+        {
+          "tract_geoid": "08001009101",
+          "overlap_area_sqm": 1846747.5,
+          "share_of_place_area": 0.0185,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001009202",
+          "overlap_area_sqm": 1754299.2,
+          "share_of_place_area": 0.0176,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001008551",
+          "overlap_area_sqm": 1718215.5,
+          "share_of_place_area": 0.0172,
+          "share_of_tract_area": 0.1912
+        },
+        {
+          "tract_geoid": "08001009207",
+          "overlap_area_sqm": 1597926.5,
+          "share_of_place_area": 0.016,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001008554",
+          "overlap_area_sqm": 1561775.3,
+          "share_of_place_area": 0.0157,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001008533",
+          "overlap_area_sqm": 1455882.5,
+          "share_of_place_area": 0.0146,
+          "share_of_tract_area": 0.4299
+        },
+        {
+          "tract_geoid": "08001009304",
+          "overlap_area_sqm": 1426188.7,
+          "share_of_place_area": 0.0143,
+          "share_of_tract_area": 0.4079
+        },
+        {
+          "tract_geoid": "08001008546",
+          "overlap_area_sqm": 1324471.3,
+          "share_of_place_area": 0.0133,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001009206",
+          "overlap_area_sqm": 1305360.9,
+          "share_of_place_area": 0.0131,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001008548",
+          "overlap_area_sqm": 1238496.9,
+          "share_of_place_area": 0.0124,
+          "share_of_tract_area": 0.9906
+        },
+        {
+          "tract_geoid": "08001009322",
+          "overlap_area_sqm": 1237699.7,
+          "share_of_place_area": 0.0124,
+          "share_of_tract_area": 0.9603
+        },
+        {
+          "tract_geoid": "08001008547",
+          "overlap_area_sqm": 1208410.5,
+          "share_of_place_area": 0.0121,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001009316",
+          "overlap_area_sqm": 1158540.6,
+          "share_of_place_area": 0.0116,
+          "share_of_tract_area": 0.5138
+        },
+        {
+          "tract_geoid": "08001015000",
+          "overlap_area_sqm": 1092478.2,
+          "share_of_place_area": 0.011,
+          "share_of_tract_area": 0.0716
+        },
+        {
+          "tract_geoid": "08001009318",
+          "overlap_area_sqm": 976424.9,
+          "share_of_place_area": 0.0098,
+          "share_of_tract_area": 0.7547
+        },
+        {
+          "tract_geoid": "08001008535",
+          "overlap_area_sqm": 942128.4,
+          "share_of_place_area": 0.0094,
+          "share_of_tract_area": 0.0587
+        },
+        {
+          "tract_geoid": "08001009307",
+          "overlap_area_sqm": 786757.9,
+          "share_of_place_area": 0.0079,
+          "share_of_tract_area": 0.441
+        },
+        {
+          "tract_geoid": "08001009001",
+          "overlap_area_sqm": 708445.5,
+          "share_of_place_area": 0.0071,
+          "share_of_tract_area": 0.3361
+        },
+        {
+          "tract_geoid": "08001008549",
+          "overlap_area_sqm": 260656.5,
+          "share_of_place_area": 0.0026,
+          "share_of_tract_area": 0.1979
+        },
+        {
+          "tract_geoid": "08001009003",
+          "overlap_area_sqm": 207782.7,
+          "share_of_place_area": 0.0021,
+          "share_of_tract_area": 0.1194
+        },
+        {
+          "tract_geoid": "08001009306",
+          "overlap_area_sqm": 55500.7,
+          "share_of_place_area": 0.0006,
+          "share_of_tract_area": 0.0323
+        },
+        {
+          "tract_geoid": "08001008560",
+          "overlap_area_sqm": 49270.7,
+          "share_of_place_area": 0.0005,
+          "share_of_tract_area": 0.004
+        },
+        {
+          "tract_geoid": "08001008507",
+          "overlap_area_sqm": 32554.3,
+          "share_of_place_area": 0.0003,
+          "share_of_tract_area": 0.0124
+        },
+        {
+          "tract_geoid": "08123002005",
+          "overlap_area_sqm": 17153.2,
+          "share_of_place_area": 0.0002,
+          "share_of_tract_area": 0.0009
+        },
+        {
+          "tract_geoid": "08123002006",
+          "overlap_area_sqm": 14576.2,
+          "share_of_place_area": 0.0001,
+          "share_of_tract_area": 0.0004
+        }
+      ]
+    },
+    "0834740": {
+      "name": "Haswell",
+      "place_area_sqm": 2078198.4,
+      "tracts": [
+        {
+          "tract_geoid": "08061960100",
+          "overlap_area_sqm": 2078198.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0004
+        }
+      ]
+    },
+    "0806090": {
+      "name": "Bennett",
+      "place_area_sqm": 18010638.1,
+      "tracts": [
+        {
+          "tract_geoid": "08001008401",
+          "overlap_area_sqm": 12087076.2,
+          "share_of_place_area": 0.6711,
+          "share_of_tract_area": 0.0241
+        },
+        {
+          "tract_geoid": "08005007101",
+          "overlap_area_sqm": 3963629.0,
+          "share_of_place_area": 0.2201,
+          "share_of_tract_area": 0.0033
+        },
+        {
+          "tract_geoid": "08001008402",
+          "overlap_area_sqm": 1282038.7,
+          "share_of_place_area": 0.0712,
+          "share_of_tract_area": 0.0007
+        },
+        {
+          "tract_geoid": "08005007103",
+          "overlap_area_sqm": 677894.2,
+          "share_of_place_area": 0.0376,
+          "share_of_tract_area": 0.0041
+        }
+      ]
+    },
+    "0803455": {
+      "name": "Arvada",
+      "place_area_sqm": 102599628.6,
+      "tracts": [
+        {
+          "tract_geoid": "08059009837",
+          "overlap_area_sqm": 15919483.2,
+          "share_of_place_area": 0.1552,
+          "share_of_tract_area": 0.6874
+        },
+        {
+          "tract_geoid": "08059009858",
+          "overlap_area_sqm": 11441545.7,
+          "share_of_place_area": 0.1115,
+          "share_of_tract_area": 0.0438
+        },
+        {
+          "tract_geoid": "08059060501",
+          "overlap_area_sqm": 9504913.7,
+          "share_of_place_area": 0.0926,
+          "share_of_tract_area": 0.3368
+        },
+        {
+          "tract_geoid": "08059010308",
+          "overlap_area_sqm": 4160683.0,
+          "share_of_place_area": 0.0406,
+          "share_of_tract_area": 0.8484
+        },
+        {
+          "tract_geoid": "08059009838",
+          "overlap_area_sqm": 4069684.9,
+          "share_of_place_area": 0.0397,
+          "share_of_tract_area": 0.9294
+        },
+        {
+          "tract_geoid": "08059009836",
+          "overlap_area_sqm": 3389556.4,
+          "share_of_place_area": 0.033,
+          "share_of_tract_area": 0.5458
+        },
+        {
+          "tract_geoid": "08059010206",
+          "overlap_area_sqm": 3268204.1,
+          "share_of_place_area": 0.0319,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059010303",
+          "overlap_area_sqm": 2939573.3,
+          "share_of_place_area": 0.0287,
+          "share_of_tract_area": 0.9601
+        },
+        {
+          "tract_geoid": "08059010210",
+          "overlap_area_sqm": 2836094.3,
+          "share_of_place_area": 0.0276,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059010213",
+          "overlap_area_sqm": 2749073.9,
+          "share_of_place_area": 0.0268,
+          "share_of_tract_area": 0.9917
+        },
+        {
+          "tract_geoid": "08059009833",
+          "overlap_area_sqm": 2718239.3,
+          "share_of_place_area": 0.0265,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059010208",
+          "overlap_area_sqm": 2576116.0,
+          "share_of_place_area": 0.0251,
+          "share_of_tract_area": 0.863
+        },
+        {
+          "tract_geoid": "08059009851",
+          "overlap_area_sqm": 2378749.1,
+          "share_of_place_area": 0.0232,
+          "share_of_tract_area": 0.5985
+        },
+        {
+          "tract_geoid": "08059010212",
+          "overlap_area_sqm": 2265563.5,
+          "share_of_place_area": 0.0221,
+          "share_of_tract_area": 0.9965
+        },
+        {
+          "tract_geoid": "08059009815",
+          "overlap_area_sqm": 2250519.3,
+          "share_of_place_area": 0.0219,
+          "share_of_tract_area": 0.4103
+        },
+        {
+          "tract_geoid": "08059009853",
+          "overlap_area_sqm": 2249124.4,
+          "share_of_place_area": 0.0219,
+          "share_of_tract_area": 0.642
+        },
+        {
+          "tract_geoid": "08059010205",
+          "overlap_area_sqm": 2206555.1,
+          "share_of_place_area": 0.0215,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059009835",
+          "overlap_area_sqm": 2047027.3,
+          "share_of_place_area": 0.02,
+          "share_of_tract_area": 0.9999
+        },
+        {
+          "tract_geoid": "08059009840",
+          "overlap_area_sqm": 1862298.1,
+          "share_of_place_area": 0.0182,
+          "share_of_tract_area": 0.9696
+        },
+        {
+          "tract_geoid": "08059010211",
+          "overlap_area_sqm": 1787450.9,
+          "share_of_place_area": 0.0174,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059010402",
+          "overlap_area_sqm": 1776817.2,
+          "share_of_place_area": 0.0173,
+          "share_of_tract_area": 0.4258
+        },
+        {
+          "tract_geoid": "08059009839",
+          "overlap_area_sqm": 1674384.8,
+          "share_of_place_area": 0.0163,
+          "share_of_tract_area": 0.9184
+        },
+        {
+          "tract_geoid": "08059010305",
+          "overlap_area_sqm": 1660210.7,
+          "share_of_place_area": 0.0162,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059010405",
+          "overlap_area_sqm": 1603891.0,
+          "share_of_place_area": 0.0156,
+          "share_of_tract_area": 0.98
+        },
+        {
+          "tract_geoid": "08059010406",
+          "overlap_area_sqm": 1511523.9,
+          "share_of_place_area": 0.0147,
+          "share_of_tract_area": 0.5381
+        },
+        {
+          "tract_geoid": "08059010307",
+          "overlap_area_sqm": 1487388.0,
+          "share_of_place_area": 0.0145,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059010306",
+          "overlap_area_sqm": 1482628.9,
+          "share_of_place_area": 0.0145,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059010304",
+          "overlap_area_sqm": 1349917.6,
+          "share_of_place_area": 0.0132,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001009608",
+          "overlap_area_sqm": 1306915.6,
+          "share_of_place_area": 0.0127,
+          "share_of_tract_area": 0.8885
+        },
+        {
+          "tract_geoid": "08059009841",
+          "overlap_area_sqm": 1255002.5,
+          "share_of_place_area": 0.0122,
+          "share_of_tract_area": 0.9747
+        },
+        {
+          "tract_geoid": "08059010209",
+          "overlap_area_sqm": 1224465.3,
+          "share_of_place_area": 0.0119,
+          "share_of_tract_area": 0.4783
+        },
+        {
+          "tract_geoid": "08059009832",
+          "overlap_area_sqm": 1099390.8,
+          "share_of_place_area": 0.0107,
+          "share_of_tract_area": 0.8256
+        },
+        {
+          "tract_geoid": "08059009834",
+          "overlap_area_sqm": 1073934.6,
+          "share_of_place_area": 0.0105,
+          "share_of_tract_area": 0.5834
+        },
+        {
+          "tract_geoid": "08059009842",
+          "overlap_area_sqm": 975331.2,
+          "share_of_place_area": 0.0095,
+          "share_of_tract_area": 0.1444
+        },
+        {
+          "tract_geoid": "08001009751",
+          "overlap_area_sqm": 211165.6,
+          "share_of_place_area": 0.0021,
+          "share_of_tract_area": 0.0626
+        },
+        {
+          "tract_geoid": "08059009852",
+          "overlap_area_sqm": 211702.0,
+          "share_of_place_area": 0.0021,
+          "share_of_tract_area": 0.0221
+        },
+        {
+          "tract_geoid": "08059010403",
+          "overlap_area_sqm": 39320.7,
+          "share_of_place_area": 0.0004,
+          "share_of_tract_area": 0.0093
+        },
+        {
+          "tract_geoid": "08059010604",
+          "overlap_area_sqm": 33093.6,
+          "share_of_place_area": 0.0003,
+          "share_of_tract_area": 0.0163
+        },
+        {
+          "tract_geoid": "08059009828",
+          "overlap_area_sqm": 2089.0,
+          "share_of_place_area": 0.0,
+          "share_of_tract_area": 0.0005
+        }
+      ]
+    },
+    "0821265": {
+      "name": "Dove Creek",
+      "place_area_sqm": 1485878.3,
+      "tracts": [
+        {
+          "tract_geoid": "08033000100",
+          "overlap_area_sqm": 1485878.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0005
+        }
+      ]
+    },
+    "0855870": {
+      "name": "Ophir",
+      "place_area_sqm": 609177.4,
+      "tracts": [
+        {
+          "tract_geoid": "08113968103",
+          "overlap_area_sqm": 609177.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0007
+        }
+      ]
+    },
+    "0837545": {
+      "name": "Hotchkiss",
+      "place_area_sqm": 2402067.7,
+      "tracts": [
+        {
+          "tract_geoid": "08029965001",
+          "overlap_area_sqm": 1510833.4,
+          "share_of_place_area": 0.629,
+          "share_of_tract_area": 0.0036
+        },
+        {
+          "tract_geoid": "08029965002",
+          "overlap_area_sqm": 891234.3,
+          "share_of_place_area": 0.371,
+          "share_of_tract_area": 0.0022
+        }
+      ]
+    },
+    "0812045": {
+      "name": "Carbondale",
+      "place_area_sqm": 5378305.1,
+      "tracts": [
+        {
+          "tract_geoid": "08045951804",
+          "overlap_area_sqm": 3136878.3,
+          "share_of_place_area": 0.5832,
+          "share_of_tract_area": 0.0331
+        },
+        {
+          "tract_geoid": "08045951803",
+          "overlap_area_sqm": 2241426.8,
+          "share_of_place_area": 0.4168,
+          "share_of_tract_area": 0.0241
+        }
+      ]
+    },
+    "0853395": {
+      "name": "New Castle",
+      "place_area_sqm": 6699613.0,
+      "tracts": [
+        {
+          "tract_geoid": "08045951902",
+          "overlap_area_sqm": 6699613.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0094
+        }
+      ]
+    },
+    "0864255": {
+      "name": "Rifle",
+      "place_area_sqm": 18390689.7,
+      "tracts": [
+        {
+          "tract_geoid": "08045952003",
+          "overlap_area_sqm": 9577977.4,
+          "share_of_place_area": 0.5208,
+          "share_of_tract_area": 0.009
+        },
+        {
+          "tract_geoid": "08045952004",
+          "overlap_area_sqm": 5059948.9,
+          "share_of_place_area": 0.2751,
+          "share_of_tract_area": 0.719
+        },
+        {
+          "tract_geoid": "08045952001",
+          "overlap_area_sqm": 3752763.4,
+          "share_of_place_area": 0.2041,
+          "share_of_tract_area": 0.0428
+        }
+      ]
+    },
+    "0886750": {
+      "name": "Yuma",
+      "place_area_sqm": 8578599.4,
+      "tracts": [
+        {
+          "tract_geoid": "08125963200",
+          "overlap_area_sqm": 8578599.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0032
+        }
+      ]
+    },
+    "0831660": {
+      "name": "Grand Junction",
+      "place_area_sqm": 106884129.4,
+      "tracts": [
+        {
+          "tract_geoid": "08077001600",
+          "overlap_area_sqm": 19113016.3,
+          "share_of_place_area": 0.1788,
+          "share_of_tract_area": 0.1678
+        },
+        {
+          "tract_geoid": "08077000900",
+          "overlap_area_sqm": 15734669.8,
+          "share_of_place_area": 0.1472,
+          "share_of_tract_area": 0.8667
+        },
+        {
+          "tract_geoid": "08077001404",
+          "overlap_area_sqm": 9615489.1,
+          "share_of_place_area": 0.09,
+          "share_of_tract_area": 0.5928
+        },
+        {
+          "tract_geoid": "08077001002",
+          "overlap_area_sqm": 8697038.8,
+          "share_of_place_area": 0.0814,
+          "share_of_tract_area": 0.9632
+        },
+        {
+          "tract_geoid": "08077000801",
+          "overlap_area_sqm": 7516256.2,
+          "share_of_place_area": 0.0703,
+          "share_of_tract_area": 0.623
+        },
+        {
+          "tract_geoid": "08077001001",
+          "overlap_area_sqm": 5376478.9,
+          "share_of_place_area": 0.0503,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08077000400",
+          "overlap_area_sqm": 3569500.6,
+          "share_of_place_area": 0.0334,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08077001403",
+          "overlap_area_sqm": 3478094.5,
+          "share_of_place_area": 0.0325,
+          "share_of_tract_area": 0.3565
+        },
+        {
+          "tract_geoid": "08077001303",
+          "overlap_area_sqm": 3409901.5,
+          "share_of_place_area": 0.0319,
+          "share_of_tract_area": 0.5684
+        },
+        {
+          "tract_geoid": "08077000700",
+          "overlap_area_sqm": 3201400.6,
+          "share_of_place_area": 0.03,
+          "share_of_tract_area": 0.9126
+        },
+        {
+          "tract_geoid": "08077001402",
+          "overlap_area_sqm": 3083968.8,
+          "share_of_place_area": 0.0289,
+          "share_of_tract_area": 0.1232
+        },
+        {
+          "tract_geoid": "08077001304",
+          "overlap_area_sqm": 2917291.8,
+          "share_of_place_area": 0.0273,
+          "share_of_tract_area": 0.6999
+        },
+        {
+          "tract_geoid": "08077000602",
+          "overlap_area_sqm": 2598030.4,
+          "share_of_place_area": 0.0243,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08077001502",
+          "overlap_area_sqm": 2599159.7,
+          "share_of_place_area": 0.0243,
+          "share_of_tract_area": 0.0026
+        },
+        {
+          "tract_geoid": "08077000601",
+          "overlap_area_sqm": 2447784.1,
+          "share_of_place_area": 0.0229,
+          "share_of_tract_area": 0.9527
+        },
+        {
+          "tract_geoid": "08077001103",
+          "overlap_area_sqm": 2187261.5,
+          "share_of_place_area": 0.0205,
+          "share_of_tract_area": 0.7629
+        },
+        {
+          "tract_geoid": "08077001302",
+          "overlap_area_sqm": 2181720.2,
+          "share_of_place_area": 0.0204,
+          "share_of_tract_area": 0.2898
+        },
+        {
+          "tract_geoid": "08077000300",
+          "overlap_area_sqm": 1446220.0,
+          "share_of_place_area": 0.0135,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08077001900",
+          "overlap_area_sqm": 1358620.3,
+          "share_of_place_area": 0.0127,
+          "share_of_tract_area": 0.0003
+        },
+        {
+          "tract_geoid": "08077001707",
+          "overlap_area_sqm": 1302281.2,
+          "share_of_place_area": 0.0122,
+          "share_of_tract_area": 0.2644
+        },
+        {
+          "tract_geoid": "08077000500",
+          "overlap_area_sqm": 1212528.2,
+          "share_of_place_area": 0.0113,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08077000200",
+          "overlap_area_sqm": 1079425.9,
+          "share_of_place_area": 0.0101,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08077000802",
+          "overlap_area_sqm": 1013213.0,
+          "share_of_place_area": 0.0095,
+          "share_of_tract_area": 0.2449
+        },
+        {
+          "tract_geoid": "08077001102",
+          "overlap_area_sqm": 871245.0,
+          "share_of_place_area": 0.0082,
+          "share_of_tract_area": 0.1936
+        },
+        {
+          "tract_geoid": "08077001104",
+          "overlap_area_sqm": 698230.8,
+          "share_of_place_area": 0.0065,
+          "share_of_tract_area": 0.2694
+        },
+        {
+          "tract_geoid": "08077001703",
+          "overlap_area_sqm": 166258.9,
+          "share_of_place_area": 0.0016,
+          "share_of_tract_area": 0.0328
+        },
+        {
+          "tract_geoid": "08077001200",
+          "overlap_area_sqm": 9043.3,
+          "share_of_place_area": 0.0001,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0835070": {
+      "name": "Hayden",
+      "place_area_sqm": 8917261.0,
+      "tracts": [
+        {
+          "tract_geoid": "08107000200",
+          "overlap_area_sqm": 8361694.4,
+          "share_of_place_area": 0.9377,
+          "share_of_tract_area": 0.255
+        },
+        {
+          "tract_geoid": "08107000300",
+          "overlap_area_sqm": 530557.3,
+          "share_of_place_area": 0.0595,
+          "share_of_tract_area": 0.0004
+        },
+        {
+          "tract_geoid": "08107000100",
+          "overlap_area_sqm": 25009.3,
+          "share_of_place_area": 0.0028,
+          "share_of_tract_area": 0.0
+        }
+      ]
+    },
+    "0855155": {
+      "name": "Oak Creek",
+      "place_area_sqm": 954556.7,
+      "tracts": [
+        {
+          "tract_geoid": "08107000300",
+          "overlap_area_sqm": 954556.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0007
+        }
+      ]
+    },
+    "0876795": {
+      "name": "Telluride",
+      "place_area_sqm": 5729755.4,
+      "tracts": [
+        {
+          "tract_geoid": "08113968101",
+          "overlap_area_sqm": 3883999.2,
+          "share_of_place_area": 0.6779,
+          "share_of_tract_area": 0.072
+        },
+        {
+          "tract_geoid": "08113968102",
+          "overlap_area_sqm": 1747462.0,
+          "share_of_place_area": 0.305,
+          "share_of_tract_area": 0.0398
+        },
+        {
+          "tract_geoid": "08113968103",
+          "overlap_area_sqm": 98294.2,
+          "share_of_place_area": 0.0172,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0886475": {
+      "name": "Yampa",
+      "place_area_sqm": 636098.4,
+      "tracts": [
+        {
+          "tract_geoid": "08107000800",
+          "overlap_area_sqm": 636098.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0004
+        }
+      ]
+    },
+    "0852550": {
+      "name": "Mountain Village",
+      "place_area_sqm": 8553547.5,
+      "tracts": [
+        {
+          "tract_geoid": "08113968102",
+          "overlap_area_sqm": 8476556.6,
+          "share_of_place_area": 0.991,
+          "share_of_tract_area": 0.1932
+        },
+        {
+          "tract_geoid": "08113968101",
+          "overlap_area_sqm": 76990.9,
+          "share_of_place_area": 0.009,
+          "share_of_tract_area": 0.0014
+        }
+      ]
+    },
+    "0804110": {
+      "name": "Avon",
+      "place_area_sqm": 21726677.9,
+      "tracts": [
+        {
+          "tract_geoid": "08037000505",
+          "overlap_area_sqm": 18475701.4,
+          "share_of_place_area": 0.8504,
+          "share_of_tract_area": 0.284
+        },
+        {
+          "tract_geoid": "08037000504",
+          "overlap_area_sqm": 2205331.5,
+          "share_of_place_area": 0.1015,
+          "share_of_tract_area": 0.8893
+        },
+        {
+          "tract_geoid": "08037000401",
+          "overlap_area_sqm": 714214.6,
+          "share_of_place_area": 0.0329,
+          "share_of_tract_area": 0.0037
+        },
+        {
+          "tract_geoid": "08037000502",
+          "overlap_area_sqm": 196994.5,
+          "share_of_place_area": 0.0091,
+          "share_of_tract_area": 0.0054
+        },
+        {
+          "tract_geoid": "08037000501",
+          "overlap_area_sqm": 134435.9,
+          "share_of_place_area": 0.0062,
+          "share_of_tract_area": 0.0027
+        }
+      ]
+    },
+    "0854880": {
+      "name": "Norwood",
+      "place_area_sqm": 906019.6,
+      "tracts": [
+        {
+          "tract_geoid": "08113968200",
+          "overlap_area_sqm": 906019.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0004
+        }
+      ]
+    },
+    "0850920": {
+      "name": "Minturn",
+      "place_area_sqm": 21165610.6,
+      "tracts": [
+        {
+          "tract_geoid": "08037000600",
+          "overlap_area_sqm": 20398419.8,
+          "share_of_place_area": 0.9638,
+          "share_of_tract_area": 0.0315
+        },
+        {
+          "tract_geoid": "08037000502",
+          "overlap_area_sqm": 589057.9,
+          "share_of_place_area": 0.0278,
+          "share_of_tract_area": 0.0162
+        },
+        {
+          "tract_geoid": "08037000701",
+          "overlap_area_sqm": 178132.9,
+          "share_of_place_area": 0.0084,
+          "share_of_tract_area": 0.0089
+        }
+      ]
+    },
+    "0863265": {
+      "name": "Red Cliff",
+      "place_area_sqm": 631425.4,
+      "tracts": [
+        {
+          "tract_geoid": "08037000600",
+          "overlap_area_sqm": 631425.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.001
+        }
+      ]
+    },
+    "0804935": {
+      "name": "Basalt",
+      "place_area_sqm": 5258887.4,
+      "tracts": [
+        {
+          "tract_geoid": "08097000102",
+          "overlap_area_sqm": 2297460.5,
+          "share_of_place_area": 0.4369,
+          "share_of_tract_area": 0.0024
+        },
+        {
+          "tract_geoid": "08037000301",
+          "overlap_area_sqm": 1505566.7,
+          "share_of_place_area": 0.2863,
+          "share_of_tract_area": 0.0625
+        },
+        {
+          "tract_geoid": "08037000302",
+          "overlap_area_sqm": 1455860.3,
+          "share_of_place_area": 0.2768,
+          "share_of_tract_area": 0.0024
+        }
+      ]
+    },
+    "0800760": {
+      "name": "Aguilar",
+      "place_area_sqm": 1015288.1,
+      "tracts": [
+        {
+          "tract_geoid": "08071000100",
+          "overlap_area_sqm": 1015288.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0013
+        }
+      ]
+    },
+    "0873715": {
+      "name": "Starkville",
+      "place_area_sqm": 188870.2,
+      "tracts": [
+        {
+          "tract_geoid": "08071000300",
+          "overlap_area_sqm": 188870.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0843550": {
+      "name": "Larkspur",
+      "place_area_sqm": 4114947.1,
+      "tracts": [
+        {
+          "tract_geoid": "08035014408",
+          "overlap_area_sqm": 4114947.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0443
+        }
+      ]
+    },
+    "0808070": {
+      "name": "Bow Mar",
+      "place_area_sqm": 2102593.4,
+      "tracts": [
+        {
+          "tract_geoid": "08005005619",
+          "overlap_area_sqm": 1393724.2,
+          "share_of_place_area": 0.6629,
+          "share_of_tract_area": 0.3269
+        },
+        {
+          "tract_geoid": "08059012050",
+          "overlap_area_sqm": 708869.2,
+          "share_of_place_area": 0.3371,
+          "share_of_tract_area": 0.1721
+        }
+      ]
+    },
+    "0813845": {
+      "name": "Cherry Hills Village",
+      "place_area_sqm": 16253673.0,
+      "tracts": [
+        {
+          "tract_geoid": "08005006704",
+          "overlap_area_sqm": 11162258.2,
+          "share_of_place_area": 0.6868,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005006705",
+          "overlap_area_sqm": 5091414.8,
+          "share_of_place_area": 0.3132,
+          "share_of_tract_area": 0.9993
+        }
+      ]
+    },
+    "0834960": {
+      "name": "Haxtun",
+      "place_area_sqm": 1542374.9,
+      "tracts": [
+        {
+          "tract_geoid": "08095967700",
+          "overlap_area_sqm": 1542374.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0019
+        }
+      ]
+    },
+    "0857245": {
+      "name": "Paoli",
+      "place_area_sqm": 766549.9,
+      "tracts": [
+        {
+          "tract_geoid": "08095967700",
+          "overlap_area_sqm": 766549.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.001
+        }
+      ]
+    },
+    "0816385": {
+      "name": "Columbine Valley",
+      "place_area_sqm": 2569343.8,
+      "tracts": [
+        {
+          "tract_geoid": "08005005622",
+          "overlap_area_sqm": 2568431.3,
+          "share_of_place_area": 0.9996,
+          "share_of_tract_area": 0.3651
+        },
+        {
+          "tract_geoid": "08005006501",
+          "overlap_area_sqm": 912.5,
+          "share_of_place_area": 0.0004,
+          "share_of_tract_area": 0.0005
+        }
+      ]
+    },
+    "0828105": {
+      "name": "Foxfield",
+      "place_area_sqm": 3424748.1,
+      "tracts": [
+        {
+          "tract_geoid": "08005086300",
+          "overlap_area_sqm": 3424748.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.6932
+        }
+      ]
+    },
+    "0830340": {
+      "name": "Glendale",
+      "place_area_sqm": 1475728.1,
+      "tracts": [
+        {
+          "tract_geoid": "08005004952",
+          "overlap_area_sqm": 1320639.4,
+          "share_of_place_area": 0.8949,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005004951",
+          "overlap_area_sqm": 155088.6,
+          "share_of_place_area": 0.1051,
+          "share_of_tract_area": 1.0
+        }
+      ]
+    },
+    "0869645": {
+      "name": "Sheridan",
+      "place_area_sqm": 5930281.5,
+      "tracts": [
+        {
+          "tract_geoid": "08005005552",
+          "overlap_area_sqm": 2163741.6,
+          "share_of_place_area": 0.3649,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005006000",
+          "overlap_area_sqm": 1063261.7,
+          "share_of_place_area": 0.1793,
+          "share_of_tract_area": 0.4046
+        },
+        {
+          "tract_geoid": "08005005551",
+          "overlap_area_sqm": 1059957.0,
+          "share_of_place_area": 0.1787,
+          "share_of_tract_area": 0.3408
+        },
+        {
+          "tract_geoid": "08005005553",
+          "overlap_area_sqm": 782629.5,
+          "share_of_place_area": 0.132,
+          "share_of_tract_area": 0.2998
+        },
+        {
+          "tract_geoid": "08005006200",
+          "overlap_area_sqm": 766883.0,
+          "share_of_place_area": 0.1293,
+          "share_of_tract_area": 0.3041
+        },
+        {
+          "tract_geoid": "08005005702",
+          "overlap_area_sqm": 93808.6,
+          "share_of_place_area": 0.0158,
+          "share_of_tract_area": 0.0796
+        }
+      ]
+    },
+    "0812815": {
+      "name": "Centennial",
+      "place_area_sqm": 78421388.7,
+      "tracts": [
+        {
+          "tract_geoid": "08005086400",
+          "overlap_area_sqm": 7786843.7,
+          "share_of_place_area": 0.0993,
+          "share_of_tract_area": 0.9589
+        },
+        {
+          "tract_geoid": "08005006863",
+          "overlap_area_sqm": 4508656.8,
+          "share_of_place_area": 0.0575,
+          "share_of_tract_area": 0.6646
+        },
+        {
+          "tract_geoid": "08005006709",
+          "overlap_area_sqm": 4182573.1,
+          "share_of_place_area": 0.0533,
+          "share_of_tract_area": 0.9993
+        },
+        {
+          "tract_geoid": "08005005611",
+          "overlap_area_sqm": 3714524.8,
+          "share_of_place_area": 0.0474,
+          "share_of_tract_area": 0.9258
+        },
+        {
+          "tract_geoid": "08005006864",
+          "overlap_area_sqm": 3563428.5,
+          "share_of_place_area": 0.0454,
+          "share_of_tract_area": 0.2953
+        },
+        {
+          "tract_geoid": "08005006707",
+          "overlap_area_sqm": 3191503.1,
+          "share_of_place_area": 0.0407,
+          "share_of_tract_area": 0.9966
+        },
+        {
+          "tract_geoid": "08005085200",
+          "overlap_area_sqm": 3092043.2,
+          "share_of_place_area": 0.0394,
+          "share_of_tract_area": 0.8588
+        },
+        {
+          "tract_geoid": "08005005635",
+          "overlap_area_sqm": 2689369.9,
+          "share_of_place_area": 0.0343,
+          "share_of_tract_area": 0.9983
+        },
+        {
+          "tract_geoid": "08005085000",
+          "overlap_area_sqm": 2618969.2,
+          "share_of_place_area": 0.0334,
+          "share_of_tract_area": 0.7235
+        },
+        {
+          "tract_geoid": "08005005630",
+          "overlap_area_sqm": 2593904.6,
+          "share_of_place_area": 0.0331,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005005627",
+          "overlap_area_sqm": 2597167.3,
+          "share_of_place_area": 0.0331,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005006708",
+          "overlap_area_sqm": 2587564.3,
+          "share_of_place_area": 0.033,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005006706",
+          "overlap_area_sqm": 2584891.0,
+          "share_of_place_area": 0.033,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005005629",
+          "overlap_area_sqm": 2583696.5,
+          "share_of_place_area": 0.0329,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005005628",
+          "overlap_area_sqm": 2566201.8,
+          "share_of_place_area": 0.0327,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005006711",
+          "overlap_area_sqm": 2513838.2,
+          "share_of_place_area": 0.0321,
+          "share_of_tract_area": 0.9702
+        },
+        {
+          "tract_geoid": "08005006862",
+          "overlap_area_sqm": 2365927.0,
+          "share_of_place_area": 0.0302,
+          "share_of_tract_area": 0.4243
+        },
+        {
+          "tract_geoid": "08005005614",
+          "overlap_area_sqm": 2242964.4,
+          "share_of_place_area": 0.0286,
+          "share_of_tract_area": 0.9643
+        },
+        {
+          "tract_geoid": "08005085500",
+          "overlap_area_sqm": 2176592.1,
+          "share_of_place_area": 0.0278,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005005626",
+          "overlap_area_sqm": 2012074.9,
+          "share_of_place_area": 0.0257,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005085400",
+          "overlap_area_sqm": 1886364.7,
+          "share_of_place_area": 0.0241,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005005631",
+          "overlap_area_sqm": 1676115.9,
+          "share_of_place_area": 0.0214,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005086200",
+          "overlap_area_sqm": 1617332.4,
+          "share_of_place_area": 0.0206,
+          "share_of_tract_area": 0.7282
+        },
+        {
+          "tract_geoid": "08005005625",
+          "overlap_area_sqm": 1536763.7,
+          "share_of_place_area": 0.0196,
+          "share_of_tract_area": 0.8171
+        },
+        {
+          "tract_geoid": "08005084900",
+          "overlap_area_sqm": 1447299.2,
+          "share_of_place_area": 0.0185,
+          "share_of_tract_area": 0.8622
+        },
+        {
+          "tract_geoid": "08005006815",
+          "overlap_area_sqm": 1383823.8,
+          "share_of_place_area": 0.0176,
+          "share_of_tract_area": 0.4314
+        },
+        {
+          "tract_geoid": "08005086100",
+          "overlap_area_sqm": 1371808.4,
+          "share_of_place_area": 0.0175,
+          "share_of_tract_area": 0.7251
+        },
+        {
+          "tract_geoid": "08005006861",
+          "overlap_area_sqm": 1148123.4,
+          "share_of_place_area": 0.0146,
+          "share_of_tract_area": 0.4347
+        },
+        {
+          "tract_geoid": "08005081700",
+          "overlap_area_sqm": 967422.3,
+          "share_of_place_area": 0.0123,
+          "share_of_tract_area": 0.5232
+        },
+        {
+          "tract_geoid": "08005005632",
+          "overlap_area_sqm": 782403.1,
+          "share_of_place_area": 0.01,
+          "share_of_tract_area": 0.3544
+        },
+        {
+          "tract_geoid": "08005006713",
+          "overlap_area_sqm": 531740.3,
+          "share_of_place_area": 0.0068,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08005084800",
+          "overlap_area_sqm": 530004.2,
+          "share_of_place_area": 0.0068,
+          "share_of_tract_area": 0.3554
+        },
+        {
+          "tract_geoid": "08005085900",
+          "overlap_area_sqm": 374747.6,
+          "share_of_place_area": 0.0048,
+          "share_of_tract_area": 0.0796
+        },
+        {
+          "tract_geoid": "08005085100",
+          "overlap_area_sqm": 363228.9,
+          "share_of_place_area": 0.0046,
+          "share_of_tract_area": 0.0972
+        },
+        {
+          "tract_geoid": "08005085800",
+          "overlap_area_sqm": 268149.2,
+          "share_of_place_area": 0.0034,
+          "share_of_tract_area": 0.1797
+        },
+        {
+          "tract_geoid": "08005005612",
+          "overlap_area_sqm": 184737.7,
+          "share_of_place_area": 0.0024,
+          "share_of_tract_area": 0.0476
+        },
+        {
+          "tract_geoid": "08005086300",
+          "overlap_area_sqm": 148082.4,
+          "share_of_place_area": 0.0019,
+          "share_of_tract_area": 0.03
+        },
+        {
+          "tract_geoid": "08005086500",
+          "overlap_area_sqm": 17958.9,
+          "share_of_place_area": 0.0002,
+          "share_of_tract_area": 0.0029
+        },
+        {
+          "tract_geoid": "08005005636",
+          "overlap_area_sqm": 4687.7,
+          "share_of_place_area": 0.0001,
+          "share_of_tract_area": 0.0009
+        },
+        {
+          "tract_geoid": "08005086001",
+          "overlap_area_sqm": 7860.6,
+          "share_of_place_area": 0.0001,
+          "share_of_tract_area": 0.0048
+        }
+      ]
+    },
+    "0837270": {
+      "name": "Holyoke",
+      "place_area_sqm": 6427124.9,
+      "tracts": [
+        {
+          "tract_geoid": "08095967600",
+          "overlap_area_sqm": 6427124.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0065
+        }
+      ]
+    },
+    "0837380": {
+      "name": "Hooper",
+      "place_area_sqm": 652305.4,
+      "tracts": [
+        {
+          "tract_geoid": "08003960000",
+          "overlap_area_sqm": 652305.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0005
+        }
+      ]
+    },
+    "0842055": {
+      "name": "La Jara",
+      "place_area_sqm": 1055606.6,
+      "tracts": [
+        {
+          "tract_geoid": "08021974900",
+          "overlap_area_sqm": 1055606.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0004
+        }
+      ]
+    },
+    "0865740": {
+      "name": "Romeo",
+      "place_area_sqm": 604128.2,
+      "tracts": [
+        {
+          "tract_geoid": "08021974800",
+          "overlap_area_sqm": 604128.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.001
+        }
+      ]
+    },
+    "0802355": {
+      "name": "Antonito",
+      "place_area_sqm": 1103974.3,
+      "tracts": [
+        {
+          "tract_geoid": "08021974800",
+          "overlap_area_sqm": 1103974.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0018
+        }
+      ]
+    },
+    "0848060": {
+      "name": "Manassa",
+      "place_area_sqm": 2410234.5,
+      "tracts": [
+        {
+          "tract_geoid": "08021974800",
+          "overlap_area_sqm": 2410234.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0039
+        }
+      ]
+    },
+    "0846465": {
+      "name": "Loveland",
+      "place_area_sqm": 96627382.2,
+      "tracts": [
+        {
+          "tract_geoid": "08069001715",
+          "overlap_area_sqm": 18226262.5,
+          "share_of_place_area": 0.1886,
+          "share_of_tract_area": 0.7657
+        },
+        {
+          "tract_geoid": "08069001714",
+          "overlap_area_sqm": 9941676.7,
+          "share_of_place_area": 0.1029,
+          "share_of_tract_area": 0.3151
+        },
+        {
+          "tract_geoid": "08069001812",
+          "overlap_area_sqm": 7314327.3,
+          "share_of_place_area": 0.0757,
+          "share_of_tract_area": 0.0961
+        },
+        {
+          "tract_geoid": "08069001706",
+          "overlap_area_sqm": 4982170.2,
+          "share_of_place_area": 0.0516,
+          "share_of_tract_area": 0.9061
+        },
+        {
+          "tract_geoid": "08069001804",
+          "overlap_area_sqm": 4900390.6,
+          "share_of_place_area": 0.0507,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069001713",
+          "overlap_area_sqm": 4796234.4,
+          "share_of_place_area": 0.0496,
+          "share_of_tract_area": 0.0853
+        },
+        {
+          "tract_geoid": "08069002007",
+          "overlap_area_sqm": 4438951.7,
+          "share_of_place_area": 0.0459,
+          "share_of_tract_area": 0.8486
+        },
+        {
+          "tract_geoid": "08069001810",
+          "overlap_area_sqm": 3843777.6,
+          "share_of_place_area": 0.0398,
+          "share_of_tract_area": 0.9887
+        },
+        {
+          "tract_geoid": "08069001710",
+          "overlap_area_sqm": 3632451.7,
+          "share_of_place_area": 0.0376,
+          "share_of_tract_area": 0.7779
+        },
+        {
+          "tract_geoid": "08069001711",
+          "overlap_area_sqm": 3528321.7,
+          "share_of_place_area": 0.0365,
+          "share_of_tract_area": 0.9023
+        },
+        {
+          "tract_geoid": "08069001901",
+          "overlap_area_sqm": 3364726.8,
+          "share_of_place_area": 0.0348,
+          "share_of_tract_area": 0.7086
+        },
+        {
+          "tract_geoid": "08069001807",
+          "overlap_area_sqm": 3202829.8,
+          "share_of_place_area": 0.0331,
+          "share_of_tract_area": 0.8381
+        },
+        {
+          "tract_geoid": "08069001813",
+          "overlap_area_sqm": 3156835.6,
+          "share_of_place_area": 0.0327,
+          "share_of_tract_area": 0.2019
+        },
+        {
+          "tract_geoid": "08069002011",
+          "overlap_area_sqm": 3144559.3,
+          "share_of_place_area": 0.0325,
+          "share_of_tract_area": 0.2002
+        },
+        {
+          "tract_geoid": "08069001808",
+          "overlap_area_sqm": 3011756.6,
+          "share_of_place_area": 0.0312,
+          "share_of_tract_area": 0.0659
+        },
+        {
+          "tract_geoid": "08069001902",
+          "overlap_area_sqm": 2761549.9,
+          "share_of_place_area": 0.0286,
+          "share_of_tract_area": 0.8283
+        },
+        {
+          "tract_geoid": "08069002008",
+          "overlap_area_sqm": 2725883.3,
+          "share_of_place_area": 0.0282,
+          "share_of_tract_area": 0.8338
+        },
+        {
+          "tract_geoid": "08069001707",
+          "overlap_area_sqm": 2598012.6,
+          "share_of_place_area": 0.0269,
+          "share_of_tract_area": 0.7675
+        },
+        {
+          "tract_geoid": "08069002005",
+          "overlap_area_sqm": 2584725.3,
+          "share_of_place_area": 0.0267,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08069001811",
+          "overlap_area_sqm": 2270283.2,
+          "share_of_place_area": 0.0235,
+          "share_of_tract_area": 0.9222
+        },
+        {
+          "tract_geoid": "08069001712",
+          "overlap_area_sqm": 1617533.7,
+          "share_of_place_area": 0.0167,
+          "share_of_tract_area": 0.0782
+        },
+        {
+          "tract_geoid": "08069002010",
+          "overlap_area_sqm": 567035.2,
+          "share_of_place_area": 0.0059,
+          "share_of_tract_area": 0.0215
+        },
+        {
+          "tract_geoid": "08069002602",
+          "overlap_area_sqm": 17086.6,
+          "share_of_place_area": 0.0002,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0877510": {
+      "name": "Timnath",
+      "place_area_sqm": 19017906.8,
+      "tracts": [
+        {
+          "tract_geoid": "08069002506",
+          "overlap_area_sqm": 10189864.6,
+          "share_of_place_area": 0.5358,
+          "share_of_tract_area": 0.3439
+        },
+        {
+          "tract_geoid": "08069002505",
+          "overlap_area_sqm": 6259322.6,
+          "share_of_place_area": 0.3291,
+          "share_of_tract_area": 0.2621
+        },
+        {
+          "tract_geoid": "08123002208",
+          "overlap_area_sqm": 1408064.8,
+          "share_of_place_area": 0.074,
+          "share_of_tract_area": 0.0131
+        },
+        {
+          "tract_geoid": "08123002300",
+          "overlap_area_sqm": 1154145.4,
+          "share_of_place_area": 0.0607,
+          "share_of_tract_area": 0.0039
+        },
+        {
+          "tract_geoid": "08069002504",
+          "overlap_area_sqm": 6509.6,
+          "share_of_place_area": 0.0003,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0812030": {
+      "name": "Carbonate",
+      "place_area_sqm": 2605847.9,
+      "tracts": [
+        {
+          "tract_geoid": "08045951600",
+          "overlap_area_sqm": 2605847.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0017
+        }
+      ]
+    },
+    "0800320": {
+      "name": "Acres Green",
+      "place_area_sqm": 1556102.8,
+      "tracts": [
+        {
+          "tract_geoid": "08035014114",
+          "overlap_area_sqm": 1556102.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.4989
+        }
+      ]
+    },
+    "0801420": {
+      "name": "Allenspark",
+      "place_area_sqm": 30928893.3,
+      "tracts": [
+        {
+          "tract_geoid": "08013013602",
+          "overlap_area_sqm": 30928893.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0621
+        }
+      ]
+    },
+    "0801640": {
+      "name": "Alpine",
+      "place_area_sqm": 2720264.8,
+      "tracts": [
+        {
+          "tract_geoid": "08105977001",
+          "overlap_area_sqm": 2720264.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0015
+        }
+      ]
+    },
+    "0801740": {
+      "name": "Altona",
+      "place_area_sqm": 4512217.8,
+      "tracts": [
+        {
+          "tract_geoid": "08013013704",
+          "overlap_area_sqm": 3747766.4,
+          "share_of_place_area": 0.8306,
+          "share_of_tract_area": 0.0516
+        },
+        {
+          "tract_geoid": "08013013601",
+          "overlap_area_sqm": 764451.4,
+          "share_of_place_area": 0.1694,
+          "share_of_tract_area": 0.0055
+        }
+      ]
+    },
+    "0801915": {
+      "name": "Amherst",
+      "place_area_sqm": 1176348.5,
+      "tracts": [
+        {
+          "tract_geoid": "08095967600",
+          "overlap_area_sqm": 1176348.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0012
+        }
+      ]
+    },
+    "0802575": {
+      "name": "Applewood",
+      "place_area_sqm": 11610558.3,
+      "tracts": [
+        {
+          "tract_geoid": "08059009806",
+          "overlap_area_sqm": 5935165.7,
+          "share_of_place_area": 0.5112,
+          "share_of_tract_area": 0.8465
+        },
+        {
+          "tract_geoid": "08059010100",
+          "overlap_area_sqm": 2970923.7,
+          "share_of_place_area": 0.2559,
+          "share_of_tract_area": 0.4236
+        },
+        {
+          "tract_geoid": "08059010901",
+          "overlap_area_sqm": 1536272.0,
+          "share_of_place_area": 0.1323,
+          "share_of_tract_area": 0.3386
+        },
+        {
+          "tract_geoid": "08059009807",
+          "overlap_area_sqm": 1063065.3,
+          "share_of_place_area": 0.0916,
+          "share_of_tract_area": 0.6063
+        },
+        {
+          "tract_geoid": "08059010504",
+          "overlap_area_sqm": 105131.5,
+          "share_of_place_area": 0.0091,
+          "share_of_tract_area": 0.0454
+        }
+      ]
+    },
+    "0802850": {
+      "name": "Arapahoe",
+      "place_area_sqm": 718659.7,
+      "tracts": [
+        {
+          "tract_geoid": "08017960600",
+          "overlap_area_sqm": 718659.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0802905": {
+      "name": "Arboles",
+      "place_area_sqm": 15987208.1,
+      "tracts": [
+        {
+          "tract_geoid": "08007940400",
+          "overlap_area_sqm": 15987208.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0155
+        }
+      ]
+    },
+    "0803015": {
+      "name": "Aristocrat Ranchettes",
+      "place_area_sqm": 3205484.2,
+      "tracts": [
+        {
+          "tract_geoid": "08123001906",
+          "overlap_area_sqm": 2046875.9,
+          "share_of_place_area": 0.6386,
+          "share_of_tract_area": 0.0458
+        },
+        {
+          "tract_geoid": "08123001914",
+          "overlap_area_sqm": 1158608.3,
+          "share_of_place_area": 0.3614,
+          "share_of_tract_area": 0.0095
+        }
+      ]
+    },
+    "0803730": {
+      "name": "Aspen Park",
+      "place_area_sqm": 6394118.6,
+      "tracts": [
+        {
+          "tract_geoid": "08059012032",
+          "overlap_area_sqm": 4021452.7,
+          "share_of_place_area": 0.6289,
+          "share_of_tract_area": 0.129
+        },
+        {
+          "tract_geoid": "08059012033",
+          "overlap_area_sqm": 2372665.9,
+          "share_of_place_area": 0.3711,
+          "share_of_tract_area": 0.0419
+        }
+      ]
+    },
+    "0803840": {
+      "name": "Atwood",
+      "place_area_sqm": 2677261.1,
+      "tracts": [
+        {
+          "tract_geoid": "08075966000",
+          "overlap_area_sqm": 2677261.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.002
+        }
+      ]
+    },
+    "0804165": {
+      "name": "Avondale",
+      "place_area_sqm": 1625484.7,
+      "tracts": [
+        {
+          "tract_geoid": "08101003200",
+          "overlap_area_sqm": 1625484.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0008
+        }
+      ]
+    },
+    "0804620": {
+      "name": "Bark Ranch",
+      "place_area_sqm": 2255362.7,
+      "tracts": [
+        {
+          "tract_geoid": "08013013703",
+          "overlap_area_sqm": 2255362.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0124
+        }
+      ]
+    },
+    "0805120": {
+      "name": "Battlement Mesa",
+      "place_area_sqm": 29447062.0,
+      "tracts": [
+        {
+          "tract_geoid": "08045952100",
+          "overlap_area_sqm": 29447062.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0088
+        }
+      ]
+    },
+    "0806172": {
+      "name": "Berkley",
+      "place_area_sqm": 10573254.8,
+      "tracts": [
+        {
+          "tract_geoid": "08001009751",
+          "overlap_area_sqm": 3156318.3,
+          "share_of_place_area": 0.2985,
+          "share_of_tract_area": 0.9358
+        },
+        {
+          "tract_geoid": "08001009502",
+          "overlap_area_sqm": 2389076.8,
+          "share_of_place_area": 0.226,
+          "share_of_tract_area": 0.548
+        },
+        {
+          "tract_geoid": "08001009752",
+          "overlap_area_sqm": 2015540.6,
+          "share_of_place_area": 0.1906,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001009606",
+          "overlap_area_sqm": 1539325.3,
+          "share_of_place_area": 0.1456,
+          "share_of_tract_area": 0.7361
+        },
+        {
+          "tract_geoid": "08001009607",
+          "overlap_area_sqm": 1365024.2,
+          "share_of_place_area": 0.1291,
+          "share_of_tract_area": 0.5126
+        },
+        {
+          "tract_geoid": "08001009608",
+          "overlap_area_sqm": 107969.7,
+          "share_of_place_area": 0.0102,
+          "share_of_tract_area": 0.0734
+        }
+      ]
+    },
+    "0806602": {
+      "name": "Beulah Valley",
+      "place_area_sqm": 6657080.9,
+      "tracts": [
+        {
+          "tract_geoid": "08101002806",
+          "overlap_area_sqm": 6657080.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0075
+        }
+      ]
+    },
+    "0806970": {
+      "name": "Black Forest",
+      "place_area_sqm": 260603126.0,
+      "tracts": [
+        {
+          "tract_geoid": "08041007502",
+          "overlap_area_sqm": 135780207.6,
+          "share_of_place_area": 0.521,
+          "share_of_tract_area": 0.9482
+        },
+        {
+          "tract_geoid": "08041007602",
+          "overlap_area_sqm": 63672318.9,
+          "share_of_place_area": 0.2443,
+          "share_of_tract_area": 0.9611
+        },
+        {
+          "tract_geoid": "08041003913",
+          "overlap_area_sqm": 31018308.1,
+          "share_of_place_area": 0.119,
+          "share_of_tract_area": 0.7197
+        },
+        {
+          "tract_geoid": "08041007501",
+          "overlap_area_sqm": 15120535.9,
+          "share_of_place_area": 0.058,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041007604",
+          "overlap_area_sqm": 12301787.3,
+          "share_of_place_area": 0.0472,
+          "share_of_tract_area": 0.944
+        },
+        {
+          "tract_geoid": "08041007603",
+          "overlap_area_sqm": 2692138.8,
+          "share_of_place_area": 0.0103,
+          "share_of_tract_area": 0.072
+        },
+        {
+          "tract_geoid": "08041007206",
+          "overlap_area_sqm": 17829.4,
+          "share_of_place_area": 0.0001,
+          "share_of_tract_area": 0.002
+        }
+      ]
+    },
+    "0807245": {
+      "name": "Blende",
+      "place_area_sqm": 2171251.5,
+      "tracts": [
+        {
+          "tract_geoid": "08101003103",
+          "overlap_area_sqm": 2171251.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.1629
+        }
+      ]
+    },
+    "0807455": {
+      "name": "Blue Valley",
+      "place_area_sqm": 2722722.7,
+      "tracts": [
+        {
+          "tract_geoid": "08019014702",
+          "overlap_area_sqm": 2722722.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0109
+        }
+      ]
+    },
+    "0807580": {
+      "name": "Bonanza Mountain Estates",
+      "place_area_sqm": 435578.1,
+      "tracts": [
+        {
+          "tract_geoid": "08013013706",
+          "overlap_area_sqm": 435578.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0024
+        }
+      ]
+    },
+    "0808290": {
+      "name": "Brandon",
+      "place_area_sqm": 304420.1,
+      "tracts": [
+        {
+          "tract_geoid": "08061960100",
+          "overlap_area_sqm": 304420.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0808620": {
+      "name": "Briggsdale",
+      "place_area_sqm": 1132466.6,
+      "tracts": [
+        {
+          "tract_geoid": "08123002501",
+          "overlap_area_sqm": 1132466.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0808950": {
+      "name": "Brook Forest",
+      "place_area_sqm": 3594030.0,
+      "tracts": [
+        {
+          "tract_geoid": "08059012031",
+          "overlap_area_sqm": 2337527.5,
+          "share_of_place_area": 0.6504,
+          "share_of_tract_area": 0.0487
+        },
+        {
+          "tract_geoid": "08019014701",
+          "overlap_area_sqm": 1152400.3,
+          "share_of_place_area": 0.3206,
+          "share_of_tract_area": 0.0049
+        },
+        {
+          "tract_geoid": "08059012030",
+          "overlap_area_sqm": 104102.2,
+          "share_of_place_area": 0.029,
+          "share_of_tract_area": 0.003
+        }
+      ]
+    },
+    "0810985": {
+      "name": "Byers",
+      "place_area_sqm": 30990990.3,
+      "tracts": [
+        {
+          "tract_geoid": "08005007101",
+          "overlap_area_sqm": 30990990.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0257
+        }
+      ]
+    },
+    "0811975": {
+      "name": "Capulin",
+      "place_area_sqm": 2451381.0,
+      "tracts": [
+        {
+          "tract_geoid": "08021974900",
+          "overlap_area_sqm": 2451381.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0009
+        }
+      ]
+    },
+    "0812393": {
+      "name": "Castle Pines Village",
+      "place_area_sqm": 11522378.4,
+      "tracts": [
+        {
+          "tract_geoid": "08035014142",
+          "overlap_area_sqm": 6205911.4,
+          "share_of_place_area": 0.5386,
+          "share_of_tract_area": 0.9919
+        },
+        {
+          "tract_geoid": "08035014123",
+          "overlap_area_sqm": 3241362.3,
+          "share_of_place_area": 0.2813,
+          "share_of_tract_area": 0.5768
+        },
+        {
+          "tract_geoid": "08035014141",
+          "overlap_area_sqm": 2075104.7,
+          "share_of_place_area": 0.1801,
+          "share_of_tract_area": 0.2773
+        }
+      ]
+    },
+    "0812450": {
+      "name": "Cathedral",
+      "place_area_sqm": 55111587.4,
+      "tracts": [
+        {
+          "tract_geoid": "08053973100",
+          "overlap_area_sqm": 55111587.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0189
+        }
+      ]
+    },
+    "0812460": {
+      "name": "Catherine",
+      "place_area_sqm": 2223261.7,
+      "tracts": [
+        {
+          "tract_geoid": "08045951804",
+          "overlap_area_sqm": 2223261.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0234
+        }
+      ]
+    },
+    "0812470": {
+      "name": "Cattle Creek",
+      "place_area_sqm": 3355464.8,
+      "tracts": [
+        {
+          "tract_geoid": "08045951802",
+          "overlap_area_sqm": 3213167.7,
+          "share_of_place_area": 0.9576,
+          "share_of_tract_area": 0.0087
+        },
+        {
+          "tract_geoid": "08045951803",
+          "overlap_area_sqm": 142297.0,
+          "share_of_place_area": 0.0424,
+          "share_of_tract_area": 0.0015
+        }
+      ]
+    },
+    "0812945": {
+      "name": "Chacra",
+      "place_area_sqm": 2549157.1,
+      "tracts": [
+        {
+          "tract_geoid": "08045951902",
+          "overlap_area_sqm": 1628440.1,
+          "share_of_place_area": 0.6388,
+          "share_of_tract_area": 0.0023
+        },
+        {
+          "tract_geoid": "08045951600",
+          "overlap_area_sqm": 920717.0,
+          "share_of_place_area": 0.3612,
+          "share_of_tract_area": 0.0006
+        }
+      ]
+    },
+    "0813590": {
+      "name": "Cherry Creek",
+      "place_area_sqm": 4321999.4,
+      "tracts": [
+        {
+          "tract_geoid": "08005006808",
+          "overlap_area_sqm": 1902126.4,
+          "share_of_place_area": 0.4401,
+          "share_of_tract_area": 0.5
+        },
+        {
+          "tract_geoid": "08005006861",
+          "overlap_area_sqm": 1145524.5,
+          "share_of_place_area": 0.265,
+          "share_of_tract_area": 0.4337
+        },
+        {
+          "tract_geoid": "08005006815",
+          "overlap_area_sqm": 1042842.2,
+          "share_of_place_area": 0.2413,
+          "share_of_tract_area": 0.3251
+        },
+        {
+          "tract_geoid": "08005006860",
+          "overlap_area_sqm": 128009.2,
+          "share_of_place_area": 0.0296,
+          "share_of_tract_area": 0.1091
+        },
+        {
+          "tract_geoid": "08005006857",
+          "overlap_area_sqm": 103497.1,
+          "share_of_place_area": 0.0239,
+          "share_of_tract_area": 0.0518
+        }
+      ]
+    },
+    "0814587": {
+      "name": "Cimarron Hills",
+      "place_area_sqm": 15255586.1,
+      "tracts": [
+        {
+          "tract_geoid": "08041005000",
+          "overlap_area_sqm": 4928960.2,
+          "share_of_place_area": 0.3231,
+          "share_of_tract_area": 0.9923
+        },
+        {
+          "tract_geoid": "08041005119",
+          "overlap_area_sqm": 2455370.0,
+          "share_of_place_area": 0.1609,
+          "share_of_tract_area": 0.7185
+        },
+        {
+          "tract_geoid": "08041005114",
+          "overlap_area_sqm": 2108509.3,
+          "share_of_place_area": 0.1382,
+          "share_of_tract_area": 0.8683
+        },
+        {
+          "tract_geoid": "08041005110",
+          "overlap_area_sqm": 1840703.7,
+          "share_of_place_area": 0.1207,
+          "share_of_tract_area": 0.9301
+        },
+        {
+          "tract_geoid": "08041005115",
+          "overlap_area_sqm": 1507686.1,
+          "share_of_place_area": 0.0988,
+          "share_of_tract_area": 0.4616
+        },
+        {
+          "tract_geoid": "08041005116",
+          "overlap_area_sqm": 1032276.0,
+          "share_of_place_area": 0.0677,
+          "share_of_tract_area": 0.5228
+        },
+        {
+          "tract_geoid": "08041004008",
+          "overlap_area_sqm": 831368.0,
+          "share_of_place_area": 0.0545,
+          "share_of_tract_area": 0.0207
+        },
+        {
+          "tract_geoid": "08041005118",
+          "overlap_area_sqm": 526515.9,
+          "share_of_place_area": 0.0345,
+          "share_of_tract_area": 0.1824
+        },
+        {
+          "tract_geoid": "08041005122",
+          "overlap_area_sqm": 24196.8,
+          "share_of_place_area": 0.0016,
+          "share_of_tract_area": 0.0007
+        }
+      ]
+    },
+    "0815165": {
+      "name": "Clifton",
+      "place_area_sqm": 15700275.2,
+      "tracts": [
+        {
+          "tract_geoid": "08077001705",
+          "overlap_area_sqm": 4494044.6,
+          "share_of_place_area": 0.2862,
+          "share_of_tract_area": 0.6648
+        },
+        {
+          "tract_geoid": "08077001707",
+          "overlap_area_sqm": 3617599.4,
+          "share_of_place_area": 0.2304,
+          "share_of_tract_area": 0.7345
+        },
+        {
+          "tract_geoid": "08077001706",
+          "overlap_area_sqm": 3263398.8,
+          "share_of_place_area": 0.2079,
+          "share_of_tract_area": 0.5965
+        },
+        {
+          "tract_geoid": "08077000802",
+          "overlap_area_sqm": 3094182.3,
+          "share_of_place_area": 0.1971,
+          "share_of_tract_area": 0.7478
+        },
+        {
+          "tract_geoid": "08077001703",
+          "overlap_area_sqm": 1229110.3,
+          "share_of_place_area": 0.0783,
+          "share_of_tract_area": 0.2424
+        },
+        {
+          "tract_geoid": "08077000801",
+          "overlap_area_sqm": 1939.8,
+          "share_of_place_area": 0.0001,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0815302": {
+      "name": "Coal Creek",
+      "place_area_sqm": 24336449.6,
+      "tracts": [
+        {
+          "tract_geoid": "08059009858",
+          "overlap_area_sqm": 15403457.8,
+          "share_of_place_area": 0.6329,
+          "share_of_tract_area": 0.059
+        },
+        {
+          "tract_geoid": "08013013706",
+          "overlap_area_sqm": 5481266.5,
+          "share_of_place_area": 0.2252,
+          "share_of_tract_area": 0.0307
+        },
+        {
+          "tract_geoid": "08047013802",
+          "overlap_area_sqm": 3451725.2,
+          "share_of_place_area": 0.1418,
+          "share_of_tract_area": 0.0193
+        }
+      ]
+    },
+    "0815440": {
+      "name": "Coaldale",
+      "place_area_sqm": 80356323.7,
+      "tracts": [
+        {
+          "tract_geoid": "08043979001",
+          "overlap_area_sqm": 80356323.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0375
+        }
+      ]
+    },
+    "0815825": {
+      "name": "Colona",
+      "place_area_sqm": 156951.4,
+      "tracts": [
+        {
+          "tract_geoid": "08091967602",
+          "overlap_area_sqm": 113233.6,
+          "share_of_place_area": 0.7215,
+          "share_of_tract_area": 0.0001
+        },
+        {
+          "tract_geoid": "08091967601",
+          "overlap_area_sqm": 43717.8,
+          "share_of_place_area": 0.2785,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0815935": {
+      "name": "Colorado City",
+      "place_area_sqm": 39135560.4,
+      "tracts": [
+        {
+          "tract_geoid": "08101002804",
+          "overlap_area_sqm": 39135560.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0534
+        }
+      ]
+    },
+    "0816110": {
+      "name": "Columbine",
+      "place_area_sqm": 17485052.2,
+      "tracts": [
+        {
+          "tract_geoid": "08059012049",
+          "overlap_area_sqm": 2629180.3,
+          "share_of_place_area": 0.1504,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059012051",
+          "overlap_area_sqm": 2609841.3,
+          "share_of_place_area": 0.1493,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059012048",
+          "overlap_area_sqm": 2602930.9,
+          "share_of_place_area": 0.1489,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059012055",
+          "overlap_area_sqm": 2463666.5,
+          "share_of_place_area": 0.1409,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059012052",
+          "overlap_area_sqm": 2433809.1,
+          "share_of_place_area": 0.1392,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059012053",
+          "overlap_area_sqm": 2221900.7,
+          "share_of_place_area": 0.1271,
+          "share_of_tract_area": 0.8745
+        },
+        {
+          "tract_geoid": "08005005621",
+          "overlap_area_sqm": 1879997.5,
+          "share_of_place_area": 0.1075,
+          "share_of_tract_area": 0.7198
+        },
+        {
+          "tract_geoid": "08059012036",
+          "overlap_area_sqm": 643725.8,
+          "share_of_place_area": 0.0368,
+          "share_of_tract_area": 0.0043
+        }
+      ]
+    },
+    "0816715": {
+      "name": "Conejos",
+      "place_area_sqm": 1253273.1,
+      "tracts": [
+        {
+          "tract_geoid": "08021974800",
+          "overlap_area_sqm": 1253273.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.002
+        }
+      ]
+    },
+    "0817100": {
+      "name": "Cope",
+      "place_area_sqm": 4730971.5,
+      "tracts": [
+        {
+          "tract_geoid": "08121924100",
+          "overlap_area_sqm": 4730971.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.001
+        }
+      ]
+    },
+    "0817150": {
+      "name": "Copper Mountain",
+      "place_area_sqm": 82984944.4,
+      "tracts": [
+        {
+          "tract_geoid": "08117000302",
+          "overlap_area_sqm": 82984944.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.315
+        }
+      ]
+    },
+    "0817485": {
+      "name": "Cotopaxi",
+      "place_area_sqm": 750305.9,
+      "tracts": [
+        {
+          "tract_geoid": "08043979001",
+          "overlap_area_sqm": 750305.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0004
+        }
+      ]
+    },
+    "0818585": {
+      "name": "Crisman",
+      "place_area_sqm": 3771885.3,
+      "tracts": [
+        {
+          "tract_geoid": "08013013706",
+          "overlap_area_sqm": 2696759.3,
+          "share_of_place_area": 0.715,
+          "share_of_tract_area": 0.0151
+        },
+        {
+          "tract_geoid": "08013013704",
+          "overlap_area_sqm": 1075126.1,
+          "share_of_place_area": 0.285,
+          "share_of_tract_area": 0.0148
+        }
+      ]
+    },
+    "0819150": {
+      "name": "Dakota Ridge",
+      "place_area_sqm": 25073476.2,
+      "tracts": [
+        {
+          "tract_geoid": "08059012043",
+          "overlap_area_sqm": 5027401.1,
+          "share_of_place_area": 0.2005,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059012044",
+          "overlap_area_sqm": 4268035.3,
+          "share_of_place_area": 0.1702,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059012038",
+          "overlap_area_sqm": 3068607.7,
+          "share_of_place_area": 0.1224,
+          "share_of_tract_area": 0.939
+        },
+        {
+          "tract_geoid": "08059012045",
+          "overlap_area_sqm": 2932069.4,
+          "share_of_place_area": 0.1169,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059012042",
+          "overlap_area_sqm": 2584342.1,
+          "share_of_place_area": 0.1031,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059012041",
+          "overlap_area_sqm": 2568997.6,
+          "share_of_place_area": 0.1025,
+          "share_of_tract_area": 0.7712
+        },
+        {
+          "tract_geoid": "08059012039",
+          "overlap_area_sqm": 2459950.6,
+          "share_of_place_area": 0.0981,
+          "share_of_tract_area": 0.9709
+        },
+        {
+          "tract_geoid": "08059015900",
+          "overlap_area_sqm": 2164072.4,
+          "share_of_place_area": 0.0863,
+          "share_of_tract_area": 0.3945
+        }
+      ]
+    },
+    "0820275": {
+      "name": "Derby",
+      "place_area_sqm": 4566572.0,
+      "tracts": [
+        {
+          "tract_geoid": "08001008802",
+          "overlap_area_sqm": 2737726.0,
+          "share_of_place_area": 0.5995,
+          "share_of_tract_area": 0.1804
+        },
+        {
+          "tract_geoid": "08001008801",
+          "overlap_area_sqm": 1471433.3,
+          "share_of_place_area": 0.3222,
+          "share_of_tract_area": 0.3784
+        },
+        {
+          "tract_geoid": "08001008901",
+          "overlap_area_sqm": 341605.3,
+          "share_of_place_area": 0.0748,
+          "share_of_tract_area": 0.0401
+        },
+        {
+          "tract_geoid": "08001008705",
+          "overlap_area_sqm": 15807.4,
+          "share_of_place_area": 0.0035,
+          "share_of_tract_area": 0.0065
+        }
+      ]
+    },
+    "0820605": {
+      "name": "Divide",
+      "place_area_sqm": 868543.5,
+      "tracts": [
+        {
+          "tract_geoid": "08119010112",
+          "overlap_area_sqm": 868543.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0091
+        }
+      ]
+    },
+    "0821155": {
+      "name": "Dotsero",
+      "place_area_sqm": 4018009.1,
+      "tracts": [
+        {
+          "tract_geoid": "08037000100",
+          "overlap_area_sqm": 2944851.4,
+          "share_of_place_area": 0.7329,
+          "share_of_tract_area": 0.0021
+        },
+        {
+          "tract_geoid": "08037000200",
+          "overlap_area_sqm": 1073157.7,
+          "share_of_place_area": 0.2671,
+          "share_of_tract_area": 0.0028
+        }
+      ]
+    },
+    "0821330": {
+      "name": "Dove Valley",
+      "place_area_sqm": 8105156.8,
+      "tracts": [
+        {
+          "tract_geoid": "08005006864",
+          "overlap_area_sqm": 5853364.8,
+          "share_of_place_area": 0.7222,
+          "share_of_tract_area": 0.4851
+        },
+        {
+          "tract_geoid": "08005006863",
+          "overlap_area_sqm": 2075972.3,
+          "share_of_place_area": 0.2561,
+          "share_of_tract_area": 0.306
+        },
+        {
+          "tract_geoid": "08005086500",
+          "overlap_area_sqm": 175819.8,
+          "share_of_place_area": 0.0217,
+          "share_of_tract_area": 0.0288
+        }
+      ]
+    },
+    "0822882": {
+      "name": "Echo Hills",
+      "place_area_sqm": 1471015.2,
+      "tracts": [
+        {
+          "tract_geoid": "08019014701",
+          "overlap_area_sqm": 1471015.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0063
+        }
+      ]
+    },
+    "0823300": {
+      "name": "Edwards",
+      "place_area_sqm": 69359518.8,
+      "tracts": [
+        {
+          "tract_geoid": "08037000402",
+          "overlap_area_sqm": 55297024.4,
+          "share_of_place_area": 0.7973,
+          "share_of_tract_area": 0.3269
+        },
+        {
+          "tract_geoid": "08037000401",
+          "overlap_area_sqm": 9585500.9,
+          "share_of_place_area": 0.1382,
+          "share_of_tract_area": 0.0502
+        },
+        {
+          "tract_geoid": "08037000501",
+          "overlap_area_sqm": 4410198.7,
+          "share_of_place_area": 0.0636,
+          "share_of_tract_area": 0.088
+        },
+        {
+          "tract_geoid": "08037000504",
+          "overlap_area_sqm": 66794.9,
+          "share_of_place_area": 0.001,
+          "share_of_tract_area": 0.0269
+        }
+      ]
+    },
+    "0823520": {
+      "name": "Elbert",
+      "place_area_sqm": 1417947.6,
+      "tracts": [
+        {
+          "tract_geoid": "08039961209",
+          "overlap_area_sqm": 1417947.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0051
+        }
+      ]
+    },
+    "0823575": {
+      "name": "Eldora",
+      "place_area_sqm": 10818906.0,
+      "tracts": [
+        {
+          "tract_geoid": "08013013705",
+          "overlap_area_sqm": 10818906.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0661
+        }
+      ]
+    },
+    "0823630": {
+      "name": "Eldorado Springs",
+      "place_area_sqm": 6690252.0,
+      "tracts": [
+        {
+          "tract_geoid": "08013012510",
+          "overlap_area_sqm": 6690252.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.1318
+        }
+      ]
+    },
+    "0823795": {
+      "name": "El Jebel",
+      "place_area_sqm": 13881980.9,
+      "tracts": [
+        {
+          "tract_geoid": "08037000301",
+          "overlap_area_sqm": 12870080.5,
+          "share_of_place_area": 0.9271,
+          "share_of_tract_area": 0.5345
+        },
+        {
+          "tract_geoid": "08037000302",
+          "overlap_area_sqm": 1011900.5,
+          "share_of_place_area": 0.0729,
+          "share_of_tract_area": 0.0017
+        }
+      ]
+    },
+    "0824235": {
+      "name": "Ellicott",
+      "place_area_sqm": 28266544.2,
+      "tracts": [
+        {
+          "tract_geoid": "08041004602",
+          "overlap_area_sqm": 16697270.4,
+          "share_of_place_area": 0.5907,
+          "share_of_tract_area": 0.0094
+        },
+        {
+          "tract_geoid": "08041004603",
+          "overlap_area_sqm": 6419231.2,
+          "share_of_place_area": 0.2271,
+          "share_of_tract_area": 0.017
+        },
+        {
+          "tract_geoid": "08041004601",
+          "overlap_area_sqm": 5150042.6,
+          "share_of_place_area": 0.1822,
+          "share_of_tract_area": 0.0278
+        }
+      ]
+    },
+    "0824290": {
+      "name": "El Moro",
+      "place_area_sqm": 28769150.2,
+      "tracts": [
+        {
+          "tract_geoid": "08071000800",
+          "overlap_area_sqm": 28769150.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.003
+        }
+      ]
+    },
+    "0825390": {
+      "name": "Evergreen",
+      "place_area_sqm": 30032095.2,
+      "tracts": [
+        {
+          "tract_geoid": "08059012030",
+          "overlap_area_sqm": 10521782.1,
+          "share_of_place_area": 0.3504,
+          "share_of_tract_area": 0.3063
+        },
+        {
+          "tract_geoid": "08059009846",
+          "overlap_area_sqm": 5877834.4,
+          "share_of_place_area": 0.1957,
+          "share_of_tract_area": 0.2134
+        },
+        {
+          "tract_geoid": "08059012026",
+          "overlap_area_sqm": 5251417.8,
+          "share_of_place_area": 0.1749,
+          "share_of_tract_area": 0.227
+        },
+        {
+          "tract_geoid": "08059009847",
+          "overlap_area_sqm": 5048461.8,
+          "share_of_place_area": 0.1681,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059009848",
+          "overlap_area_sqm": 3332599.1,
+          "share_of_place_area": 0.111,
+          "share_of_tract_area": 0.0971
+        }
+      ]
+    },
+    "0825550": {
+      "name": "Fairmount",
+      "place_area_sqm": 16244963.4,
+      "tracts": [
+        {
+          "tract_geoid": "08059009852",
+          "overlap_area_sqm": 8429199.3,
+          "share_of_place_area": 0.5189,
+          "share_of_tract_area": 0.878
+        },
+        {
+          "tract_geoid": "08059009842",
+          "overlap_area_sqm": 3426400.1,
+          "share_of_place_area": 0.2109,
+          "share_of_tract_area": 0.5072
+        },
+        {
+          "tract_geoid": "08059009854",
+          "overlap_area_sqm": 1807729.7,
+          "share_of_place_area": 0.1113,
+          "share_of_tract_area": 0.1188
+        },
+        {
+          "tract_geoid": "08059009851",
+          "overlap_area_sqm": 1588026.5,
+          "share_of_place_area": 0.0978,
+          "share_of_tract_area": 0.3995
+        },
+        {
+          "tract_geoid": "08059009853",
+          "overlap_area_sqm": 987831.4,
+          "share_of_place_area": 0.0608,
+          "share_of_tract_area": 0.282
+        },
+        {
+          "tract_geoid": "08059010308",
+          "overlap_area_sqm": 5776.4,
+          "share_of_place_area": 0.0004,
+          "share_of_tract_area": 0.0012
+        }
+      ]
+    },
+    "0827095": {
+      "name": "Florissant",
+      "place_area_sqm": 1334528.5,
+      "tracts": [
+        {
+          "tract_geoid": "08119010109",
+          "overlap_area_sqm": 955969.5,
+          "share_of_place_area": 0.7163,
+          "share_of_tract_area": 0.0099
+        },
+        {
+          "tract_geoid": "08119010112",
+          "overlap_area_sqm": 378559.0,
+          "share_of_place_area": 0.2837,
+          "share_of_tract_area": 0.004
+        }
+      ]
+    },
+    "0827175": {
+      "name": "Floyd Hill",
+      "place_area_sqm": 16285760.1,
+      "tracts": [
+        {
+          "tract_geoid": "08019014702",
+          "overlap_area_sqm": 16285760.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.065
+        }
+      ]
+    },
+    "0827535": {
+      "name": "Fort Garland",
+      "place_area_sqm": 972049.5,
+      "tracts": [
+        {
+          "tract_geoid": "08023972600",
+          "overlap_area_sqm": 972049.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0006
+        }
+      ]
+    },
+    "0828250": {
+      "name": "Franktown",
+      "place_area_sqm": 7654815.1,
+      "tracts": [
+        {
+          "tract_geoid": "08035013909",
+          "overlap_area_sqm": 4137658.9,
+          "share_of_place_area": 0.5405,
+          "share_of_tract_area": 0.065
+        },
+        {
+          "tract_geoid": "08035014602",
+          "overlap_area_sqm": 2472754.7,
+          "share_of_place_area": 0.323,
+          "share_of_tract_area": 0.0115
+        },
+        {
+          "tract_geoid": "08035014604",
+          "overlap_area_sqm": 1044401.5,
+          "share_of_place_area": 0.1364,
+          "share_of_tract_area": 0.016
+        }
+      ]
+    },
+    "0828800": {
+      "name": "Fruitvale",
+      "place_area_sqm": 7342549.7,
+      "tracts": [
+        {
+          "tract_geoid": "08077001703",
+          "overlap_area_sqm": 3674887.3,
+          "share_of_place_area": 0.5005,
+          "share_of_tract_area": 0.7248
+        },
+        {
+          "tract_geoid": "08077001102",
+          "overlap_area_sqm": 3629349.1,
+          "share_of_place_area": 0.4943,
+          "share_of_tract_area": 0.8063
+        },
+        {
+          "tract_geoid": "08077000802",
+          "overlap_area_sqm": 30294.1,
+          "share_of_place_area": 0.0041,
+          "share_of_tract_area": 0.0073
+        },
+        {
+          "tract_geoid": "08077001707",
+          "overlap_area_sqm": 5416.2,
+          "share_of_place_area": 0.0007,
+          "share_of_tract_area": 0.0011
+        },
+        {
+          "tract_geoid": "08077001103",
+          "overlap_area_sqm": 2603.0,
+          "share_of_place_area": 0.0004,
+          "share_of_tract_area": 0.0009
+        }
+      ]
+    },
+    "0828830": {
+      "name": "Fulford",
+      "place_area_sqm": 574986.5,
+      "tracts": [
+        {
+          "tract_geoid": "08037000404",
+          "overlap_area_sqm": 574986.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0015
+        }
+      ]
+    },
+    "0829240": {
+      "name": "Gardner",
+      "place_area_sqm": 6397697.1,
+      "tracts": [
+        {
+          "tract_geoid": "08055960901",
+          "overlap_area_sqm": 6397697.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0021
+        }
+      ]
+    },
+    "0829295": {
+      "name": "Garfield",
+      "place_area_sqm": 882463.3,
+      "tracts": [
+        {
+          "tract_geoid": "08015000300",
+          "overlap_area_sqm": 882463.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0008
+        }
+      ]
+    },
+    "0829625": {
+      "name": "Genesee",
+      "place_area_sqm": 17148484.9,
+      "tracts": [
+        {
+          "tract_geoid": "08059009845",
+          "overlap_area_sqm": 17148484.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.398
+        }
+      ]
+    },
+    "0829845": {
+      "name": "Gerrard",
+      "place_area_sqm": 3101774.8,
+      "tracts": [
+        {
+          "tract_geoid": "08105977001",
+          "overlap_area_sqm": 3101774.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0018
+        }
+      ]
+    },
+    "0830350": {
+      "name": "Glendale",
+      "place_area_sqm": 3248475.9,
+      "tracts": [
+        {
+          "tract_geoid": "08013013703",
+          "overlap_area_sqm": 2156018.6,
+          "share_of_place_area": 0.6637,
+          "share_of_tract_area": 0.0119
+        },
+        {
+          "tract_geoid": "08013013704",
+          "overlap_area_sqm": 1092457.3,
+          "share_of_place_area": 0.3363,
+          "share_of_tract_area": 0.0151
+        }
+      ]
+    },
+    "0830420": {
+      "name": "Gleneagle",
+      "place_area_sqm": 6041858.3,
+      "tracts": [
+        {
+          "tract_geoid": "08041007203",
+          "overlap_area_sqm": 4579727.0,
+          "share_of_place_area": 0.758,
+          "share_of_tract_area": 0.9028
+        },
+        {
+          "tract_geoid": "08041007204",
+          "overlap_area_sqm": 1462131.3,
+          "share_of_place_area": 0.242,
+          "share_of_tract_area": 0.1481
+        }
+      ]
+    },
+    "0830890": {
+      "name": "Goldfield",
+      "place_area_sqm": 364533.1,
+      "tracts": [
+        {
+          "tract_geoid": "08119010203",
+          "overlap_area_sqm": 364533.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0006
+        }
+      ]
+    },
+    "0830945": {
+      "name": "Gold Hill",
+      "place_area_sqm": 5371569.3,
+      "tracts": [
+        {
+          "tract_geoid": "08013013703",
+          "overlap_area_sqm": 5147638.2,
+          "share_of_place_area": 0.9583,
+          "share_of_tract_area": 0.0284
+        },
+        {
+          "tract_geoid": "08013013704",
+          "overlap_area_sqm": 223931.2,
+          "share_of_place_area": 0.0417,
+          "share_of_tract_area": 0.0031
+        }
+      ]
+    },
+    "0831935": {
+      "name": "Grand View Estates",
+      "place_area_sqm": 2632709.8,
+      "tracts": [
+        {
+          "tract_geoid": "08035014007",
+          "overlap_area_sqm": 2632709.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.2641
+        }
+      ]
+    },
+    "0833420": {
+      "name": "Guffey",
+      "place_area_sqm": 22501822.7,
+      "tracts": [
+        {
+          "tract_geoid": "08093000500",
+          "overlap_area_sqm": 22501822.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0107
+        }
+      ]
+    },
+    "0833502": {
+      "name": "Gunbarrel",
+      "place_area_sqm": 16319895.7,
+      "tracts": [
+        {
+          "tract_geoid": "08013012709",
+          "overlap_area_sqm": 9149416.9,
+          "share_of_place_area": 0.5606,
+          "share_of_tract_area": 0.9285
+        },
+        {
+          "tract_geoid": "08013012708",
+          "overlap_area_sqm": 3708872.5,
+          "share_of_place_area": 0.2273,
+          "share_of_tract_area": 0.6533
+        },
+        {
+          "tract_geoid": "08013012705",
+          "overlap_area_sqm": 1830395.1,
+          "share_of_place_area": 0.1122,
+          "share_of_tract_area": 0.4089
+        },
+        {
+          "tract_geoid": "08013013205",
+          "overlap_area_sqm": 1631211.2,
+          "share_of_place_area": 0.1,
+          "share_of_tract_area": 0.0715
+        }
+      ]
+    },
+    "0834630": {
+      "name": "Hartsel",
+      "place_area_sqm": 529804.7,
+      "tracts": [
+        {
+          "tract_geoid": "08093000400",
+          "overlap_area_sqm": 334634.1,
+          "share_of_place_area": 0.6316,
+          "share_of_tract_area": 0.0001
+        },
+        {
+          "tract_geoid": "08093000500",
+          "overlap_area_sqm": 195170.6,
+          "share_of_place_area": 0.3684,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0834685": {
+      "name": "Hasty",
+      "place_area_sqm": 7131809.6,
+      "tracts": [
+        {
+          "tract_geoid": "08011966702",
+          "overlap_area_sqm": 7131809.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0018
+        }
+      ]
+    },
+    "0835400": {
+      "name": "Heeney",
+      "place_area_sqm": 588498.2,
+      "tracts": [
+        {
+          "tract_geoid": "08117000103",
+          "overlap_area_sqm": 588498.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0009
+        }
+      ]
+    },
+    "0835860": {
+      "name": "Hidden Lake",
+      "place_area_sqm": 1619477.5,
+      "tracts": [
+        {
+          "tract_geoid": "08013013703",
+          "overlap_area_sqm": 1619477.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0089
+        }
+      ]
+    },
+    "0836410": {
+      "name": "Highlands Ranch",
+      "place_area_sqm": 62869668.4,
+      "tracts": [
+        {
+          "tract_geoid": "08035014131",
+          "overlap_area_sqm": 9688505.8,
+          "share_of_place_area": 0.1541,
+          "share_of_tract_area": 0.672
+        },
+        {
+          "tract_geoid": "08035014135",
+          "overlap_area_sqm": 4659024.4,
+          "share_of_place_area": 0.0741,
+          "share_of_tract_area": 0.0693
+        },
+        {
+          "tract_geoid": "08035014133",
+          "overlap_area_sqm": 4108319.7,
+          "share_of_place_area": 0.0653,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014139",
+          "overlap_area_sqm": 3747467.6,
+          "share_of_place_area": 0.0596,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014130",
+          "overlap_area_sqm": 3532035.3,
+          "share_of_place_area": 0.0562,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014132",
+          "overlap_area_sqm": 3306567.0,
+          "share_of_place_area": 0.0526,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014108",
+          "overlap_area_sqm": 3087987.1,
+          "share_of_place_area": 0.0491,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014107",
+          "overlap_area_sqm": 2744311.3,
+          "share_of_place_area": 0.0437,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014110",
+          "overlap_area_sqm": 2691576.1,
+          "share_of_place_area": 0.0428,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014144",
+          "overlap_area_sqm": 2682307.9,
+          "share_of_place_area": 0.0427,
+          "share_of_tract_area": 0.2723
+        },
+        {
+          "tract_geoid": "08035014124",
+          "overlap_area_sqm": 2623331.4,
+          "share_of_place_area": 0.0417,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014134",
+          "overlap_area_sqm": 2295752.2,
+          "share_of_place_area": 0.0365,
+          "share_of_tract_area": 0.7231
+        },
+        {
+          "tract_geoid": "08035014140",
+          "overlap_area_sqm": 2132047.0,
+          "share_of_place_area": 0.0339,
+          "share_of_tract_area": 0.5446
+        },
+        {
+          "tract_geoid": "08035014128",
+          "overlap_area_sqm": 2068565.6,
+          "share_of_place_area": 0.0329,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014138",
+          "overlap_area_sqm": 1883895.6,
+          "share_of_place_area": 0.03,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014112",
+          "overlap_area_sqm": 1695874.2,
+          "share_of_place_area": 0.027,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014145",
+          "overlap_area_sqm": 1678837.6,
+          "share_of_place_area": 0.0267,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014146",
+          "overlap_area_sqm": 1665862.3,
+          "share_of_place_area": 0.0265,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014143",
+          "overlap_area_sqm": 1652612.3,
+          "share_of_place_area": 0.0263,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014109",
+          "overlap_area_sqm": 1544343.5,
+          "share_of_place_area": 0.0246,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014129",
+          "overlap_area_sqm": 1380463.4,
+          "share_of_place_area": 0.022,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014113",
+          "overlap_area_sqm": 1263679.9,
+          "share_of_place_area": 0.0201,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014126",
+          "overlap_area_sqm": 714958.1,
+          "share_of_place_area": 0.0114,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014114",
+          "overlap_area_sqm": 21343.2,
+          "share_of_place_area": 0.0003,
+          "share_of_tract_area": 0.0068
+        }
+      ]
+    },
+    "0836940": {
+      "name": "Hoehne",
+      "place_area_sqm": 8039894.1,
+      "tracts": [
+        {
+          "tract_geoid": "08071000800",
+          "overlap_area_sqm": 8039894.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0008
+        }
+      ]
+    },
+    "0837220": {
+      "name": "Holly Hills",
+      "place_area_sqm": 1502119.3,
+      "tracts": [
+        {
+          "tract_geoid": "08005015100",
+          "overlap_area_sqm": 1502119.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 1.0
+        }
+      ]
+    },
+    "0837655": {
+      "name": "Howard",
+      "place_area_sqm": 43330775.5,
+      "tracts": [
+        {
+          "tract_geoid": "08043979001",
+          "overlap_area_sqm": 43330775.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0202
+        }
+      ]
+    },
+    "0838425": {
+      "name": "Idalia",
+      "place_area_sqm": 236821.9,
+      "tracts": [
+        {
+          "tract_geoid": "08125963100",
+          "overlap_area_sqm": 236821.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0838480": {
+      "name": "Idledale",
+      "place_area_sqm": 716800.9,
+      "tracts": [
+        {
+          "tract_geoid": "08059009845",
+          "overlap_area_sqm": 580718.8,
+          "share_of_place_area": 0.8102,
+          "share_of_tract_area": 0.0135
+        },
+        {
+          "tract_geoid": "08059012027",
+          "overlap_area_sqm": 136082.1,
+          "share_of_place_area": 0.1898,
+          "share_of_tract_area": 0.0025
+        }
+      ]
+    },
+    "0838810": {
+      "name": "Indian Hills",
+      "place_area_sqm": 14048379.6,
+      "tracts": [
+        {
+          "tract_geoid": "08059012027",
+          "overlap_area_sqm": 14048379.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.256
+        }
+      ]
+    },
+    "0838910": {
+      "name": "Inverness",
+      "place_area_sqm": 2923128.9,
+      "tracts": [
+        {
+          "tract_geoid": "08005006864",
+          "overlap_area_sqm": 2645303.4,
+          "share_of_place_area": 0.905,
+          "share_of_tract_area": 0.2192
+        },
+        {
+          "tract_geoid": "08005006815",
+          "overlap_area_sqm": 277825.5,
+          "share_of_place_area": 0.095,
+          "share_of_tract_area": 0.0866
+        }
+      ]
+    },
+    "0839250": {
+      "name": "Jansen",
+      "place_area_sqm": 3032239.3,
+      "tracts": [
+        {
+          "tract_geoid": "08071000100",
+          "overlap_area_sqm": 3032239.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0038
+        }
+      ]
+    },
+    "0839745": {
+      "name": "Joes",
+      "place_area_sqm": 1934123.0,
+      "tracts": [
+        {
+          "tract_geoid": "08125963200",
+          "overlap_area_sqm": 1934123.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0007
+        }
+      ]
+    },
+    "0839800": {
+      "name": "Johnson Village",
+      "place_area_sqm": 773595.4,
+      "tracts": [
+        {
+          "tract_geoid": "08015000402",
+          "overlap_area_sqm": 773595.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0017
+        }
+      ]
+    },
+    "0840377": {
+      "name": "Ken Caryl",
+      "place_area_sqm": 25525408.1,
+      "tracts": [
+        {
+          "tract_geoid": "08059012024",
+          "overlap_area_sqm": 8056886.0,
+          "share_of_place_area": 0.3156,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059012022",
+          "overlap_area_sqm": 5231768.1,
+          "share_of_place_area": 0.205,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059012057",
+          "overlap_area_sqm": 3841192.9,
+          "share_of_place_area": 0.1505,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059012023",
+          "overlap_area_sqm": 2117771.8,
+          "share_of_place_area": 0.083,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059012059",
+          "overlap_area_sqm": 1945093.5,
+          "share_of_place_area": 0.0762,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059012047",
+          "overlap_area_sqm": 1733713.5,
+          "share_of_place_area": 0.0679,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059012046",
+          "overlap_area_sqm": 1377903.3,
+          "share_of_place_area": 0.054,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08059012060",
+          "overlap_area_sqm": 1221079.0,
+          "share_of_place_area": 0.0478,
+          "share_of_tract_area": 1.0
+        }
+      ]
+    },
+    "0840550": {
+      "name": "Keystone",
+      "place_area_sqm": 107248680.6,
+      "tracts": [
+        {
+          "tract_geoid": "08117000201",
+          "overlap_area_sqm": 105182094.1,
+          "share_of_place_area": 0.9807,
+          "share_of_tract_area": 0.4481
+        },
+        {
+          "tract_geoid": "08117000203",
+          "overlap_area_sqm": 2066586.5,
+          "share_of_place_area": 0.0193,
+          "share_of_tract_area": 0.0525
+        }
+      ]
+    },
+    "0840900": {
+      "name": "Kirk",
+      "place_area_sqm": 403152.3,
+      "tracts": [
+        {
+          "tract_geoid": "08125963200",
+          "overlap_area_sqm": 403152.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0002
+        }
+      ]
+    },
+    "0841065": {
+      "name": "Kittredge",
+      "place_area_sqm": 4877023.3,
+      "tracts": [
+        {
+          "tract_geoid": "08059009846",
+          "overlap_area_sqm": 3384552.4,
+          "share_of_place_area": 0.694,
+          "share_of_tract_area": 0.1229
+        },
+        {
+          "tract_geoid": "08059012026",
+          "overlap_area_sqm": 1384762.6,
+          "share_of_place_area": 0.2839,
+          "share_of_tract_area": 0.0599
+        },
+        {
+          "tract_geoid": "08059012027",
+          "overlap_area_sqm": 107708.2,
+          "share_of_place_area": 0.0221,
+          "share_of_tract_area": 0.002
+        }
+      ]
+    },
+    "0842000": {
+      "name": "Laird",
+      "place_area_sqm": 389296.8,
+      "tracts": [
+        {
+          "tract_geoid": "08125963100",
+          "overlap_area_sqm": 389296.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0842165": {
+      "name": "La Junta Gardens",
+      "place_area_sqm": 1380854.3,
+      "tracts": [
+        {
+          "tract_geoid": "08089968500",
+          "overlap_area_sqm": 1380854.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0029
+        }
+      ]
+    },
+    "0843220": {
+      "name": "Laporte",
+      "place_area_sqm": 16107612.8,
+      "tracts": [
+        {
+          "tract_geoid": "08069001301",
+          "overlap_area_sqm": 15304554.5,
+          "share_of_place_area": 0.9501,
+          "share_of_tract_area": 0.2773
+        },
+        {
+          "tract_geoid": "08069002503",
+          "overlap_area_sqm": 800513.9,
+          "share_of_place_area": 0.0497,
+          "share_of_tract_area": 0.001
+        },
+        {
+          "tract_geoid": "08069002300",
+          "overlap_area_sqm": 2544.3,
+          "share_of_place_area": 0.0002,
+          "share_of_tract_area": 0.0
+        }
+      ]
+    },
+    "0844265": {
+      "name": "Lazear",
+      "place_area_sqm": 4152258.5,
+      "tracts": [
+        {
+          "tract_geoid": "08029965002",
+          "overlap_area_sqm": 4152258.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0101
+        }
+      ]
+    },
+    "0844270": {
+      "name": "Lazy Acres",
+      "place_area_sqm": 13692867.1,
+      "tracts": [
+        {
+          "tract_geoid": "08013013704",
+          "overlap_area_sqm": 13692867.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.1887
+        }
+      ]
+    },
+    "0844595": {
+      "name": "Lewis",
+      "place_area_sqm": 8070755.1,
+      "tracts": [
+        {
+          "tract_geoid": "08083969200",
+          "overlap_area_sqm": 8070755.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0062
+        }
+      ]
+    },
+    "0844695": {
+      "name": "Leyner",
+      "place_area_sqm": 611617.1,
+      "tracts": [
+        {
+          "tract_geoid": "08013012802",
+          "overlap_area_sqm": 611617.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0244
+        }
+      ]
+    },
+    "0845145": {
+      "name": "Lincoln Park",
+      "place_area_sqm": 9796791.2,
+      "tracts": [
+        {
+          "tract_geoid": "08043979100",
+          "overlap_area_sqm": 8265532.8,
+          "share_of_place_area": 0.8437,
+          "share_of_tract_area": 0.5107
+        },
+        {
+          "tract_geoid": "08043978800",
+          "overlap_area_sqm": 1243209.7,
+          "share_of_place_area": 0.1269,
+          "share_of_tract_area": 0.2419
+        },
+        {
+          "tract_geoid": "08043978400",
+          "overlap_area_sqm": 288048.7,
+          "share_of_place_area": 0.0294,
+          "share_of_tract_area": 0.0341
+        }
+      ]
+    },
+    "0845680": {
+      "name": "Loghill Village",
+      "place_area_sqm": 16102619.9,
+      "tracts": [
+        {
+          "tract_geoid": "08091967601",
+          "overlap_area_sqm": 16102619.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0399
+        }
+      ]
+    },
+    "0845750": {
+      "name": "Loma",
+      "place_area_sqm": 28255471.9,
+      "tracts": [
+        {
+          "tract_geoid": "08077001502",
+          "overlap_area_sqm": 28255471.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0281
+        }
+      ]
+    },
+    "0846410": {
+      "name": "Louviers",
+      "place_area_sqm": 4089986.4,
+      "tracts": [
+        {
+          "tract_geoid": "08035014135",
+          "overlap_area_sqm": 2160667.0,
+          "share_of_place_area": 0.5283,
+          "share_of_tract_area": 0.0321
+        },
+        {
+          "tract_geoid": "08035014205",
+          "overlap_area_sqm": 1929319.4,
+          "share_of_place_area": 0.4717,
+          "share_of_tract_area": 0.0262
+        }
+      ]
+    },
+    "0847015": {
+      "name": "Lynn",
+      "place_area_sqm": 1855492.1,
+      "tracts": [
+        {
+          "tract_geoid": "08071000100",
+          "overlap_area_sqm": 1651694.2,
+          "share_of_place_area": 0.8902,
+          "share_of_tract_area": 0.0021
+        },
+        {
+          "tract_geoid": "08071000800",
+          "overlap_area_sqm": 203797.9,
+          "share_of_place_area": 0.1098,
+          "share_of_tract_area": 0.0
+        }
+      ]
+    },
+    "0847235": {
+      "name": "McClave",
+      "place_area_sqm": 4956662.6,
+      "tracts": [
+        {
+          "tract_geoid": "08011966702",
+          "overlap_area_sqm": 4956662.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0012
+        }
+      ]
+    },
+    "0847345": {
+      "name": "McCoy",
+      "place_area_sqm": 761271.7,
+      "tracts": [
+        {
+          "tract_geoid": "08037000100",
+          "overlap_area_sqm": 761271.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0005
+        }
+      ]
+    },
+    "0848940": {
+      "name": "Marvel",
+      "place_area_sqm": 345111.2,
+      "tracts": [
+        {
+          "tract_geoid": "08067940400",
+          "overlap_area_sqm": 345111.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0849215": {
+      "name": "Matheson",
+      "place_area_sqm": 4441474.5,
+      "tracts": [
+        {
+          "tract_geoid": "08039961100",
+          "overlap_area_sqm": 4441474.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0015
+        }
+      ]
+    },
+    "0849325": {
+      "name": "Maybell",
+      "place_area_sqm": 1360083.2,
+      "tracts": [
+        {
+          "tract_geoid": "08081000600",
+          "overlap_area_sqm": 1360083.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0849490": {
+      "name": "Maysville",
+      "place_area_sqm": 32184924.0,
+      "tracts": [
+        {
+          "tract_geoid": "08015000300",
+          "overlap_area_sqm": 32184924.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0293
+        }
+      ]
+    },
+    "0850012": {
+      "name": "Meridian",
+      "place_area_sqm": 6631224.9,
+      "tracts": [
+        {
+          "tract_geoid": "08035014007",
+          "overlap_area_sqm": 4457463.0,
+          "share_of_place_area": 0.6722,
+          "share_of_tract_area": 0.4472
+        },
+        {
+          "tract_geoid": "08035014014",
+          "overlap_area_sqm": 1435372.2,
+          "share_of_place_area": 0.2165,
+          "share_of_tract_area": 0.1587
+        },
+        {
+          "tract_geoid": "08035014011",
+          "overlap_area_sqm": 738389.6,
+          "share_of_place_area": 0.1114,
+          "share_of_tract_area": 0.0246
+        }
+      ]
+    },
+    "0850026": {
+      "name": "Meridian Village",
+      "place_area_sqm": 1320301.3,
+      "tracts": [
+        {
+          "tract_geoid": "08035014008",
+          "overlap_area_sqm": 887370.4,
+          "share_of_place_area": 0.6721,
+          "share_of_tract_area": 0.1537
+        },
+        {
+          "tract_geoid": "08035014011",
+          "overlap_area_sqm": 432930.9,
+          "share_of_place_area": 0.3279,
+          "share_of_tract_area": 0.0144
+        }
+      ]
+    },
+    "0850380": {
+      "name": "Midland",
+      "place_area_sqm": 4501089.3,
+      "tracts": [
+        {
+          "tract_geoid": "08119010110",
+          "overlap_area_sqm": 4501089.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0187
+        }
+      ]
+    },
+    "0851975": {
+      "name": "Morgan Heights",
+      "place_area_sqm": 738590.9,
+      "tracts": [
+        {
+          "tract_geoid": "08087000100",
+          "overlap_area_sqm": 738590.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0006
+        }
+      ]
+    },
+    "0852210": {
+      "name": "Mountain Meadows",
+      "place_area_sqm": 4458423.8,
+      "tracts": [
+        {
+          "tract_geoid": "08013013706",
+          "overlap_area_sqm": 4458423.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.025
+        }
+      ]
+    },
+    "0852820": {
+      "name": "Mulford",
+      "place_area_sqm": 1731126.4,
+      "tracts": [
+        {
+          "tract_geoid": "08045951804",
+          "overlap_area_sqm": 1731126.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0183
+        }
+      ]
+    },
+    "0853010": {
+      "name": "Nathrop",
+      "place_area_sqm": 1872037.5,
+      "tracts": [
+        {
+          "tract_geoid": "08015000402",
+          "overlap_area_sqm": 1853850.7,
+          "share_of_place_area": 0.9903,
+          "share_of_tract_area": 0.004
+        },
+        {
+          "tract_geoid": "08015000403",
+          "overlap_area_sqm": 18186.7,
+          "share_of_place_area": 0.0097,
+          "share_of_tract_area": 0.0
+        }
+      ]
+    },
+    "0853780": {
+      "name": "Niwot",
+      "place_area_sqm": 10364664.7,
+      "tracts": [
+        {
+          "tract_geoid": "08013013205",
+          "overlap_area_sqm": 10364664.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.4541
+        }
+      ]
+    },
+    "0853875": {
+      "name": "No Name",
+      "place_area_sqm": 462956.7,
+      "tracts": [
+        {
+          "tract_geoid": "08045951600",
+          "overlap_area_sqm": 365208.4,
+          "share_of_place_area": 0.7889,
+          "share_of_tract_area": 0.0002
+        },
+        {
+          "tract_geoid": "08045951802",
+          "overlap_area_sqm": 97748.3,
+          "share_of_place_area": 0.2111,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0853945": {
+      "name": "Norrie",
+      "place_area_sqm": 487313.5,
+      "tracts": [
+        {
+          "tract_geoid": "08097000500",
+          "overlap_area_sqm": 487313.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0004
+        }
+      ]
+    },
+    "0854495": {
+      "name": "North La Junta",
+      "place_area_sqm": 3600065.8,
+      "tracts": [
+        {
+          "tract_geoid": "08089968500",
+          "overlap_area_sqm": 3600065.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0074
+        }
+      ]
+    },
+    "0854750": {
+      "name": "North Washington",
+      "place_area_sqm": 14041947.0,
+      "tracts": [
+        {
+          "tract_geoid": "08001015000",
+          "overlap_area_sqm": 8603293.3,
+          "share_of_place_area": 0.6127,
+          "share_of_tract_area": 0.5642
+        },
+        {
+          "tract_geoid": "08001009553",
+          "overlap_area_sqm": 5379374.5,
+          "share_of_place_area": 0.3831,
+          "share_of_tract_area": 0.6954
+        },
+        {
+          "tract_geoid": "08001008901",
+          "overlap_area_sqm": 59279.2,
+          "share_of_place_area": 0.0042,
+          "share_of_tract_area": 0.007
+        }
+      ]
+    },
+    "0855925": {
+      "name": "Orchard",
+      "place_area_sqm": 413686.6,
+      "tracts": [
+        {
+          "tract_geoid": "08087000100",
+          "overlap_area_sqm": 413686.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0856035": {
+      "name": "Orchard Mesa",
+      "place_area_sqm": 9661284.2,
+      "tracts": [
+        {
+          "tract_geoid": "08077001302",
+          "overlap_area_sqm": 5320632.0,
+          "share_of_place_area": 0.5507,
+          "share_of_tract_area": 0.7067
+        },
+        {
+          "tract_geoid": "08077001200",
+          "overlap_area_sqm": 1607124.0,
+          "share_of_place_area": 0.1663,
+          "share_of_tract_area": 0.0478
+        },
+        {
+          "tract_geoid": "08077001303",
+          "overlap_area_sqm": 1482493.8,
+          "share_of_place_area": 0.1534,
+          "share_of_tract_area": 0.2471
+        },
+        {
+          "tract_geoid": "08077001304",
+          "overlap_area_sqm": 1251034.4,
+          "share_of_place_area": 0.1295,
+          "share_of_tract_area": 0.3001
+        }
+      ]
+    },
+    "0856695": {
+      "name": "Padroni",
+      "place_area_sqm": 2100603.6,
+      "tracts": [
+        {
+          "tract_geoid": "08075966000",
+          "overlap_area_sqm": 2100603.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0015
+        }
+      ]
+    },
+    "0857445": {
+      "name": "Paragon Estates",
+      "place_area_sqm": 4357780.9,
+      "tracts": [
+        {
+          "tract_geoid": "08013012710",
+          "overlap_area_sqm": 4016517.9,
+          "share_of_place_area": 0.9217,
+          "share_of_tract_area": 0.1975
+        },
+        {
+          "tract_geoid": "08013013003",
+          "overlap_area_sqm": 341263.0,
+          "share_of_place_area": 0.0783,
+          "share_of_tract_area": 0.0277
+        }
+      ]
+    },
+    "0857465": {
+      "name": "Park Center",
+      "place_area_sqm": 17015153.2,
+      "tracts": [
+        {
+          "tract_geoid": "08043978500",
+          "overlap_area_sqm": 12311392.9,
+          "share_of_place_area": 0.7236,
+          "share_of_tract_area": 0.5361
+        },
+        {
+          "tract_geoid": "08043978300",
+          "overlap_area_sqm": 4703760.3,
+          "share_of_place_area": 0.2764,
+          "share_of_tract_area": 0.023
+        }
+      ]
+    },
+    "0857850": {
+      "name": "Parshall",
+      "place_area_sqm": 773929.2,
+      "tracts": [
+        {
+          "tract_geoid": "08049000100",
+          "overlap_area_sqm": 773929.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0858400": {
+      "name": "Penrose",
+      "place_area_sqm": 46184022.9,
+      "tracts": [
+        {
+          "tract_geoid": "08043978100",
+          "overlap_area_sqm": 46184022.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.1091
+        }
+      ]
+    },
+    "0858510": {
+      "name": "Peoria",
+      "place_area_sqm": 35729802.4,
+      "tracts": [
+        {
+          "tract_geoid": "08005007101",
+          "overlap_area_sqm": 35729802.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0296
+        }
+      ]
+    },
+    "0858592": {
+      "name": "Perry Park",
+      "place_area_sqm": 22222800.0,
+      "tracts": [
+        {
+          "tract_geoid": "08035014404",
+          "overlap_area_sqm": 22222800.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0933
+        }
+      ]
+    },
+    "0858675": {
+      "name": "Peyton",
+      "place_area_sqm": 5945690.9,
+      "tracts": [
+        {
+          "tract_geoid": "08041003911",
+          "overlap_area_sqm": 5887959.2,
+          "share_of_place_area": 0.9903,
+          "share_of_tract_area": 0.0167
+        },
+        {
+          "tract_geoid": "08041003910",
+          "overlap_area_sqm": 57731.6,
+          "share_of_place_area": 0.0097,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0858785": {
+      "name": "Phippsburg",
+      "place_area_sqm": 3071577.9,
+      "tracts": [
+        {
+          "tract_geoid": "08107000300",
+          "overlap_area_sqm": 2893304.2,
+          "share_of_place_area": 0.942,
+          "share_of_tract_area": 0.0022
+        },
+        {
+          "tract_geoid": "08107000800",
+          "overlap_area_sqm": 178273.7,
+          "share_of_place_area": 0.058,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0858960": {
+      "name": "Piedra",
+      "place_area_sqm": 30100867.5,
+      "tracts": [
+        {
+          "tract_geoid": "08053973100",
+          "overlap_area_sqm": 30100867.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0103
+        }
+      ]
+    },
+    "0859240": {
+      "name": "Pine Brook Hill",
+      "place_area_sqm": 7851208.0,
+      "tracts": [
+        {
+          "tract_geoid": "08013013704",
+          "overlap_area_sqm": 7851208.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.1082
+        }
+      ]
+    },
+    "0859520": {
+      "name": "Pine Valley",
+      "place_area_sqm": 2131172.8,
+      "tracts": [
+        {
+          "tract_geoid": "08019014701",
+          "overlap_area_sqm": 2131172.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0091
+        }
+      ]
+    },
+    "0859885": {
+      "name": "Placerville",
+      "place_area_sqm": 2002256.8,
+      "tracts": [
+        {
+          "tract_geoid": "08113968103",
+          "overlap_area_sqm": 2002256.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0024
+        }
+      ]
+    },
+    "0860655": {
+      "name": "Ponderosa Park",
+      "place_area_sqm": 37370068.2,
+      "tracts": [
+        {
+          "tract_geoid": "08039961206",
+          "overlap_area_sqm": 37370068.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.6975
+        }
+      ]
+    },
+    "0860765": {
+      "name": "Portland",
+      "place_area_sqm": 8297637.9,
+      "tracts": [
+        {
+          "tract_geoid": "08091967602",
+          "overlap_area_sqm": 8297637.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0083
+        }
+      ]
+    },
+    "0862220": {
+      "name": "Pueblo West",
+      "place_area_sqm": 128442826.0,
+      "tracts": [
+        {
+          "tract_geoid": "08101002922",
+          "overlap_area_sqm": 27520932.9,
+          "share_of_place_area": 0.2143,
+          "share_of_tract_area": 0.1627
+        },
+        {
+          "tract_geoid": "08101002921",
+          "overlap_area_sqm": 21530128.1,
+          "share_of_place_area": 0.1676,
+          "share_of_tract_area": 0.6107
+        },
+        {
+          "tract_geoid": "08101002923",
+          "overlap_area_sqm": 19859836.9,
+          "share_of_place_area": 0.1546,
+          "share_of_tract_area": 0.1226
+        },
+        {
+          "tract_geoid": "08101002906",
+          "overlap_area_sqm": 18762611.5,
+          "share_of_place_area": 0.1461,
+          "share_of_tract_area": 0.2598
+        },
+        {
+          "tract_geoid": "08101002911",
+          "overlap_area_sqm": 11258533.8,
+          "share_of_place_area": 0.0877,
+          "share_of_tract_area": 0.5771
+        },
+        {
+          "tract_geoid": "08101002917",
+          "overlap_area_sqm": 8650782.5,
+          "share_of_place_area": 0.0674,
+          "share_of_tract_area": 0.193
+        },
+        {
+          "tract_geoid": "08101002914",
+          "overlap_area_sqm": 5188756.9,
+          "share_of_place_area": 0.0404,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101002913",
+          "overlap_area_sqm": 4940183.0,
+          "share_of_place_area": 0.0385,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101002912",
+          "overlap_area_sqm": 3895330.2,
+          "share_of_place_area": 0.0303,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101002915",
+          "overlap_area_sqm": 2867909.4,
+          "share_of_place_area": 0.0223,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101002916",
+          "overlap_area_sqm": 2491137.5,
+          "share_of_place_area": 0.0194,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08101002920",
+          "overlap_area_sqm": 1476683.5,
+          "share_of_place_area": 0.0115,
+          "share_of_tract_area": 0.0645
+        }
+      ]
+    },
+    "0863320": {
+      "name": "Red Feather Lakes",
+      "place_area_sqm": 24969359.9,
+      "tracts": [
+        {
+          "tract_geoid": "08069002401",
+          "overlap_area_sqm": 23811897.9,
+          "share_of_place_area": 0.9536,
+          "share_of_tract_area": 0.023
+        },
+        {
+          "tract_geoid": "08069002404",
+          "overlap_area_sqm": 976319.2,
+          "share_of_place_area": 0.0391,
+          "share_of_tract_area": 0.0035
+        },
+        {
+          "tract_geoid": "08069002403",
+          "overlap_area_sqm": 181142.8,
+          "share_of_place_area": 0.0073,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0863375": {
+      "name": "Redlands",
+      "place_area_sqm": 34850832.2,
+      "tracts": [
+        {
+          "tract_geoid": "08077001402",
+          "overlap_area_sqm": 21818886.9,
+          "share_of_place_area": 0.6261,
+          "share_of_tract_area": 0.8718
+        },
+        {
+          "tract_geoid": "08077001404",
+          "overlap_area_sqm": 6425880.3,
+          "share_of_place_area": 0.1844,
+          "share_of_tract_area": 0.3962
+        },
+        {
+          "tract_geoid": "08077001403",
+          "overlap_area_sqm": 6148746.2,
+          "share_of_place_area": 0.1764,
+          "share_of_tract_area": 0.6302
+        },
+        {
+          "tract_geoid": "08077001900",
+          "overlap_area_sqm": 401267.0,
+          "share_of_place_area": 0.0115,
+          "share_of_tract_area": 0.0001
+        },
+        {
+          "tract_geoid": "08077000900",
+          "overlap_area_sqm": 56051.8,
+          "share_of_place_area": 0.0016,
+          "share_of_tract_area": 0.0031
+        }
+      ]
+    },
+    "0863650": {
+      "name": "Redstone",
+      "place_area_sqm": 1134142.6,
+      "tracts": [
+        {
+          "tract_geoid": "08097000102",
+          "overlap_area_sqm": 1134142.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0012
+        }
+      ]
+    },
+    "0863705": {
+      "name": "Redvale",
+      "place_area_sqm": 12137547.4,
+      "tracts": [
+        {
+          "tract_geoid": "08085966100",
+          "overlap_area_sqm": 12137547.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0042
+        }
+      ]
+    },
+    "0864870": {
+      "name": "Rock Creek Park",
+      "place_area_sqm": 687328.7,
+      "tracts": [
+        {
+          "tract_geoid": "08041003306",
+          "overlap_area_sqm": 687328.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0041
+        }
+      ]
+    },
+    "0865685": {
+      "name": "Rollinsville",
+      "place_area_sqm": 3654997.0,
+      "tracts": [
+        {
+          "tract_geoid": "08047013801",
+          "overlap_area_sqm": 3654997.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0174
+        }
+      ]
+    },
+    "0866197": {
+      "name": "Roxborough Park",
+      "place_area_sqm": 24219235.8,
+      "tracts": [
+        {
+          "tract_geoid": "08035014203",
+          "overlap_area_sqm": 16719026.3,
+          "share_of_place_area": 0.6903,
+          "share_of_tract_area": 0.8897
+        },
+        {
+          "tract_geoid": "08035014205",
+          "overlap_area_sqm": 5923052.9,
+          "share_of_place_area": 0.2446,
+          "share_of_tract_area": 0.0806
+        },
+        {
+          "tract_geoid": "08035014208",
+          "overlap_area_sqm": 764498.6,
+          "share_of_place_area": 0.0316,
+          "share_of_tract_area": 0.0274
+        },
+        {
+          "tract_geoid": "08035014207",
+          "overlap_area_sqm": 655021.3,
+          "share_of_place_area": 0.027,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035014300",
+          "overlap_area_sqm": 157636.5,
+          "share_of_place_area": 0.0065,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0866995": {
+      "name": "Saddle Ridge",
+      "place_area_sqm": 450303.2,
+      "tracts": [
+        {
+          "tract_geoid": "08087000100",
+          "overlap_area_sqm": 450303.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0867040": {
+      "name": "St. Ann Highlands",
+      "place_area_sqm": 3598850.4,
+      "tracts": [
+        {
+          "tract_geoid": "08013013706",
+          "overlap_area_sqm": 3598850.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0202
+        }
+      ]
+    },
+    "0867445": {
+      "name": "Salt Creek",
+      "place_area_sqm": 1119108.6,
+      "tracts": [
+        {
+          "tract_geoid": "08101003103",
+          "overlap_area_sqm": 1119108.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.084
+        }
+      ]
+    },
+    "0867500": {
+      "name": "San Acacio",
+      "place_area_sqm": 3252656.4,
+      "tracts": [
+        {
+          "tract_geoid": "08023972700",
+          "overlap_area_sqm": 3252656.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.002
+        }
+      ]
+    },
+    "0868875": {
+      "name": "Sedalia",
+      "place_area_sqm": 3528355.8,
+      "tracts": [
+        {
+          "tract_geoid": "08035014135",
+          "overlap_area_sqm": 3528355.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0524
+        }
+      ]
+    },
+    "0868985": {
+      "name": "Segundo",
+      "place_area_sqm": 1795929.9,
+      "tracts": [
+        {
+          "tract_geoid": "08071000300",
+          "overlap_area_sqm": 1795929.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0011
+        }
+      ]
+    },
+    "0869110": {
+      "name": "Seven Hills",
+      "place_area_sqm": 1266089.5,
+      "tracts": [
+        {
+          "tract_geoid": "08013013704",
+          "overlap_area_sqm": 1266089.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0174
+        }
+      ]
+    },
+    "0869480": {
+      "name": "Shaw Heights",
+      "place_area_sqm": 1752718.9,
+      "tracts": [
+        {
+          "tract_geoid": "08001009407",
+          "overlap_area_sqm": 1012558.4,
+          "share_of_place_area": 0.5777,
+          "share_of_tract_area": 0.5341
+        },
+        {
+          "tract_geoid": "08001009401",
+          "overlap_area_sqm": 740160.6,
+          "share_of_place_area": 0.4223,
+          "share_of_tract_area": 0.2108
+        }
+      ]
+    },
+    "0869810": {
+      "name": "Sherrelwood",
+      "place_area_sqm": 6374550.7,
+      "tracts": [
+        {
+          "tract_geoid": "08001009306",
+          "overlap_area_sqm": 1660358.9,
+          "share_of_place_area": 0.2605,
+          "share_of_tract_area": 0.9677
+        },
+        {
+          "tract_geoid": "08001009310",
+          "overlap_area_sqm": 1491050.1,
+          "share_of_place_area": 0.2339,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001009308",
+          "overlap_area_sqm": 1481836.9,
+          "share_of_place_area": 0.2325,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08001009307",
+          "overlap_area_sqm": 997341.7,
+          "share_of_place_area": 0.1565,
+          "share_of_tract_area": 0.559
+        },
+        {
+          "tract_geoid": "08001009309",
+          "overlap_area_sqm": 698751.8,
+          "share_of_place_area": 0.1096,
+          "share_of_tract_area": 0.5461
+        },
+        {
+          "tract_geoid": "08001009320",
+          "overlap_area_sqm": 45211.3,
+          "share_of_place_area": 0.0071,
+          "share_of_tract_area": 0.0236
+        }
+      ]
+    },
+    "0870112": {
+      "name": "Sierra Ridge",
+      "place_area_sqm": 1310961.2,
+      "tracts": [
+        {
+          "tract_geoid": "08035014008",
+          "overlap_area_sqm": 1310961.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.2271
+        }
+      ]
+    },
+    "0871625": {
+      "name": "Smeltertown",
+      "place_area_sqm": 377903.6,
+      "tracts": [
+        {
+          "tract_geoid": "08015000100",
+          "overlap_area_sqm": 377903.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0959
+        }
+      ]
+    },
+    "0871790": {
+      "name": "Snyder",
+      "place_area_sqm": 916781.2,
+      "tracts": [
+        {
+          "tract_geoid": "08087000100",
+          "overlap_area_sqm": 916781.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0007
+        }
+      ]
+    },
+    "0871845": {
+      "name": "Somerset",
+      "place_area_sqm": 492053.8,
+      "tracts": [
+        {
+          "tract_geoid": "08051963900",
+          "overlap_area_sqm": 492053.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0001
+        }
+      ]
+    },
+    "0873925": {
+      "name": "Stepping Stone",
+      "place_area_sqm": 1955773.8,
+      "tracts": [
+        {
+          "tract_geoid": "08035014011",
+          "overlap_area_sqm": 1953625.0,
+          "share_of_place_area": 0.9989,
+          "share_of_tract_area": 0.065
+        },
+        {
+          "tract_geoid": "08035014006",
+          "overlap_area_sqm": 2148.8,
+          "share_of_place_area": 0.0011,
+          "share_of_tract_area": 0.0004
+        }
+      ]
+    },
+    "0873943": {
+      "name": "Sterling Ranch",
+      "place_area_sqm": 14308497.6,
+      "tracts": [
+        {
+          "tract_geoid": "08035014205",
+          "overlap_area_sqm": 8674087.2,
+          "share_of_place_area": 0.6062,
+          "share_of_tract_area": 0.118
+        },
+        {
+          "tract_geoid": "08035014208",
+          "overlap_area_sqm": 5634410.4,
+          "share_of_place_area": 0.3938,
+          "share_of_tract_area": 0.2016
+        }
+      ]
+    },
+    "0874080": {
+      "name": "Stonegate",
+      "place_area_sqm": 4766100.7,
+      "tracts": [
+        {
+          "tract_geoid": "08035014005",
+          "overlap_area_sqm": 2415996.1,
+          "share_of_place_area": 0.5069,
+          "share_of_tract_area": 0.9276
+        },
+        {
+          "tract_geoid": "08035014008",
+          "overlap_area_sqm": 2192136.6,
+          "share_of_place_area": 0.4599,
+          "share_of_tract_area": 0.3797
+        },
+        {
+          "tract_geoid": "08035014007",
+          "overlap_area_sqm": 157968.0,
+          "share_of_place_area": 0.0331,
+          "share_of_tract_area": 0.0158
+        }
+      ]
+    },
+    "0874275": {
+      "name": "Stonewall Gap",
+      "place_area_sqm": 4969693.0,
+      "tracts": [
+        {
+          "tract_geoid": "08071000300",
+          "overlap_area_sqm": 4969693.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.003
+        }
+      ]
+    },
+    "0874375": {
+      "name": "Strasburg",
+      "place_area_sqm": 53901301.2,
+      "tracts": [
+        {
+          "tract_geoid": "08005007101",
+          "overlap_area_sqm": 48787667.4,
+          "share_of_place_area": 0.9051,
+          "share_of_tract_area": 0.0404
+        },
+        {
+          "tract_geoid": "08001008402",
+          "overlap_area_sqm": 5113633.8,
+          "share_of_place_area": 0.0949,
+          "share_of_tract_area": 0.0029
+        }
+      ]
+    },
+    "0874430": {
+      "name": "Stratmoor",
+      "place_area_sqm": 6902055.1,
+      "tracts": [
+        {
+          "tract_geoid": "08041004501",
+          "overlap_area_sqm": 4281597.6,
+          "share_of_place_area": 0.6203,
+          "share_of_tract_area": 0.3149
+        },
+        {
+          "tract_geoid": "08041003303",
+          "overlap_area_sqm": 2395232.7,
+          "share_of_place_area": 0.347,
+          "share_of_tract_area": 0.4512
+        },
+        {
+          "tract_geoid": "08041003307",
+          "overlap_area_sqm": 113233.7,
+          "share_of_place_area": 0.0164,
+          "share_of_tract_area": 0.0499
+        },
+        {
+          "tract_geoid": "08041003308",
+          "overlap_area_sqm": 111991.0,
+          "share_of_place_area": 0.0162,
+          "share_of_tract_area": 0.067
+        }
+      ]
+    },
+    "0874980": {
+      "name": "Sugarloaf",
+      "place_area_sqm": 5636133.4,
+      "tracts": [
+        {
+          "tract_geoid": "08013013706",
+          "overlap_area_sqm": 5636133.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0316
+        }
+      ]
+    },
+    "0875585": {
+      "name": "Sunshine",
+      "place_area_sqm": 4477573.7,
+      "tracts": [
+        {
+          "tract_geoid": "08013013704",
+          "overlap_area_sqm": 4477573.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0617
+        }
+      ]
+    },
+    "0876190": {
+      "name": "Tabernash",
+      "place_area_sqm": 12507094.6,
+      "tracts": [
+        {
+          "tract_geoid": "08049000205",
+          "overlap_area_sqm": 12507094.6,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0433
+        }
+      ]
+    },
+    "0876325": {
+      "name": "Tall Timber",
+      "place_area_sqm": 1485464.9,
+      "tracts": [
+        {
+          "tract_geoid": "08013013706",
+          "overlap_area_sqm": 1485464.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0083
+        }
+      ]
+    },
+    "0877235": {
+      "name": "The Pinery",
+      "place_area_sqm": 26955942.0,
+      "tracts": [
+        {
+          "tract_geoid": "08035014013",
+          "overlap_area_sqm": 10311593.4,
+          "share_of_place_area": 0.3825,
+          "share_of_tract_area": 0.2494
+        },
+        {
+          "tract_geoid": "08035013914",
+          "overlap_area_sqm": 6807340.7,
+          "share_of_place_area": 0.2525,
+          "share_of_tract_area": 0.3153
+        },
+        {
+          "tract_geoid": "08035013915",
+          "overlap_area_sqm": 6195590.9,
+          "share_of_place_area": 0.2298,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08035013909",
+          "overlap_area_sqm": 3641417.1,
+          "share_of_place_area": 0.1351,
+          "share_of_tract_area": 0.0572
+        }
+      ]
+    },
+    "0877757": {
+      "name": "Todd Creek",
+      "place_area_sqm": 26031432.5,
+      "tracts": [
+        {
+          "tract_geoid": "08001008560",
+          "overlap_area_sqm": 12052848.5,
+          "share_of_place_area": 0.463,
+          "share_of_tract_area": 0.9892
+        },
+        {
+          "tract_geoid": "08001008561",
+          "overlap_area_sqm": 10818589.4,
+          "share_of_place_area": 0.4156,
+          "share_of_tract_area": 0.4783
+        },
+        {
+          "tract_geoid": "08001008540",
+          "overlap_area_sqm": 3113465.5,
+          "share_of_place_area": 0.1196,
+          "share_of_tract_area": 0.1964
+        },
+        {
+          "tract_geoid": "08001008606",
+          "overlap_area_sqm": 46529.1,
+          "share_of_place_area": 0.0018,
+          "share_of_tract_area": 0.0116
+        }
+      ]
+    },
+    "0878280": {
+      "name": "Towaoc",
+      "place_area_sqm": 9301890.6,
+      "tracts": [
+        {
+          "tract_geoid": "08083941100",
+          "overlap_area_sqm": 8493442.4,
+          "share_of_place_area": 0.9131,
+          "share_of_tract_area": 0.0047
+        },
+        {
+          "tract_geoid": "08083969600",
+          "overlap_area_sqm": 808448.3,
+          "share_of_place_area": 0.0869,
+          "share_of_tract_area": 0.0025
+        }
+      ]
+    },
+    "0878335": {
+      "name": "Towner",
+      "place_area_sqm": 96596.2,
+      "tracts": [
+        {
+          "tract_geoid": "08061960100",
+          "overlap_area_sqm": 96596.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0
+        }
+      ]
+    },
+    "0878345": {
+      "name": "Trail Side",
+      "place_area_sqm": 1854895.4,
+      "tracts": [
+        {
+          "tract_geoid": "08087000600",
+          "overlap_area_sqm": 1854895.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0063
+        }
+      ]
+    },
+    "0879100": {
+      "name": "Twin Lakes",
+      "place_area_sqm": 4293090.0,
+      "tracts": [
+        {
+          "tract_geoid": "08001009553",
+          "overlap_area_sqm": 2356435.4,
+          "share_of_place_area": 0.5489,
+          "share_of_tract_area": 0.3046
+        },
+        {
+          "tract_geoid": "08001009502",
+          "overlap_area_sqm": 1500696.7,
+          "share_of_place_area": 0.3496,
+          "share_of_tract_area": 0.3443
+        },
+        {
+          "tract_geoid": "08001009501",
+          "overlap_area_sqm": 435957.9,
+          "share_of_place_area": 0.1015,
+          "share_of_tract_area": 0.4012
+        }
+      ]
+    },
+    "0879105": {
+      "name": "Twin Lakes",
+      "place_area_sqm": 17435138.4,
+      "tracts": [
+        {
+          "tract_geoid": "08065961900",
+          "overlap_area_sqm": 17435138.4,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0183
+        }
+      ]
+    },
+    "0879785": {
+      "name": "Upper Bear Creek",
+      "place_area_sqm": 9811562.7,
+      "tracts": [
+        {
+          "tract_geoid": "08019014701",
+          "overlap_area_sqm": 9811562.7,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0419
+        }
+      ]
+    },
+    "0879800": {
+      "name": "Upper Witter Gulch",
+      "place_area_sqm": 2356438.9,
+      "tracts": [
+        {
+          "tract_geoid": "08019014701",
+          "overlap_area_sqm": 2356438.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0101
+        }
+      ]
+    },
+    "0880095": {
+      "name": "Valdez",
+      "place_area_sqm": 4162523.9,
+      "tracts": [
+        {
+          "tract_geoid": "08071000300",
+          "overlap_area_sqm": 4162523.9,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0025
+        }
+      ]
+    },
+    "0880370": {
+      "name": "Valmont",
+      "place_area_sqm": 882353.5,
+      "tracts": [
+        {
+          "tract_geoid": "08013012707",
+          "overlap_area_sqm": 882353.5,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0254
+        }
+      ]
+    },
+    "0880755": {
+      "name": "Vernon",
+      "place_area_sqm": 2935034.1,
+      "tracts": [
+        {
+          "tract_geoid": "08125963100",
+          "overlap_area_sqm": 2935034.1,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0008
+        }
+      ]
+    },
+    "0881305": {
+      "name": "Vineland",
+      "place_area_sqm": 1465928.8,
+      "tracts": [
+        {
+          "tract_geoid": "08101003200",
+          "overlap_area_sqm": 1465928.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0007
+        }
+      ]
+    },
+    "0882900": {
+      "name": "Watkins",
+      "place_area_sqm": 64044227.4,
+      "tracts": [
+        {
+          "tract_geoid": "08005007103",
+          "overlap_area_sqm": 52661785.7,
+          "share_of_place_area": 0.8223,
+          "share_of_tract_area": 0.3177
+        },
+        {
+          "tract_geoid": "08005007111",
+          "overlap_area_sqm": 9051114.5,
+          "share_of_place_area": 0.1413,
+          "share_of_tract_area": 0.1433
+        },
+        {
+          "tract_geoid": "08001008354",
+          "overlap_area_sqm": 2331327.3,
+          "share_of_place_area": 0.0364,
+          "share_of_tract_area": 0.0215
+        }
+      ]
+    },
+    "0883120": {
+      "name": "Welby",
+      "place_area_sqm": 9806115.0,
+      "tracts": [
+        {
+          "tract_geoid": "08001015000",
+          "overlap_area_sqm": 5533462.9,
+          "share_of_place_area": 0.5643,
+          "share_of_tract_area": 0.3629
+        },
+        {
+          "tract_geoid": "08001009003",
+          "overlap_area_sqm": 1531934.9,
+          "share_of_place_area": 0.1562,
+          "share_of_tract_area": 0.8806
+        },
+        {
+          "tract_geoid": "08001009001",
+          "overlap_area_sqm": 1399341.1,
+          "share_of_place_area": 0.1427,
+          "share_of_tract_area": 0.6639
+        },
+        {
+          "tract_geoid": "08001009004",
+          "overlap_area_sqm": 1341376.1,
+          "share_of_place_area": 0.1368,
+          "share_of_tract_area": 1.0
+        }
+      ]
+    },
+    "0883175": {
+      "name": "Weldona",
+      "place_area_sqm": 405636.2,
+      "tracts": [
+        {
+          "tract_geoid": "08087000100",
+          "overlap_area_sqm": 405636.2,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0003
+        }
+      ]
+    },
+    "0883500": {
+      "name": "Westcreek",
+      "place_area_sqm": 3255394.3,
+      "tracts": [
+        {
+          "tract_geoid": "08035014300",
+          "overlap_area_sqm": 3255394.3,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0066
+        }
+      ]
+    },
+    "0884000": {
+      "name": "Weston",
+      "place_area_sqm": 8019493.8,
+      "tracts": [
+        {
+          "tract_geoid": "08071000300",
+          "overlap_area_sqm": 8019493.8,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0049
+        }
+      ]
+    },
+    "0885760": {
+      "name": "Wolcott",
+      "place_area_sqm": 996213.0,
+      "tracts": [
+        {
+          "tract_geoid": "08037000404",
+          "overlap_area_sqm": 600729.6,
+          "share_of_place_area": 0.603,
+          "share_of_tract_area": 0.0016
+        },
+        {
+          "tract_geoid": "08037000401",
+          "overlap_area_sqm": 395483.4,
+          "share_of_place_area": 0.397,
+          "share_of_tract_area": 0.0021
+        }
+      ]
+    },
+    "0886117": {
+      "name": "Woodmoor",
+      "place_area_sqm": 15912020.1,
+      "tracts": [
+        {
+          "tract_geoid": "08041007401",
+          "overlap_area_sqm": 12187631.8,
+          "share_of_place_area": 0.7659,
+          "share_of_tract_area": 1.0
+        },
+        {
+          "tract_geoid": "08041007302",
+          "overlap_area_sqm": 3091552.7,
+          "share_of_place_area": 0.1943,
+          "share_of_tract_area": 0.1319
+        },
+        {
+          "tract_geoid": "08041007402",
+          "overlap_area_sqm": 632835.6,
+          "share_of_place_area": 0.0398,
+          "share_of_tract_area": 0.033
+        }
+      ]
+    },
+    "0886200": {
+      "name": "Woody Creek",
+      "place_area_sqm": 1586410.0,
+      "tracts": [
+        {
+          "tract_geoid": "08097000500",
+          "overlap_area_sqm": 1586410.0,
+          "share_of_place_area": 1.0,
+          "share_of_tract_area": 0.0013
+        }
+      ]
+    }
+  }
+}

--- a/js/cross-county-disclosure.js
+++ b/js/cross-county-disclosure.js
@@ -38,7 +38,10 @@
 (function () {
   'use strict';
 
-  var DATA_URL = 'data/hna/cross-county-places.json';
+  // Path is relative to the data/ root. DataService.baseData() prepends
+  // 'data/' (so passing 'data/hna/foo.json' would produce 'data/data/hna/...');
+  // the standalone fallback below also prepends 'data/'.
+  var DATA_PATH = 'hna/cross-county-places.json';
   var _cache = null;
   var _byCounty = null;
   var _loadPromise = null;
@@ -47,9 +50,9 @@
     // Honor DataService.baseData if present (handles GitHub Pages prefix);
     // otherwise fall back to the relative URL.
     if (typeof window !== 'undefined' && window.DataService && typeof window.DataService.baseData === 'function') {
-      return window.DataService.baseData(DATA_URL);
+      return window.DataService.baseData(DATA_PATH);
     }
-    return DATA_URL;
+    return 'data/' + DATA_PATH;
   }
 
   function init() {

--- a/js/place-chas-lookup.js
+++ b/js/place-chas-lookup.js
@@ -32,40 +32,71 @@
 (function () {
   'use strict';
 
-  var DATA_URL = 'data/hna/place-chas.json';
+  var DATA_URL  = 'data/hna/place-chas.json';
+  // PR-C4: phantom→canonical alias map. The geography-registry has 29
+  // duplicate places where each appears with both a Census-canonical
+  // GEOID (matches TIGER) and a non-Census "phantom" GEOID. Existing
+  // dropdowns + lookups reference the phantom GEOIDs, so we resolve
+  // them to canonical when looking up place-CHAS data. Otherwise major
+  // CO cities (Pueblo, Englewood, Parker, Commerce City, Durango, Vail,
+  // Steamboat Springs, etc.) silently fall back to county-CHAS even
+  // though TIGER place-CHAS exists for them.
+  var ALIAS_URL = 'data/hna/place-phantom-aliases.json';
   var _cache = null;
+  var _aliases = null;
   var _loadPromise = null;
 
-  function _resolveDataUrl() {
+  function _resolveDataUrl(rel) {
     if (typeof window !== 'undefined' && window.DataService
         && typeof window.DataService.baseData === 'function') {
-      return window.DataService.baseData(DATA_URL);
+      return window.DataService.baseData(rel);
     }
-    return DATA_URL;
+    return rel;
+  }
+
+  function _fetchJson(url) {
+    if (typeof window !== 'undefined' && window.DataService && window.DataService.getJSON) {
+      return window.DataService.getJSON(url);
+    }
+    return fetch(url).then(function (r) { return r.json(); });
   }
 
   function init() {
-    if (_cache) return Promise.resolve(_cache);
+    if (_cache && _aliases) return Promise.resolve(_cache);
     if (_loadPromise) return _loadPromise;
-    var url = _resolveDataUrl();
-    var loader = (typeof window !== 'undefined' && window.DataService && window.DataService.getJSON)
-      ? window.DataService.getJSON(url)
-      : fetch(url).then(function (r) { return r.json(); });
-    _loadPromise = loader.then(function (doc) {
-      _cache = doc || { places: {}, meta: {} };
-      return _cache;
-    }).catch(function (err) {
-      console.warn('[place-chas-lookup] Could not load ' + url + ':', err);
-      _cache = { places: {}, meta: {} };
+    _loadPromise = Promise.all([
+      _fetchJson(_resolveDataUrl(DATA_URL)).catch(function (err) {
+        console.warn('[place-chas-lookup] Could not load ' + DATA_URL + ':', err);
+        return { places: {}, meta: {} };
+      }),
+      _fetchJson(_resolveDataUrl(ALIAS_URL)).catch(function () {
+        // Aliases optional — soft-fail (older deployments may not have it yet)
+        return { aliases: {}, meta: {} };
+      }),
+    ]).then(function (results) {
+      _cache = results[0] || { places: {}, meta: {} };
+      _aliases = (results[1] && results[1].aliases) || {};
       return _cache;
     });
     return _loadPromise;
   }
 
-  /** Lookup place CHAS by 7-digit place geoid. Returns null if not present. */
+  /** Resolve a phantom geoid to its canonical TIGER GEOID. Returns the
+   *  input geoid unchanged if no alias entry exists. Always returns a
+   *  zero-padded 7-digit string. */
+  function resolveAlias(geoid) {
+    var key = String(geoid).padStart(7, '0');
+    if (!_aliases) return key;
+    return _aliases[key] || key;
+  }
+
+  /** Lookup place CHAS by 7-digit place geoid. Phantom geoids are
+   *  resolved to their canonical TIGER twin before lookup. Returns null
+   *  if not present. */
   function lookup(geoid) {
     if (!_cache) return null;
-    return (_cache.places || {})[String(geoid).padStart(7, '0')] || null;
+    var resolved = resolveAlias(geoid);
+    return (_cache.places || {})[resolved] || null;
   }
 
   /** Given a place geoid + a county CHAS record (from data/market/chas_co.json),
@@ -130,6 +161,7 @@
   window.PlaceChas = {
     init: init,
     lookup: lookup,
+    resolveAlias: resolveAlias,
     compareToCounty: compareToCounty,
     formatComparison: formatComparison,
   };

--- a/js/place-chas-lookup.js
+++ b/js/place-chas-lookup.js
@@ -32,7 +32,11 @@
 (function () {
   'use strict';
 
-  var DATA_URL  = 'data/hna/place-chas.json';
+  // Paths are relative to the data/ root. DataService.baseData() prepends
+  // 'data/' (so passing 'data/hna/foo.json' would produce 'data/data/hna/...'
+  // — the bug surfaced in the 2026-05-10 site-audit run); the standalone
+  // fallback below also prepends 'data/'.
+  var DATA_PATH  = 'hna/place-chas.json';
   // PR-C4: phantom→canonical alias map. The geography-registry has 29
   // duplicate places where each appears with both a Census-canonical
   // GEOID (matches TIGER) and a non-Census "phantom" GEOID. Existing
@@ -41,17 +45,18 @@
   // CO cities (Pueblo, Englewood, Parker, Commerce City, Durango, Vail,
   // Steamboat Springs, etc.) silently fall back to county-CHAS even
   // though TIGER place-CHAS exists for them.
-  var ALIAS_URL = 'data/hna/place-phantom-aliases.json';
+  var ALIAS_PATH = 'hna/place-phantom-aliases.json';
   var _cache = null;
   var _aliases = null;
   var _loadPromise = null;
 
   function _resolveDataUrl(rel) {
+    // rel is relative to the data/ root (e.g. 'hna/place-chas.json').
     if (typeof window !== 'undefined' && window.DataService
         && typeof window.DataService.baseData === 'function') {
       return window.DataService.baseData(rel);
     }
-    return rel;
+    return 'data/' + rel;
   }
 
   function _fetchJson(url) {
@@ -65,11 +70,11 @@
     if (_cache && _aliases) return Promise.resolve(_cache);
     if (_loadPromise) return _loadPromise;
     _loadPromise = Promise.all([
-      _fetchJson(_resolveDataUrl(DATA_URL)).catch(function (err) {
-        console.warn('[place-chas-lookup] Could not load ' + DATA_URL + ':', err);
+      _fetchJson(_resolveDataUrl(DATA_PATH)).catch(function (err) {
+        console.warn('[place-chas-lookup] Could not load ' + DATA_PATH + ':', err);
         return { places: {}, meta: {} };
       }),
-      _fetchJson(_resolveDataUrl(ALIAS_URL)).catch(function () {
+      _fetchJson(_resolveDataUrl(ALIAS_PATH)).catch(function () {
         // Aliases optional — soft-fail (older deployments may not have it yet)
         return { aliases: {}, meta: {} };
       }),

--- a/scripts/hna/build_place_phantom_aliases.py
+++ b/scripts/hna/build_place_phantom_aliases.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""scripts/hna/build_place_phantom_aliases.py
+
+Identify duplicate place entries in geography-registry.json and produce
+a phantom→canonical alias map.
+
+Background
+----------
+The geography-registry.json contains 29 duplicate places — each real
+Colorado place (Pueblo, Englewood, Parker, Commerce City, Steamboat
+Springs, Vail, Telluride, Durango, Glenwood Springs, etc.) appears
+TWICE: once with the canonical Census GEOID (matching TIGER 2024) and
+once with a non-Census "phantom" GEOID. The phantoms are referenced by
+existing UI dropdowns + derived lookups, so we can't simply delete
+them without coordinated downstream cleanup.
+
+Effect of duplicates without aliasing
+-------------------------------------
+When a user picks "Pueblo (city)" in the picker, the dropdown sends
+the phantom GEOID 0855745. PlaceChas.lookup('0855745') returns null
+(place-chas.json only contains the canonical 0862000), so the chart
+falls back to county-CHAS rather than tract-aggregated place-CHAS.
+Methodologically inconsistent — Aurora gets place-level data, Pueblo
+doesn't.
+
+Output
+------
+    data/hna/place-phantom-aliases.json::
+
+    {
+      "meta": {
+        "generated_at": "...",
+        "count_aliases": 29,
+        "method": "Match duplicate (name, containingCounty) in registry; identify canonical = the GEOID that exists in TIGER 2024 PLACE shapefile."
+      },
+      "aliases": {
+        "0855745": "0862000",   # Pueblo phantom → canonical
+        "0822465": "0824785",   # Englewood phantom → canonical
+        ...
+      }
+    }
+
+Use cases
+---------
+1. js/place-chas-lookup.js consumes this alias map so lookups against
+   either the phantom or canonical GEOID resolve to place-CHAS data.
+2. Future registry-cleanup PR can use this list to safely remove
+   phantom entries (or merge them with their canonical twins).
+
+Usage
+-----
+    python3 scripts/hna/build_place_phantom_aliases.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+
+REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..'))
+GEO_REGISTRY = os.path.join(REPO_ROOT, 'data', 'hna', 'geography-registry.json')
+TIGER_PLACE_SHP = os.path.join(REPO_ROOT, '.cache', 'tiger2024', 'place', 'tl_2024_08_place.shp')
+OUT_FILE = os.path.join(REPO_ROOT, 'data', 'hna', 'place-phantom-aliases.json')
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+
+def load_tiger_geoids() -> set[str]:
+    """Return the set of GEOIDs present in the TIGER 2024 PLACE shapefile."""
+    if not os.path.exists(TIGER_PLACE_SHP):
+        raise FileNotFoundError(
+            f'TIGER PLACE shapefile not found at {TIGER_PLACE_SHP}. '
+            f'Run scripts/hna/build_place_tract_membership.py first '
+            f'(or manually download tl_2024_08_place.zip into .cache/).'
+        )
+    import shapefile
+    sf = shapefile.Reader(TIGER_PLACE_SHP)
+    fields = [f[0] for f in sf.fields[1:]]
+    geoid_idx = fields.index('GEOID')
+    return {str(rec[geoid_idx]) for rec in sf.iterRecords()}
+
+
+def main() -> int:
+    with open(GEO_REGISTRY, 'r', encoding='utf-8') as f:
+        reg = json.load(f)
+
+    # Find duplicate (name, containingCounty) entries
+    by_key = defaultdict(list)
+    for g in reg.get('geographies', []):
+        if g.get('type') in ('place', 'cdp'):
+            key = (g.get('name'), g.get('containingCounty'))
+            by_key[key].append(g.get('geoid'))
+    duplicates = {k: v for k, v in by_key.items() if len(v) >= 2}
+    print(f'Found {len(duplicates)} duplicate (name, county) pairs in registry')
+
+    # Determine canonical GEOID for each (the one in TIGER PLACE shapefile)
+    tiger_geoids = load_tiger_geoids()
+    print(f'TIGER 2024 PLACE shapefile has {len(tiger_geoids)} CO place GEOIDs')
+
+    aliases: dict[str, str] = {}
+    unresolvable: list[tuple] = []
+    for (name, county), geoids in sorted(duplicates.items()):
+        in_tiger = [g for g in geoids if g in tiger_geoids]
+        not_in_tiger = [g for g in geoids if g not in tiger_geoids]
+        if len(in_tiger) == 1 and not_in_tiger:
+            # Standard case: one canonical (in TIGER) + phantom(s) (not in TIGER)
+            canonical = in_tiger[0]
+            for phantom in not_in_tiger:
+                aliases[phantom] = canonical
+        else:
+            unresolvable.append((name, county, geoids, in_tiger, not_in_tiger))
+
+    print(f'Built {len(aliases)} phantom → canonical aliases')
+    if unresolvable:
+        print(f'⚠ {len(unresolvable)} pairs could not be resolved cleanly:')
+        for u in unresolvable[:5]:
+            print(f'  {u}')
+
+    payload = {
+        'meta': {
+            'generated_at': utc_now(),
+            'count_duplicates': len(duplicates),
+            'count_aliases': len(aliases),
+            'count_unresolvable': len(unresolvable),
+            'tiger_vintage': 2024,
+            'method': (
+                'Match duplicate (name, containingCounty) pairs in '
+                'geography-registry.json; identify canonical = the GEOID '
+                'that exists in TIGER 2024 PLACE shapefile.'
+            ),
+            'note': (
+                'Consumers should resolve phantom geoids via this map '
+                'before looking up place data. See js/place-chas-lookup.js '
+                'for an example consumer.'
+            ),
+        },
+        'aliases': aliases,
+    }
+    with open(OUT_FILE, 'w', encoding='utf-8') as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+    print(f'\n✓ Wrote {OUT_FILE} ({os.path.getsize(OUT_FILE):,} bytes)')
+
+    print('\nSample aliases:')
+    for k, v in list(sorted(aliases.items()))[:10]:
+        # Find name for context
+        name = next((g.get('name') for g in reg['geographies'] if g.get('geoid') == k), '?')
+        print(f'  {k} ({name[:30]:<30}) → {v}')
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/test/place-chas-lookup.test.js
+++ b/test/place-chas-lookup.test.js
@@ -35,10 +35,38 @@ console.log('\n[test] place-chas-lookup.js exposes expected API');
 const helperSrc = readRel('js/place-chas-lookup.js');
 assert(/window\.PlaceChas\s*=\s*\{/.test(helperSrc),
   'attaches PlaceChas to window');
-['init', 'lookup', 'compareToCounty', 'formatComparison'].forEach((fn) => {
+['init', 'lookup', 'resolveAlias', 'compareToCounty', 'formatComparison'].forEach((fn) => {
   assert(new RegExp('function\\s+' + fn + '\\s*\\(').test(helperSrc),
     'defines ' + fn + '() function');
 });
+
+console.log('\n[test] PR-C4: phantom→canonical alias support');
+assert(/place-phantom-aliases\.json/.test(helperSrc),
+  'place-chas-lookup.js loads place-phantom-aliases.json');
+assert(/_aliases/.test(helperSrc),
+  'place-chas-lookup.js maintains an aliases cache');
+assert(/resolveAlias\(geoid\)/.test(helperSrc),
+  'lookup() resolves geoid through alias map');
+
+const aliasData = JSON.parse(readRel('data/hna/place-phantom-aliases.json'));
+assert(aliasData.aliases && Object.keys(aliasData.aliases).length >= 27,
+  'place-phantom-aliases.json has ≥27 aliases (29 expected, allow ±2)');
+const placeChas = JSON.parse(readRel('data/hna/place-chas.json'));
+const phantomCoverage = Object.entries(aliasData.aliases).filter(([p, c]) => placeChas.places[c] != null).length;
+assert(phantomCoverage === Object.keys(aliasData.aliases).length,
+  'every alias canonical resolves to a place-CHAS record');
+
+// Spot-check Pueblo
+const PUEBLO_PHANTOM = '0855745', PUEBLO_CANONICAL = '0862000';
+assert(aliasData.aliases[PUEBLO_PHANTOM] === PUEBLO_CANONICAL,
+  'Pueblo phantom 0855745 → canonical 0862000');
+assert(placeChas.places[PUEBLO_CANONICAL] != null,
+  'Pueblo canonical has place-CHAS data');
+const pueblo = placeChas.places[PUEBLO_CANONICAL];
+assert(pueblo.tract_count > 30,
+  'Pueblo (TIGER) aggregates from many tracts (>30)');
+assert(pueblo.summary.total_renter_hh > 10000,
+  'Pueblo has >10K renter HHs (large city sanity check)');
 
 console.log('\n[test] place-chas.json data file structure');
 const data = JSON.parse(readRel('data/hna/place-chas.json'));

--- a/test/place-chas-lookup.test.js
+++ b/test/place-chas-lookup.test.js
@@ -48,6 +48,16 @@ assert(/_aliases/.test(helperSrc),
 assert(/resolveAlias\(geoid\)/.test(helperSrc),
   'lookup() resolves geoid through alias map');
 
+console.log('\n[test] DataService.baseData() path convention (regression: 2026-05-10 audit)');
+// DataService.baseData() prepends 'data/' to its input. Passing a path
+// that already starts with 'data/' produces 'data/data/...' and 404s.
+// This test catches that bug class so we never re-introduce it.
+assert(!/baseData\s*\(\s*['"]data\//.test(helperSrc),
+  'no path passed to baseData() starts with "data/" (otherwise produces "data/data/...")');
+const ccSrc = readRel('js/cross-county-disclosure.js');
+assert(!/baseData\s*\(\s*['"]data\//.test(ccSrc),
+  'cross-county-disclosure.js path passed to baseData() does not start with "data/"');
+
 const aliasData = JSON.parse(readRel('data/hna/place-phantom-aliases.json'));
 assert(aliasData.aliases && Object.keys(aliasData.aliases).length >= 27,
   'place-phantom-aliases.json has ≥27 aliases (29 expected, allow ±2)');

--- a/tests/test_place_phantom_aliases.py
+++ b/tests/test_place_phantom_aliases.py
@@ -1,0 +1,159 @@
+"""tests/test_place_phantom_aliases.py
+
+Tests for the phantom→canonical alias map produced by
+scripts/hna/build_place_phantom_aliases.py (PR-C4).
+
+Background
+----------
+The geography-registry.json contains 29 duplicate places — Pueblo,
+Englewood, Parker, Commerce City, Steamboat Springs, Vail, Telluride,
+Durango, etc. — where each appears with TWO geoids: a Census-canonical
+GEOID (matches TIGER 2024 PLACE shapefile) and a non-Census "phantom"
+GEOID. UI dropdowns reference the phantom GEOIDs, so without the alias
+map, looking up place-CHAS for these places returns null and the
+dashboard falls back to county-level data — methodologically
+inconsistent with the rest of the place-CHAS pipeline.
+
+This test suite verifies:
+  - The alias map covers all 29 known duplicates
+  - Every alias canonical GEOID exists in place-CHAS
+  - Every phantom GEOID, when resolved, looks up valid place data
+  - Coverage stat: ≥99% of registry place geoids resolve to place-CHAS
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+ALIAS_FILE       = REPO_ROOT / 'data' / 'hna' / 'place-phantom-aliases.json'
+PLACE_CHAS_FILE  = REPO_ROOT / 'data' / 'hna' / 'place-chas.json'
+GEO_REGISTRY     = REPO_ROOT / 'data' / 'hna' / 'geography-registry.json'
+
+
+@pytest.fixture(scope='module')
+def alias_doc():
+    if not ALIAS_FILE.exists():
+        pytest.skip('Alias file not present')
+    with open(ALIAS_FILE) as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope='module')
+def place_chas_doc():
+    if not PLACE_CHAS_FILE.exists():
+        pytest.skip('Place-CHAS file not present')
+    with open(PLACE_CHAS_FILE) as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope='module')
+def registry():
+    with open(GEO_REGISTRY) as f:
+        return json.load(f)
+
+
+class TestAliasMap:
+
+    def test_alias_count_matches_known_duplicates(self, alias_doc):
+        n = alias_doc['meta']['count_aliases']
+        # As of 2026-05-09 there are exactly 29 duplicate (name, county) pairs.
+        # Allow ±2 if registry maintenance adds/removes a duplicate.
+        assert 27 <= n <= 31, (
+            f'Expected ~29 phantom-canonical aliases, found {n}. '
+            f'Either registry duplicates were partially cleaned up '
+            f'(good — see future PR) or new duplicates were introduced (bad).'
+        )
+
+    def test_no_unresolvable_duplicates(self, alias_doc):
+        """Every duplicate (name, county) pair should resolve to exactly one
+        canonical (in TIGER) + one or more phantoms (not in TIGER).
+        Unresolvable duplicates (e.g. neither geoid in TIGER, or both in TIGER)
+        indicate a registry data quality problem requiring manual triage."""
+        unresolvable = alias_doc['meta'].get('count_unresolvable', 0)
+        assert unresolvable == 0, (
+            f'{unresolvable} duplicate place pairs could not be resolved '
+            f'to a canonical TIGER GEOID — needs manual triage.'
+        )
+
+    def test_phantoms_and_canonicals_are_7digit_co(self, alias_doc):
+        for phantom, canonical in alias_doc['aliases'].items():
+            assert len(phantom) == 7, f'phantom {phantom} not 7-digit'
+            assert phantom.startswith('08'), f'phantom {phantom} not CO'
+            assert len(canonical) == 7, f'canonical {canonical} not 7-digit'
+            assert canonical.startswith('08'), f'canonical {canonical} not CO'
+
+    def test_every_canonical_exists_in_place_chas(self, alias_doc, place_chas_doc):
+        """The whole point of aliasing is that the canonical GEOID's place-
+        CHAS data IS available. If any canonical has no place-CHAS, the
+        alias resolution still produces a missing lookup."""
+        missing = []
+        for phantom, canonical in alias_doc['aliases'].items():
+            if canonical not in place_chas_doc['places']:
+                missing.append((phantom, canonical))
+        assert not missing, (
+            f'{len(missing)} aliased canonicals not in place-CHAS '
+            f'(showing first 3): {missing[:3]}'
+        )
+
+    def test_no_self_aliases(self, alias_doc):
+        """Phantom should never alias to itself."""
+        for phantom, canonical in alias_doc['aliases'].items():
+            assert phantom != canonical, (
+                f'Self-alias detected: {phantom} → {phantom}'
+            )
+
+
+class TestKnownLargeCitiesCovered:
+    """Spot-check that the major LIHTC markets I know are duplicates
+    are now covered by aliases. If any of these break, the user-visible
+    impact is huge — these are CO's most-analyzed places."""
+
+    EXPECTED_PHANTOM_TO_CANONICAL = {
+        '0855745': '0862000',   # Pueblo
+        '0822465': '0824785',   # Englewood
+        '0852290': '0857630',   # Parker
+        '0875140': '0816495',   # Commerce City
+        '0823680': '0822035',   # Durango
+        '0873220': '0873825',   # Steamboat Springs
+        '0882870': '0880040',   # Vail
+        '0877580': '0876795',   # Telluride
+        '0830475': '0830780',   # Glenwood Springs
+    }
+
+    def test_known_phantom_aliases_present(self, alias_doc):
+        for phantom, expected_canon in self.EXPECTED_PHANTOM_TO_CANONICAL.items():
+            actual = alias_doc['aliases'].get(phantom)
+            assert actual == expected_canon, (
+                f'Phantom {phantom} should alias to {expected_canon}, '
+                f'got {actual}'
+            )
+
+
+class TestCoverageImproved:
+    """Before PR-C4: ~445 of 513 registry places have place-CHAS via
+    direct lookup (~87%). After PR-C4: 445 + 29 aliased = 474 of 513
+    (~92%). Verify the post-alias coverage is meaningfully higher."""
+
+    def test_post_alias_coverage_ge_90pct(self, alias_doc, place_chas_doc, registry):
+        reg_geoids = {
+            g['geoid'] for g in registry['geographies']
+            if g.get('type') in ('place', 'cdp')
+        }
+        place_chas_geoids = set(place_chas_doc['places'].keys())
+        aliases = alias_doc['aliases']
+
+        def resolve(g):
+            return aliases.get(g, g)
+
+        covered = sum(
+            1 for g in reg_geoids if resolve(g) in place_chas_geoids
+        )
+        coverage = covered / len(reg_geoids)
+        assert coverage >= 0.90, (
+            f'Post-alias coverage {coverage*100:.1f}% < 90% '
+            f'(covered {covered}/{len(reg_geoids)}). '
+            f'Either alias map is incomplete or registry has new gaps.'
+        )


### PR DESCRIPTION
## Summary

Answers user's question: "do all places now use underlying tract-level CHAS data?"

**Before this PR**: ~445 of 513 registry places (87%) had tract-aggregated CHAS via TIGER. The other 68 fell back to county-level CHAS — methodologically inconsistent.

**Root cause**: 29 of 513 places appear as duplicates in `geography-registry.json` — each real Colorado place (Pueblo, Englewood, Parker, Commerce City, Steamboat Springs, Vail, Telluride, Durango, Glenwood Springs, Vail, Eagle, Montrose, Sterling, Trinidad, Fort Morgan, Lamar, ...) shows up with **TWO geoids**: a Census-canonical GEOID matching TIGER, AND a non-Census "phantom" GEOID. UI dropdowns reference the phantom; place-CHAS keys are canonical → lookup returns null → falls back to county.

**After this PR**: 474 of 513 (92%) — including all 29 major cities that previously fell back. Resolved by adding a phantom→canonical alias map applied inside `PlaceChas.lookup()`.

## Concrete impact

| Place | Phantom GEOID | Canonical GEOID | Before | After |
|---|---|---|---|---|
| Pueblo | 0855745 | 0862000 | County fallback | 47.8% renter cb30 (44 tracts) |
| Englewood | 0822465 | 0824785 | County fallback | TIGER place-level |
| Parker | 0852290 | 0857630 | County fallback | TIGER place-level |
| Commerce City | 0875140 | 0816495 | County fallback | TIGER place-level |
| Durango | 0823680 | 0822035 | County fallback | TIGER place-level |
| Steamboat Springs | 0873220 | 0873825 | County fallback | TIGER place-level |
| ...23 more | | | County fallback | TIGER place-level |

## Files

| File | Purpose |
|---|---|
| `scripts/hna/build_place_phantom_aliases.py` | One-shot: matches duplicate `(name, containingCounty)` pairs in registry, identifies canonical via TIGER PLACE shapefile presence |
| `data/hna/place-phantom-aliases.json` | 29 phantom→canonical aliases |
| `js/place-chas-lookup.js` | Adds `resolveAlias()` helper + automatic resolution inside `lookup()`. Soft-fails if alias file missing. |
| `tests/test_place_phantom_aliases.py` | 7 plausibility tests |
| `test/place-chas-lookup.test.js` | +10 JS assertions for alias data + API + Pueblo spot-check |

## Bonus: restored `place-tract-membership.json`

PR #790's squash-merge inadvertently removed `data/hna/place-tract-membership.json` (a known stacked-squash-PR pitfall — file existed in PR-C2's squash but not in PR-C3's). This PR restores it from PR #789's commit so future `build_place_chas.py` runs work without manual regeneration.

## Why aliasing rather than removing the phantoms?

Phantom GEOIDs are referenced from at least 4 places (`js/hna/hna-utils.js`, `data/hna/geo-config.json`, `data/hna/derived/place_county_lookup.json`, `data/dda-colorado.json`). Removing them outright would break dropdowns + cached lookups. Aliasing is the surgical, low-risk fix. A future PR can do the proper registry cleanup once we've audited every reference.

## Test plan

- [x] `python3 scripts/hna/build_place_phantom_aliases.py` → 29 aliases, 0 unresolvable
- [x] `python3 -m pytest tests/test_place_phantom_aliases.py tests/test_place_chas.py` → 19/19 pass
- [x] `node test/place-chas-lookup.test.js` → 48/48 pass
- [x] Manual: `PlaceChas.lookup('0855745')` (phantom Pueblo) returns 44-tract aggregated record with 47.8% renter cb30 share

🤖 Generated with [Claude Code](https://claude.com/claude-code)