### PR TITLE
fix(hna): 5 real bugs from the deep-dive batch (rent burden, income needed, LIHTC dots, Statewide loading, methodology bullets)

### DIFF
--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -524,6 +524,38 @@ footer.site-footer { margin-top: var(--sp6); border-top: 1px solid var(--border)
 .map-legend .swatch-qct { width:14px;height:10px;border-radius:3px;display:inline-block;flex-shrink:0;background:rgba(120,255,170,.24);border:1px solid rgba(120,255,170,.55); }
 .map-legend .marker-lihtc { width:10px;height:10px;border-radius:50%;background:#5fa8ff;display:inline-block;flex-shrink:0; }
 .map-legend .marker-county { width:10px;height:10px;border-radius:2px;background:rgba(200,200,255,.35);border:1px solid rgba(130,130,220,.5);display:inline-block;flex-shrink:0; }
+/* Actual on-map LIHTC marker dot — built by the divIcon in hna-renderers
+   renderLihtcLayer(). Without explicit styling the inner <span> renders
+   as a zero-width inline element and markers are effectively invisible
+   even though the layer is on the map. Match the legend swatch so the
+   legend explains what's on the map. */
+.lihtc-marker { display:block; }
+.lihtc-marker .lihtc-dot {
+  display:block;
+  width:12px;height:12px;
+  border-radius:50%;
+  background:#5fa8ff;
+  border:2px solid #fff;
+  box-shadow:0 0 0 1px rgba(0,0,0,.35), 0 1px 3px rgba(0,0,0,.4);
+  box-sizing:border-box;
+}
+
+/* Methodology & Data Sources panel (HNA). The renderer injects
+   <ul class="method-list"> inside a card; default UA bullet indent
+   pushes the markers outside the card padding. Constrain the indent
+   so bullets sit inside the box. */
+.method-section { margin: 0 0 1rem; }
+.method-section h4 { font-size: .92rem; margin: 0 0 .35rem; color: var(--text); }
+.method-section p { margin: 0 0 .35rem; font-size: .85rem; color: var(--muted); line-height: 1.5; }
+.method-section .method-list {
+  margin: 0 0 .35rem;
+  padding-left: 1.25rem;
+  font-size: .85rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+.method-section .method-list li { margin: .15rem 0; }
+.method-section .method-list strong { color: var(--text); }
 .map-reset-btn { padding:8px 12px;font-size:13px;cursor:pointer;background:#fff;border:1px solid #ccc;border-radius:4px;box-shadow:0 1px 3px rgba(0,0,0,0.2);font-family:inherit; }
 .kpi-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px,1fr)); gap: 12px; margin: var(--sp3) 0; }
 .delta { font-weight: 700; font-size: 0.82rem; }

--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -1234,17 +1234,25 @@
 
     // ── Statewide card ──
     var swEl = document.getElementById('bridgeStatewideCard');
-    if (swEl && summary.statewide) {
-      var sw = summary.statewide;
-      var swHtml = '<strong style="font-size:.9rem;display:block;margin-bottom:.5rem">Statewide Context</strong>';
-      swHtml += '<div style="font-size:.82rem;color:var(--muted)">';
-      swHtml += '<div style="margin-bottom:.3rem">Statewide median assessed value: <strong style="color:var(--text)">' + fmtK(sw.median_assessed_value) + '</strong>' + tierBadge(sw.land_cost_tier) + '</div>';
-      swHtml += '<div style="margin-bottom:.3rem">Total transactions (12mo): <strong style="color:var(--text)">' + (sw.transaction_count_12mo != null ? sw.transaction_count_12mo.toLocaleString() : 'N/A') + '</strong></div>';
-      if (sw.data_generated) {
-        swHtml += '<div style="margin-top:.4rem;border-top:1px solid var(--border);padding-top:.4rem;font-size:.76rem">Data generated: ' + sw.data_generated + '</div>';
+    if (swEl) {
+      if (summary.statewide) {
+        var sw = summary.statewide;
+        var swHtml = '<strong style="font-size:.9rem;display:block;margin-bottom:.5rem">Statewide Context</strong>';
+        swHtml += '<div style="font-size:.82rem;color:var(--muted)">';
+        swHtml += '<div style="margin-bottom:.3rem">Statewide median assessed value: <strong style="color:var(--text)">' + fmtK(sw.median_assessed_value) + '</strong>' + tierBadge(sw.land_cost_tier) + '</div>';
+        swHtml += '<div style="margin-bottom:.3rem">Total transactions (12mo): <strong style="color:var(--text)">' + (sw.transaction_count_12mo != null ? sw.transaction_count_12mo.toLocaleString() : 'N/A') + '</strong></div>';
+        if (sw.data_generated) {
+          swHtml += '<div style="margin-top:.4rem;border-top:1px solid var(--border);padding-top:.4rem;font-size:.76rem">Data generated: ' + sw.data_generated + '</div>';
+        }
+        swHtml += '</div>';
+        swEl.innerHTML = swHtml;
+      } else {
+        // Bridge returned rural/region data but no statewide rollup — finalize the
+        // card so it doesn't sit on "Loading…" forever.
+        swEl.innerHTML =
+          '<strong style="font-size:.9rem;display:block;margin-bottom:.5rem">Statewide Context</strong>' +
+          '<p style="font-size:.8rem;color:var(--muted);margin:0">Statewide rollup pending — region-level data is shown above.</p>';
       }
-      swHtml += '</div>';
-      swEl.innerHTML = swHtml;
     }
   }
 

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -253,8 +253,17 @@
     const rb30 = U().rentBurden30Plus ? U().rentBurden30Plus(profile) : null;
     if (els.statRentBurden) els.statRentBurden.textContent = rb30 !== null ? fmtPct(rb30) : '—';
 
-    // Income needed to afford median rent (30% rule)
-    const incNeeded = U().computeIncomeNeeded ? U().computeIncomeNeeded(profile) : null;
+    // Income needed to buy the median home at the 30%-rule front-end
+    // ratio. computeIncomeNeeded takes a scalar home value and returns
+    // an object { annualIncome, ... } — earlier we were passing the
+    // whole profile and then formatting the object, which rendered as
+    // "—" (the function returned null on NaN input).
+    const incRes = U().computeIncomeNeeded
+      ? U().computeIncomeNeeded(homeVal)
+      : null;
+    const incNeeded = incRes && Number.isFinite(incRes.annualIncome)
+      ? incRes.annualIncome
+      : null;
     if (els.statIncomeNeed) {
       els.statIncomeNeed.textContent = incNeeded !== null ? fmtMoney(incNeeded) : '—';
     }

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -1648,51 +1648,395 @@
   // Labor market / economic sections (stubs — delegate to loaded modules)
   // ---------------------------------------------------------------------------
 
+  // ─────────────────────────────────────────────────────────────────────
+  // Labor Market + Economic Indicators
+  // ─────────────────────────────────────────────────────────────────────
+  //
+  // These renderers consume the LEHD cache loaded by the controller into
+  // `window.__HNA_LEHD_CACHE[geoid]`. They were stubs until 2026-05-16
+  // (the Labor Market section had no implementation, and the Economic
+  // Indicators trend charts read from a `state.lehdData` slot that was
+  // never populated). The data is rich — annualEmployment, annualWages,
+  // industries[], CNS01..CNS20, CE01–CE03, yoyGrowth — so the renderers
+  // are straightforward Chart.js wrappers over the existing utility
+  // helpers (calculateWageDistribution / parseIndustries).
+
+  /**
+   * Get the LEHD blob for a given geoid out of the controller's cache.
+   * Returns null if the cache hasn't been populated yet (e.g. state-level
+   * selection that didn't fetch a county file).
+   */
+  function _lehdFor(geoid) {
+    var cache = (typeof window !== 'undefined') && window.__HNA_LEHD_CACHE;
+    if (!cache) return null;
+    return cache[geoid] || cache['08'] || null;
+  }
+
+  /**
+   * Render an inline "no data" placeholder inside a chart container so
+   * an empty canvas doesn't pretend to be a working chart. Used by the
+   * stubs-now-implemented Labor Market + Economic Indicators panels.
+   */
+  function _placeholderInBox(canvas, message) {
+    if (!canvas) return;
+    var box = canvas.parentElement;
+    if (!box) return;
+    box.innerHTML = '<p style="margin:0;padding:1rem;color:var(--muted);font-size:.85rem;text-align:center">'
+      + escHtml(message) + '</p>';
+  }
+
   function renderLaborMarketSection(lehd, profile, geoType) {
-    if (!lehd && !profile) return;
-    const container = document.getElementById('laborMarketSection');
-    if (container && !lehd) {
-      container.textContent = 'LEHD flow cache not yet available for this geography.';
+    var t       = chartTheme();
+    var fmtNum  = U().fmtNum;
+    var fmtMoney = U().fmtMoney;
+
+    // ── jobMetrics cards ────────────────────────────────────────────
+    var metricsEl = document.getElementById('jobMetrics');
+    if (metricsEl) {
+      if (lehd) {
+        var metrics = U().calculateJobMetrics
+          ? U().calculateJobMetrics(lehd, profile)
+          : null;
+        if (metrics) {
+          var cards = [];
+          if (metrics.jobs)    cards.push({ label: 'Total Jobs',   value: fmtNum(metrics.jobs) });
+          if (metrics.within)  cards.push({ label: 'Live & Work Here', value: fmtNum(metrics.within) });
+          if (metrics.inflow)  cards.push({ label: 'Inflow Workers',   value: fmtNum(metrics.inflow) });
+          if (metrics.outflow) cards.push({ label: 'Outflow Workers',  value: fmtNum(metrics.outflow) });
+          if (metrics.jwRatio) cards.push({
+            label: 'Jobs : Workers',
+            value: (Math.round(metrics.jwRatio * 100) / 100).toFixed(2),
+          });
+          metricsEl.innerHTML = cards.map(function (c) {
+            return '<div class="metric"><h3>' + escHtml(c.label)
+              + '</h3><div class="value">' + escHtml(c.value) + '</div></div>';
+          }).join('');
+        } else {
+          metricsEl.innerHTML = '';
+        }
+      } else {
+        metricsEl.innerHTML = '<p style="margin:0;padding:.5rem;color:var(--muted);font-size:.85rem">'
+          + 'LEHD cache not yet available for this geography.</p>';
+      }
+    }
+
+    // ── chartWage — wage distribution snapshot ─────────────────────
+    var wageCanvas = document.getElementById('chartWage');
+    if (wageCanvas) {
+      var dist = lehd && U().calculateWageDistribution
+        ? U().calculateWageDistribution(lehd)
+        : null;
+      if (dist) {
+        makeChart(wageCanvas.getContext('2d'), {
+          type: 'bar',
+          data: {
+            labels: ['Low (≤$15k/yr)', 'Medium ($15–40k)', 'High ($40k+)'],
+            datasets: [{
+              data: [dist.low, dist.medium, dist.high],
+              backgroundColor: [t.c5, t.c3, t.c1],
+            }],
+          },
+          options: {
+            responsive: true, maintainAspectRatio: false,
+            plugins: {
+              legend: { display: false },
+              tooltip: { callbacks: { label: function (c) { return fmtNum(c.parsed.y) + ' jobs'; } } },
+            },
+            scales: {
+              x: { ticks: { color: t.muted }, grid: { color: t.border } },
+              y: { ticks: { color: t.muted, callback: function (v) { return fmtNum(v); } }, grid: { color: t.border } },
+            },
+          },
+        });
+      } else {
+        _placeholderInBox(wageCanvas, 'LEHD wage data not available for this geography.');
+      }
+    }
+
+    // ── chartIndustry — top industries by employment ───────────────
+    var indCanvas = document.getElementById('chartIndustry');
+    if (indCanvas) {
+      var industries = lehd && U().parseIndustries
+        ? U().parseIndustries(lehd, 6)
+        : [];
+      if (industries.length) {
+        makeChart(indCanvas.getContext('2d'), {
+          type: 'bar',
+          data: {
+            labels: industries.map(function (i) { return i.label; }),
+            datasets: [{ data: industries.map(function (i) { return i.count; }), backgroundColor: t.c1 }],
+          },
+          options: {
+            indexAxis: 'y',
+            responsive: true, maintainAspectRatio: false,
+            plugins: {
+              legend: { display: false },
+              tooltip: { callbacks: { label: function (c) { return fmtNum(c.parsed.x) + ' jobs'; } } },
+            },
+            scales: {
+              x: { ticks: { color: t.muted, callback: function (v) { return fmtNum(v); } }, grid: { color: t.border } },
+              y: { ticks: { color: t.muted }, grid: { color: t.border } },
+            },
+          },
+        });
+      } else {
+        _placeholderInBox(indCanvas, 'LEHD industry data not available for this geography.');
+      }
     }
   }
 
   function renderEmploymentTrend(geoid) {
-    const canvas = document.getElementById('chartEmploymentTrend');
+    var canvas = document.getElementById('chartEmploymentTrend');
     if (!canvas) return;
-    const econData = S().state && S().state.lehdData;
-    if (!econData) return;
-    const t = chartTheme();
-    const annual = (econData.annualEmployment || []);
-    if (!annual.length) return;
+    var lehd = _lehdFor(geoid);
+    var ae = lehd && lehd.annualEmployment;
+    // annualEmployment is a dict { year → totalJobs } in cache files.
+    var years = ae && typeof ae === 'object'
+      ? Object.keys(ae).sort()
+      : [];
+    if (!years.length) {
+      _placeholderInBox(canvas, 'Employment trend data not yet cached for this geography.');
+      return;
+    }
+    var t = chartTheme();
+    var fmtNum = U().fmtNum;
     makeChart(canvas.getContext('2d'), {
       type: 'line',
       data: {
-        labels: annual.map(d => d.year),
-        datasets: [{ label: 'Total Jobs', data: annual.map(d => d.total || 0), borderColor: t.c1, borderWidth: 2, pointRadius: 3, tension: 0.2 }],
+        labels: years,
+        datasets: [{
+          label: 'Total Jobs',
+          data: years.map(function (y) { return Number(ae[y]) || 0; }),
+          borderColor: t.c1, backgroundColor: 'rgba(9,110,101,.12)',
+          borderWidth: 2, pointRadius: 3, tension: 0.2, fill: true,
+        }],
       },
-      options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { labels: { color: t.text } } },
-        scales: { x: { ticks: { color: t.muted } }, y: { ticks: { color: t.muted } } } },
+      options: {
+        responsive: true, maintainAspectRatio: false,
+        plugins: {
+          legend: { labels: { color: t.text } },
+          tooltip: { callbacks: { label: function (c) { return fmtNum(c.parsed.y) + ' jobs'; } } },
+        },
+        scales: {
+          x: { ticks: { color: t.muted }, grid: { color: t.border } },
+          y: { ticks: { color: t.muted, callback: function (v) { return fmtNum(v); } }, grid: { color: t.border } },
+        },
+      },
     });
   }
 
   function renderWageTrend(geoid) {
-    const canvas = document.getElementById('chartWageTrend');
+    var canvas = document.getElementById('chartWageTrend');
     if (!canvas) return;
+    var lehd = _lehdFor(geoid);
+    var aw = lehd && lehd.annualWages;
+    var years = aw && typeof aw === 'object'
+      ? Object.keys(aw).sort()
+      : [];
+    if (!years.length) {
+      _placeholderInBox(canvas, 'Wage trend data not yet cached for this geography.');
+      return;
+    }
+    var t = chartTheme();
+    var fmtNum = U().fmtNum;
+    // Each year's wage record has {low, medium, high} job counts at the
+    // three LEHD WAC wage bands. Render three lines so the band-by-band
+    // year-over-year shift is glance-able.
+    var lowVals    = years.map(function (y) { return Number(aw[y] && aw[y].low)    || 0; });
+    var mediumVals = years.map(function (y) { return Number(aw[y] && aw[y].medium) || 0; });
+    var highVals   = years.map(function (y) { return Number(aw[y] && aw[y].high)   || 0; });
+    makeChart(canvas.getContext('2d'), {
+      type: 'line',
+      data: {
+        labels: years,
+        datasets: [
+          { label: 'Low (≤$15k)',    data: lowVals,    borderColor: t.c5, backgroundColor: t.c5, borderWidth: 2, pointRadius: 3, tension: 0.2 },
+          { label: 'Medium ($15–40k)', data: mediumVals, borderColor: t.c3, backgroundColor: t.c3, borderWidth: 2, pointRadius: 3, tension: 0.2 },
+          { label: 'High ($40k+)',   data: highVals,   borderColor: t.c1, backgroundColor: t.c1, borderWidth: 2, pointRadius: 3, tension: 0.2 },
+        ],
+      },
+      options: {
+        responsive: true, maintainAspectRatio: false,
+        plugins: {
+          legend: { labels: { color: t.text } },
+          tooltip: { callbacks: { label: function (c) { return c.dataset.label + ': ' + fmtNum(c.parsed.y) + ' jobs'; } } },
+        },
+        scales: {
+          x: { ticks: { color: t.muted }, grid: { color: t.border } },
+          y: { ticks: { color: t.muted, callback: function (v) { return fmtNum(v); } }, grid: { color: t.border } },
+        },
+      },
+    });
   }
 
   function renderIndustryAnalysis(geoid) {
-    const canvas = document.getElementById('chartIndustryAnalysis');
+    var canvas = document.getElementById('chartIndustryAnalysis');
     if (!canvas) return;
+    var lehd = _lehdFor(geoid);
+    var industries = lehd && U().parseIndustries
+      ? U().parseIndustries(lehd, 8)
+      : [];
+    if (!industries.length) {
+      _placeholderInBox(canvas, 'Industry analysis data not yet cached for this geography.');
+      return;
+    }
+    var t = chartTheme();
+    var fmtNum = U().fmtNum;
+    // Compute share-of-total for the share-axis label. Falls back to
+    // raw count when the pct field is absent (state-aggregate files
+    // already populate pct; per-county files don't always).
+    var total = industries.reduce(function (s, i) { return s + (i.count || 0); }, 0);
+    makeChart(canvas.getContext('2d'), {
+      type: 'bar',
+      data: {
+        labels: industries.map(function (i) { return i.label; }),
+        datasets: [{
+          data: industries.map(function (i) { return i.count; }),
+          backgroundColor: t.c2,
+        }],
+      },
+      options: {
+        indexAxis: 'y',
+        responsive: true, maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false },
+          tooltip: { callbacks: { label: function (c) {
+            var pct = total > 0 ? ' (' + ((c.parsed.x / total) * 100).toFixed(1) + '%)' : '';
+            return fmtNum(c.parsed.x) + ' jobs' + pct;
+          } } },
+        },
+        scales: {
+          x: { ticks: { color: t.muted, callback: function (v) { return fmtNum(v); } }, grid: { color: t.border } },
+          y: { ticks: { color: t.muted }, grid: { color: t.border } },
+        },
+      },
+    });
   }
 
   function renderEconomicIndicators(geoid) {
-    const container = document.getElementById('economicIndicatorsCards');
+    // Cards container — the HTML has #econIndicatorCards (lower section)
+    // and the legacy #economicIndicatorsCards is unused. Prefer the
+    // current one; fall back so the old ID keeps working if anything
+    // out-of-tree references it.
+    var container = document.getElementById('econIndicatorCards') ||
+      document.getElementById('economicIndicatorsCards');
     if (!container) return;
+    var lehd = _lehdFor(geoid);
+    if (!lehd) {
+      container.innerHTML = '<p style="margin:0;padding:.5rem;color:var(--muted);font-size:.85rem">'
+        + 'Economic indicators not yet cached for this geography.</p>';
+      return;
+    }
+    var fmtNum = U().fmtNum;
+    var ae    = lehd.annualEmployment || {};
+    var yoy   = lehd.yoyGrowth || {};
+    var years = Object.keys(ae).sort();
+    var latestYear  = years[years.length - 1];
+    var prevYear    = years[years.length - 2];
+    var latestJobs  = latestYear ? Number(ae[latestYear]) : null;
+    var prevJobs    = prevYear   ? Number(ae[prevYear])   : null;
+    var latestYoy   = yoy[latestYear];
+    var cumulative  = (latestJobs && prevJobs && years.length >= 5)
+      ? (((latestJobs - Number(ae[years[0]])) / Number(ae[years[0]])) * 100)
+      : null;
+
+    var cards = [];
+    if (latestJobs) {
+      cards.push({
+        label: 'Total Jobs (' + (latestYear || '') + ')',
+        value: fmtNum(latestJobs),
+      });
+    }
+    if (typeof latestYoy === 'number') {
+      cards.push({
+        label: 'YoY Change',
+        value: (latestYoy > 0 ? '+' : '') + latestYoy.toFixed(2) + '%',
+      });
+    }
+    if (cumulative !== null) {
+      cards.push({
+        label: years[0] + '–' + latestYear + ' Cumulative',
+        value: (cumulative > 0 ? '+' : '') + cumulative.toFixed(1) + '%',
+      });
+    }
+    if (lehd.industries && lehd.industries.length) {
+      cards.push({
+        label: 'Top Industry',
+        value: lehd.industries[0].label,
+      });
+    }
+    container.innerHTML = cards.map(function (c) {
+      return '<div class="metric"><h3>' + escHtml(c.label)
+        + '</h3><div class="value">' + escHtml(c.value) + '</div></div>';
+    }).join('');
   }
 
   function renderWageGaps(geoid, profile) {
-    const container = document.getElementById('wageGapsTable');
-    if (!container) return;
+    // Find the empty .chart-container--bar div the HTML reserves
+    // and inject a canvas for the wage-gap bar chart. The container
+    // is empty by design (HTML doesn't ship a canvas — the renderer
+    // owns the chart instance lifecycle).
+    var wrap = document.getElementById('wageGapsContainer');
+    if (!wrap) return;
+    var box = wrap.querySelector('.chart-container');
+    if (!box) return;
+
+    var lehd = _lehdFor(geoid);
+    var dist = lehd && U().calculateWageDistribution
+      ? U().calculateWageDistribution(lehd)
+      : null;
+    if (!dist || !dist.total) {
+      box.innerHTML = '<p style="margin:0;padding:1rem;color:var(--muted);font-size:.85rem;text-align:center">'
+        + 'Wage gap data not yet cached for this geography.</p>';
+      return;
+    }
+
+    // Ensure a canvas exists inside the box (idempotent on re-render).
+    var canvasId = 'chartWageGaps';
+    var canvas = document.getElementById(canvasId);
+    if (!canvas) {
+      box.innerHTML = '';
+      canvas = document.createElement('canvas');
+      canvas.id = canvasId;
+      canvas.setAttribute('role', 'img');
+      canvas.setAttribute('aria-label', 'Wage gap distribution: high vs medium vs low');
+      box.appendChild(canvas);
+    }
+
+    var t = chartTheme();
+    var fmtNum = U().fmtNum;
+    var lowPct    = (dist.low    / dist.total) * 100;
+    var mediumPct = (dist.medium / dist.total) * 100;
+    var highPct   = (dist.high   / dist.total) * 100;
+
+    makeChart(canvas.getContext('2d'), {
+      type: 'bar',
+      data: {
+        labels: ['Low (≤$15k/yr)', 'Medium ($15–40k)', 'High ($40k+)'],
+        datasets: [{
+          data: [lowPct, mediumPct, highPct],
+          backgroundColor: [t.c5, t.c3, t.c1],
+        }],
+      },
+      options: {
+        responsive: true, maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false },
+          tooltip: { callbacks: { label: function (c) {
+            var counts = [dist.low, dist.medium, dist.high][c.dataIndex];
+            return c.parsed.y.toFixed(1) + '% (' + fmtNum(counts) + ' jobs)';
+          } } },
+        },
+        scales: {
+          x: { ticks: { color: t.muted }, grid: { color: t.border } },
+          y: {
+            beginAtZero: true,
+            ticks: { color: t.muted, callback: function (v) { return v + '%'; } },
+            grid: { color: t.border },
+          },
+        },
+      },
+    });
   }
 
   // ---------------------------------------------------------------------------

--- a/js/hna/hna-utils.js
+++ b/js/hna/hna-utils.js
@@ -981,9 +981,14 @@
   }
 
   function rentBurden30Plus(pcts){
-    // DP04_0145PE (30-34.9) + DP04_0146PE (35+)
-    const a = Number(pcts.DP04_0145PE);
-    const b = Number(pcts.DP04_0146PE);
+    // ACS 2023 DP04 gross-rent-as-pct-of-income bins:
+    //   DP04_0141PE = 30-34.9%
+    //   DP04_0142PE = 35%+
+    // The legacy 2022-vintage codes (DP04_0145PE + 0146PE) were removed
+    // from the DP04 profile table starting with ACS 2023; the cache
+    // and fetchAcsExtended both publish the 2023 codes.
+    const a = Number(pcts.DP04_0141PE);
+    const b = Number(pcts.DP04_0142PE);
     if (!Number.isFinite(a) || !Number.isFinite(b)) return null;
     return a + b;
   }

--- a/test/hna-deep-dive-batch1.test.js
+++ b/test/hna-deep-dive-batch1.test.js
@@ -1,0 +1,106 @@
+'use strict';
+/**
+ * test/hna-deep-dive-batch1.test.js
+ *
+ * Regression for 2026-05-16 HNA deep-dive batch 1. The user reported a
+ * laundry list of broken or missing UI on housing-needs-assessment.html.
+ * This file locks down the five that were unambiguous bugs with clear
+ * fixes — leaving zombie / unimplemented features for a follow-up.
+ *
+ * Bugs in scope:
+ *   1. rentBurden30Plus() summed legacy 2022 codes (DP04_0145PE +
+ *      DP04_0146PE) that don't exist in the 2023 vintage cache,
+ *      so the Executive Snapshot "Rent burdened (≥30%)" stat read "—".
+ *   2. computeIncomeNeeded(profile) was called with the whole profile,
+ *      but the helper takes a scalar home value and returns an OBJECT;
+ *      then renderSnapshot tried to fmtMoney() the object. Stat read "—".
+ *   3. LIHTC map markers built by divIcon(<span class="lihtc-dot">)
+ *      had no CSS — span rendered zero-width, dots were invisible.
+ *   4. Bridge Statewide Context card sat on "Loading statewide data…"
+ *      forever when summary.statewide was missing because the renderer
+ *      had no else branch.
+ *   5. Methodology & Data Sources ULs (.method-list) had no CSS — the
+ *      default UA bullet indent pushed markers outside the card.
+ *
+ * What this test asserts (source-grep only — see hna-rent-burden-bins
+ * test for the precedent and rationale):
+ *   - rentBurden30Plus() now reads DP04_0141PE / DP04_0142PE
+ *   - renderSnapshot's incomeNeeded call passes a home-value scalar
+ *     and reads .annualIncome from the result
+ *   - css/site-theme.css carries non-zero-size .lihtc-marker .lihtc-dot
+ *   - css/site-theme.css carries a .method-section .method-list padding
+ *   - housing-needs-assessment.html's bridgeStatewideCard has an else
+ *     branch (no longer ONLY renders when summary.statewide is truthy)
+ *
+ * Run: node test/hna-deep-dive-batch1.test.js
+ */
+
+const fs   = require('fs');
+const path = require('path');
+
+let passed = 0;
+let failed = 0;
+function assert(cond, msg) {
+  if (cond) { console.log('  ✅ PASS:', msg); passed++; }
+  else       { console.error('  ❌ FAIL:', msg); failed++; }
+}
+
+const root  = path.join(__dirname, '..');
+const utils = fs.readFileSync(path.join(root, 'js/hna/hna-utils.js'), 'utf8');
+const rend  = fs.readFileSync(path.join(root, 'js/hna/hna-renderers.js'), 'utf8');
+const theme = fs.readFileSync(path.join(root, 'css/site-theme.css'), 'utf8');
+const html  = fs.readFileSync(path.join(root, 'housing-needs-assessment.html'), 'utf8');
+
+console.log('\n[test] #1 rentBurden30Plus reads ACS 2023 PE codes');
+const rbMatch = utils.match(/function rentBurden30Plus\(pcts\)\s*\{([\s\S]*?)\n\s*\}/);
+assert(rbMatch != null, 'rentBurden30Plus() body found');
+if (rbMatch) {
+  // Strip // line-comments so the "no longer referenced" checks only
+  // see executable code, not the historical-context comment that
+  // names the legacy codes.
+  const body = rbMatch[1].replace(/\/\/[^\n]*/g, '');
+  assert(/DP04_0141PE/.test(body), 'reads DP04_0141PE (30-34.9% bin, 2023)');
+  assert(/DP04_0142PE/.test(body), 'reads DP04_0142PE (35%+ bin, 2023)');
+  assert(!/DP04_0145PE/.test(body), 'legacy DP04_0145PE no longer referenced in executable code');
+  assert(!/DP04_0146PE/.test(body), 'legacy DP04_0146PE no longer referenced in executable code');
+}
+
+console.log('\n[test] #2 renderSnapshot passes home value, reads .annualIncome');
+// The snapshot block we patched uses homeVal (the DP04_0089E value
+// captured a few lines earlier) and pulls annualIncome off the result.
+const incBlock = rend.match(/computeIncomeNeeded\([\s\S]{0,40}\)\s*[\s\S]{0,200}annualIncome/);
+assert(incBlock != null,
+  'snapshot block calls computeIncomeNeeded then accesses .annualIncome');
+assert(/computeIncomeNeeded\(homeVal\)/.test(rend),
+  'computeIncomeNeeded receives homeVal (scalar), not the whole profile');
+
+console.log('\n[test] #3 .lihtc-marker .lihtc-dot has non-zero width + height');
+const lihtcDot = theme.match(/\.lihtc-marker\s+\.lihtc-dot\s*\{([\s\S]*?)\}/);
+assert(lihtcDot != null, '.lihtc-marker .lihtc-dot block exists');
+if (lihtcDot) {
+  const body = lihtcDot[1];
+  assert(/width\s*:\s*\d+px/.test(body), 'sets an explicit width');
+  assert(/height\s*:\s*\d+px/.test(body), 'sets an explicit height');
+  assert(/border-radius\s*:\s*50%/.test(body), 'rounded — matches the legend swatch');
+}
+
+console.log('\n[test] #4 bridgeStatewideCard finalizes even when summary.statewide is missing');
+// Match the renderer slice — must have an else branch for the swEl block.
+const swBlock = html.match(/\/\/ ── Statewide card ──[\s\S]{0,1200}else\s*\{[\s\S]{0,400}bridgeStatewideCard|bridgeStatewideCard[\s\S]{0,1500}?\bif\s*\(summary\.statewide\)[\s\S]{0,1500}\belse\s*\{/);
+assert(swBlock != null,
+  'Statewide card has an else-branch (finalizes when statewide rollup missing)');
+assert(/Statewide rollup pending/.test(html),
+  'else-branch shows "Statewide rollup pending" text instead of "Loading…"');
+
+console.log('\n[test] #5 .method-list has a padding to keep bullets inside the card');
+const methodList = theme.match(/\.method-section\s+\.method-list\s*\{([\s\S]*?)\}/);
+assert(methodList != null, '.method-section .method-list block exists');
+if (methodList) {
+  const body = methodList[1];
+  assert(/padding-left\s*:/.test(body),
+    'padding-left set so default UA indent does not push bullets outside the card');
+}
+
+console.log('\n=========================================');
+console.log('Results: ' + passed + ' passed, ' + failed + ' failed');
+process.exit(failed === 0 ? 0 : 1);

--- a/test/hna-labor-market-renderers.test.js
+++ b/test/hna-labor-market-renderers.test.js
@@ -1,0 +1,95 @@
+'use strict';
+/**
+ * test/hna-labor-market-renderers.test.js
+ *
+ * Regression for 2026-05-16 deep-dive batch 2. The Labor Market section
+ * (chartWage, chartIndustry, jobMetrics) and Economic Indicators panel
+ * (chartEmploymentTrend, chartWageTrend, chartIndustryAnalysis,
+ * Wage Gaps, econIndicatorCards) were either:
+ *   - stubs that found their canvas and returned, or
+ *   - the existing trend renderer read from `state.lehdData`, a slot
+ *     that was never populated (data lives in `__HNA_LEHD_CACHE` and
+ *     is keyed by geoid).
+ *
+ * What this test asserts (source-grep):
+ *   - Each of the 6 renderers is no longer a stub — it consumes lehd
+ *     data and renders a chart or placeholder.
+ *   - renderEmploymentTrend reads `__HNA_LEHD_CACHE` (the cache the
+ *     controller actually populates), not `state.lehdData`.
+ *   - renderEmploymentTrend / renderWageTrend handle the
+ *     `{year: count}` dict shape that lives in the cache files
+ *     (previous code did `.map(d => d.year)` on a dict — would render
+ *     `["0","1","2",…]` if it didn't return early).
+ *   - renderWageGaps injects a canvas into wageGapsContainer because
+ *     the HTML container ships empty (no canvas).
+ *
+ * Run: node test/hna-labor-market-renderers.test.js
+ */
+
+const fs   = require('fs');
+const path = require('path');
+
+let passed = 0, failed = 0;
+function assert(cond, msg) {
+  if (cond) { console.log('  ✅ PASS:', msg); passed++; }
+  else       { console.error('  ❌ FAIL:', msg); failed++; }
+}
+
+const src = fs.readFileSync(
+  path.join(__dirname, '..', 'js/hna/hna-renderers.js'),
+  'utf8'
+);
+
+// Helper: extract a function body by name. Stops at the next top-level
+// "function " declaration (renderers.js uses one-per-line declarations
+// at the same indent so this is reliable).
+function fnBody(name) {
+  const re = new RegExp(
+    'function\\s+' + name + '\\s*\\([\\s\\S]*?\\)\\s*\\{([\\s\\S]*?)\\n  \\}\\n',
+    'm'
+  );
+  const m = src.match(re);
+  return m ? m[1] : null;
+}
+
+console.log('\n[test] renderers are no longer stubs');
+['renderLaborMarketSection',
+ 'renderEmploymentTrend',
+ 'renderWageTrend',
+ 'renderIndustryAnalysis',
+ 'renderEconomicIndicators',
+ 'renderWageGaps'].forEach(function (name) {
+  const body = fnBody(name);
+  assert(body != null && /makeChart|innerHTML|appendChild|metric/.test(body),
+    name + '() does real work (makeChart / DOM write)');
+});
+
+console.log('\n[test] cache source is correct');
+const srcNoComments = src
+  .replace(/\/\/[^\n]*/g, '')           // strip line comments
+  .replace(/\/\*[\s\S]*?\*\//g, '');    // strip block comments
+assert(/__HNA_LEHD_CACHE/.test(srcNoComments),
+  'renderers reference window.__HNA_LEHD_CACHE (where the controller puts the data)');
+assert(!/state\.lehdData/.test(srcNoComments),
+  'no lingering reads of state.lehdData in executable code (the slot that was never populated)');
+
+console.log('\n[test] annualEmployment + annualWages handled as dicts');
+const empBody = fnBody('renderEmploymentTrend') || '';
+assert(/Object\.keys\(ae\)/.test(empBody) || /Object\.keys\([^)]*annualEmployment/.test(empBody),
+  'renderEmploymentTrend treats annualEmployment as a {year: count} dict');
+const wageBody = fnBody('renderWageTrend') || '';
+assert(/Object\.keys\(aw\)/.test(wageBody) || /Object\.keys\([^)]*annualWages/.test(wageBody),
+  'renderWageTrend treats annualWages as a {year: {low,medium,high}} dict');
+
+console.log('\n[test] renderWageGaps injects a canvas into the empty container');
+const wgBody = fnBody('renderWageGaps') || '';
+assert(/wageGapsContainer/.test(wgBody),
+  'renderWageGaps looks up #wageGapsContainer');
+assert(/createElement\(['"]canvas/.test(wgBody),
+  'renderWageGaps creates a <canvas> element');
+assert(/chartWageGaps/.test(wgBody),
+  'the injected canvas has id="chartWageGaps"');
+
+console.log('\n=========================================');
+console.log('Results: ' + passed + ' passed, ' + failed + ' failed');
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary
HNA "deep dive" — fixes the bugs **and** implements the missing-feature renderers the user asked for. Two commits on this branch:

### Commit 1 — five real bugs
| # | Bug | Fix |
|---|---|---|
| 1 | "Rent burdened (≥30%)" stat showed `—` | `rentBurden30Plus` was summing legacy 2022 codes; switched to `DP04_0141PE + 0142PE`. Adams shows **56.5%** |
| 2 | "Income needed to buy" showed `—` | `computeIncomeNeeded` was passed the whole profile (expects scalar) and the result (an object) was being `fmtMoney()`d. Pass `DP04_0089E`, read `.annualIncome`. Adams shows **$143,319** |
| 3 | LIHTC map markers invisible | `<span class="lihtc-dot">` had zero CSS. Added 12px blue dot matching the legend. **49 dots** show |
| 4 | "Statewide Context" stuck on "Loading…" | Renderer skipped finalizing when `summary.statewide` was missing. Added else-branch placeholder |
| 5 | Methodology bullets outside the card | `.method-list` had no CSS; default UA indent leaked past padding. Added `padding-left: 1.25rem` |

### Commit 2 — Labor Market + Economic Indicators renderers
- `renderLaborMarketSection` was a no-op stub — implemented chartWage, chartIndustry, and jobMetrics cards
- 4 Economic-Indicators stubs (`renderEmploymentTrend`, `renderWageTrend`, `renderIndustryAnalysis`, `renderWageGaps`, `renderEconomicIndicators`) all now render against the cached LEHD blobs at `data/hna/lehd/{geoid}.json`
- Switched data source from `state.lehdData` (slot never populated) to `window.__HNA_LEHD_CACHE` (where the controller actually puts it)
- Fixed the `annualEmployment` shape bug — the dict-shaped cache was being treated as an array
- Inject a `<canvas>` into `wageGapsContainer` (the HTML ships an empty `.chart-container` div for this card)
- Added `_placeholderInBox()` so missing-data states show a clear message instead of an empty canvas pretending to be a chart

## Verification (real browser via preview server, Adams County 08001)
| Element | Result |
|---|---|
| statRentBurden | `"56.5%"` |
| statIncomeNeed | `"$143,319"` |
| LIHTC dots | 49 visible, 12×12 |
| Statewide card | "Statewide rollup pending — region-level data is shown above" |
| .method-list padding | 18.76px (matches `1.25rem`) |
| chartEmploymentTrend | 5-yr line (2019–2023) |
| chartWageTrend | 5 yr × 3 bands |
| chartIndustryAnalysis | top-8 NAICS bars |
| chartWage | 3-tier wage bar |
| chartIndustry | top-6 industry bars |
| chartWageGaps | 3-tier % bar (canvas injected) |
| jobMetrics cards | 5 cards |
| econIndicatorCards | 4 cards |

No console errors after either commit.

## Test plan
- [x] `node test/hna-deep-dive-batch1.test.js` — 15 source-grep assertions for the 5 bug fixes
- [x] `node test/hna-labor-market-renderers.test.js` — 13 assertions for renderer implementation
- [ ] After merge, hard-refresh HNA on a county and confirm all 6 charts + 2 KPI grids populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)