### PR TITLE
fix(hna): chart-canvas ID drift — chartIncomeDistribution + chartScenarioComparison + audit guard

### DIFF
--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -1102,7 +1102,10 @@
    */
   function _renderScenarioSection(proj, popSel, years, baseYear, countyFips5, t) {
     // Scenario comparison chart
-    const compCanvas = document.getElementById('chartScenarioComp');
+    // ID drift fix: HTML canvas is "chartScenarioComparison"; this code
+    // previously looked for the truncated "chartScenarioComp" and the
+    // chart never rendered. Audit pass 2026-05-10.
+    const compCanvas = document.getElementById('chartScenarioComparison');
     if (compCanvas && proj) {
       const scenarios = window.HNAUtils.PROJECTION_SCENARIOS || {};
       const datasets = Object.entries(scenarios).map(([key, meta]) => {
@@ -1236,7 +1239,10 @@
   }
 
   function renderIncomeDistribution(profile) {
-    const canvas = document.getElementById('chartIncomeDistrib');
+    // ID drift fix: HTML canvas is "chartIncomeDistribution" (full name);
+    // this code previously looked for the truncated "chartIncomeDistrib"
+    // and the chart never rendered. Audit pass 2026-05-10.
+    const canvas = document.getElementById('chartIncomeDistribution');
     if (!canvas || !profile) return;
     const t = chartTheme();
     const safeNum = U().safeNum;

--- a/test/chart-id-coherence.test.js
+++ b/test/chart-id-coherence.test.js
@@ -1,0 +1,126 @@
+// test/chart-id-coherence.test.js
+//
+// Regression test for chart-canvas ID drift.
+//
+// Pre-fix bug discovered during 2026-05-10 audit:
+//   - js/hna/hna-renderers.js renderIncomeDistribution() looked up
+//     'chartIncomeDistrib' (truncated) but the HTML canvas has
+//     'chartIncomeDistribution' (full name).  Result: chart never
+//     rendered.
+//   - Same drift on _renderScenarioSection — looked up
+//     'chartScenarioComp' but HTML has 'chartScenarioComparison'.
+//
+// This test does an automated coherence check: every getElementById(...)
+// call in the JS that targets a chart/map ID must correspond to a real
+// canvas/element ID in some HTML file. Catches truncation/typo bugs.
+//
+// Allow-listed exceptions:
+//   - 'chartChasGapProxyNote' — created dynamically by the renderer
+//   - 'bmComparisonChart'      — injected by benchmark-ui.js itself
+//   - 'map-error-notification' — created dynamically by error handler
+//
+// Run: node test/chart-id-coherence.test.js
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond, msg) {
+  if (cond) { console.log('  ✅ PASS: ' + msg); passed++; }
+  else { console.error('  ❌ FAIL: ' + msg); failed++; }
+}
+
+const REPO_ROOT = path.join(__dirname, '..');
+
+function listFiles(dir, pattern) {
+  const out = [];
+  function walk(d) {
+    let entries;
+    try { entries = fs.readdirSync(d, { withFileTypes: true }); }
+    catch (_) { return; }
+    for (const e of entries) {
+      const p = path.join(d, e.name);
+      if (e.isDirectory()) {
+        if (e.name === 'node_modules' || e.name === 'archive') continue;
+        walk(p);
+      } else if (e.isFile() && pattern.test(e.name)) {
+        out.push(p);
+      }
+    }
+  }
+  walk(dir);
+  return out;
+}
+
+// 1) Collect chart/map IDs from getElementById in all JS
+const idPattern = /getElementById\(\s*['"](chart[A-Za-z0-9_-]+|map[A-Za-z0-9_-]+|[a-zA-Z]+Chart|[a-zA-Z]+Map)['"]\s*\)/g;
+const jsFiles = listFiles(path.join(REPO_ROOT, 'js'), /\.js$/);
+const jsIds = new Map();
+for (const f of jsFiles) {
+  const text = fs.readFileSync(f, 'utf8');
+  let m;
+  while ((m = idPattern.exec(text)) !== null) {
+    const id = m[1];
+    if (!jsIds.has(id)) jsIds.set(id, []);
+    jsIds.get(id).push(path.relative(REPO_ROOT, f));
+  }
+}
+
+// 2) Collect ALL element IDs from HTML
+const htmlIds = new Set();
+const htmlFiles = listFiles(REPO_ROOT, /\.html$/);
+const idAttr = /id="([a-zA-Z][a-zA-Z0-9_-]+)"/g;
+for (const f of htmlFiles) {
+  const rel = path.relative(REPO_ROOT, f);
+  if (rel.includes('archive/') || rel.includes('docs/') || rel.includes('assets/')) continue;
+  const text = fs.readFileSync(f, 'utf8');
+  let m;
+  while ((m = idAttr.exec(text)) !== null) {
+    htmlIds.add(m[1]);
+  }
+}
+
+// 3) Allow-list known dynamic IDs
+const ALLOWLIST = new Set([
+  'chartChasGapProxyNote',   // dynamically created by renderer
+  'bmComparisonChart',       // injected by benchmark-ui.js
+  'map-error-notification',  // dynamically created by error handler
+]);
+
+console.log('\n[test] All JS-referenced chart/map IDs exist in some HTML page');
+console.log('  Discovered ' + jsIds.size + ' chart/map IDs in JS, ' + htmlIds.size + ' total IDs in HTML');
+
+let mismatches = 0;
+for (const [id, refs] of jsIds) {
+  if (ALLOWLIST.has(id)) continue;
+  if (!htmlIds.has(id)) {
+    console.error('  ❌ FAIL: JS getElementById("' + id + '") but no HTML has id="' + id + '"');
+    console.error('         referenced from: ' + refs.join(', '));
+    failed++;
+    mismatches++;
+  }
+}
+if (mismatches === 0) {
+  console.log('  ✅ PASS: every JS-referenced chart/map ID resolves to an HTML element');
+  passed++;
+}
+
+// 4) Spot-check the two specific bugs fixed in this PR
+console.log('\n[test] Specific drift-bug regression guards');
+const renderersSrc = fs.readFileSync(path.join(REPO_ROOT, 'js/hna/hna-renderers.js'), 'utf8');
+assert(/getElementById\(\s*['"]chartIncomeDistribution['"]/.test(renderersSrc),
+  "renderIncomeDistribution looks up 'chartIncomeDistribution' (full name)");
+assert(!/getElementById\(\s*['"]chartIncomeDistrib['"]/.test(renderersSrc),
+  "no remaining lookup for truncated 'chartIncomeDistrib'");
+assert(/getElementById\(\s*['"]chartScenarioComparison['"]/.test(renderersSrc),
+  "_renderScenarioSection looks up 'chartScenarioComparison' (full name)");
+assert(!/getElementById\(\s*['"]chartScenarioComp['"][\s,)]/.test(renderersSrc),
+  "no remaining lookup for truncated 'chartScenarioComp'");
+
+console.log('\n=========================================');
+console.log('Results: ' + passed + ' passed, ' + failed + ' failed');
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## User-driven audit: "check all other charts and maps data... for failures"

Followed the chart drift fix in PR #796 with a full audit of every chart canvas + map container across all root HTML pages. Two more drift bugs found and fixed; 7 latent orphans surfaced + flagged for separate PRs; all map data files verified.

## Bugs fixed

| ID expected by JS | ID in HTML | Effect |
|---|---|---|
| `chartIncomeDistrib` | `chartIncomeDistribution` | Income distribution chart never rendered |
| `chartScenarioComp` | `chartScenarioComparison` | "Population projection by scenario" headline chart never rendered |

Both are 1-line corrections to match canonical HTML IDs.

## What this audit found

| Category | Count | Status |
|---|---|---|
| Total chart/map IDs cataloged across root HTML | 71 | — |
| JS `getElementById(...)` calls with chart/map IDs | 35 | — |
| ID drift bugs found + fixed in this PR | 2 | ✅ Fixed |
| Latent orphan canvases (HTML present, no JS renderer ever wired) | 7 | 🟡 Flagged for follow-up |
| Map data files verified (boundaries, QCT/DDA, CHFA, HMDA, place-CHAS, etc.) | 8 | ✅ All exist + parse |

## Latent orphans (out of scope — flagged for separate PRs)

These canvases exist in HTML but have no JS renderer at all. Pre-existing gaps, not caused by recent changes:

- `chartProjectedHH` — Projected households over time
- `chartProjectionDetail` — Selected scenario detail
- `chartHouseholdDemand` — Housing demand by AMI tier (renderer exists but no caller wires the canvas)
- `chartProp123Growth` — Prop 123 annual growth tracking
- `chartProp123Historical` — Prop 123 historical compliance
- `chartConstructionEra` — already flagged via prior `spawn_task` chip
- `chartHousingTypeComposition` — already flagged via prior `spawn_task` chip

These need data-flow wiring (not just ID corrections), so each is its own focused follow-up PR rather than bundling here.

## Ongoing protection

`test/chart-id-coherence.test.js` (new):
- Automated coherence check: every `getElementById('chart...')` / `getElementById('map...')` in JS must correspond to a real `id="..."` in some HTML file (with allow-list for dynamically-created elements: `chartChasGapProxyNote`, `bmComparisonChart`, `map-error-notification`).
- Catches truncation/typo drift at test time so this class of bug doesn't reach production again.
- Plus 4 specific regression guards for the two bugs fixed here.

## Test plan

- [x] `node test/chart-id-coherence.test.js` → 5/5 pass
- [x] **Regression sweep across 12 JS test suites: 391/391 pass**
  - dc-constants, dc-rent-achievability, place-chas-lookup, cross-county-disclosure, hmda-lookup, place-chas-coverage-panel, hmda-trend-and-chas-badge, unit-mix-validation, county-from-coords, hna-dp04-codes, acs-integration, chart-id-coherence
- [x] `node -c js/hna/hna-renderers.js` → syntax OK
- [ ] After merge: confirm "Income distribution" chart on HNA renders, and "Population projection by scenario" chart in the projections section renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)