### PR TITLE
fix(deal-calc): pre-select county from jx.fips, not bogus jx.countyFips

### DIFF
--- a/js/deal-calculator.js
+++ b/js/deal-calculator.js
@@ -2209,12 +2209,17 @@
       // After populating, pre-select the county from WorkflowState / SiteState.
       var _populateRetries = 0;
       var _afterPopulate = function () {
-        // Pre-select jurisdiction county so user doesn't re-enter it
+        // Pre-select jurisdiction county so user doesn't re-enter it.
+        // WorkflowState / select-jurisdiction.js / HNA all write the
+        // county FIPS to `jx.fips` — the legacy `jx.countyFips` field
+        // doesn't exist anywhere in the schema, so this lookup silently
+        // returned undefined and the county dropdown never auto-selected
+        // the user's project jurisdiction.
         var fips = null;
         try {
           var _proj = window.WorkflowState && window.WorkflowState.getActiveProject();
           var _jx   = _proj && (_proj.jurisdiction || (_proj.steps && _proj.steps.jurisdiction));
-          if (_jx && _jx.countyFips) fips = _jx.countyFips;
+          if (_jx && _jx.fips) fips = _jx.fips;
         } catch (_) {}
         if (!fips) {
           try {

--- a/js/pma-ui-controller.js
+++ b/js/pma-ui-controller.js
@@ -229,7 +229,12 @@
       try {
         var _proj = window.WorkflowState && window.WorkflowState.getActiveProject();
         var _jx   = _proj && (_proj.jurisdiction || (_proj.steps && _proj.steps.jurisdiction));
-        if (_jx && _jx.countyFips) countyFips = _jx.countyFips;
+        // WorkflowState / select-jurisdiction.js / HNA all write the
+        // county FIPS to `jx.fips` — the `jx.countyFips` field doesn't
+        // exist anywhere in the schema, so this lookup silently returned
+        // undefined and the PMA CHFA-awards / AMI-gap data never wired
+        // when the user came from a prior workflow step.
+        if (_jx && _jx.fips) countyFips = _jx.fips;
       } catch (_) {}
       if (!countyFips) {
         try {

--- a/test/deal-calc-workflow-prefill.test.js
+++ b/test/deal-calc-workflow-prefill.test.js
@@ -1,0 +1,57 @@
+'use strict';
+/**
+ * test/deal-calc-workflow-prefill.test.js
+ *
+ * Regression for 2026-05-16: Deal Calculator and PMA UI controller
+ * both looked up the user's project county from a non-existent
+ * `jx.countyFips` field. WorkflowState / select-jurisdiction.js /
+ * HNA all write the county FIPS to `jx.fips` — there's no
+ * `countyFips` field anywhere in the schema. So the county
+ * pre-selection silently no-op'd: a user who picked Adams County on
+ * Step 1 still landed on Deal Calc with the dropdown sitting on
+ * "Select a county…".
+ *
+ * What this asserts (source-grep):
+ *   - Neither file references the legacy `jx.countyFips` /
+ *     `_jx.countyFips` field in executable code.
+ *   - Both files use `jx.fips` / `_jx.fips` instead.
+ *
+ * Run: node test/deal-calc-workflow-prefill.test.js
+ */
+
+const fs   = require('fs');
+const path = require('path');
+
+let passed = 0, failed = 0;
+function assert(cond, msg) {
+  if (cond) { console.log('  ✅ PASS:', msg); passed++; }
+  else       { console.error('  ❌ FAIL:', msg); failed++; }
+}
+
+function execOnly(src) {
+  return src
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+const root = path.join(__dirname, '..');
+const dc   = fs.readFileSync(path.join(root, 'js/deal-calculator.js'),    'utf8');
+const pma  = fs.readFileSync(path.join(root, 'js/pma-ui-controller.js'),  'utf8');
+
+console.log('\n[test] deal-calculator.js reads jx.fips (not jx.countyFips)');
+const dcExec = execOnly(dc);
+assert(!/_jx\.countyFips|jx\.countyFips/.test(dcExec),
+  'no executable references to the bogus jx.countyFips field');
+assert(/_jx\s*&&\s*_jx\.fips\s*\)\s*fips\s*=\s*_jx\.fips/.test(dcExec),
+  'pre-selection lookup uses _jx.fips correctly');
+
+console.log('\n[test] pma-ui-controller.js reads jx.fips (not jx.countyFips)');
+const pmaExec = execOnly(pma);
+assert(!/_jx\.countyFips|jx\.countyFips/.test(pmaExec),
+  'no executable references to the bogus jx.countyFips field');
+assert(/_jx\s*&&\s*_jx\.fips\s*\)\s*countyFips\s*=\s*_jx\.fips/.test(pmaExec),
+  'CHFA-awards / AMI-gap wiring uses _jx.fips correctly');
+
+console.log('\n=========================================');
+console.log('Results: ' + passed + ' passed, ' + failed + ' failed');
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary
Audit of the rest of the site after HNA (Market Analysis, Deal Calculator, Scenario Builder, Comparative Ranking) found **one real bug**: Deal Calculator and the PMA UI controller both look up the user's project county from a non-existent `jx.countyFips` field.

`WorkflowState` / `select-jurisdiction.js` / HNA all write the county FIPS to `jx.fips` — there's no `countyFips` field anywhere in the schema. So the pre-selection silently no-op'd: a user who picked Adams County on Step 1 still landed on Deal Calculator with the dropdown stuck on "Select a county…".

The PMA UI controller's CHFA historical awards + AMI-gap wiring was also silently disabled for the same reason. Both files were adjacent to the matching `SiteState` fallback, so this was a typo from the start, not a schema change.

## Verified live (preview server)
- Cleared storage
- `setJurisdiction({fips:'08001', name:'Adams County', type:'county'})`
- Load Deal Calculator
- `#dc-county-select.value` → `"08001"`
- Display text → `"Adams County — Denver-Aurora-Lakewood HUD Metro FMR Area"`

Before this PR the dropdown stayed on its placeholder.

## Other pages audited — no actionable bugs
- **Market Analysis** — `pmaRadarChart` is by-design empty until the user picks a site on the map; "Loading map data…" overlay correctly hides once data loads.
- **Scenario Builder** — `sbProjectionChart` attaches with 27 data points.
- **Comparative Ranking** — table-only page, no canvases.

"Earlier Step Incomplete" banners on these pages are correct behavior when the user lands without WorkflowState — not a bug.

## Test plan
- [x] `node test/deal-calc-workflow-prefill.test.js` — 4 source-grep assertions confirming both files use `_jx.fips` and no longer reference `jx.countyFips`
- [ ] After merge, end-to-end flow: Select Jurisdiction → HNA → Deal Calculator. Confirm the DC county dropdown auto-shows the user's county.

🤖 Generated with [Claude Code](https://claude.com/claude-code)