### PR TITLE
feat(hmda+pma): mortgage credit access + cross-county disclosure on Deal Calc + PMA

### DIFF
--- a/deal-calculator.html
+++ b/deal-calculator.html
@@ -48,6 +48,10 @@
   <!-- Cross-county disclosure helper (loads BEFORE deal-calculator so it's
        ready when the county selector first renders the disclosure note) -->
   <script defer src="js/cross-county-disclosure.js"></script>
+  <!-- HMDA mortgage-credit-access lookup (per-county denial rate, mean loan
+       amount, multifamily originations) — loaded BEFORE deal-calculator so
+       _renderHmdaContext() can find window.HmdaLookup. Data shipped in PR #786. -->
+  <script defer src="js/hmda-lookup.js"></script>
   <!-- Deferred: deal calculator (renders into #dealCalcMount) -->
   <script defer src="js/deal-calculator.js"></script>
   <script defer src="js/deal-comparison.js"></script>

--- a/js/deal-calculator.js
+++ b/js/deal-calculator.js
@@ -446,6 +446,16 @@
                  background:#eff6ff;border:1px solid #93c5fd;color:#1e3a8a;
                  font-size:var(--tiny);line-height:1.5;">
         </div>
+        <!-- HMDA mortgage credit access context for the chosen county.
+             Per-county denial rate, mean loan size, and multifamily
+             originations from CFPB HMDA Data Browser data shipped in
+             PR #786. Populated by js/hmda-lookup.js when the user
+             selects a county. -->
+        <div id="dc-hmda-context" hidden role="status" aria-live="polite"
+          style="margin:0 0 var(--sp2);padding:0.5rem 0.75rem;border-radius:var(--radius);
+                 background:rgba(34,197,94,0.06);border:1px solid rgba(34,197,94,0.4);color:var(--text);
+                 font-size:var(--tiny);line-height:1.5;">
+        </div>
       </fieldset>
 
       <!-- Debt / Mortgage Inputs -->
@@ -2033,6 +2043,47 @@
     });
   }
 
+  /**
+   * Render the HMDA mortgage-credit-access context for the chosen county.
+   * Surfaces 1-line callout: origination count, denial rate, mean loan size,
+   * multifamily originations, with state benchmarks. Sourced from CFPB HMDA
+   * Data Browser data (PR #786, refreshed monthly).
+   *
+   * Why this matters: tightening credit (rising denial rate, falling
+   * originations) precedes slowdown in multifamily starts and reduced LIHTC
+   * bond demand. Per-county denial-rate variance also exposes underserved
+   * markets that LIHTC deals can target.
+   *
+   * Idempotent: calling with no fips hides the banner.
+   */
+  function _renderHmdaContext(fips) {
+    var noteEl = document.getElementById('dc-hmda-context');
+    if (!noteEl) return;
+    if (!fips || !window.HmdaLookup) {
+      noteEl.hidden = true;
+      noteEl.innerHTML = '';
+      return;
+    }
+    window.HmdaLookup.init().then(function () {
+      var comparison = window.HmdaLookup.getCountyVsState(fips);
+      if (!comparison) {
+        noteEl.hidden = true;
+        noteEl.innerHTML = '';
+        return;
+      }
+      // Try to use the county selector's display name for a nicer label
+      var countySel = document.getElementById('dc-county-select');
+      var countyName = null;
+      if (countySel && countySel.selectedOptions && countySel.selectedOptions[0]) {
+        var label = countySel.selectedOptions[0].textContent || '';
+        // Strip "(08001)" suffix if present
+        countyName = label.replace(/\s*\([^)]*\)\s*$/, '').trim();
+      }
+      noteEl.innerHTML = window.HmdaLookup.formatCountyCallout(comparison, countyName);
+      noteEl.hidden = false;
+    });
+  }
+
   function _runDealPredictor(fips) {
     var predictor = window.LIHTCDealPredictor;
     if (!predictor) return;
@@ -2186,6 +2237,7 @@
         _renderAmiGapInfo(fips);
         _runDealPredictor(fips);
         _renderCrossCountyDisclosure(fips);
+        _renderHmdaContext(fips);
         recalculate();
       });
 

--- a/js/hmda-lookup.js
+++ b/js/hmda-lookup.js
@@ -1,0 +1,190 @@
+/**
+ * hmda-lookup.js
+ *
+ * Browser-side helper for the CFPB HMDA (Home Mortgage Disclosure Act)
+ * data shipped in PR #786. Two source files are bundled:
+ *
+ *   data/hmda/co-state-trends.json       — statewide YoY (3.6 KB)
+ *   data/hmda/co-county-aggregates.json  — 64 CO counties × 7 years (~250 KB)
+ *
+ * The Deal Calculator and PMA simulator use this helper to surface
+ * mortgage-credit-access context next to a deal: per-county origination
+ * count, denial rate, mean loan amount, multifamily originations
+ * (LIHTC-adjacent subset), plus a state benchmark.
+ *
+ * Why mortgage credit access matters for LIHTC analysts
+ * -----------------------------------------------------
+ *   - Rising county denial rate / falling origination count signals
+ *     tightening credit, which precedes slowdown in multifamily starts
+ *     and reduced demand for LIHTC bond execution.
+ *   - Multifamily-only subset (HMDA dwelling_categories=Multifamily:
+ *     Site-Built) is directly LIHTC-adjacent — quick read on the
+ *     county's competitive lending environment.
+ *   - Per-county denial-rate variance (Adams 27.8% vs Denver 20.1% in
+ *     2024) exposes underserved markets that LIHTC deals can target.
+ *
+ * Public API
+ * ----------
+ *   window.HmdaLookup.init() — fetch + cache both data files
+ *   window.HmdaLookup.getCounty(countyFips) — return latest-year metrics
+ *     for a county, or null if not found
+ *   window.HmdaLookup.getCountyTrend(countyFips)
+ *     — return all years for a county, sorted ascending, or [] if not found
+ *   window.HmdaLookup.getStateLatest() — latest-year statewide metrics
+ *   window.HmdaLookup.getCountyVsState(countyFips)
+ *     — { county, state, delta: { denial_rate_pp, mean_loan_pct,
+ *         originations_pct } } — useful for "this county is X
+ *         relative to the CO statewide picture" callouts.
+ */
+(function () {
+  'use strict';
+
+  // Paths are RELATIVE to data/. DataService.baseData() prepends 'data/';
+  // the standalone fallback below also prepends 'data/'. Passing a path
+  // that already starts with 'data/' produces 'data/data/...' (the bug
+  // fixed in PR #791). Keep these without the prefix.
+  var COUNTY_PATH = 'hmda/co-county-aggregates.json';
+  var STATE_PATH  = 'hmda/co-state-trends.json';
+  var _county = null;
+  var _state = null;
+  var _loadPromise = null;
+
+  function _resolveDataUrl(rel) {
+    if (typeof window !== 'undefined' && window.DataService
+        && typeof window.DataService.baseData === 'function') {
+      return window.DataService.baseData(rel);
+    }
+    return 'data/' + rel;
+  }
+
+  function _fetchJson(url) {
+    if (typeof window !== 'undefined' && window.DataService && window.DataService.getJSON) {
+      return window.DataService.getJSON(url);
+    }
+    return fetch(url).then(function (r) { return r.json(); });
+  }
+
+  function init() {
+    if (_county && _state) return Promise.resolve({ county: _county, state: _state });
+    if (_loadPromise) return _loadPromise;
+    _loadPromise = Promise.all([
+      _fetchJson(_resolveDataUrl(COUNTY_PATH)).catch(function (err) {
+        console.warn('[hmda-lookup] Could not load ' + COUNTY_PATH + ':', err);
+        return { counties: {}, meta: {} };
+      }),
+      _fetchJson(_resolveDataUrl(STATE_PATH)).catch(function (err) {
+        console.warn('[hmda-lookup] Could not load ' + STATE_PATH + ':', err);
+        return { years: {}, meta: {} };
+      }),
+    ]).then(function (results) {
+      _county = results[0];
+      _state = results[1];
+      return { county: _county, state: _state };
+    });
+    return _loadPromise;
+  }
+
+  function _latestYear(yearMap) {
+    if (!yearMap) return null;
+    var years = Object.keys(yearMap).sort();
+    return years.length ? years[years.length - 1] : null;
+  }
+
+  /** Return latest-year HMDA metrics for a county FIPS (5-digit), or null. */
+  function getCounty(countyFips) {
+    if (!_county) return null;
+    var fips = String(countyFips).padStart(5, '0');
+    var rec = (_county.counties || {})[fips];
+    if (!rec) return null;
+    var latest = _latestYear(rec.years);
+    if (!latest) return null;
+    return Object.assign({ year: latest, fips: fips, name: rec.name }, rec.years[latest]);
+  }
+
+  /** Return [{year, originations, denial_rate, ...}] across all years for
+   *  a county, sorted by year ascending. */
+  function getCountyTrend(countyFips) {
+    if (!_county) return [];
+    var fips = String(countyFips).padStart(5, '0');
+    var rec = (_county.counties || {})[fips];
+    if (!rec) return [];
+    var out = [];
+    Object.keys(rec.years).sort().forEach(function (year) {
+      out.push(Object.assign({ year: year }, rec.years[year]));
+    });
+    return out;
+  }
+
+  /** Return latest-year statewide metrics, or null. */
+  function getStateLatest() {
+    if (!_state) return null;
+    var latest = _latestYear(_state.years);
+    if (!latest) return null;
+    return Object.assign({ year: latest, state: 'CO' }, _state.years[latest]);
+  }
+
+  /** Return a county-vs-state comparison for the latest year:
+   *    {
+   *      county: {originations, denial_rate, mean_loan_amount_usd, ...},
+   *      state:  {...},
+   *      delta:  {
+   *        denial_rate_pp:    (county - state) * 100,
+   *        mean_loan_pct:     (county - state) / state * 100,
+   *        originations_pct:  per-100K-pop normalized? — for now skip.
+   *      }
+   *    }
+   *  Returns null if either side is unavailable. */
+  function getCountyVsState(countyFips) {
+    var county = getCounty(countyFips);
+    var state = getStateLatest();
+    if (!county || !state) return null;
+    return {
+      county: county,
+      state: state,
+      delta: {
+        denial_rate_pp: ((county.denial_rate || 0) - (state.denial_rate || 0)) * 100,
+        mean_loan_pct: state.mean_loan_amount_usd
+          ? ((county.mean_loan_amount_usd - state.mean_loan_amount_usd) / state.mean_loan_amount_usd) * 100
+          : 0,
+        multifamily_share_county: county.originations
+          ? (county.multifamily.originations / county.originations) * 100
+          : 0,
+        multifamily_share_state: state.originations
+          ? (state.multifamily.originations / state.originations) * 100
+          : 0,
+      },
+    };
+  }
+
+  /** Build ready-to-render HTML for a county HMDA context callout.
+   *  Returns '' when data is unavailable. */
+  function formatCountyCallout(comparison, countyName) {
+    if (!comparison || !comparison.county) return '';
+    var c = comparison.county;
+    var s = comparison.state;
+    var d = comparison.delta;
+    var name = countyName || c.name || ('FIPS ' + c.fips);
+    var denialDir = d.denial_rate_pp > 0 ? 'higher' : 'lower';
+    var loanDir = d.mean_loan_pct > 0 ? 'higher' : 'lower';
+    return (
+      '<strong>Mortgage credit (' + c.year + '):</strong> ' +
+      name + ' had ' + c.originations.toLocaleString() + ' originations ' +
+      'at a ' + (c.denial_rate * 100).toFixed(1) + '% denial rate ' +
+      '(' + Math.abs(d.denial_rate_pp).toFixed(1) + 'pp ' + denialDir + ' than CO statewide ' +
+      (s.denial_rate * 100).toFixed(1) + '%). ' +
+      'Mean loan: $' + (c.mean_loan_amount_usd || 0).toLocaleString() + ' ' +
+      '(' + Math.abs(d.mean_loan_pct).toFixed(0) + '% ' + loanDir + ' than state). ' +
+      'Multifamily originations: ' + (c.multifamily.originations || 0).toLocaleString() +
+      ' (LIHTC-adjacent).'
+    );
+  }
+
+  window.HmdaLookup = {
+    init: init,
+    getCounty: getCounty,
+    getCountyTrend: getCountyTrend,
+    getStateLatest: getStateLatest,
+    getCountyVsState: getCountyVsState,
+    formatCountyCallout: formatCountyCallout,
+  };
+})();

--- a/js/market-analysis.js
+++ b/js/market-analysis.js
@@ -897,6 +897,76 @@
     renderBenchmark(result);
     renderPipeline(result);
     renderScenarios(result);
+    renderHmdaContext(result);
+  }
+
+  /* ── Mortgage credit access (HMDA + cross-county disclosure) ─────────
+   * Shows buffer-primary-county HMDA metrics (origination volume, denial
+   * rate, mean loan, multifamily share) with state benchmark, plus a
+   * cross-county disclosure when the PMA buffer spans multiple counties
+   * — meaning the parcel's HUD AMI tier depends on which side of the
+   * line it sits.
+   *
+   * Why both signals in one card: the same investor question — "what's
+   * the credit/AMI environment for this site?" — needs both the credit
+   * picture (HMDA) and the AMI-tier ambiguity (cross-county). Putting
+   * them together avoids forcing the user to look in two places. */
+  function renderHmdaContext(result) {
+    var mountEl = el('pmaHmdaResult');
+    if (!mountEl) return;
+    if (!result || !result._tractIds || !result._tractIds.length) {
+      mountEl.innerHTML = '<div class="pma-empty">Place a site to load mortgage credit context.</div>';
+      return;
+    }
+    if (!window.HmdaLookup) {
+      mountEl.innerHTML = '<div class="pma-empty">HMDA module not loaded.</div>';
+      return;
+    }
+
+    // Identify counties touched by the PMA buffer (5-digit FIPS prefix
+    // of each tract). Sort by frequency descending → largest is the
+    // primary county.
+    var counts = {};
+    result._tractIds.forEach(function (geoid) {
+      var c = String(geoid).slice(0, 5);
+      counts[c] = (counts[c] || 0) + 1;
+    });
+    var rankedCounties = Object.keys(counts).sort(function (a, b) {
+      return counts[b] - counts[a];
+    });
+    var primaryFips = rankedCounties[0];
+    var crossCounty = rankedCounties.length > 1;
+
+    window.HmdaLookup.init().then(function () {
+      var comparison = window.HmdaLookup.getCountyVsState(primaryFips);
+      if (!comparison) {
+        mountEl.innerHTML =
+          '<div class="pma-empty">HMDA data unavailable for FIPS ' + primaryFips + '.</div>';
+        return;
+      }
+      var html = '<div style="line-height:1.5;font-size:var(--small);">' +
+        window.HmdaLookup.formatCountyCallout(comparison, comparison.county.name) +
+        '</div>';
+
+      // Buffer crosses counties → show a secondary line listing the
+      // other counties in the buffer with their denial rates so the
+      // analyst can see the full picture.
+      if (crossCounty) {
+        var others = rankedCounties.slice(1).map(function (fips) {
+          var c = window.HmdaLookup.getCounty(fips);
+          if (!c) return null;
+          return c.name + ' (' + (c.denial_rate * 100).toFixed(1) + '% denial)';
+        }).filter(Boolean);
+        html += '<div style="margin-top:0.5rem;padding:0.4rem 0.6rem;border-radius:4px;' +
+          'background:rgba(59,130,246,0.08);border:1px solid rgba(59,130,246,0.3);' +
+          'color:var(--text);font-size:var(--tiny);">' +
+          '<strong>⚠ PMA buffer spans ' + rankedCounties.length + ' counties.</strong> ' +
+          'HUD AMI is set per-county; if the parcel is on the wrong side of the county line, ' +
+          'the binding AMI tier may differ. Other counties in buffer: ' + others.join(', ') +
+          '.</div>';
+      }
+      mountEl.innerHTML = html;
+    });
   }
 
   /* ── Data Coverage panel ────────────────────────────────────────── */

--- a/market-analysis.html
+++ b/market-analysis.html
@@ -601,6 +601,26 @@
           </div>
         </div>
 
+        <!-- Mortgage Credit Access (HMDA + cross-county disclosure) -->
+        <div class="pma-card">
+          <h2 style="display:inline-block;margin:0;">Mortgage Credit Access</h2>
+          <details class="info-tooltip">
+            <summary title="What does this show?" aria-label="Show HMDA methodology">i</summary>
+            <div class="info-tooltip-body">
+              <p><strong>What this shows.</strong> Mortgage origination + denial-rate context for the buffer's primary county, sourced from CFPB HMDA Data Browser data. Tightening credit (rising denial rate, falling originations) precedes slowdowns in multifamily starts and reduced LIHTC bond demand.</p>
+              <dl>
+                <dt>Per-county metrics</dt><dd>originations, denial rate, mean loan amount, multifamily-only origination count (LIHTC-adjacent)</dd>
+                <dt>State benchmark</dt><dd>delta vs CO statewide (pp for rates, % for amounts)</dd>
+                <dt>Cross-county disclosure</dt><dd>when the buffer spans multiple counties, both counties' rates are summarized so you can see which side the parcel sits on matters for HUD AMI tier rents</dd>
+              </dl>
+              <p style="margin-top:0.5rem;font-size:0.76rem;color:var(--muted)">Source: <a href="https://ffiec.cfpb.gov/data-browser/" target="_blank" rel="noopener">CFPB HMDA Data Browser</a>. Vintages 2018-2024.</p>
+            </div>
+          </details>
+          <div id="pmaHmdaResult" style="margin-top:0.5rem;">
+            <div class="pma-empty">Place a site to load mortgage credit context.</div>
+          </div>
+        </div>
+
         <!-- Peer Benchmarking -->
         <div class="pma-card">
           <h2 style="display:inline-block;margin:0;">Peer Benchmarking</h2>
@@ -1027,6 +1047,13 @@
   <script defer src="js/data-connectors/cdot-traffic.js"></script>
   <!-- PMA heuristic confidence module -->
   <script defer src="js/pma-confidence.js"></script>
+  <!-- HMDA mortgage-credit-access lookup (per-county denial rate, mean loan
+       amount, multifamily originations) — must load before market-analysis.js
+       so renderHmdaContext() can find window.HmdaLookup. Data shipped in PR #786. -->
+  <script defer src="js/hmda-lookup.js"></script>
+  <!-- Cross-county disclosure helper (PR #787 + #791 alias support). Used
+       by PMA to flag buffers that cross county lines for HUD AMI ambiguity. -->
+  <script defer src="js/cross-county-disclosure.js"></script>
   <!-- ACS cache persistence fix — must load before market-analysis.js -->
   <script defer src="js/market-analysis-cache-fix.js"></script>
   <script defer src="js/market-analysis/market-analysis-controller.js"></script>

--- a/test/hmda-lookup.test.js
+++ b/test/hmda-lookup.test.js
@@ -1,0 +1,147 @@
+// test/hmda-lookup.test.js
+//
+// Tests for js/hmda-lookup.js + the HMDA data files shipped in PR #786.
+// Verifies:
+//   - Helper module exposes the expected API
+//   - Data file paths follow the relative-to-data/ convention
+//     (regression for the bug class fixed in PR #791)
+//   - HmdaLookup is referenced by Deal Calculator + PMA simulator
+//   - HTML script tags wire the module before its consumers
+//   - State-vs-county delta math is well-defined for a known county
+//
+// Run: node test/hmda-lookup.test.js
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    console.log('  ✅ PASS: ' + message);
+    passed++;
+  } else {
+    console.error('  ❌ FAIL: ' + message);
+    failed++;
+  }
+}
+
+function readRel(rel) {
+  return fs.readFileSync(path.join(__dirname, '..', rel), 'utf8');
+}
+
+console.log('\n[test] hmda-lookup.js exposes expected API');
+const helperSrc = readRel('js/hmda-lookup.js');
+assert(/window\.HmdaLookup\s*=\s*\{/.test(helperSrc),
+  'attaches HmdaLookup to window');
+['init', 'getCounty', 'getCountyTrend', 'getStateLatest', 'getCountyVsState', 'formatCountyCallout'].forEach((fn) => {
+  assert(new RegExp('function\\s+' + fn + '\\s*\\(').test(helperSrc),
+    'defines ' + fn + '() function');
+});
+
+console.log('\n[test] No double-data/ prefix bug (regression: 2026-05-10 audit)');
+assert(!/baseData\s*\(\s*['"]data\//.test(helperSrc),
+  'no path passed to baseData() starts with "data/"');
+assert(/COUNTY_PATH\s*=\s*['"]hmda\//.test(helperSrc),
+  'COUNTY_PATH starts with hmda/ (relative to data/)');
+assert(/STATE_PATH\s*=\s*['"]hmda\//.test(helperSrc),
+  'STATE_PATH starts with hmda/ (relative to data/)');
+
+console.log('\n[test] HMDA data files exist + load');
+const countyDoc = JSON.parse(readRel('data/hmda/co-county-aggregates.json'));
+const stateDoc = JSON.parse(readRel('data/hmda/co-state-trends.json'));
+assert(countyDoc.counties && Object.keys(countyDoc.counties).length === 64,
+  'county doc has 64 CO counties');
+assert(stateDoc.years && Object.keys(stateDoc.years).length >= 5,
+  'state doc has ≥5 years of data');
+
+// Spot-check a known county
+const denver = countyDoc.counties['08031'];
+assert(denver != null, 'Denver County (08031) present in HMDA county doc');
+const denver2024 = denver && denver.years && denver.years['2024'];
+assert(denver2024 != null, 'Denver has 2024 data');
+assert(denver2024 && denver2024.originations > 5000,
+  'Denver 2024 originations > 5000 (sanity)');
+assert(denver2024 && denver2024.denial_rate > 0 && denver2024.denial_rate < 1,
+  'Denver 2024 denial_rate in [0, 1]');
+assert(denver2024 && denver2024.multifamily && denver2024.multifamily.originations > 0,
+  'Denver 2024 has at least one multifamily origination');
+
+console.log('\n[test] Deal Calculator wires HMDA context');
+const dcSrc = readRel('js/deal-calculator.js');
+assert(/dc-hmda-context/.test(dcSrc),
+  'Deal Calculator HTML includes #dc-hmda-context container');
+assert(/_renderHmdaContext/.test(dcSrc),
+  'Deal Calculator defines _renderHmdaContext helper');
+assert(/window\.HmdaLookup/.test(dcSrc),
+  'Deal Calculator references window.HmdaLookup');
+assert(/_renderHmdaContext\(fips\)/.test(dcSrc),
+  'Deal Calculator calls _renderHmdaContext on county change');
+
+console.log('\n[test] PMA simulator wires HMDA + cross-county disclosure');
+const maSrc = readRel('js/market-analysis.js');
+assert(/renderHmdaContext\s*\(/.test(maSrc),
+  'PMA defines renderHmdaContext()');
+assert(/window\.HmdaLookup/.test(maSrc),
+  'PMA references window.HmdaLookup');
+assert(/PMA buffer spans/.test(maSrc),
+  'PMA shows multi-county buffer disclosure');
+
+console.log('\n[test] HTML script tags load HMDA before consumers');
+const dcHtml = readRel('deal-calculator.html');
+const dcHmdaIdx = dcHtml.indexOf('hmda-lookup.js');
+const dcCalcIdx = dcHtml.indexOf('js/deal-calculator.js');
+assert(dcHmdaIdx >= 0,
+  'deal-calculator.html includes hmda-lookup.js');
+assert(dcHmdaIdx < dcCalcIdx,
+  'deal-calculator.html: hmda-lookup.js loads BEFORE deal-calculator.js');
+
+const maHtml = readRel('market-analysis.html');
+const maHmdaIdx = maHtml.indexOf('hmda-lookup.js');
+const maMaIdx = maHtml.indexOf('js/market-analysis.js');
+assert(maHmdaIdx >= 0,
+  'market-analysis.html includes hmda-lookup.js');
+assert(maHmdaIdx < maMaIdx,
+  'market-analysis.html: hmda-lookup.js loads BEFORE market-analysis.js');
+
+const maCcIdx = maHtml.indexOf('cross-county-disclosure.js');
+assert(maCcIdx >= 0,
+  'market-analysis.html includes cross-county-disclosure.js');
+assert(maCcIdx < maMaIdx,
+  'market-analysis.html: cross-county-disclosure.js loads BEFORE market-analysis.js');
+
+console.log('\n[test] PMA HTML has the new card');
+assert(/id="pmaHmdaResult"/.test(maHtml),
+  'market-analysis.html has #pmaHmdaResult container');
+assert(/Mortgage Credit Access/.test(maHtml),
+  'market-analysis.html has Mortgage Credit Access heading');
+
+console.log('\n[test] Math sanity: state-vs-county delta is well-defined');
+// Stub global window for module-style logic check (we just simulate the
+// comparison computation here against the actual data).
+function getCounty(fips) {
+  var rec = countyDoc.counties[fips];
+  if (!rec) return null;
+  var years = Object.keys(rec.years).sort();
+  var latest = years[years.length - 1];
+  return Object.assign({ year: latest }, rec.years[latest]);
+}
+function getStateLatest() {
+  var years = Object.keys(stateDoc.years).sort();
+  var latest = years[years.length - 1];
+  return Object.assign({ year: latest }, stateDoc.years[latest]);
+}
+const arapahoe = getCounty('08005');
+const stateLatest = getStateLatest();
+assert(arapahoe.year === stateLatest.year,
+  'Arapahoe and state latest year align (' + arapahoe.year + ')');
+const arapDelta = (arapahoe.denial_rate - stateLatest.denial_rate) * 100;
+assert(Number.isFinite(arapDelta),
+  'Arapahoe vs state denial-rate delta is finite (' + arapDelta.toFixed(2) + 'pp)');
+
+console.log('\n=========================================');
+console.log('Results: ' + passed + ' passed, ' + failed + ' failed');
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Wires data already shipped in earlier PRs into the two user-facing surfaces (Deal Calculator + PMA simulator). No new ETL — just analyst-visible context.

| Earlier PR | What this PR uses |
|---|---|
| #786 | HMDA county aggregates → per-county denial rate, mean loan, multifamily originations |
| #787 + #791 | Cross-county registry + phantom aliases → not directly used here, but the same problem class motivates the PMA buffer-spans-counties disclosure |

## What users see now

**Deal Calculator (under the county selector):**
> Mortgage credit (2024): Adams had 13,324 originations at a 27.8% denial rate (6.2pp higher than CO statewide 21.6%). Mean loan: $384,000 (8% lower than state). Multifamily originations: 24 (LIHTC-adjacent).

**PMA simulator (new "Mortgage Credit Access" card):**
> Same per-county HMDA callout, plus when the buffer spans multiple counties:
> > ⚠ PMA buffer spans 3 counties. HUD AMI is set per-county; if the parcel is on the wrong side of the county line, the binding AMI tier may differ. Other counties in buffer: Boulder (16.4% denial), Weld (24.1% denial).

## Files

| File | Purpose |
|---|---|
| `js/hmda-lookup.js` | New `window.HmdaLookup` helper (init/getCounty/getCountyTrend/getStateLatest/getCountyVsState/formatCountyCallout) |
| `js/deal-calculator.js` + `deal-calculator.html` | `#dc-hmda-context` container + `_renderHmdaContext(fips)` wired into county-change handler |
| `js/market-analysis.js` + `market-analysis.html` | `#pmaHmdaResult` card + `renderHmdaContext(result)` called from `renderScore()`. Buffer-mode cross-county detection via `_tractIds` mode-frequency. |
| `test/hmda-lookup.test.js` | 34 assertions: API surface, path convention regression-guard, data file shape, Deal Calc + PMA wiring, HTML script ordering, math sanity |

## Why buffer-based cross-county detection (vs place-based)

PMA's buffer commonly crosses county lines independent of any place — a 1.5-mile buffer at the Boulder/Weld line spans both counties whether or not the site is in Erie/Longmont. Buffer-based detection (any 2+ counties in `_tractIds`) is a more general signal than place-based, and it's the variant that matters for HUD AMI ambiguity when picking tier rents. Place-based disclosure (Deal Calculator path) is still reachable via `window.CrossCountyDisclosure` from PR #787.

## Test plan

- [x] `node test/hmda-lookup.test.js` → 34/34 pass
- [x] `node test/dc-constants.test.js` → 29/29 pass (regression)
- [x] `node test/dc-rent-achievability.test.js` → 28/28 pass (regression)
- [x] `node test/place-chas-lookup.test.js` → 50/50 pass (regression — confirms the PR-C4 path-convention guard still passes)
- [x] `node test/cross-county-disclosure.test.js` → 53/53 pass (regression)
- [x] `node -c` on all touched JS files → syntax OK
- [ ] After merge: select Adams County on Deal Calculator → confirm HMDA callout renders. Run PMA at Boulder/Weld line → confirm buffer-spans-2-counties disclosure renders.

## Next up (per session plan)

After this merges, item #3: coverage transparency stat — surface "X of Y places use TIGER place-level CHAS, Z fall back to county" on the data-sources/quality dashboard so analysts can see methodological status at a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)