### PR TITLE
fix(hna): 7 more bugs from deep-dive batch 2 (FMR year, theme colors, commute/age/senior/owner-burden, LIHTC bullets, horizontal cards)

### DIFF
--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -556,6 +556,22 @@ footer.site-footer { margin-top: var(--sp6); border-top: 1px solid var(--border)
 }
 .method-section .method-list li { margin: .15rem 0; }
 .method-section .method-list strong { color: var(--text); }
+
+/* LIHTC info panel on the HNA map — same pattern as method-list:
+   the renderer injects <ul class="lihtc-list"><li class="lihtc-item">
+   and without padding the default UA indent pushes bullets outside
+   the card. */
+.lihtc-list {
+  margin: .35rem 0 0;
+  padding-left: 1.25rem;
+  font-size: .85rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+.lihtc-list .lihtc-item { margin: .15rem 0; }
+.lihtc-list .lihtc-item strong { color: var(--text); }
+.lihtc-source { margin: 0 0 .35rem; font-size: .82rem; color: var(--muted); }
+.lihtc-empty  { margin: .35rem 0; font-size: .85rem; color: var(--muted); font-style: italic; }
 .map-reset-btn { padding:8px 12px;font-size:13px;cursor:pointer;background:#fff;border:1px solid #ccc;border-radius:4px;box-shadow:0 1px 3px rgba(0,0,0,0.2);font-family:inherit; }
 .kpi-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px,1fr)); gap: 12px; margin: var(--sp3) 0; }
 .delta { font-weight: 700; font-size: 0.82rem; }

--- a/js/config/financial-constants.js
+++ b/js/config/financial-constants.js
@@ -60,7 +60,7 @@
     // ── Data Source Metadata ────────────────────────────────────────
     acsVintage:       '2024',      // ACS 5-year estimates vintage (2025 pending Census release)
     acsYear:          '2024',      // for display labels
-    hudFmrYear:       'FY2026',    // HUD FMR fiscal year (updated from FY2025)
+    hudFmrYear:       'FY2025',    // HUD FMR fiscal year — FY2026 not yet published
     dolaProjectionYr: '2050',      // DOLA population projection horizon
     lastReviewDate:   '2026-04-11',
   };

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -403,14 +403,14 @@
         type: 'doughnut',
         data: {
           labels: ['Owner-occupied', 'Renter-occupied'],
-          // Use high-contrast colors instead of theme c1/c2 — both
-          // theme colors are similar mid-tones (teal + blue) that
-          // looked indistinguishable in the doughnut. Slate-700 vs
-          // amber-500 reads clearly in both light + dark mode.
+          // Use theme palette tokens (c1 + c4). c1 is navy/sky-blue
+          // and c4 is brown/amber in both light + dark CSS — high
+          // contrast against each other and consistent with every
+          // other chart's color story on the page.
           datasets: [{
             data: [owner, renter],
-            backgroundColor: ['#334155', '#f59e0b'],
-            borderColor: ['#1e293b', '#d97706'],
+            backgroundColor: [t.c1, t.c4],
+            borderColor: [t.c1, t.c4],
             borderWidth: 1,
           }],
         },
@@ -578,26 +578,38 @@
     }
     const t = chartTheme();
     const safeNum = U().safeNum;
-    const flows = lehd.flows || [];
-    const labels = flows.map(f => f.year || f.label || '');
-    const inflow  = flows.map(f => safeNum(f.inflow)  || 0);
-    const outflow = flows.map(f => safeNum(f.outflow) || 0);
+    const fmtNum  = U().fmtNum;
+    // The cache files publish scalar `within`, `inflow`, `outflow` —
+    // not a yearly `flows[]` array. Render the current snapshot as
+    // three grouped bars so the commuter-flow story is readable at a
+    // glance. (A future enhancement could plot history if the cache
+    // ever starts shipping flows[].)
+    const within  = safeNum(lehd.within)  || 0;
+    const inflow  = safeNum(lehd.inflow)  || 0;
+    const outflow = safeNum(lehd.outflow) || 0;
+    if (within === 0 && inflow === 0 && outflow === 0) {
+      _placeholderInBox(canvas, 'LEHD flow data not available for this geography.');
+      return;
+    }
     makeChart(canvas.getContext('2d'), {
       type: 'bar',
       data: {
-        labels,
-        datasets: [
-          { label: 'Jobs in area',  data: inflow,  backgroundColor: t.c1 },
-          { label: 'Jobs out of area', data: outflow, backgroundColor: t.c3 },
-        ],
+        labels: ['Live & work in area', 'Inflow (commute in)', 'Outflow (commute out)'],
+        datasets: [{
+          data: [within, inflow, outflow],
+          backgroundColor: [t.c3, t.c1, t.c5],
+        }],
       },
       options: {
         responsive: true,
         maintainAspectRatio: false,
-        plugins: { legend: { labels: { color: t.text } } },
+        plugins: {
+          legend: { display: false },
+          tooltip: { callbacks: { label: function (c) { return fmtNum(c.parsed.y) + ' workers'; } } },
+        },
         scales: {
           x: { ticks: { color: t.muted }, grid: { color: t.border } },
-          y: { ticks: { color: t.muted }, grid: { color: t.border } },
+          y: { ticks: { color: t.muted, callback: function (v) { return fmtNum(v); } }, grid: { color: t.border } },
         },
       },
     });
@@ -619,60 +631,114 @@
       return;
     }
     const t = chartTheme();
-    const safeNum = U().safeNum;
+    const fmtNum = U().fmtNum;
 
-    const cohorts = dola.cohorts || dola.ageCohorts || [];
-    const maleData   = cohorts.map(c => -(safeNum(c.male)   || 0));
-    const femaleData = cohorts.map(c =>   safeNum(c.female) || 0);
-    const labels     = cohorts.map(c => c.label || c.ageGroup || '');
+    // DOLA SYA cache files store age data as three parallel arrays:
+    //   ages   = [0, 1, 2, …, 100]   (single year of age)
+    //   male   = [count_age_0, count_age_1, …]
+    //   female = [count_age_0, count_age_1, …]
+    // Earlier code assumed a `cohorts[]` shape that this file format
+    // doesn't have — so both charts rendered empty. Bin into standard
+    // 5-year cohorts here.
+    const COHORTS = [
+      { label: '0–4',   from: 0,  to: 4  },
+      { label: '5–9',   from: 5,  to: 9  },
+      { label: '10–14', from: 10, to: 14 },
+      { label: '15–19', from: 15, to: 19 },
+      { label: '20–24', from: 20, to: 24 },
+      { label: '25–29', from: 25, to: 29 },
+      { label: '30–34', from: 30, to: 34 },
+      { label: '35–39', from: 35, to: 39 },
+      { label: '40–44', from: 40, to: 44 },
+      { label: '45–49', from: 45, to: 49 },
+      { label: '50–54', from: 50, to: 54 },
+      { label: '55–59', from: 55, to: 59 },
+      { label: '60–64', from: 60, to: 64 },
+      { label: '65–69', from: 65, to: 69 },
+      { label: '70–74', from: 70, to: 74 },
+      { label: '75–79', from: 75, to: 79 },
+      { label: '80–84', from: 80, to: 84 },
+      { label: '85+',   from: 85, to: 200 },
+    ];
+
+    const maleArr   = Array.isArray(dola.male)   ? dola.male   : [];
+    const femaleArr = Array.isArray(dola.female) ? dola.female : [];
+    const sumRange = (arr, from, to) => {
+      let s = 0;
+      for (let age = from; age <= to && age < arr.length; age++) s += Number(arr[age]) || 0;
+      return s;
+    };
+
+    const labels = COHORTS.map(c => c.label);
+    const malePos   = COHORTS.map(c => sumRange(maleArr,   c.from, c.to));
+    const femalePos = COHORTS.map(c => sumRange(femaleArr, c.from, c.to));
+    // Pyramid convention: male bars to the left (negative), female to right.
+    const maleData = malePos.map(v => -v);
+    const femaleData = femalePos;
 
     if (pyramidCanvas) {
-      makeChart(pyramidCanvas.getContext('2d'), {
-        type: 'bar',
-        data: {
-          labels,
-          datasets: [
-            { label: 'Male',   data: maleData,   backgroundColor: t.c2, borderWidth: 0 },
-            { label: 'Female', data: femaleData, backgroundColor: t.c4, borderWidth: 0 },
-          ],
-        },
-        options: {
-          indexAxis: 'y',
-          responsive: true,
-          maintainAspectRatio: false,
-          plugins: { legend: { labels: { color: t.text } } },
-          scales: {
-            x: { ticks: { color: t.muted, callback: v => Math.abs(v).toLocaleString() }, grid: { color: t.border } },
-            y: { ticks: { color: t.muted }, grid: { color: t.border } },
+      if (malePos.every(v => v === 0) && femaleData.every(v => v === 0)) {
+        _placeholderInBox(pyramidCanvas, 'DOLA age data not available for this geography.');
+      } else {
+        makeChart(pyramidCanvas.getContext('2d'), {
+          type: 'bar',
+          data: {
+            labels,
+            datasets: [
+              { label: 'Male',   data: maleData,   backgroundColor: t.c2, borderWidth: 0 },
+              { label: 'Female', data: femaleData, backgroundColor: t.c4, borderWidth: 0 },
+            ],
           },
-        },
-      });
+          options: {
+            indexAxis: 'y',
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: { labels: { color: t.text } },
+              tooltip: { callbacks: { label: function (c) {
+                return c.dataset.label + ': ' + fmtNum(Math.abs(c.parsed.x));
+              } } },
+            },
+            scales: {
+              x: { stacked: false, ticks: { color: t.muted, callback: v => fmtNum(Math.abs(v)) }, grid: { color: t.border } },
+              y: { ticks: { color: t.muted }, grid: { color: t.border } },
+            },
+          },
+        });
+      }
     }
 
     if (seniorCanvas) {
-      const senior65plus = cohorts.filter(c => {
-        const lbl = String(c.label || c.ageGroup || '');
-        return lbl.includes('65') || lbl.includes('70') ||
-               lbl.includes('75') || lbl.includes('80') || lbl.includes('85+');
-      });
-      const seniorLabels = senior65plus.map(c => c.label || c.ageGroup || '');
-      const seniorValues = senior65plus.map(c => (safeNum(c.male) || 0) + (safeNum(c.female) || 0));
-      makeChart(seniorCanvas.getContext('2d'), {
-        type: 'bar',
-        data: {
-          labels: seniorLabels,
-          datasets: [{ data: seniorValues, backgroundColor: t.c4 }],
-        },
-        options: {
-          responsive: true,
-          maintainAspectRatio: false,
-          plugins: { legend: { display: false } },
-          scales: {
-            x: { ticks: { color: t.muted }, grid: { color: t.border } },
-            y: { ticks: { color: t.muted }, grid: { color: t.border } },
+      // Senior cohorts are the last 4 entries (65–69, 70–74, 75–79, 80–84, 85+).
+      const seniorIdxStart = COHORTS.findIndex(c => c.from === 65);
+      const seniorCohorts = seniorIdxStart >= 0 ? COHORTS.slice(seniorIdxStart) : [];
+      const seniorLabels = seniorCohorts.map(c => c.label);
+      const seniorValues = seniorCohorts.map(c =>
+        sumRange(maleArr, c.from, c.to) + sumRange(femaleArr, c.from, c.to)
+      );
+      if (seniorValues.every(v => v === 0)) {
+        _placeholderInBox(seniorCanvas, 'DOLA senior age data not available for this geography.');
+      } else {
+        makeChart(seniorCanvas.getContext('2d'), {
+          type: 'bar',
+          data: {
+            labels: seniorLabels,
+            datasets: [{ data: seniorValues, backgroundColor: t.c4 }],
           },
-        },
-      });
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: { display: false },
+              tooltip: { callbacks: { label: function (c) { return fmtNum(c.parsed.y) + ' people'; } } },
+            },
+            scales: {
+              x: { ticks: { color: t.muted }, grid: { color: t.border } },
+              y: { ticks: { color: t.muted, callback: function (v) { return fmtNum(v); } }, grid: { color: t.border } },
+            },
+          },
+        });
+      }
     }
 
     if (noteEl) noteEl.textContent = '';
@@ -1611,19 +1677,30 @@
     if (!canvas || !profile) return;
     const t = chartTheme();
     const safeNum = U().safeNum;
+    // ACS 2023 SMOCAPI (selected monthly owner costs as % of income)
+    // bins are published as percent fields, not counts. fetchAcsExtended
+    // pulls these PE codes; the cache also stores them.
     const bins = [
-      { label: '<20%',   key: 'DP04_0113E' },
-      { label: '20–25%', key: 'DP04_0114E' },
-      { label: '25–30%', key: 'DP04_0115E' },
-      { label: '30–35%', key: 'DP04_0116E' },
-      { label: '35%+',   key: 'DP04_0117E' },
+      { label: '<20%',   key: 'DP04_0111PE' },
+      { label: '20–25%', key: 'DP04_0112PE' },
+      { label: '25–30%', key: 'DP04_0113PE' },
+      { label: '30–35%', key: 'DP04_0114PE' },
+      { label: '35%+',   key: 'DP04_0115PE' },
     ];
     const values = bins.map(b => safeNum(profile[b.key]) || 0);
+    if (values.every(v => v === 0)) {
+      _placeholderInBox(canvas, 'Owner cost-burden data not available for this geography.');
+      return;
+    }
     makeChart(canvas.getContext('2d'), {
       type: 'bar',
       data: { labels: bins.map(b => b.label), datasets: [{ data: values, backgroundColor: [t.c1,t.c1,t.c1,t.c5,t.c5] }] },
       options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { display: false } },
-        scales: { x: { ticks: { color: t.muted } }, y: { ticks: { color: t.muted } } } },
+        scales: {
+          x: { ticks: { color: t.muted } },
+          y: { ticks: { color: t.muted, callback: function (v) { return v + '%'; } } },
+        },
+      },
     });
   }
 
@@ -1708,8 +1785,8 @@
             value: (Math.round(metrics.jwRatio * 100) / 100).toFixed(2),
           });
           metricsEl.innerHTML = cards.map(function (c) {
-            return '<div class="metric"><h3>' + escHtml(c.label)
-              + '</h3><div class="value">' + escHtml(c.value) + '</div></div>';
+            return '<div class="metric-card"><div class="mc-label">' + escHtml(c.label)
+              + '</div><div class="mc-value">' + escHtml(c.value) + '</div></div>';
           }).join('');
         } else {
           metricsEl.innerHTML = '';
@@ -1966,8 +2043,8 @@
       });
     }
     container.innerHTML = cards.map(function (c) {
-      return '<div class="metric"><h3>' + escHtml(c.label)
-        + '</h3><div class="value">' + escHtml(c.value) + '</div></div>';
+      return '<div class="metric-card"><div class="mc-label">' + escHtml(c.label)
+        + '</div><div class="mc-value">' + escHtml(c.value) + '</div></div>';
     }).join('');
   }
 

--- a/test/hna-deep-dive-batch2.test.js
+++ b/test/hna-deep-dive-batch2.test.js
@@ -1,0 +1,131 @@
+'use strict';
+/**
+ * test/hna-deep-dive-batch2.test.js
+ *
+ * Regression for 2026-05-16 HNA deep-dive batch 2. Eight more bugs the
+ * user surfaced after batch 1 landed and the page started showing real
+ * data. Each verified live in the preview browser before commit.
+ *
+ * Bugs in scope:
+ *   1. FMR year was bumped to FY2026 (which HUD hasn't published) —
+ *      every UI label that quoted FY2025 was now wrong. Reverted to
+ *      FY2025 in financial-constants.js.
+ *   2. chartTenure used hard-coded slate+amber from PR #809 — user
+ *      asked for theme palette consistency. Switched to c1 + c4.
+ *   3. chartLehd expected lehd.flows[] (yearly array) but the cache
+ *      ships scalar within/inflow/outflow. Render as 3-bar snapshot.
+ *   4. chartPyramid + chartSenior expected cohorts[] but the DOLA
+ *      cache ships parallel arrays ages[]/male[]/female[] (single
+ *      year of age). Bin into 5-year cohorts at render time.
+ *   5. chartOwnerCostBurden read DP04_0113E..DP04_0117E (count fields,
+ *      not all valid in 2023) — switched to the SMOCAPI PE codes
+ *      DP04_0111PE..DP04_0115PE that fetchAcsExtended actually pulls.
+ *   6. LIHTC info-panel <ul class="lihtc-list"> bullets sat outside
+ *      the card — no CSS. Added padding-left.
+ *   7. jobMetrics + econIndicatorCards rendered .metric cards (with
+ *      grid-column: span 4) inside a parent that uses a 3-col grid
+ *      meant for .metric-card — children stacked vertically. Output
+ *      .metric-card so they lay out horizontally per the CSS.
+ *
+ * Run: node test/hna-deep-dive-batch2.test.js
+ */
+
+const fs   = require('fs');
+const path = require('path');
+
+let passed = 0, failed = 0;
+function assert(cond, msg) {
+  if (cond) { console.log('  ✅ PASS:', msg); passed++; }
+  else       { console.error('  ❌ FAIL:', msg); failed++; }
+}
+
+const root  = path.join(__dirname, '..');
+const consts = fs.readFileSync(path.join(root, 'js/config/financial-constants.js'), 'utf8');
+const rend   = fs.readFileSync(path.join(root, 'js/hna/hna-renderers.js'), 'utf8');
+const theme  = fs.readFileSync(path.join(root, 'css/site-theme.css'), 'utf8');
+
+console.log('\n[test] #1 hudFmrYear is FY2025');
+assert(/hudFmrYear:\s*['"]FY2025['"]/.test(consts),
+  'financial-constants.hudFmrYear is FY2025 (FY2026 not yet published)');
+assert(!/hudFmrYear:\s*['"]FY2026['"]/.test(consts),
+  'no lingering FY2026 reference for hudFmrYear');
+
+console.log('\n[test] #2 chartTenure uses theme palette (c1 + c4)');
+// Restrict to the chartTenure block to avoid colliding with other charts
+// that use c1/c4. The doughnut is rendered after the comment about
+// theme palette tokens.
+const tenureBlock = rend.match(
+  /chartTenure[\s\S]*?backgroundColor:\s*\[([^\]]*)\]/
+);
+assert(tenureBlock != null, 'chartTenure block found with backgroundColor');
+if (tenureBlock) {
+  const colors = tenureBlock[1];
+  assert(/t\.c1/.test(colors), 'uses t.c1 (theme blue/sky)');
+  assert(/t\.c4/.test(colors), 'uses t.c4 (theme amber/brown)');
+  assert(!/#334155/.test(colors), 'no longer hard-codes slate-700');
+  assert(!/#f59e0b/.test(colors), 'no longer hard-codes amber-500');
+}
+
+console.log('\n[test] #3 chartLehd renders scalar within/inflow/outflow');
+const lehdBody = rend.match(/function renderLehd\([\s\S]*?\n  \}/);
+assert(lehdBody != null, 'renderLehd() found');
+if (lehdBody) {
+  const body = lehdBody[0];
+  assert(/lehd\.within/.test(body), 'reads lehd.within (scalar)');
+  assert(/lehd\.inflow/.test(body),  'reads lehd.inflow (scalar)');
+  assert(/lehd\.outflow/.test(body), 'reads lehd.outflow (scalar)');
+  assert(/Live & work in area|Inflow.*commute|Outflow.*commute/i.test(body),
+    'labels describe the 3-flow snapshot');
+}
+
+console.log('\n[test] #4 renderDolaPyramid handles ages[]/male[]/female[] shape');
+const dolaBody = rend.match(/function renderDolaPyramid\(dola\)\s*\{[\s\S]*?\n  \}/);
+assert(dolaBody != null, 'renderDolaPyramid() found');
+if (dolaBody) {
+  const body = dolaBody[0];
+  assert(/dola\.male|Array\.isArray\(dola\.male\)/.test(body),
+    'reads dola.male as an array');
+  assert(/dola\.female|Array\.isArray\(dola\.female\)/.test(body),
+    'reads dola.female as an array');
+  assert(/COHORTS|cohort/i.test(body),
+    'bins into 5-year cohorts at render time');
+}
+
+console.log('\n[test] #5 chartOwnerCostBurden uses ACS 2023 PE codes');
+const ownerBody = rend.match(/function renderOwnerCostBurdenChart\([\s\S]*?\n  \}/);
+assert(ownerBody != null, 'renderOwnerCostBurdenChart() found');
+if (ownerBody) {
+  const body = ownerBody[0].replace(/\/\/[^\n]*/g, '');  // strip comments
+  ['DP04_0111PE','DP04_0112PE','DP04_0113PE','DP04_0114PE','DP04_0115PE'].forEach(c => {
+    assert(body.includes(c), 'uses ' + c);
+  });
+  ['DP04_0113E','DP04_0114E','DP04_0115E','DP04_0116E','DP04_0117E'].forEach(c => {
+    assert(!body.includes(c),
+      'legacy count code ' + c + ' no longer referenced in executable code');
+  });
+}
+
+console.log('\n[test] #6 LIHTC info panel has CSS padding');
+const lihtcCss = theme.match(/\.lihtc-list\s*\{([\s\S]*?)\}/);
+assert(lihtcCss != null, '.lihtc-list block exists in site-theme.css');
+if (lihtcCss) {
+  assert(/padding-left\s*:/.test(lihtcCss[1]),
+    'sets padding-left so bullets stay inside the card');
+}
+
+console.log('\n[test] #7 KPI cards use .metric-card markup');
+// Both renderLaborMarketSection (jobMetrics) and renderEconomicIndicators
+// must emit .metric-card / .mc-label / .mc-value markup so they lay out
+// horizontally via the existing .metric-cards grid CSS.
+const noComments = rend
+  .replace(/\/\/[^\n]*/g, '')
+  .replace(/\/\*[\s\S]*?\*\//g, '');
+const metricCardEmits = (noComments.match(/class="metric-card"/g) || []).length;
+assert(metricCardEmits >= 2,
+  'at least two renderers emit .metric-card markup (jobMetrics + econIndicatorCards)');
+assert(!/class="metric"><h3>/.test(noComments),
+  'old .metric><h3> markup is fully replaced in executable code');
+
+console.log('\n=========================================');
+console.log('Results: ' + passed + ' passed, ' + failed + ' failed');
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary
Round 2 of the user's HNA punch list. Seven distinct bugs, each verified live in the preview browser (Adams County) before commit.

| # | Bug | Fix |
|---|---|---|
| 1 | `hudFmrYear` was `FY2026` — HUD hasn't published FY2026 yet, so every "FY2025" label across the site was now wrong | Reverted to `FY2025` in `financial-constants.js` |
| 2 | `chartTenure` used hard-coded slate+amber from PR #809 — user wanted theme consistency | Switched to palette tokens `t.c1` + `t.c4` (sky-blue + amber) |
| 3 | "Commuting: inflow & outflow" chart was empty | Renderer expected `lehd.flows[]` (yearly array) but cache ships scalar `within`/`inflow`/`outflow`. Render as 3 grouped bars |
| 4 | "Age pyramid" + "Senior growth pressure" were empty | Renderer expected `dola.cohorts[]` but cache ships parallel `ages[]`/`male[]`/`female[]` arrays. Bin into 5-year cohorts at render time |
| 5 | "Owner Housing Cost Burden" rendered 5 zero-height bars | Read `DP04_0113E..0117E` (partly renamed in 2023). Switched to SMOCAPI `DP04_0111PE..0115PE` that `fetchAcsExtended` actually pulls. Empty state now shows a placeholder |
| 6 | LIHTC "Source: HUD · X project(s) in view" bullets sat outside the card | No CSS for `.lihtc-list`. Added `padding-left: 1.25rem` (matches the methodology fix from batch 1) |
| 7 | "Labor Market Context" + "Economic Indicators" KPIs stacked vertically | Cards used `.metric` markup (built for the 12-col grid) inside a `.metric-cards` parent (built for `.metric-card`). Output `.metric-card / .mc-label / .mc-value` so they pick up the existing 3-col / 4-col grid |

## Verification (live, Adams County)
| Element | Probe result |
|---|---|
| `chartLehd.data.datasets[0].data` | `[74379, 166606, 178318]` |
| `chartPyramid.data.labels.length` | `18` (5-year cohorts) |
| `chartSenior.data.datasets[0].data[0..2]` | `[23395, 17967, 13213]` |
| `chartTenure.data.datasets[0].backgroundColor` | `["#5b9bd5", "#fbbf24"]` (theme tokens) |
| `#jobMetrics .metric-card` count | `5`, `display: grid` |
| `#econIndicatorCards .metric-card` count | `4`, `display: grid` |
| `.lihtc-list` `padding-left` | `18.76px` |
| FMR mentions on page | only `FY2025` (no `FY2026`) |
| `statRentBurden` | `56.5%` (no regression from batch 1) |

## Test plan
- [x] `node test/hna-deep-dive-batch2.test.js` — 31 source-grep assertions across all 7 fixes
- [ ] After merge, hard-refresh HNA on a county and confirm all 4 previously-empty charts now show data, KPI cards are horizontal, LIHTC bullets sit inside the card, no "FY2026" anywhere on the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)