### PR TITLE
ci: run chart-population audit on chart-related PRs + weekly

### DIFF
--- a/.github/workflows/chart-audit.yml
+++ b/.github/workflows/chart-audit.yml
@@ -1,0 +1,85 @@
+name: HNA Chart-Population Audit
+
+# Headless-Chrome regression guard for the "tests pass but UI broken"
+# class of bug. Opens housing-needs-assessment.html at a known county
+# AND a known place, waits for renderers to settle, then asserts that
+# every named Chart.js canvas in scripts/audit/chart-population-audit.mjs
+# attaches a chart with at least one non-zero data point.
+#
+# Local: npm run audit:charts
+# CI:    runs on PRs that touch chart code / data, and weekly on main.
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'housing-needs-assessment.html'
+      - 'js/hna/**'
+      - 'js/place-lehd-lookup.js'
+      - 'js/place-chas-lookup.js'
+      - 'data/hna/**.json'
+      - 'data/hna/lehd/**'
+      - 'data/hna/dola_sya/**'
+      - 'scripts/audit/chart-population-audit.mjs'
+      - '.github/workflows/chart-audit.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'housing-needs-assessment.html'
+      - 'js/hna/**'
+      - 'js/place-lehd-lookup.js'
+      - 'js/place-chas-lookup.js'
+      - 'data/hna/**.json'
+      - 'data/hna/lehd/**'
+      - 'data/hna/dola_sya/**'
+      - 'scripts/audit/chart-population-audit.mjs'
+      - '.github/workflows/chart-audit.yml'
+  schedule:
+    - cron: '0 6 * * 1'   # Mondays at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  chart-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium --with-deps
+
+      - name: Start local HTTP server
+        run: npx http-server . -p 8080 --silent &
+
+      - name: Wait for server to be ready
+        run: npx wait-on http://localhost:8080 --timeout 15000
+
+      - name: Run chart-population audit
+        env:
+          AUDIT_BASE_URL: http://localhost:8080
+          # Slightly longer settle window than the local default
+          # (CI runners are slower than local dev preview).
+          CHART_SETTLE_MS: '12000'
+        run: npm run audit:charts
+
+      - name: Upload audit report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chart-audit-report
+          path: audit-report/chart-population/
+          retention-days: 14
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
Wires the headless-Chrome chart-population audit landed in #825 into GitHub Actions, so the **"tests pass but UI broken"** regression class gets caught before users file bugs.

## Triggers
| When | Why |
|---|---|
| **PR / push to main** touching chart code or HNA data | Catch the obvious case — a renderer / data change empties a chart |
| **Monday 06:00 UTC scheduled** | Catch silent upstream-data drift even when no PR is open |
| **workflow_dispatch** | Manual re-run on demand |

Path filters keep the workflow from running on unrelated docs/CSS-only PRs:
- `housing-needs-assessment.html`
- `js/hna/**`
- `js/place-lehd-lookup.js` / `js/place-chas-lookup.js`
- `data/hna/**.json` (summary cache + place-LEHD / place-CHAS)
- `data/hna/lehd/**` (county LEHD)
- `data/hna/dola_sya/**` (county DOLA)
- the audit script + this workflow itself

## Job
- Boots `npx http-server` on :8080
- `npx playwright install chromium --with-deps`
- `CHART_SETTLE_MS=12000 npm run audit:charts` (longer settle window than local default — CI runners are slower)
- Uploads the timestamped JSON report from `audit-report/chart-population/` as a 14-day artifact

## Failure mode
Exits non-zero when any expected chart is missing, has no Chart.js instance attached, or paints only zero / no-finite data — exactly the regression class fixed throughout this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)