### PR TITLE
fix(hna): chartRentBurdenBins reads correct ACS 2023 PE codes

### DIFF
--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -479,16 +479,19 @@
     if (!canvas || !profile) return;
     const t       = chartTheme();
     const safeNum = U().safeNum;
-    // DP04 gross-rent-as-pct-of-income bins (2023 ACS confirmed)
+    // DP04 gross-rent-as-pct-of-income bins (ACS 2023). The cached
+    // summary files and fetchAcsExtended both populate the *PE
+    // (percent-of-renters) fields, not the *E (count) fields.
     const bins = [
-      { label: '<15%',    key: 'DP04_0136E' },
-      { label: '15–20%',  key: 'DP04_0137E' },
-      { label: '20–25%',  key: 'DP04_0138E' },
-      { label: '25–30%',  key: 'DP04_0139E' },
-      { label: '30–35%',  key: 'DP04_0140E' },
-      { label: '35%+',    key: 'DP04_0141E' },
+      { label: '<15%',    key: 'DP04_0137PE' },
+      { label: '15–20%',  key: 'DP04_0138PE' },
+      { label: '20–25%',  key: 'DP04_0139PE' },
+      { label: '25–30%',  key: 'DP04_0140PE' },
+      { label: '30–35%',  key: 'DP04_0141PE' },
+      { label: '35%+',    key: 'DP04_0142PE' },
     ];
     const values = bins.map(b => safeNum(profile[b.key]) || 0);
+    if (values.every(v => v === 0)) return;
     const colors = bins.map((_b, i) => i < 4 ? t.c1 : t.c5);
     makeChart(canvas.getContext('2d'), {
       type: 'bar',
@@ -502,7 +505,10 @@
         plugins: { legend: { display: false } },
         scales: {
           x: { ticks: { color: t.muted }, grid: { color: t.border } },
-          y: { ticks: { color: t.muted }, grid: { color: t.border } },
+          y: {
+            ticks: { color: t.muted, callback: v => `${v}%` },
+            grid: { color: t.border },
+          },
         },
       },
     });

--- a/test/hna-rent-burden-bins.test.js
+++ b/test/hna-rent-burden-bins.test.js
@@ -1,0 +1,86 @@
+// test/hna-rent-burden-bins.test.js
+//
+// Regression for 2026-05-15 fix: renderRentBurdenBins was reading
+// DP04_0136E..DP04_0141E (count fields), but the cached summary and
+// fetchAcsExtended only populate DP04_0137PE..DP04_0142PE (percent
+// fields). Every bar rendered as zero — chart looked broken in the
+// browser, but the test suite passed because nothing actually
+// validated which codes the renderer consumed.
+//
+// What it asserts:
+//   - The renderer's `bins` array uses the 6 PE codes that are
+//     actually populated by the data pipeline
+//   - The codes that fetchAcsExtended.batchA fetches (DP04_0141PE,
+//     DP04_0142PE) are still represented in the renderer
+//   - Sample summary file 08001.json carries the PE fields (cache
+//     parity check — catches data-pipeline regressions too)
+//
+// Run: node test/hna-rent-burden-bins.test.js
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond, msg) {
+  if (cond) { console.log('  ✅ PASS: ' + msg); passed++; }
+  else { console.error('  ❌ FAIL: ' + msg); failed++; }
+}
+
+const REND_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'js/hna/hna-renderers.js'),
+  'utf8'
+);
+
+console.log('\n[test] renderRentBurdenBins uses ACS 2023 PE codes');
+
+// Extract the bins array inside renderRentBurdenBins
+const fnMatch = REND_SRC.match(
+  /function renderRentBurdenBins\([\s\S]*?const bins = \[([\s\S]*?)\];/
+);
+assert(fnMatch != null, 'renderRentBurdenBins() found with bins literal');
+
+if (fnMatch) {
+  const binsBody = fnMatch[1];
+  const codes = (binsBody.match(/'DP04_\d{4}PE?'/g) || []).map(s => s.replace(/'/g, ''));
+
+  ['DP04_0137PE','DP04_0138PE','DP04_0139PE','DP04_0140PE','DP04_0141PE','DP04_0142PE']
+    .forEach(c => {
+      assert(codes.includes(c), 'bins use ' + c);
+    });
+
+  // The old broken count-codes should be gone
+  ['DP04_0136E','DP04_0137E','DP04_0140E','DP04_0141E']
+    .forEach(c => {
+      assert(!codes.includes(c),
+        'legacy count code ' + c + ' is no longer in bins');
+    });
+
+  // Y-axis tick callback should emit a percent suffix (post-fix change)
+  const yCallback = REND_SRC.match(
+    /function renderRentBurdenBins[\s\S]*?ticks:\s*\{\s*color:\s*t\.muted,\s*callback:\s*v\s*=>\s*`\$\{v\}%`/
+  );
+  assert(yCallback != null,
+    'y-axis ticks callback formats values with `%` suffix');
+}
+
+console.log('\n[test] cache parity — sample summary has the PE fields');
+const sampleSummary = path.join(__dirname, '..', 'data/hna/summary/08001.json');
+if (fs.existsSync(sampleSummary)) {
+  const parsed = JSON.parse(fs.readFileSync(sampleSummary, 'utf8'));
+  const ap = (parsed && parsed.acsProfile) || {};
+  ['DP04_0137PE','DP04_0138PE','DP04_0139PE','DP04_0140PE','DP04_0141PE','DP04_0142PE']
+    .forEach(c => {
+      assert(Object.prototype.hasOwnProperty.call(ap, c),
+        '08001 acsProfile carries ' + c);
+    });
+} else {
+  console.warn('  ⚠ data/hna/summary/08001.json not present; skipping cache parity');
+}
+
+console.log('\n=========================================');
+console.log('Results: ' + passed + ' passed, ' + failed + ' failed');
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary
- `renderRentBurdenBins` was reading `DP04_0136E..DP04_0141E` (count fields)
- The cached summary files + `fetchAcsExtended` only populate `DP04_0137PE..DP04_0142PE` (percent fields)
- Every bar rendered as zero → chart looked broken in the browser, but tests passed because nothing validated which codes the renderer actually consumed

## Changes
- Bins now use the 6 PE codes the data layer publishes
- Y-axis ticks formatted with `%` suffix (they're percentages)
- Early-return when all 6 values are zero so a missing-data state doesn't render six flat zero-bars

## Verification (real browser, not just source-grep)
Started the local http-server preview and pushed a synthetic profile through the renderer:
- Chart.js attaches to the canvas ✓
- All 6 labeled bars render with the realistic test values ✓
- Y-axis shows percent ticks ✓
- Empty-data path returns without rendering (no zero-bar masquerade) ✓

## Test plan
- [x] `node test/hna-rent-burden-bins.test.js` — 18 assertions covering renderer codes + cache parity
- [ ] After merge: hard-refresh HNA on a county (e.g. 08001 Adams) and confirm the renter cost-burden bin chart now shows 6 bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)