### PR TITLE
data(place-aliases): map Cañon City + Central City to canonical TIGER

### DIFF
--- a/data/hna/place-phantom-aliases.json
+++ b/data/hna/place-phantom-aliases.json
@@ -1,5 +1,7 @@
 {
   "aliases": {
+    "0810270": "0811810",
+    "0812910": "0812900",
     "0800775": "0801090",
     "0803875": "0809555",
     "0817320": "0817760",
@@ -31,12 +33,17 @@
     "0884330": "0882350"
   },
   "meta": {
-    "count_aliases": 29,
+    "count_aliases": 31,
     "count_duplicates": 29,
     "count_unresolvable": 0,
     "generated_at": "2026-05-10T04:33:27Z",
+    "updated_at": "2026-05-16",
     "method": "Match duplicate (name, containingCounty) pairs in geography-registry.json; identify canonical = the GEOID that exists in TIGER 2024 PLACE shapefile.",
     "note": "Consumers should resolve phantom geoids via this map before looking up place data. See js/place-chas-lookup.js for an example consumer.",
-    "tiger_vintage": 2024
+    "tiger_vintage": 2024,
+    "manual_additions": {
+      "0810270": "Cañon City — registry name uses ñ; TIGER places shapefile lists it under canonical GEOID 0811810 (likely an ASCII-normalization mismatch in the registry build script).",
+      "0812910": "Central City — registry uses long-form 'Central City'; TIGER places lists it under canonical GEOID 0812900 'Central' (Census short form). Same place, different label conventions."
+    }
   }
 }


### PR DESCRIPTION
## Summary
Closes the last coverage gap from the place-LEHD apportionment audit. With this PR, **all 513 of 513 registry places + CDPs** resolve to a place-level LEHD blob (directly or via alias).

Two stragglers after #821:
- `0810270` **Cañon City** — registry uses `ñ`; TIGER places shapefile lists this place under canonical `0811810` (ASCII-normalization mismatch in the registry build script).
- `0812910` **Central City** — registry uses long-form "Central City"; TIGER places lists it under canonical `0812900` "Central" (Census short form).

Both canonical GEOIDs already have place-LEHD entries; this PR just adds the alias redirects so the existing `PlaceLehd.lookup` / `PlaceChas.lookup` modules pick them up.

## Verification
```
reg_places = 513
truly_missing post-fix = 0   (was 2)
0810270 → 0811810: in place-LEHD = True
0812910 → 0812900: in place-LEHD = True
```

Also benefits place-CHAS (PR #803), economic-housing-bridge, and every other consumer that calls `PlaceChas.lookup` / `PlaceLehd.lookup` — they all share this single alias map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)