### PR TITLE
fix(hna): sub-county charts + Prop 123 cards + HSA→WorkflowState sync

### DIFF
--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -2092,6 +2092,13 @@
     // Prop 123 compliance section (uses ACS profile + geoType + county FIPS for regional factor)
     window.HNARenderers.renderProp123Section(profile, geoType, contextCounty);
 
+    // Prop 123 baseline + fast-track eligibility cards. These containers
+    // shipped with "Select a geography…" placeholders and no renderer —
+    // even after the user picked one they sat on the placeholder text.
+    if (window.HNARenderers.renderProp123BaselineAndFastTrack) {
+      window.HNARenderers.renderProp123BaselineAndFastTrack(profile, geoType, label);
+    }
+
     // Stash profile + contextCounty for Phase 2 panels (scorecard,
     // historical-section delegation, etc.) that need them without
     // re-fetching. Idempotent — overwritten on every render cycle.
@@ -2199,11 +2206,16 @@
     // containing-county FIPS) so countyFromGeoid resolves correctly for
     // any CO place — not just the small subset in __HNA_GEO_CONFIG.
     // Previously, missing entries silently fell back to Mesa County
-    // (08077), causing the Fruita/Boulder anomaly. Non-blocking — if
-    // the registry fails to load, countyFromGeoid returns null for
-    // unknown geoids and callers fall back to state-level data.
+    // (08077), causing the Fruita/Boulder anomaly.
+    //
+    // AWAIT the load: update() runs countyFromGeoid synchronously to
+    // pick the LEHD/DOLA cache file for non-featured places like
+    // Paonia (08029). Without await, the registry hadn't finished
+    // loading by the time update() ran and countyFromGeoid returned
+    // null, so the LEHD/DOLA charts rendered empty.
     if (typeof window.HNAUtils.ensureGeographyRegistry === 'function') {
-      window.HNAUtils.ensureGeographyRegistry();
+      try { await window.HNAUtils.ensureGeographyRegistry(); }
+      catch (_) { /* soft-fail: callers handle null county lookup */ }
     }
 
     // Wire up aria-live announcement helper for screen reader updates (Rule 11)
@@ -2318,11 +2330,60 @@
       if (firstOpt) window.HNAState.els.geoSelect.value = firstOpt.value;
     }
 
+    // ── HSA → WorkflowState sync ─────────────────────────────────────
+    // Whenever the user changes the HNA dropdowns, write the new
+    // selection back to WorkflowState so the Select Jurisdiction page
+    // (and every other workflow step) stays in sync. Without this, HNA
+    // is read-only — the user picks Adams on HNA, then revisits Select
+    // Jurisdiction and the old/default selection is still showing.
+    function _syncJurisdictionToWorkflowState() {
+      var gt = window.HNAState.els.geoType.value;
+      var gid = window.HNAState.els.geoSelect.value;
+      if (!gid) return;
+      var selOpt = window.HNAState.els.geoSelect.options[window.HNAState.els.geoSelect.selectedIndex];
+      var label = selOpt ? selOpt.textContent : gid;
+      try {
+        if (window.WorkflowState && typeof window.WorkflowState.setJurisdiction === 'function') {
+          // Workflow-state convention from select-jurisdiction.js: place
+          // selections use type='city' with placeGeoid; county selections
+          // use type='county' with fips. Match it so the restoration logic
+          // (Priority 1 in update() init) reads it back cleanly next time.
+          var payload;
+          if (gt === 'county') {
+            payload = { type: 'county', fips: gid, name: label, geoid: gid };
+          } else if (gt === 'state') {
+            payload = { type: 'state', fips: '08', name: 'Colorado', geoid: '08' };
+          } else {
+            // place / cdp — restoration code expects 'city' + placeGeoid +
+            // displayName + a containing-county fips for legacy fallbacks.
+            var contextCounty = window.HNAUtils.countyFromGeoid(gt, gid);
+            payload = {
+              type: 'city',
+              displayName: label,
+              placeGeoid: gid,
+              geoid: gid,
+              fips: contextCounty || '08',
+              name: label,
+            };
+          }
+          window.WorkflowState.setJurisdiction(payload);
+        }
+      } catch (e) {
+        if (typeof console !== 'undefined' && console.warn) {
+          console.warn('[HNA] WorkflowState sync failed:', e && e.message);
+        }
+      }
+    }
+
     window.HNAState.els.geoType.addEventListener('change', ()=>{
       buildSelect();
+      _syncJurisdictionToWorkflowState();
       update();
     });
-    window.HNAState.els.geoSelect.addEventListener('change', update);
+    window.HNAState.els.geoSelect.addEventListener('change', () => {
+      _syncJurisdictionToWorkflowState();
+      update();
+    });
     window.HNAState.els.btnRefresh.addEventListener('click', update);
     window.HNAState.els.btnPdf?.addEventListener('click', exportPdf);
     window.HNAState.els.btnCsv?.addEventListener('click', ()=>{

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -2337,6 +2337,78 @@
     }
   }
 
+  /**
+   * Populate the Prop 123 baseline / fast-track cards on HNA. The HTML
+   * ships these with "Select a geography…" placeholders that never
+   * cleared because no renderer touched them. With a profile in hand
+   * we can derive a directional baseline (6% of housing stock) and
+   * surface the fast-track eligibility check the utility already
+   * computes (population threshold per HB 22-1093).
+   *
+   * The baseline is intentionally a directional estimate — the
+   * jurisdiction-specific number comes from CDOLA Prop 123
+   * commitment filings. Labelled so the user knows it's an estimate.
+   */
+  function renderProp123BaselineAndFastTrack(profile, geoType, geoLabel) {
+    var safeNum = U().safeNum;
+    var fmtNum  = U().fmtNum;
+
+    // ── Baseline: 60% AMI rentals (directional) ─────────────────────
+    var baselineEl = document.getElementById('prop123BaselineContent');
+    if (baselineEl) {
+      var totalUnits = safeNum(profile && profile.DP04_0001E) || 0;
+      if (totalUnits > 0) {
+        // Heuristic: ~6% of total housing stock is the directional
+        // affordable baseline (mix of LIHTC, HOME, vouchers, NHTF).
+        // Jurisdiction-specific numbers come from CDOLA filings;
+        // matches the estimator used by chartProp123Growth.
+        var baseline = Math.round(totalUnits * 0.06);
+        var required3yr = Math.round(baseline * Math.pow(1.03, 3));
+        baselineEl.innerHTML =
+          '<div style="font-size:1.5rem;font-weight:800;color:var(--text);margin:0 0 .25rem">'
+            + fmtNum(baseline) + ' units</div>'
+          + '<p style="margin:0;color:var(--muted);font-size:.85rem;line-height:1.45">'
+            + '<strong>Directional estimate</strong> (~6% of '
+            + fmtNum(totalUnits) + ' total housing units in '
+            + escHtml(geoLabel || 'this area')
+            + '). 3-yr target at 3% growth: <strong style="color:var(--text)">'
+            + fmtNum(required3yr) + ' units</strong>.<br>'
+            + 'Jurisdiction-specific baselines come from CDOLA Prop 123 '
+            + 'commitment filings.</p>';
+      } else {
+        baselineEl.innerHTML =
+          '<p style="margin:0;color:var(--muted);font-size:.9rem">'
+          + 'Housing-stock data not available for this geography.</p>';
+      }
+    }
+
+    // ── Fast-track approval eligibility (HB 22-1093) ────────────────
+    var fastTrackEl = document.getElementById('prop123FastTrackContent');
+    if (fastTrackEl) {
+      var pop = safeNum(profile && profile.DP05_0001E);
+      var check = (U().checkFastTrackEligibility && pop != null)
+        ? U().checkFastTrackEligibility(pop, geoType)
+        : null;
+      if (check && check.eligible !== null) {
+        var iconColor = check.eligible ? 'var(--good,#16a34a)' : 'var(--warn,#d97706)';
+        var icon = check.eligible ? '✓' : '⚠';
+        var label = check.eligible ? 'Eligible' : 'Not Eligible';
+        fastTrackEl.innerHTML =
+          '<div style="font-size:1.5rem;font-weight:800;color:' + iconColor + ';margin:0 0 .25rem">'
+            + icon + ' ' + label + '</div>'
+          + '<p style="margin:0;color:var(--muted);font-size:.85rem;line-height:1.45">'
+            + escHtml(check.reason)
+            + '. Per HB 22-1093 fast-track (60-day) permitting requires the '
+            + 'jurisdiction to be at or above the population threshold and '
+            + 'to have filed a Prop 123 commitment.</p>';
+      } else {
+        fastTrackEl.innerHTML =
+          '<p style="margin:0;color:var(--muted);font-size:.9rem">'
+          + 'Population data not available for this geography.</p>';
+      }
+    }
+  }
+
   function renderFastTrackCalculatorSection() {
     // Renders the Prop 123 / HB 22-1093 fast-track timeline calculator
     // output. Reads the form values, computes a permitting-duration
@@ -2980,6 +3052,7 @@
     renderCountyScopeNote: _renderCountyScopeNote,
     // Prop 123
     renderProp123Section,
+    renderProp123BaselineAndFastTrack,
     renderFastTrackCalculatorSection,
     renderHistoricalSection,
     renderComplianceTable,

--- a/scripts/audit/source-url-sweep.mjs
+++ b/scripts/audit/source-url-sweep.mjs
@@ -65,7 +65,9 @@ const ALLOW_LIST = new Set([
   "https://www.bls.gov/jlt",
   "https://www.bls.gov/lau/",
   "https://www.bls.gov/data/",
-  // Colorado Division of Local Government — blocks CI agents.
+  // Colorado Division of Local Government — blocks CI agents on
+  // every path (returns 403 to non-browser user-agents).
+  "https://dlg.colorado.gov/",
   "https://dlg.colorado.gov/news-article/final-housing-needs-assessment-methodology-and-displacement-risk-assessment-guidance",
   // GitHub settings URLs require authentication and are not publicly reachable.
   "https://github.com/pggLLC/Housing-Analytics/settings/secrets/actions",

--- a/test/hna-functionality-check.js
+++ b/test/hna-functionality-check.js
@@ -287,8 +287,13 @@ test('JS: cache status is reflected in the methodology section', () => {
 // JS: UI controls and event listeners
 // ---------------------------------------------------------------------------
 test('JS: geoType and geoSelect change events trigger update()', () => {
-    assert(js.includes("addEventListener('change', ()=>"), 'geoType change listener calls buildSelect + update');
-    assert(js.includes("addEventListener('change', update)"), 'geoSelect change listener calls update');
+    // Both listeners are arrow functions that call update() (geoSelect's
+    // also calls _syncJurisdictionToWorkflowState before update so the
+    // HSA selection writes back to WorkflowState).
+    assert(/geoType\.addEventListener\('change',\s*\(\)\s*=>\s*\{[\s\S]{0,400}update\(\)/.test(js),
+      'geoType change listener calls update() inside an arrow handler');
+    assert(/geoSelect\.addEventListener\('change',\s*\(\)\s*=>\s*\{[\s\S]{0,400}update\(\)/.test(js),
+      'geoSelect change listener calls update() inside an arrow handler');
 });
 
 test('JS: Refresh button triggers update()', () => {

--- a/test/hna-sub-county-and-sync.test.js
+++ b/test/hna-sub-county-and-sync.test.js
@@ -1,0 +1,84 @@
+'use strict';
+/**
+ * test/hna-sub-county-and-sync.test.js
+ *
+ * Regression for 2026-05-16 batch:
+ *
+ *   1. Small towns (Paonia, etc.) showed empty Commuting / Age pyramid /
+ *      Senior growth pressure charts. Root cause: ensureGeographyRegistry
+ *      was fired non-blocking; update() ran countyFromGeoid() before the
+ *      registry had loaded, so non-featured place lookups returned null
+ *      and the LEHD/DOLA fallback never ran.
+ *
+ *   2. "Baseline: 60% AMI Rentals" + "Fast-Track Approval Eligibility"
+ *      cards stayed on their "Select a geography…" placeholders forever
+ *      — no renderer touched the prop123BaselineContent or
+ *      prop123FastTrackContent containers.
+ *
+ *   3. Changing the HNA dropdown selections did NOT write back to
+ *      WorkflowState. HSA was read-only from the workflow's POV, so
+ *      revisiting Select Jurisdiction showed the old selection.
+ *
+ * Run: node test/hna-sub-county-and-sync.test.js
+ */
+
+const fs   = require('fs');
+const path = require('path');
+
+let passed = 0, failed = 0;
+function assert(cond, msg) {
+  if (cond) { console.log('  ✅ PASS:', msg); passed++; }
+  else       { console.error('  ❌ FAIL:', msg); failed++; }
+}
+
+const root = path.join(__dirname, '..');
+const ctl  = fs.readFileSync(path.join(root, 'js/hna/hna-controller.js'),  'utf8');
+const rend = fs.readFileSync(path.join(root, 'js/hna/hna-renderers.js'),   'utf8');
+
+console.log('\n[test] #1 ensureGeographyRegistry is awaited before update()');
+// The await must appear inside an async function and BEFORE update()
+// uses countyFromGeoid for non-featured places.
+assert(/await\s+window\.HNAUtils\.ensureGeographyRegistry\(\)/.test(ctl),
+  'controller awaits ensureGeographyRegistry()');
+
+console.log('\n[test] #2 renderProp123BaselineAndFastTrack exists and is wired up');
+assert(/function renderProp123BaselineAndFastTrack\(profile, geoType, geoLabel\)/.test(rend),
+  'renderer accepts (profile, geoType, geoLabel)');
+assert(/renderProp123BaselineAndFastTrack,/.test(rend),
+  'renderer is exported on HNARenderers');
+assert(/renderProp123BaselineAndFastTrack\(profile, geoType, label\)/.test(ctl),
+  'controller calls the renderer in the update() flow');
+assert(/prop123BaselineContent/.test(rend),
+  'renderer writes #prop123BaselineContent');
+assert(/prop123FastTrackContent/.test(rend),
+  'renderer writes #prop123FastTrackContent');
+// Fast-track uses the existing eligibility helper (population + threshold).
+assert(/checkFastTrackEligibility\(pop,\s*geoType\)/.test(rend),
+  'fast-track delegates to checkFastTrackEligibility utility');
+
+console.log('\n[test] #3 HSA dropdown changes sync back to WorkflowState');
+assert(/_syncJurisdictionToWorkflowState\(\)/.test(ctl),
+  'sync helper defined in controller init');
+assert(/setJurisdiction\(payload\)/.test(ctl),
+  'sync calls WorkflowState.setJurisdiction');
+// Convention: place selections use type='city' + placeGeoid (matches
+// the convention select-jurisdiction.js writes, so restoration in
+// update() init reads it back cleanly).
+const placeBranch = ctl.match(
+  /if \(gt === 'county'\)[\s\S]*?else\s*\{[\s\S]*?type:\s*'city'/
+);
+assert(placeBranch != null,
+  'place/cdp sync payload uses type:"city" + placeGeoid (matches selector convention)');
+// Wired to BOTH change events so geoType swaps and geoSelect swaps both sync.
+const gtListener = ctl.match(
+  /geoType\.addEventListener\('change'[\s\S]{0,200}_syncJurisdictionToWorkflowState/
+);
+const gsListener = ctl.match(
+  /geoSelect\.addEventListener\('change'[\s\S]{0,200}_syncJurisdictionToWorkflowState/
+);
+assert(gtListener != null, 'geoType change listener calls sync');
+assert(gsListener != null, 'geoSelect change listener calls sync');
+
+console.log('\n=========================================');
+console.log('Results: ' + passed + ' passed, ' + failed + ' failed');
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary
Three user-reported issues, each verified live in the preview against Paonia (0857300, small town in Delta County).

### 1. Sub-county charts empty (Paonia → Delta) — race condition fix
`ensureGeographyRegistry()` was fired non-blocking, then `update()` ran `countyFromGeoid()` synchronously. For non-featured places like Paonia (only in the 577-entry registry, not the small featured set), the lookup returned `null` before the registry finished loading — so the LEHD / DOLA county-fallback never resolved.

**Fix:** `await ensureGeographyRegistry()` before `update()`. Paonia now reads Delta County data: `chartLehd` dataLen `3`, `chartPyramid` `18`, `chartSenior` `5`. (Owner Housing Cost Burden still shows "data not available" for tiny ACS-suppressed geographies — that's correct.)

### 2. Baseline 60% AMI + Fast-Track cards
`#prop123BaselineContent` and `#prop123FastTrackContent` shipped with "Select a geography…" placeholders that **no renderer touched**. Added `renderProp123BaselineAndFastTrack(profile, geoType, geoLabel)`:

- **Baseline:** 6% of `DP04_0001E` total housing stock (matches the heuristic `chartProp123Growth` already uses, labeled as a directional estimate). Paonia: "57 units. Directional estimate (~6% of 943 total housing units in Paonia (town))."
- **Fast-Track:** delegates to the existing `checkFastTrackEligibility(population, geoType)` utility — applies HB 22-1093 population thresholds and the CDP-ineligibility rule. Paonia: "✓ Eligible. Population (1,661) meets the 1,000 threshold."

### 3. HSA → WorkflowState sync (answer to "does HSA change Select Jurisdiction?")
**Before this PR: no.** HSA was read-only from the workflow's POV — pick a county on HSA, then revisit Select Jurisdiction, the old selection still showed.

**Fix:** `_syncJurisdictionToWorkflowState` wired to both the `geoType` and `geoSelect` change listeners. Place/cdp selections use `type:'city' + placeGeoid + containing-county fips`, matching the convention `select-jurisdiction.js` writes so the restoration path in `update()` init reads it back cleanly.

Verified live: changed dropdown on HSA → `WorkflowState.getJurisdiction()` returned `{type:'city', placeGeoid:'0800320', fips:'08035', …}`.

## Answer to "should we use other sources or build an alternative for sub-county data?"
For Paonia + most CO towns, the **containing-county data is already cached and ready** — the race condition was hiding it. With this fix, every place/CDP that maps to a county in the registry will get LEHD/DOLA via the county fallback, paired with the county-scope disclosure note (PR #817) so the user sees where the data is sourced.

The only sub-county data gaps that remain are inherently irreducible:
- ACS DP04 owner cost-burden PE codes for tiny places (ACS suppresses for ≤~250 households).
- Per-place LEHD WAC; the methodology'd require place-share apportionment (similar approach to what TIGER place-CHAS does for HUD CHAS — a real piece of work).

## Test plan
- [x] `node test/hna-sub-county-and-sync.test.js` — 12 source-grep assertions across all three fixes
- [ ] After merge, navigate to HNA?geoType=place&geoid=0857300&auto=1 and confirm chartLehd, chartPyramid, chartSenior populate; Baseline/Fast-Track cards show data; changing the dropdown updates the workflow stepper / Select Jurisdiction state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)