### PR TITLE
feat: HMDA YoY trend chart + CHAS provenance badge

### DIFF
--- a/economic-dashboard.html
+++ b/economic-dashboard.html
@@ -254,6 +254,87 @@ document.addEventListener('DOMContentLoaded', function () {
     </p>
 
 <!-- ══════════════════════════════════════════════════════════════
+     HMDA — Colorado Mortgage Credit Access Trends (2018-current)
+     Statewide YoY trends from CFPB HMDA Data Browser (PR #786 +
+     #792 panel additions). Complements the FRED housing-cycle
+     section above by showing the actual transaction flow underneath
+     the macro signals: how many mortgages got originated, denial
+     rates, mean loan amount, multifamily share.
+     ══════════════════════════════════════════════════════════════ -->
+    <details class="card" open="" id="hmda-trends-section" style="margin-top:var(--sp4);">
+      <summary>
+        Mortgage Credit Access — Statewide Trends
+        <span class="pill small">CFPB HMDA</span>
+      </summary>
+      <div class="section-body">
+        <p class="section-desc">
+          Annual mortgage origination volume, denial rate, mean loan size,
+          and multifamily-only originations for Colorado from the federal
+          Home Mortgage Disclosure Act (HMDA). Tightening credit (rising
+          denial, falling originations) precedes slowdowns in multifamily
+          starts and reduced LIHTC bond demand. Multifamily series is
+          directly LIHTC-adjacent — competitive lending environment for
+          LIHTC capital stacks.
+        </p>
+        <div id="hmdaTrendsLoading" style="color:var(--muted);font-size:.88rem;padding:.5rem 0;">
+          Loading HMDA trends&hellip;
+        </div>
+        <div id="hmdaTrendsContent" style="display:none;">
+          <div class="kpi-strip" role="region" aria-label="HMDA latest-year statewide indicators"
+               style="margin-bottom:1rem;">
+            <div class="kpi-strip-item">
+              <div id="hmdaTrendOriginations" class="kpi-strip-value">—</div>
+              <div class="kpi-strip-label">Originations</div>
+              <div id="hmdaTrendOriginationsDelta" class="kpi-delta">—</div>
+              <div class="kpi-source">CFPB HMDA</div>
+            </div>
+            <div class="kpi-strip-item">
+              <div id="hmdaTrendDenialRate" class="kpi-strip-value">—</div>
+              <div class="kpi-strip-label">Denial Rate</div>
+              <div id="hmdaTrendDenialRateDelta" class="kpi-delta">—</div>
+              <div class="kpi-source">CFPB HMDA</div>
+            </div>
+            <div class="kpi-strip-item">
+              <div id="hmdaTrendMeanLoan" class="kpi-strip-value">—</div>
+              <div class="kpi-strip-label">Mean Loan Amount</div>
+              <div id="hmdaTrendMeanLoanDelta" class="kpi-delta">—</div>
+              <div class="kpi-source">CFPB HMDA</div>
+            </div>
+            <div class="kpi-strip-item">
+              <div id="hmdaTrendMultifamily" class="kpi-strip-value">—</div>
+              <div class="kpi-strip-label">Multifamily Originations</div>
+              <div id="hmdaTrendMultifamilyDelta" class="kpi-delta">—</div>
+              <div class="kpi-source">CFPB HMDA</div>
+            </div>
+          </div>
+          <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem;">
+            <div class="chart-wrap" style="position:relative;height:240px;">
+              <canvas id="hmdaTrendOriginationsChart"
+                      aria-label="HMDA originations time series chart"></canvas>
+            </div>
+            <div class="chart-wrap" style="position:relative;height:240px;">
+              <canvas id="hmdaTrendDenialChart"
+                      aria-label="HMDA denial rate time series chart"></canvas>
+            </div>
+            <div class="chart-wrap" style="position:relative;height:240px;">
+              <canvas id="hmdaTrendMeanLoanChart"
+                      aria-label="HMDA mean loan amount time series chart"></canvas>
+            </div>
+            <div class="chart-wrap" style="position:relative;height:240px;">
+              <canvas id="hmdaTrendMultifamilyChart"
+                      aria-label="HMDA multifamily originations time series chart"></canvas>
+            </div>
+          </div>
+          <p class="note small" style="margin-top:.75rem;">
+            Source: <a href="https://ffiec.cfpb.gov/data-browser/" target="_blank" rel="noopener">CFPB HMDA Data Browser</a>.
+            Vintages 2018-current. Refreshed monthly by
+            <a href="https://github.com/pggLLC/Housing-Analytics/blob/main/.github/workflows/fetch-hmda-data.yml" target="_blank" rel="noopener">fetch-hmda-data.yml</a>.
+          </p>
+        </div>
+      </div>
+    </details>
+
+<!-- ══════════════════════════════════════════════════════════════
      HOUSING PREDICTIVE MODELING SECTION — moved to Colorado Deep Dive
      ══════════════════════════════════════════════════════════════ -->
     <div class="card" style="margin-top:var(--sp4); padding:1.25rem;" aria-label="Housing predictions moved">
@@ -960,6 +1041,8 @@ function getKey(){ return CONFIG_KEY || ""; }
 })();
 </script>
 <script src="js/contrast-guard.js"></script><script src="js/census-geo.js"></script><script src="js/fred-cards.js"></script>
+<!-- HMDA statewide trend chart (PR #786 data + this PR's panel) -->
+<script src="js/hmda-trend-chart.js"></script>
 
 <script defer src="js/housing-predictions.js"></script>
 <script defer src="js/audit-hook.js"></script>

--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -382,7 +382,22 @@
       </div>
 
       <div class="chart-card span-6">
-        <h2>Cost burden by AMI tier (HUD CHAS)<span id="chasApproxHint" class="data-approx-hint" hidden title="When a place or CDP is selected, CHAS tiers are scaled from the containing county — the selected geography may not have its own CHAS breakdown. See comparative-analysis detail panel for full disclaimer.">(county-approx)</span></h2>
+        <h2>Cost burden by AMI tier (HUD CHAS)
+          <!-- Provenance badge — set dynamically by hna-renderers.js to show
+               which methodology drove the chart for the current selection:
+                 - TIGER 2024 (green)  → place-level via tract apportionment
+                 - County (blue)       → user picked a county directly
+                 - County-approx (amber) → place selected but no TIGER coverage
+                                           (chart shows county fallback)
+               See PR-C3 / PR-C4 / PR-this for the methodology arc. -->
+          <span id="chasProvenanceBadge" hidden
+            style="display:inline-block;margin-left:.5rem;padding:.1rem .5rem;
+                   font-size:.7rem;font-weight:600;border-radius:9999px;
+                   line-height:1.4;vertical-align:middle;"></span>
+          <!-- Legacy hint kept for backward-compat with comparative-analysis
+               panel; new provenance badge above is the preferred surface. -->
+          <span id="chasApproxHint" class="data-approx-hint" hidden title="When a place or CDP is selected, CHAS tiers are scaled from the containing county — the selected geography may not have its own CHAS breakdown. See comparative-analysis detail panel for full disclaimer.">(county-approx)</span>
+        </h2>
         <p>Renter households by income tier (% of Area Median Income) showing not-burdened, moderately burdened (30–50% of income), and severely burdened (&gt;50%) households. Source: HUD Comprehensive Housing Affordability Strategy (CHAS).</p>
         <div class="chart-box" data-source="HUD CHAS 2018-2022" data-source-url="https://www.huduser.gov/portal/datasets/cp.html" data-vintage="CHAS 2018–2022" data-source-type="raw"><canvas id="chartChasGap" role="img" aria-label="Renter cost burden by AMI income tier chart (HUD CHAS)"></canvas></div>
         <p class="sr-only">Stacked bar chart showing renter households at each AMI income tier (≤30%, 31–50%, 51–80%, 81–100%) broken down by housing cost burden status.</p>

--- a/js/hmda-trend-chart.js
+++ b/js/hmda-trend-chart.js
@@ -1,0 +1,196 @@
+/**
+ * hmda-trend-chart.js
+ *
+ * Renders the "Mortgage Credit Access — Statewide Trends" panel on
+ * economic-dashboard.html. Pulls the statewide HMDA YoY data shipped
+ * in PR #786 (data/hmda/co-state-trends.json) and shows:
+ *   - 4 KPI cards: latest-year originations, denial rate, mean loan,
+ *     multifamily originations (with YoY delta on each)
+ *   - 4 small line charts: each metric across all available years
+ *
+ * Why a separate panel
+ * --------------------
+ * The economic-dashboard already groups FRED housing-cycle indicators
+ * (HSN1F, TLRESCONS, USCONS — leading/coincident/lagging). HMDA is the
+ * actual transaction-flow data underneath those macro signals: the
+ * pairing answers "what's the mortgage market doing right now?" with
+ * both macro outlook and ground-truth credit-access metrics.
+ *
+ * Boots on DOMContentLoaded; soft-fails if data file is missing.
+ */
+(function () {
+  'use strict';
+
+  // Path is RELATIVE to data/. DataService.baseData() prepends 'data/';
+  // standalone fallback below also prepends 'data/'. Path-convention
+  // regression-protected by tests (see PR #791).
+  var STATE_TRENDS_PATH = 'hmda/co-state-trends.json';
+
+  function _resolveDataUrl(rel) {
+    if (typeof window !== 'undefined' && window.DataService
+        && typeof window.DataService.baseData === 'function') {
+      return window.DataService.baseData(rel);
+    }
+    return 'data/' + rel;
+  }
+
+  function _fetchJson(url) {
+    if (typeof window !== 'undefined' && window.DataService && window.DataService.getJSON) {
+      return window.DataService.getJSON(url);
+    }
+    return fetch(url).then(function (r) { return r.json(); });
+  }
+
+  function init() {
+    if (!document.getElementById('hmda-trends-section')) return;
+    var loadingEl = document.getElementById('hmdaTrendsLoading');
+    var contentEl = document.getElementById('hmdaTrendsContent');
+    if (!contentEl) return;
+
+    _fetchJson(_resolveDataUrl(STATE_TRENDS_PATH))
+      .then(function (doc) {
+        if (!doc || !doc.years || !Object.keys(doc.years).length) {
+          if (loadingEl) loadingEl.textContent = 'HMDA trends unavailable.';
+          return;
+        }
+        render(doc);
+        if (loadingEl) loadingEl.style.display = 'none';
+        contentEl.style.display = '';
+      })
+      .catch(function (err) {
+        console.warn('[hmda-trend-chart] Could not load:', err);
+        if (loadingEl) loadingEl.textContent = 'HMDA trends unavailable: ' +
+          (err && err.message ? err.message : err);
+      });
+  }
+
+  function render(doc) {
+    var years = Object.keys(doc.years).sort();
+    var latest = years[years.length - 1];
+    var prior = years.length >= 2 ? years[years.length - 2] : null;
+    var L = doc.years[latest];
+    var P = prior ? doc.years[prior] : null;
+
+    // KPI cards
+    _setText('hmdaTrendOriginations', _formatCompact(L.originations));
+    _setText('hmdaTrendDenialRate', (L.denial_rate * 100).toFixed(1) + '%');
+    _setText('hmdaTrendMeanLoan', '$' + _formatCompact(L.mean_loan_amount_usd, true));
+    _setText('hmdaTrendMultifamily', _formatCompact(L.multifamily.originations));
+
+    if (P) {
+      _setDelta('hmdaTrendOriginationsDelta', _yoyPct(L.originations, P.originations), prior);
+      _setDelta('hmdaTrendDenialRateDelta', _yoyPp(L.denial_rate, P.denial_rate), prior, /* isPp */ true);
+      _setDelta('hmdaTrendMeanLoanDelta', _yoyPct(L.mean_loan_amount_usd, P.mean_loan_amount_usd), prior);
+      _setDelta('hmdaTrendMultifamilyDelta', _yoyPct(L.multifamily.originations, P.multifamily.originations), prior);
+    }
+
+    // Build chart series
+    var labels = years;
+    var origs = years.map(function (y) { return doc.years[y].originations; });
+    var denials = years.map(function (y) { return (doc.years[y].denial_rate || 0) * 100; });
+    var means = years.map(function (y) { return doc.years[y].mean_loan_amount_usd || 0; });
+    var mf = years.map(function (y) {
+      return (doc.years[y].multifamily && doc.years[y].multifamily.originations) || 0;
+    });
+
+    _drawChart('hmdaTrendOriginationsChart', labels, origs, 'Originations', '#2563eb', /* yLabel */ null);
+    _drawChart('hmdaTrendDenialChart', labels, denials, 'Denial Rate (%)', '#dc2626', /* yLabel */ '%');
+    _drawChart('hmdaTrendMeanLoanChart', labels, means, 'Mean Loan ($)', '#7c3aed', /* yLabel */ '$');
+    _drawChart('hmdaTrendMultifamilyChart', labels, mf, 'Multifamily Originations', '#059669', null);
+  }
+
+  function _drawChart(canvasId, labels, values, label, color, yPrefix) {
+    var canvas = document.getElementById(canvasId);
+    if (!canvas || typeof Chart === 'undefined') return;
+    var ctx = canvas.getContext('2d');
+    new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: labels,
+        datasets: [{
+          label: label,
+          data: values,
+          borderColor: color,
+          backgroundColor: color + '22',
+          fill: true,
+          tension: 0.25,
+          pointRadius: 3,
+          pointHoverRadius: 5,
+          borderWidth: 2,
+        }],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: true, position: 'top', labels: { font: { size: 11 } } },
+          tooltip: {
+            callbacks: {
+              label: function (ctx) {
+                var v = ctx.parsed.y;
+                if (yPrefix === '%') return label + ': ' + v.toFixed(1) + '%';
+                if (yPrefix === '$') return label + ': $' + Math.round(v).toLocaleString();
+                return label + ': ' + v.toLocaleString();
+              },
+            },
+          },
+        },
+        scales: {
+          x: { grid: { display: false }, ticks: { font: { size: 11 } } },
+          y: {
+            grid: { color: 'rgba(148,163,184,.22)' },
+            ticks: {
+              font: { size: 11 },
+              callback: function (v) {
+                if (yPrefix === '%') return v.toFixed(0) + '%';
+                if (yPrefix === '$') return '$' + _formatCompact(v, true);
+                return _formatCompact(v);
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  function _setText(id, txt) {
+    var el = document.getElementById(id);
+    if (el) el.textContent = txt;
+  }
+
+  function _setDelta(id, val, priorYear, isPp) {
+    var el = document.getElementById(id);
+    if (!el || val == null) return;
+    var arrow = val > 0 ? '▲' : val < 0 ? '▼' : '→';
+    var color = val > 0 ? 'var(--good,#16a34a)' : val < 0 ? 'var(--bad,#dc2626)' : 'var(--muted)';
+    el.style.color = color;
+    el.textContent = arrow + ' ' + Math.abs(val).toFixed(isPp ? 1 : 1) +
+      (isPp ? 'pp' : '%') + ' YoY';
+  }
+
+  function _yoyPct(curr, prev) {
+    if (prev == null || prev === 0) return null;
+    return ((curr - prev) / prev) * 100;
+  }
+
+  function _yoyPp(curr, prev) {
+    if (curr == null || prev == null) return null;
+    return (curr - prev) * 100;
+  }
+
+  function _formatCompact(n, currency) {
+    if (n == null || !isFinite(n)) return '—';
+    if (n >= 1e9) return (n / 1e9).toFixed(1) + 'B';
+    if (n >= 1e6) return (n / 1e6).toFixed(1) + 'M';
+    if (n >= 1e3) return (n / 1e3).toFixed(currency ? 0 : 1) + 'K';
+    return n.toLocaleString();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  window.HmdaTrendChart = { init: init, render: render };
+})();

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -1514,6 +1514,7 @@
     const tigerTiers = _tigerPlaceTiers();
     if (tigerTiers && tigerTiers.length) {
       _renderProxyNote(null, /* isTigerPlace */ true);
+      _setProvenanceBadge('tiger');
       _renderTiers(tigerTiers, /* sourceLabel */ (selectedGeo && selectedGeo.name) || 'place', /* tigerSource */ true);
       return;
     }
@@ -1521,17 +1522,79 @@
     if (!chasData) {
       if (statusEl) statusEl.textContent = 'CHAS affordability data not available.';
       _renderProxyNote('');
+      _setProvenanceBadge('none');
       return;
     }
 
     const county = chasData[countyFips5] || chasData['statewide'] || null;
     if (!county) {
       if (statusEl) statusEl.textContent = `No CHAS data for FIPS ${countyFips5}.`;
+      _setProvenanceBadge('none');
       return;
     }
 
     _renderProxyNote(county.name || countyFips5);
+    // Distinguish "user picked a county directly" (clean) from "user picked
+    // a place/cdp but TIGER didn't have it, so we're showing county fallback"
+    // (less clean — flag with amber badge).
+    const isPlaceProxy = selectedGeo &&
+      (selectedGeo.type === 'place' || selectedGeo.type === 'cdp') &&
+      selectedGeo.geoid && selectedGeo.geoid !== countyFips5 && countyFips5;
+    _setProvenanceBadge(isPlaceProxy ? 'county-approx' : 'county');
     _renderTiers(county.tiers || [], county.name || countyFips5, /* tigerSource */ false);
+  }
+
+  /**
+   * Set the provenance badge next to the CHAS chart title to make the
+   * methodology stamp glance-able. Three states:
+   *   'tiger'         → green "TIGER 2024 place-level"
+   *   'county'        → blue "County" (clean — user picked a county directly)
+   *   'county-approx' → amber "County-approx" (user picked a place/cdp not in
+   *                     TIGER coverage; chart shows containing county data)
+   *   'none'          → hidden
+   */
+  function _setProvenanceBadge(state) {
+    const badge = document.getElementById('chasProvenanceBadge');
+    if (!badge) return;
+    if (state === 'none' || !state) {
+      badge.hidden = true;
+      badge.textContent = '';
+      return;
+    }
+    const states = {
+      'tiger': {
+        text:   '✓ TIGER 2024 place-level',
+        bg:     'rgba(22,163,74,.12)',
+        border: 'rgba(22,163,74,.5)',
+        color:  'var(--good,#16a34a)',
+        title:  'CHAS rates computed by area-weighted apportionment of underlying tracts inside the place. Accurate for cross-county jurisdictions.',
+      },
+      'county': {
+        text:   'County',
+        bg:     'rgba(37,99,235,.10)',
+        border: 'rgba(37,99,235,.5)',
+        color:  '#2563eb',
+        title:  'CHAS rates from HUD’s county-level publication. You selected a county directly.',
+      },
+      'county-approx': {
+        text:   '⚠ County-approx',
+        bg:     'rgba(217,119,6,.10)',
+        border: 'rgba(217,119,6,.5)',
+        color:  'var(--warn,#d97706)',
+        title:  'You selected a place/CDP not covered by TIGER 2024 place-CHAS — the chart shows the containing county’s rates as a proxy. See data-quality dashboard for coverage stats.',
+      },
+    };
+    const s = states[state];
+    if (!s) {
+      badge.hidden = true;
+      return;
+    }
+    badge.textContent = s.text;
+    badge.style.background = s.bg;
+    badge.style.border = '1px solid ' + s.border;
+    badge.style.color = s.color;
+    badge.title = s.title;
+    badge.hidden = false;
   }
 
   // Shared chart-rendering helper used by both the TIGER place-CHAS path

--- a/test/hmda-trend-and-chas-badge.test.js
+++ b/test/hmda-trend-and-chas-badge.test.js
@@ -1,0 +1,109 @@
+// test/hmda-trend-and-chas-badge.test.js
+//
+// Tests for two ship items in this PR:
+//   #2 — Statewide HMDA YoY trend chart on economic-dashboard
+//        (js/hmda-trend-chart.js + economic-dashboard.html)
+//   #3 — Provenance badge on CHAS chart title
+//        (js/hna/hna-renderers.js _setProvenanceBadge + housing-needs-assessment.html
+//         #chasProvenanceBadge)
+//
+// Run: node test/hmda-trend-and-chas-badge.test.js
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond, msg) {
+  if (cond) { console.log('  ✅ PASS: ' + msg); passed++; }
+  else { console.error('  ❌ FAIL: ' + msg); failed++; }
+}
+
+function readRel(rel) {
+  return fs.readFileSync(path.join(__dirname, '..', rel), 'utf8');
+}
+
+console.log('\n[test] HMDA trend chart module structure');
+const hmdaSrc = readRel('js/hmda-trend-chart.js');
+assert(/window\.HmdaTrendChart\s*=\s*\{/.test(hmdaSrc),
+  'attaches HmdaTrendChart to window');
+['init', 'render'].forEach((fn) => {
+  assert(new RegExp('function\\s+' + fn + '\\s*\\(').test(hmdaSrc),
+    'defines ' + fn + '() function');
+});
+['_drawChart', '_setText', '_setDelta', '_yoyPct', '_yoyPp', '_formatCompact'].forEach((fn) => {
+  assert(new RegExp('function\\s+' + fn + '\\s*\\(').test(hmdaSrc),
+    'defines internal helper ' + fn + '()');
+});
+
+console.log('\n[test] Path convention regression guard (PR #791)');
+assert(!/baseData\s*\(\s*['"]data\//.test(hmdaSrc),
+  'no path passed to baseData() starts with "data/"');
+assert(/STATE_TRENDS_PATH\s*=\s*['"]hmda\//.test(hmdaSrc),
+  'STATE_TRENDS_PATH starts with "hmda/" (relative to data/)');
+
+console.log('\n[test] Economic-dashboard wires the HMDA trend section');
+const econSrc = readRel('economic-dashboard.html');
+assert(/hmda-trends-section/.test(econSrc),
+  'economic-dashboard.html has #hmda-trends-section');
+assert(/hmdaTrendOriginations/.test(econSrc),
+  'has #hmdaTrendOriginations KPI placeholder');
+assert(/hmdaTrendDenialRate/.test(econSrc),
+  'has #hmdaTrendDenialRate KPI placeholder');
+assert(/hmdaTrendMeanLoan/.test(econSrc),
+  'has #hmdaTrendMeanLoan KPI placeholder');
+assert(/hmdaTrendMultifamily/.test(econSrc),
+  'has #hmdaTrendMultifamily KPI placeholder');
+assert(/hmdaTrendOriginationsChart/.test(econSrc),
+  'has 4 trend chart canvases (originations)');
+assert(/hmdaTrendDenialChart/.test(econSrc),
+  'has 4 trend chart canvases (denial)');
+assert(/hmdaTrendMeanLoanChart/.test(econSrc),
+  'has 4 trend chart canvases (mean loan)');
+assert(/hmdaTrendMultifamilyChart/.test(econSrc),
+  'has 4 trend chart canvases (multifamily)');
+assert(/js\/hmda-trend-chart\.js/.test(econSrc),
+  'economic-dashboard.html loads js/hmda-trend-chart.js');
+
+console.log('\n[test] CHAS provenance badge (item #3)');
+const renderersSrc = readRel('js/hna/hna-renderers.js');
+assert(/_setProvenanceBadge/.test(renderersSrc),
+  'hna-renderers.js defines _setProvenanceBadge()');
+['tiger', 'county', 'county-approx'].forEach((state) => {
+  assert(new RegExp("'" + state + "'").test(renderersSrc),
+    '_setProvenanceBadge handles state: ' + state);
+});
+assert(/chasProvenanceBadge/.test(renderersSrc),
+  'hna-renderers.js targets #chasProvenanceBadge element');
+
+const hnaHtml = readRel('housing-needs-assessment.html');
+assert(/id="chasProvenanceBadge"/.test(hnaHtml),
+  'housing-needs-assessment.html has #chasProvenanceBadge span');
+
+console.log('\n[test] CHAS renderer wires badge through all three paths');
+assert(/_setProvenanceBadge\(['"]tiger['"]\)/.test(renderersSrc),
+  'TIGER path sets badge to "tiger"');
+assert(/_setProvenanceBadge\(['"]none['"]\)/.test(renderersSrc),
+  '"no data" path sets badge to "none"');
+assert(/_setProvenanceBadge\(isPlaceProxy/.test(renderersSrc),
+  'fallback path distinguishes county vs county-approx via isPlaceProxy');
+
+console.log('\n[test] Statewide HMDA data file shape');
+const stateDoc = JSON.parse(readRel('data/hmda/co-state-trends.json'));
+assert(stateDoc.years && Object.keys(stateDoc.years).length >= 5,
+  'co-state-trends.json has ≥5 years');
+const years = Object.keys(stateDoc.years).sort();
+const latest = stateDoc.years[years[years.length - 1]];
+assert(latest && typeof latest.originations === 'number' && latest.originations > 50000,
+  'latest year has originations > 50K (CO sanity)');
+assert(typeof latest.denial_rate === 'number' && latest.denial_rate > 0 && latest.denial_rate < 1,
+  'latest year denial_rate in [0, 1]');
+assert(latest.multifamily && typeof latest.multifamily.originations === 'number',
+  'latest year has multifamily.originations');
+
+console.log('\n=========================================');
+console.log('Results: ' + passed + ' passed, ' + failed + ' failed');
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Two visibility improvements building on the HMDA + TIGER work shipped earlier this session.

### #1 — HMDA statewide trend chart on economic-dashboard

New "Mortgage Credit Access — Statewide Trends" panel after the FRED housing-cycle indicators. Pairs the macro outlook (FRED) with actual transaction-flow data (HMDA).

| KPI | Latest year | YoY |
|---|---|---|
| Originations | total + delta | ↑↓% |
| Denial Rate | % | pp delta |
| Mean Loan Amount | $ | % delta |
| Multifamily Originations | count | ↑↓% |

Plus 4 small line charts showing the full 7-vintage history (2018-current).

### #2 — CHAS provenance badge on housing-needs-assessment

Replaces the implicit "(county-approx)" hint next to the CHAS chart title with an explicit pill that updates per selection:

| State | Badge | Meaning |
|---|---|---|
| `tiger` | green ✓ "TIGER 2024 place-level" | Tract-aggregated via spatial join (PR-C3) |
| `county` | blue "County" | User picked a county directly |
| `county-approx` | amber ⚠ "County-approx" | Place not in TIGER coverage; showing county fallback |

Each badge has a hover-tooltip explaining the methodology. Makes provenance visible at point of consumption, complementing the coverage stats added on the data-quality dashboard in PR #793.

## Files

| File | Purpose |
|---|---|
| `js/hmda-trend-chart.js` | New module; boots on `DOMContentLoaded`, renders 4 KPIs + 4 line charts |
| `economic-dashboard.html` | New `<details id="hmda-trends-section">` + script tag |
| `js/hna/hna-renderers.js` | New `_setProvenanceBadge(state)` helper; called from all three branches of `renderChasAffordabilityGap()` |
| `housing-needs-assessment.html` | New `#chasProvenanceBadge` span in chart-card title |
| `test/hmda-trend-and-chas-badge.test.js` | 34 assertions: module API, path-convention regression guard, dashboard wiring, badge state machine, statewide data sanity |

## Test plan

- [x] `node test/hmda-trend-and-chas-badge.test.js` → 34/34 pass
- [x] Regression sweep (6 existing JS test suites, 208 assertions) → all pass
- [x] `node -c` on all touched JS → syntax OK
- [ ] After merge: `economic-dashboard.html` → confirm HMDA trend section renders 4 KPIs + 4 charts
- [ ] After merge: `housing-needs-assessment.html` → pick Aurora (TIGER) vs Pueblo (alias) vs Eads (county-approx) → confirm 3 different badge states

🤖 Generated with [Claude Code](https://claude.com/claude-code)