### PR TITLE
fix(hna): "County-level data" disclosure on place/cdp selections

### DIFF
--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -557,6 +557,24 @@ footer.site-footer { margin-top: var(--sp6); border-top: 1px solid var(--border)
 .method-section .method-list li { margin: .15rem 0; }
 .method-section .method-list strong { color: var(--text); }
 
+/* "County-level data" disclosure on HNA sections whose data only exists
+   at county granularity (LEHD, DOLA SYA, BLS QCEW). The renderer
+   injects a <div class="hna-county-scope-note" role="note"> after the
+   section's h2 when the user has picked a place/cdp. Visual matches
+   the chartChasGap proxy-note pattern: amber left-border, muted
+   background, role=note for screen readers. */
+.hna-county-scope-note {
+  margin: 0 0 .75rem;
+  padding: .55rem .85rem;
+  border-left: 3px solid var(--warn, #d97706);
+  border-radius: 0 4px 4px 0;
+  background: var(--warn-dim, rgba(217,119,6,.10));
+  font-size: .82rem;
+  line-height: 1.45;
+  color: var(--text);
+}
+.hna-county-scope-note strong { color: var(--text); }
+
 /* LIHTC info panel on the HNA map — same pattern as method-list:
    the renderer injects <ul class="lihtc-list"><li class="lihtc-item">
    and without padding the default UA indent pushes bullets outside

--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -418,7 +418,7 @@
         <div class="chart-box" data-source="ACS S0801 Commuting" data-source-url="https://data.census.gov/table/ACSST5Y2023.S0801" data-vintage="ACS 2019–2023" data-source-type="raw"><canvas id="chartMode" role="img" aria-label="Commuting mode share chart"></canvas></div>
       </div>
 
-      <div class="chart-card span-6">
+      <div id="lehdCommuteCard" class="chart-card span-6">
         <h2>Commuting: inflow &amp; outflow (LEHD LODES)</h2>
         <p>
           Workplace-based flows: <strong>inflow</strong> = jobs located here filled by residents of other areas;

--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -2026,6 +2026,28 @@
     window.HNARenderers.renderIndustryAnalysis(econGeoid);
     window.HNARenderers.renderWageGaps(econGeoid, profile);
 
+    // ── County-scope disclosures ────────────────────────────────────
+    // LEHD, DOLA SYA, and BLS QCEW are county-only datasets. When the
+    // user picked a place/cdp, the charts above and below show their
+    // containing-county's numbers — without a disclosure that reads as
+    // misattribution. Inject a "County-level data" note on each affected
+    // section so the chart's geographic scope is glance-able. Hides
+    // itself on county / state selections.
+    if (window.HNARenderers.renderCountyScopeNote) {
+      window.HNARenderers.renderCountyScopeNote(
+        'lehdCommuteCard', geoType, econGeoid,
+        'LEHD LODES commute flows',
+      );
+      window.HNARenderers.renderCountyScopeNote(
+        'labor-market-section', geoType, econGeoid,
+        'LEHD WAC employment data',
+      );
+      window.HNARenderers.renderCountyScopeNote(
+        'economicIndicatorsContainer', geoType, econGeoid,
+        'LEHD trend + industry data',
+      );
+    }
+
     // CHAS affordability gap (county context; loaded once and cached on state object)
     if (!window.HNAState.state.chasData) {
       try {

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -1762,6 +1762,82 @@
       + escHtml(message) + '</p>';
   }
 
+  /**
+   * Look up a Colorado county's display label from a 5-digit FIPS,
+   * consulting the in-memory geography config first then the canonical
+   * registry. Returns the geoid if neither config has a hit so callers
+   * never paste raw FIPS into user-facing copy.
+   */
+  function _countyLabel(fips) {
+    if (!fips) return '';
+    var conf = window.__HNA_GEO_CONFIG;
+    if (conf && Array.isArray(conf.counties)) {
+      var hit = conf.counties.find(function (c) { return c.geoid === fips; });
+      if (hit && hit.label) return hit.label;
+    }
+    var reg = window.__HNA_GEOGRAPHY_REGISTRY;
+    if (reg && Array.isArray(reg.geographies)) {
+      var match = reg.geographies.find(function (g) { return g.geoid === fips; });
+      if (match && match.label) return match.label;
+    }
+    return fips;
+  }
+
+  /**
+   * Inject (or update) a "county-scope" disclosure note inside a section
+   * when the user has picked a place/cdp but the section's data only
+   * exists at county granularity (LEHD, DOLA SYA, BLS QCEW). Hides
+   * itself for county / state selections.
+   *
+   * Matches the visual pattern of chartChasGap's proxy note: amber
+   * left-border, muted background, role="note" for screen-reader
+   * announcement.
+   *
+   * @param {string} sectionId  ID of the parent <section>.
+   * @param {string} geoType    'state' | 'county' | 'place' | 'cdp'.
+   * @param {string} countyFips Containing-county 5-digit FIPS.
+   * @param {string} dataKind   Short label for the data source, e.g.
+   *                            "LEHD employment data", "DOLA age pyramid".
+   */
+  function _renderCountyScopeNote(sectionId, geoType, countyFips, dataKind) {
+    var section = document.getElementById(sectionId);
+    if (!section) return;
+    var noteId = sectionId + '__countyScopeNote';
+    var existing = document.getElementById(noteId);
+
+    // Hide / remove for non-place selections.
+    if (geoType !== 'place' && geoType !== 'cdp') {
+      if (existing) existing.remove();
+      return;
+    }
+
+    var countyLabel = _countyLabel(countyFips);
+    var html =
+      '<strong>County-level data.</strong> ' +
+      escHtml(dataKind) +
+      ' is published only at county granularity. The chart' +
+      ' below shows <strong>' + escHtml(countyLabel) +
+      '</strong>; your selected place may differ.';
+
+    if (existing) {
+      existing.innerHTML = html;
+      return;
+    }
+    var note = document.createElement('div');
+    note.id = noteId;
+    note.className = 'hna-county-scope-note';
+    note.setAttribute('role', 'note');
+    note.innerHTML = html;
+    // Insert after the first h2 so it sits between the section title
+    // and the chart grid below.
+    var anchor = section.querySelector('h2') || section.firstElementChild;
+    if (anchor && anchor.parentNode) {
+      anchor.parentNode.insertBefore(note, anchor.nextSibling);
+    } else {
+      section.insertBefore(note, section.firstChild);
+    }
+  }
+
   function renderLaborMarketSection(lehd, profile, geoType) {
     var t       = chartTheme();
     var fmtNum  = U().fmtNum;
@@ -2900,6 +2976,8 @@
     renderIndustryAnalysis,
     renderEconomicIndicators,
     renderWageGaps,
+    // County-scope disclosure (place/cdp selections)
+    renderCountyScopeNote: _renderCountyScopeNote,
     // Prop 123
     renderProp123Section,
     renderFastTrackCalculatorSection,

--- a/test/hna-county-scope-disclosures.test.js
+++ b/test/hna-county-scope-disclosures.test.js
@@ -1,0 +1,96 @@
+'use strict';
+/**
+ * test/hna-county-scope-disclosures.test.js
+ *
+ * Regression for 2026-05-16: when a user picks a place/cdp on HNA, the
+ * Labor Market, Economic Indicators, and LEHD Commute sections all
+ * showed county-derived data (because LEHD/DOLA/BLS-QCEW are county-only
+ * datasets) with NO disclosure. The chart titles and axis labels read
+ * as if the data were place-specific. User flagged this as misleading.
+ *
+ * Fix: a `_renderCountyScopeNote(sectionId, geoType, countyFips, kind)`
+ * helper that injects an amber "County-level data" note inside the
+ * section header when geoType is 'place' or 'cdp', and removes itself
+ * for 'county' / 'state'.
+ *
+ * What this test asserts (source-grep):
+ *   - The helper exists, is exported as renderCountyScopeNote
+ *   - It hides itself on county / state selections (no false noise)
+ *   - It targets specific sections in the controller (labor-market,
+ *     economic-indicators, lehd commute card)
+ *   - CSS provides the amber accent (matches chartChasGap proxy note)
+ *   - The HTML has the IDs the controller wires up
+ *
+ * Run: node test/hna-county-scope-disclosures.test.js
+ */
+
+const fs   = require('fs');
+const path = require('path');
+
+let passed = 0, failed = 0;
+function assert(cond, msg) {
+  if (cond) { console.log('  ✅ PASS:', msg); passed++; }
+  else       { console.error('  ❌ FAIL:', msg); failed++; }
+}
+
+const root = path.join(__dirname, '..');
+const rend = fs.readFileSync(path.join(root, 'js/hna/hna-renderers.js'),  'utf8');
+const ctl  = fs.readFileSync(path.join(root, 'js/hna/hna-controller.js'),  'utf8');
+const css  = fs.readFileSync(path.join(root, 'css/site-theme.css'),         'utf8');
+const html = fs.readFileSync(path.join(root, 'housing-needs-assessment.html'), 'utf8');
+
+console.log('\n[test] disclosure helper is exported');
+assert(/function _renderCountyScopeNote\(sectionId, geoType, countyFips, dataKind\)/.test(rend),
+  'helper signature accepts (sectionId, geoType, countyFips, dataKind)');
+assert(/renderCountyScopeNote\s*:\s*_renderCountyScopeNote/.test(rend),
+  'exported on the HNARenderers public surface');
+
+console.log('\n[test] helper hides itself for county / state selections');
+const helperBody = rend.match(
+  /function _renderCountyScopeNote[\s\S]*?\n  \}/
+);
+assert(helperBody != null, 'helper body found');
+if (helperBody) {
+  const body = helperBody[0];
+  assert(/geoType\s*!==\s*['"]place['"][\s\S]*geoType\s*!==\s*['"]cdp['"]/.test(body),
+    'guards against geoType other than place/cdp (no false-positive disclosures)');
+  assert(/existing\.remove\(\)/.test(body),
+    'removes any previously-inserted note when guard trips');
+}
+
+console.log('\n[test] controller wires up the three county-scope sections');
+['lehdCommuteCard',
+ 'labor-market-section',
+ 'economicIndicatorsContainer'].forEach(function (id) {
+  const pattern = new RegExp(
+    'renderCountyScopeNote\\(\\s*[\'"]' + id + '[\'"]'
+  );
+  assert(pattern.test(ctl),
+    'controller calls disclosure for #' + id);
+});
+
+console.log('\n[test] HTML carries the IDs the disclosure targets');
+['lehdCommuteCard',
+ 'labor-market-section',
+ 'economicIndicatorsContainer'].forEach(function (id) {
+  const pattern = new RegExp('id="' + id + '"');
+  assert(pattern.test(html),
+    'housing-needs-assessment.html has #' + id);
+});
+
+console.log('\n[test] CSS for .hna-county-scope-note matches the chartChasGap proxy-note style');
+const cssBlock = css.match(/\.hna-county-scope-note\s*\{([\s\S]*?)\}/);
+assert(cssBlock != null, '.hna-county-scope-note CSS block exists');
+if (cssBlock) {
+  const block = cssBlock[1];
+  assert(/border-left\s*:\s*\d+px\s+solid/.test(block),
+    'has amber border-left accent');
+  assert(/background\s*:/.test(block),
+    'has a muted background fill');
+  assert(/var\(--warn/.test(block) || /#d97706/.test(block),
+    'uses the warn color token (or its hex)');
+}
+
+console.log('\n=========================================');
+console.log('Results: ' + passed + ' passed, ' + failed + ' failed');
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary
User reported that HNA's Economic Indicators (and other LEHD-driven sections) "look like they are attributable to the jurisdiction, but seems like they are county level." Real fix.

When the user picks a place or CDP (e.g. Aurora), the Labor Market Context, Economic Indicators, and LEHD Commute flow charts all show the **containing-county's** data — because LEHD / DOLA SYA / BLS QCEW are county-only datasets. Without a disclosure, this reads as misattribution.

## Fix
A new `_renderCountyScopeNote(sectionId, geoType, countyFips, dataKind)` helper that injects an amber "County-level data" note inside the section header **only** when `geoType === 'place' || 'cdp'`. Hides itself for county / state selections so we don't introduce false noise.

Wired up for three sections:
- `#lehdCommuteCard` — LEHD LODES commute flows
- `#labor-market-section` — LEHD WAC employment data
- `#economicIndicatorsContainer` — LEHD trend + industry data

Looks like chartChasGap's existing proxy-note: amber left-border, muted background, `role="note"`.

For Aurora (0804000, place geoid spanning Arapahoe / Adams / Douglas) the note reads:
> **County-level data.** LEHD WAC employment data is published only at county granularity. The chart below shows **Arapahoe County**; your selected place may differ.

## What's NOT covered here
- **Age pyramid + senior pressure** — section's HTML already carries the prose "For municipal/CDP selections, this uses the containing county as context." Left as-is.
- **CHAS Cost burden by AMI tier** — already has a more nuanced disclosure (TIGER place-CHAS preferred over county fallback, per PR #803).

## Verification (real browser via preview)
- Set `geoType=place, geoid=0804000` via dropdowns → all three notes rendered, each saying "...Arapahoe County..."
- Direct call with `geoType='county'` → note disappears (no false positives)
- CSS computed `border-left: 3px solid rgb(251, 191, 36)` (warn amber)

## Test plan
- [x] `node test/hna-county-scope-disclosures.test.js` — 15 source-grep assertions
- [ ] After merge, hard-refresh HNA, pick a place (Aurora, Boulder city), and confirm all three sections show the amber "County-level data — Arapahoe / Boulder County" note. Pick a county and confirm no note appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)