### PR TITLE
feat(deal-calc): parcel→county auto-detect via TIGER point-in-polygon

### DIFF
--- a/deal-calculator.html
+++ b/deal-calculator.html
@@ -52,6 +52,11 @@
        amount, multifamily originations) — loaded BEFORE deal-calculator so
        _renderHmdaContext() can find window.HmdaLookup. Data shipped in PR #786. -->
   <script defer src="js/hmda-lookup.js"></script>
+  <!-- Parcel→county auto-detect (PR #795): lat/lon → TIGER point-in-polygon
+       → county FIPS. Lets users in cross-county jurisdictions (Erie, Aurora,
+       Longmont) auto-fill the county selector from the parcel's actual
+       location rather than guessing the place's "primary" county. -->
+  <script defer src="js/county-from-coords.js"></script>
   <!-- Deferred: deal calculator (renders into #dealCalcMount) -->
   <script defer src="js/deal-calculator.js"></script>
   <script defer src="js/deal-comparison.js"></script>

--- a/js/county-from-coords.js
+++ b/js/county-from-coords.js
@@ -1,0 +1,198 @@
+/**
+ * county-from-coords.js
+ *
+ * Browser-side point-in-polygon utility: maps a Colorado lat/lon to its
+ * containing county FIPS by testing against TIGER county boundaries
+ * (data/co-county-boundaries.json — 64 features, ~126 KB).
+ *
+ * Why this exists
+ * ---------------
+ * The Deal Calculator currently asks users to manually pick a county
+ * for HUD AMI rent limits. That's friction for the user (and a
+ * correctness risk in cross-county jurisdictions like Erie, Aurora,
+ * Longmont — where a parcel on the wrong side of the line is in a
+ * DIFFERENT HUD AMI tier than the place's "primary" county). With
+ * this helper, the user can paste a lat/lon (or use browser
+ * geolocation) and have the county auto-detected from the parcel's
+ * actual geographic location.
+ *
+ * Public API
+ * ----------
+ *   window.CountyFromCoords.init() — fetch + cache boundaries
+ *   window.CountyFromCoords.lookup(lat, lon) — returns {fips, name} or null
+ *   window.CountyFromCoords.lookupSync(lat, lon) — same but throws if not init'd
+ *
+ * Algorithm
+ * ---------
+ * Standard ray-casting point-in-polygon (PnP). For each county feature:
+ *   1. Bounding-box pre-filter (skip if (lat,lon) outside bbox).
+ *   2. Walk the polygon edges; count how many edges a horizontal ray
+ *      from (lat,lon) crosses. Odd = inside, even = outside.
+ *   3. For MultiPolygon: any ring containing the point counts as a hit.
+ *      Inner rings (holes) are subtracted via even-odd accumulation.
+ *
+ * The TIGER 2024 boundary data has ~60 vertices/county on average. A
+ * full scan of all 64 counties is ~3,800 vertex tests in the worst
+ * case — sub-millisecond on any modern device. Bbox pre-filter typically
+ * cuts this to <100 vertex tests.
+ */
+(function () {
+  'use strict';
+
+  // Path is RELATIVE to data/. DataService.baseData() prepends 'data/';
+  // standalone fallback below also prepends 'data/'. Path-convention
+  // regression-protected by tests (see PR #791).
+  var BOUNDARIES_PATH = 'co-county-boundaries.json';
+  var _features = null;        // [{ name, fips, bbox: [minLon, minLat, maxLon, maxLat], rings: [[[lon,lat],...],...] }]
+  var _loadPromise = null;
+
+  function _resolveDataUrl(rel) {
+    if (typeof window !== 'undefined' && window.DataService
+        && typeof window.DataService.baseData === 'function') {
+      return window.DataService.baseData(rel);
+    }
+    return 'data/' + rel;
+  }
+
+  function _fetchJson(url) {
+    if (typeof window !== 'undefined' && window.DataService && window.DataService.getJSON) {
+      return window.DataService.getJSON(url);
+    }
+    return fetch(url).then(function (r) { return r.json(); });
+  }
+
+  function init() {
+    if (_features) return Promise.resolve(_features);
+    if (_loadPromise) return _loadPromise;
+    _loadPromise = _fetchJson(_resolveDataUrl(BOUNDARIES_PATH))
+      .then(function (gj) {
+        _features = _normalizeFeatures(gj);
+        return _features;
+      })
+      .catch(function (err) {
+        console.warn('[county-from-coords] Could not load ' + BOUNDARIES_PATH + ':', err);
+        _features = [];
+        return _features;
+      });
+    return _loadPromise;
+  }
+
+  /** Convert a raw GeoJSON FeatureCollection into our compact internal
+   *  representation: every county becomes one record with {name, fips,
+   *  bbox, rings}. Polygons → 1 ring set; MultiPolygons → flattened
+   *  list of ring sets. Simplifies the lookup loop downstream. */
+  function _normalizeFeatures(gj) {
+    var out = [];
+    var feats = (gj && gj.features) || [];
+    for (var i = 0; i < feats.length; i++) {
+      var f = feats[i];
+      if (!f || !f.geometry) continue;
+      var props = f.properties || {};
+      var name = props.NAME || props.name || '';
+      var fips = String(props.GEOID || props.FIPS || '').padStart(5, '0');
+      if (!fips || fips.length !== 5) continue;
+      var rings = _extractRings(f.geometry);
+      if (!rings.length) continue;
+      var bbox = _computeBbox(rings);
+      out.push({ name: name, fips: fips, bbox: bbox, rings: rings });
+    }
+    return out;
+  }
+
+  /** Extract rings as an array of arrays of [lon, lat]. Handles
+   *  Polygon (single set of rings) and MultiPolygon (multiple sets). */
+  function _extractRings(geom) {
+    if (!geom || !geom.coordinates) return [];
+    if (geom.type === 'Polygon') {
+      return geom.coordinates;  // [outer, hole1, hole2, ...]
+    }
+    if (geom.type === 'MultiPolygon') {
+      var flat = [];
+      for (var i = 0; i < geom.coordinates.length; i++) {
+        var rings = geom.coordinates[i];
+        for (var j = 0; j < rings.length; j++) {
+          flat.push(rings[j]);
+        }
+      }
+      return flat;
+    }
+    return [];
+  }
+
+  function _computeBbox(rings) {
+    var minLon = Infinity, minLat = Infinity, maxLon = -Infinity, maxLat = -Infinity;
+    for (var i = 0; i < rings.length; i++) {
+      var r = rings[i];
+      for (var j = 0; j < r.length; j++) {
+        var p = r[j];
+        if (p[0] < minLon) minLon = p[0];
+        if (p[0] > maxLon) maxLon = p[0];
+        if (p[1] < minLat) minLat = p[1];
+        if (p[1] > maxLat) maxLat = p[1];
+      }
+    }
+    return [minLon, minLat, maxLon, maxLat];
+  }
+
+  /** Standard ray-casting point-in-polygon. Tests whether (lat, lon) is
+   *  inside the ring. Even-odd rule means rings can be added together
+   *  for MultiPolygon-with-holes correctness. */
+  function _pointInRing(lat, lon, ring) {
+    var inside = false;
+    var nVertices = ring.length;
+    for (var i = 0, j = nVertices - 1; i < nVertices; j = i++) {
+      var xi = ring[i][0], yi = ring[i][1];
+      var xj = ring[j][0], yj = ring[j][1];
+      var intersect = ((yi > lat) !== (yj > lat)) &&
+                      (lon < (xj - xi) * (lat - yi) / (yj - yi) + xi);
+      if (intersect) inside = !inside;
+    }
+    return inside;
+  }
+
+  /** Test whether (lat, lon) is inside ANY ring of the feature.
+   *  Even-odd accumulation handles holes correctly. */
+  function _pointInFeature(lat, lon, feat) {
+    // Bbox pre-filter
+    var bb = feat.bbox;
+    if (lon < bb[0] || lon > bb[2] || lat < bb[1] || lat > bb[3]) return false;
+    var insideCount = 0;
+    for (var i = 0; i < feat.rings.length; i++) {
+      if (_pointInRing(lat, lon, feat.rings[i])) insideCount++;
+    }
+    return (insideCount % 2) === 1;
+  }
+
+  /** Find the county containing (lat, lon). Returns {fips, name} or null.
+   *  Async — call init() first or wait for the returned promise. */
+  function lookup(lat, lon) {
+    return init().then(function () {
+      return lookupSync(lat, lon);
+    });
+  }
+
+  /** Synchronous lookup. Throws if init() hasn't completed yet. */
+  function lookupSync(lat, lon) {
+    if (!_features) return null;
+    if (!isFinite(lat) || !isFinite(lon)) return null;
+    for (var i = 0; i < _features.length; i++) {
+      var f = _features[i];
+      if (_pointInFeature(lat, lon, f)) {
+        return { fips: f.fips, name: f.name };
+      }
+    }
+    return null;
+  }
+
+  /** Test whether init() has completed and data is ready. */
+  function isReady() {
+    return _features !== null && _features.length > 0;
+  }
+
+  window.CountyFromCoords = {
+    init: init,
+    lookup: lookup,
+    lookupSync: lookupSync,
+    isReady: isReady,
+  };
+})();

--- a/js/deal-calculator.js
+++ b/js/deal-calculator.js
@@ -434,6 +434,54 @@
             <option value="">Default (Denver MSA)</option>
           </select>
         </label>
+        <!-- Site coords → county auto-detect (PR #794+1). Useful when the
+             site is in a cross-county place (Erie, Aurora, Longmont) and
+             the user doesn't know which county's HUD AMI applies. Fed by
+             js/county-from-coords.js (point-in-polygon vs TIGER). -->
+        <details style="margin-top:-0.25rem;margin-bottom:var(--sp2);">
+          <summary style="font-size:var(--tiny);color:var(--accent,#096e65);cursor:pointer;
+                          padding:0.25rem 0;font-weight:600;">
+            Auto-detect county from site coordinates &rarr;
+          </summary>
+          <div style="margin-top:0.4rem;padding:0.5rem 0.75rem;border:1px solid var(--border);
+                      border-radius:var(--radius);background:var(--bg2);">
+            <p style="font-size:var(--tiny);color:var(--muted);margin:0 0 0.4rem;">
+              Useful when the site is in a town that spans multiple counties (Erie, Aurora,
+              Longmont, etc.). Paste lat/lon below — the county will auto-fill above.
+            </p>
+            <div style="display:grid;grid-template-columns:1fr 1fr auto;gap:0.4rem;align-items:end;">
+              <label style="display:block;font-size:var(--tiny);">
+                <span style="color:var(--muted);">Latitude</span>
+                <input id="dc-coords-lat" type="number" step="0.000001" placeholder="39.7392"
+                  style="display:block;width:100%;margin-top:0.2rem;padding:0.3rem 0.4rem;
+                         border:1px solid var(--border);border-radius:4px;background:var(--bg);
+                         color:var(--text);font-size:var(--small);">
+              </label>
+              <label style="display:block;font-size:var(--tiny);">
+                <span style="color:var(--muted);">Longitude</span>
+                <input id="dc-coords-lon" type="number" step="0.000001" placeholder="-104.9847"
+                  style="display:block;width:100%;margin-top:0.2rem;padding:0.3rem 0.4rem;
+                         border:1px solid var(--border);border-radius:4px;background:var(--bg);
+                         color:var(--text);font-size:var(--small);">
+              </label>
+              <button type="button" id="dc-coords-detect"
+                style="padding:0.4rem 0.6rem;border:1px solid var(--accent,#096e65);
+                       background:var(--accent,#096e65);color:#fff;border-radius:4px;
+                       font-size:var(--tiny);font-weight:600;cursor:pointer;height:fit-content;">
+                Detect
+              </button>
+            </div>
+            <div style="margin-top:0.4rem;display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap;">
+              <button type="button" id="dc-coords-geo"
+                style="padding:0.3rem 0.5rem;border:1px solid var(--border);background:transparent;
+                       color:var(--text);border-radius:4px;font-size:var(--tiny);cursor:pointer;">
+                Use my location
+              </button>
+              <span id="dc-coords-result" style="font-size:var(--tiny);color:var(--muted);
+                                                 line-height:1.4;flex:1;min-width:200px;"></span>
+            </div>
+          </div>
+        </details>
         <div id="dc-fmr-note" style="font-size:var(--tiny);color:var(--warn, #e6a23c);margin-top:-0.25rem;margin-bottom:var(--sp2);">
           Select a county above to load HUD-published AMI rent limits for that county.
         </div>
@@ -2252,6 +2300,108 @@
       console.warn('[deal-calculator] AMI gap data unavailable');
       if (window.CohoToast) window.CohoToast.show('AMI gap data unavailable — some affordability context may be missing.', 'warn');
     });
+
+    // ── Parcel→county auto-detect (PR #795) ───────────────────────────
+    // Wire the lat/lon detect button + browser geolocation. On a hit,
+    // set the county selector to the detected county and dispatch the
+    // change event so all downstream renders fire.
+    _wireCountyDetect(countySel);
+    }
+  }
+
+  /**
+   * Hook up the lat/lon → county auto-detection UI controls.
+   * @param {HTMLSelectElement} countySel - the dc-county-select element
+   */
+  function _wireCountyDetect(countySel) {
+    var detectBtn = document.getElementById('dc-coords-detect');
+    var geoBtn    = document.getElementById('dc-coords-geo');
+    var latEl     = document.getElementById('dc-coords-lat');
+    var lonEl     = document.getElementById('dc-coords-lon');
+    var resultEl  = document.getElementById('dc-coords-result');
+    if (!detectBtn || !latEl || !lonEl || !resultEl || !countySel) return;
+
+    function setResult(html, color) {
+      resultEl.innerHTML = html;
+      resultEl.style.color = color || 'var(--muted)';
+    }
+
+    function runLookup(lat, lon) {
+      if (!isFinite(lat) || !isFinite(lon)) {
+        setResult('Enter valid lat/lon coordinates.', 'var(--bad,#dc2626)');
+        return;
+      }
+      // Clamp sanity-check: CO is roughly 37-41N, -109 to -102W
+      if (lat < 36 || lat > 42 || lon < -110 || lon > -101) {
+        setResult('Coordinates appear to be outside Colorado (CO is ~37-41°N, -109 to -102°W).',
+          'var(--warn,#d97706)');
+      }
+      if (!window.CountyFromCoords) {
+        setResult('County lookup module not loaded.', 'var(--bad,#dc2626)');
+        return;
+      }
+      setResult('Looking up county…', 'var(--muted)');
+      window.CountyFromCoords.lookup(lat, lon).then(function (county) {
+        if (!county) {
+          setResult('No CO county found for those coordinates. Try the County dropdown above directly.',
+            'var(--warn,#d97706)');
+          return;
+        }
+        // Find + select the matching option
+        var matched = false;
+        for (var i = 0; i < countySel.options.length; i++) {
+          if (countySel.options[i].value === county.fips) {
+            countySel.value = county.fips;
+            countySel.dispatchEvent(new Event('change', { bubbles: true }));
+            matched = true;
+            break;
+          }
+        }
+        if (matched) {
+          setResult(
+            '✓ Detected: <strong>' + county.name + ' County</strong> (' + county.fips +
+            '). HUD AMI rent limits + cross-county disclosure updated above.',
+            'var(--good,#16a34a)'
+          );
+        } else {
+          setResult(
+            'Detected ' + county.name + ' County (' + county.fips +
+            ') but it is not in the dropdown — pick manually.',
+            'var(--warn,#d97706)'
+          );
+        }
+      }).catch(function (err) {
+        setResult('Lookup failed: ' + (err && err.message ? err.message : err),
+          'var(--bad,#dc2626)');
+      });
+    }
+
+    detectBtn.addEventListener('click', function () {
+      var lat = parseFloat(latEl.value);
+      var lon = parseFloat(lonEl.value);
+      runLookup(lat, lon);
+    });
+
+    if (geoBtn) {
+      geoBtn.addEventListener('click', function () {
+        if (!navigator.geolocation) {
+          setResult('Browser geolocation not available.', 'var(--bad,#dc2626)');
+          return;
+        }
+        setResult('Requesting your location…', 'var(--muted)');
+        navigator.geolocation.getCurrentPosition(
+          function (pos) {
+            latEl.value = pos.coords.latitude.toFixed(6);
+            lonEl.value = pos.coords.longitude.toFixed(6);
+            runLookup(pos.coords.latitude, pos.coords.longitude);
+          },
+          function (err) {
+            setResult('Geolocation denied or unavailable: ' + err.message,
+              'var(--warn,#d97706)');
+          },
+          { enableHighAccuracy: false, timeout: 10000, maximumAge: 60000 }
+        );
+      });
     }
   }
 

--- a/test/county-from-coords.test.js
+++ b/test/county-from-coords.test.js
@@ -1,0 +1,147 @@
+// test/county-from-coords.test.js
+//
+// Tests for js/county-from-coords.js — point-in-polygon lookup of CO
+// counties from lat/lon. Verifies:
+//   - Module structure + API surface
+//   - Path-convention regression guard (PR #791)
+//   - Point-in-polygon math for known city centroids
+//     (Denver, Colorado Springs, Pueblo, Aurora, Boulder, Fort Collins,
+//      Grand Junction, Durango, Steamboat Springs)
+//   - Bbox pre-filter rejects outside-CO points
+//   - Deal Calculator wiring + HTML script ordering
+//
+// Run: node test/county-from-coords.test.js
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+const vm   = require('vm');
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond, msg) {
+  if (cond) { console.log('  ✅ PASS: ' + msg); passed++; }
+  else { console.error('  ❌ FAIL: ' + msg); failed++; }
+}
+
+function readRel(rel) {
+  return fs.readFileSync(path.join(__dirname, '..', rel), 'utf8');
+}
+
+console.log('\n[test] Module structure');
+const src = readRel('js/county-from-coords.js');
+assert(/window\.CountyFromCoords\s*=\s*\{/.test(src),
+  'attaches CountyFromCoords to window');
+['init', 'lookup', 'lookupSync', 'isReady'].forEach((fn) => {
+  assert(new RegExp('function\\s+' + fn + '\\s*\\(').test(src),
+    'defines ' + fn + '() function');
+});
+['_pointInRing', '_pointInFeature', '_extractRings', '_normalizeFeatures', '_computeBbox'].forEach((fn) => {
+  assert(new RegExp('function\\s+' + fn + '\\s*\\(').test(src),
+    'defines internal helper ' + fn + '()');
+});
+
+console.log('\n[test] Path convention regression guard (PR #791)');
+assert(!/baseData\s*\(\s*['"]data\//.test(src),
+  'no path passed to baseData() starts with "data/"');
+assert(/BOUNDARIES_PATH\s*=\s*['"](?!data\/)/.test(src),
+  'BOUNDARIES_PATH does not start with "data/"');
+
+console.log('\n[test] Point-in-polygon math: known city centroids land in correct county');
+
+// Load the module in a sandbox + run point-in-polygon tests against
+// the real boundary data.
+const boundaries = JSON.parse(readRel('data/co-county-boundaries.json'));
+const sandbox = { window: {}, fetch: function () { return Promise.resolve({ json: () => Promise.resolve(boundaries) }); } };
+sandbox.window.fetch = sandbox.fetch;
+vm.createContext(sandbox);
+vm.runInContext(src, sandbox);
+const cfc = sandbox.window.CountyFromCoords;
+assert(typeof cfc === 'object' && cfc != null,
+  'module loads in sandbox');
+
+// Pre-load synchronously by calling _normalizeFeatures equivalent
+// — easier path: call init() and await
+async function runMathTests() {
+  await cfc.init();
+  assert(cfc.isReady(), 'isReady() returns true after init');
+
+  // Known city-hall lat/lon → expected county FIPS
+  // Sources: standard public knowledge / GeoNames
+  const cases = [
+    { lat: 39.7392, lon: -104.9903,  expectedFips: '08031', expectedName: 'Denver',     city: 'Denver' },
+    { lat: 38.8339, lon: -104.8214,  expectedFips: '08041', expectedName: 'El Paso',    city: 'Colorado Springs' },
+    { lat: 38.2544, lon: -104.6091,  expectedFips: '08101', expectedName: 'Pueblo',     city: 'Pueblo' },
+    { lat: 39.7294, lon: -104.8319,  expectedFips: '08005', expectedName: 'Arapahoe',   city: 'Aurora (Arapahoe portion)' },
+    { lat: 40.0150, lon: -105.2705,  expectedFips: '08013', expectedName: 'Boulder',    city: 'Boulder' },
+    { lat: 40.5853, lon: -105.0844,  expectedFips: '08069', expectedName: 'Larimer',    city: 'Fort Collins' },
+    { lat: 39.0639, lon: -108.5506,  expectedFips: '08077', expectedName: 'Mesa',       city: 'Grand Junction' },
+    { lat: 37.2753, lon: -107.8801,  expectedFips: '08067', expectedName: 'La Plata',   city: 'Durango' },
+    { lat: 40.4850, lon: -106.8317,  expectedFips: '08107', expectedName: 'Routt',      city: 'Steamboat Springs' },
+    { lat: 39.5501, lon: -105.7821,  expectedFips: '08093', expectedName: 'Park',       city: 'Bailey' },
+  ];
+
+  for (const c of cases) {
+    const result = cfc.lookupSync(c.lat, c.lon);
+    if (result && result.fips === c.expectedFips) {
+      console.log('  ✅ PASS: ' + c.city + ' (' + c.lat + ',' + c.lon + ') → ' + result.name + ' County (' + result.fips + ')');
+      passed++;
+    } else {
+      const got = result ? (result.name + ' County / ' + result.fips) : 'null';
+      console.error('  ❌ FAIL: ' + c.city + ' expected ' + c.expectedName + ' (' + c.expectedFips + '), got ' + got);
+      failed++;
+    }
+  }
+
+  // Outside-CO bbox should return null
+  const outside = [
+    { lat: 35.0,    lon: -100.0,  city: 'Texas Panhandle' },
+    { lat: 41.5,    lon: -111.0,  city: 'Wyoming' },
+    { lat: 40.0,    lon: -100.0,  city: 'Nebraska' },
+  ];
+  for (const c of outside) {
+    const result = cfc.lookupSync(c.lat, c.lon);
+    assert(result === null,
+      'Outside-CO point (' + c.city + ') returns null');
+  }
+
+  // Invalid input handling
+  assert(cfc.lookupSync(NaN, -105) === null,
+    'NaN lat returns null');
+  assert(cfc.lookupSync(40, undefined) === null,
+    'undefined lon returns null');
+}
+
+(async function () {
+  await runMathTests();
+
+  console.log('\n[test] Deal Calculator wiring');
+  const dcSrc = readRel('js/deal-calculator.js');
+  assert(/dc-coords-lat/.test(dcSrc) && /dc-coords-lon/.test(dcSrc),
+    'Deal Calculator HTML has #dc-coords-lat and #dc-coords-lon inputs');
+  assert(/dc-coords-detect/.test(dcSrc),
+    'Deal Calculator has #dc-coords-detect button');
+  assert(/dc-coords-geo/.test(dcSrc),
+    'Deal Calculator has #dc-coords-geo (geolocation) button');
+  assert(/_wireCountyDetect/.test(dcSrc),
+    'Deal Calculator defines _wireCountyDetect helper');
+  assert(/window\.CountyFromCoords/.test(dcSrc),
+    'Deal Calculator references window.CountyFromCoords');
+  assert(/navigator\.geolocation/.test(dcSrc),
+    'Deal Calculator uses navigator.geolocation for "Use my location"');
+
+  console.log('\n[test] HTML script tag ordering');
+  const html = readRel('deal-calculator.html');
+  const cfcIdx = html.indexOf('county-from-coords.js');
+  const dcIdx  = html.indexOf('js/deal-calculator.js');
+  assert(cfcIdx >= 0,
+    'deal-calculator.html includes county-from-coords.js');
+  assert(cfcIdx < dcIdx,
+    'county-from-coords.js loads BEFORE deal-calculator.js');
+
+  console.log('\n=========================================');
+  console.log('Results: ' + passed + ' passed, ' + failed + ' failed');
+  process.exit(failed === 0 ? 0 : 1);
+})();


### PR DESCRIPTION
## Summary

Closes the highest-value remaining item from the cross-county arc. Lets users in cross-county jurisdictions (Erie, Aurora, Longmont, etc.) auto-fill the county selector from the parcel's actual lat/lon, using TIGER county boundary data already on disk and a 30-line ray-casting algorithm in the browser.

## Why

The Deal Calculator currently asks the user to manually pick a county. That's friction AND a correctness risk in the 26 cross-county CO places (PR #787): a parcel on the wrong side of a county line is in a DIFFERENT HUD AMI tier than the place's "primary" county. With this PR, the user pastes lat/lon (or uses browser geolocation) → point-in-polygon against TIGER county boundaries → county auto-fills above. The downstream cascade (HUD FMR rent limits → AMI gap → deal predictor → cross-county disclosure → HMDA context) fires automatically via the existing `change` event.

## Mechanism

1. **`js/county-from-coords.js`** — new browser-side module exposing `window.CountyFromCoords.{init, lookup, lookupSync, isReady}`. Loads `data/co-county-boundaries.json` (TIGER, 126 KB), normalizes Polygon + MultiPolygon to a flat ring-list, bbox-pre-filters, runs ray-casting PnP with even-odd ring accumulation. ~3,800 vertex tests worst-case across all 64 counties — sub-millisecond.

2. **Deal Calculator UI** — new collapsible "Auto-detect county from site coordinates" details element under the county selector. Lat/lon inputs + "Detect" button + "Use my location" button. Result line shows `✓ Detected: Boulder County (08013) ...`.

3. **No new data files, no new runtime deps.** Reuses existing `data/co-county-boundaries.json` already on disk for the map layer.

## Test plan

- [x] `node test/county-from-coords.test.js` → 37/37 pass, including 10 known city centroids:
  - Denver → 08031, Colorado Springs → 08041, Pueblo → 08101, Aurora → 08005, Boulder → 08013, Fort Collins → 08069, Grand Junction → 08077, Durango → 08067, Steamboat Springs → 08107, Bailey → 08093
- [x] Outside-CO bbox: TX panhandle, WY, NE → null
- [x] NaN/undefined coords → null
- [x] **Regression sweep: 257 existing JS assertions across 8 test suites still pass**
- [ ] After merge: pick a CO site lat/lon → confirm county auto-fills + downstream HMDA + cross-county disclosure update

## What's next after this merges

| # | Item | Source |
|---|---|---|
| **A** | Affordability rate + price/rent ratio metrics on colorado-deep-dive | Comparison review (flamingo_project) |
| **B** | Rent vs buy breakeven horizon on Deal Calc | Comparison review (flamingo_project) |
| **C** | Plain-language methodology side panel | Comparison review (striblab) |
| **D** | Per-place detail pages (larger arc) | Comparison review (striblab) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)