### PR TITLE
feat(audit): extend chart-population coverage to 24 charts / 4 fixtures

### DIFF
--- a/.github/workflows/chart-audit.yml
+++ b/.github/workflows/chart-audit.yml
@@ -14,7 +14,12 @@ on:
     branches: [ main ]
     paths:
       - 'housing-needs-assessment.html'
+      - 'hna-scenario-builder.html'
+      - 'colorado-deep-dive.html'
       - 'js/hna/**'
+      - 'js/scenario-builder*.js'
+      - 'js/co-lihtc-map.js'
+      - 'js/colorado-deep-dive*.js'
       - 'js/place-lehd-lookup.js'
       - 'js/place-chas-lookup.js'
       - 'data/hna/**.json'
@@ -26,7 +31,12 @@ on:
     branches: [ main ]
     paths:
       - 'housing-needs-assessment.html'
+      - 'hna-scenario-builder.html'
+      - 'colorado-deep-dive.html'
       - 'js/hna/**'
+      - 'js/scenario-builder*.js'
+      - 'js/co-lihtc-map.js'
+      - 'js/colorado-deep-dive*.js'
       - 'js/place-lehd-lookup.js'
       - 'js/place-chas-lookup.js'
       - 'data/hna/**.json'

--- a/scripts/audit/chart-population-audit.mjs
+++ b/scripts/audit/chart-population-audit.mjs
@@ -68,6 +68,26 @@ const EXPECTED = [
   { fixture: 'hna-paonia', url: '/housing-needs-assessment.html?geoType=place&geoid=0857300&auto=1', chart: 'chartWage',         note: 'wage tiers (apportioned)' },
   { fixture: 'hna-paonia', url: '/housing-needs-assessment.html?geoType=place&geoid=0857300&auto=1', chart: 'chartIndustry',     note: 'industries (apportioned)' },
   { fixture: 'hna-paonia', url: '/housing-needs-assessment.html?geoType=place&geoid=0857300&auto=1', chart: 'chartEmploymentTrend', note: 'employment trend (apportioned)' },
+
+  // ── Scenario Builder (Step 4): renders a default scenario on load ──
+  { fixture: 'scenario-builder', url: '/hna-scenario-builder.html', chart: 'sbProjectionChart',
+    note: 'default scenario projection line' },
+
+  // ── Colorado Deep Dive: 6 charts that paint on initial page load ──
+  // (The remaining ~9 canvases on this page only render after the user
+  // picks a county / metric in the dropdowns — out of scope here.)
+  { fixture: 'colorado-deep-dive', url: '/colorado-deep-dive.html', chart: 'ami-need-chart',
+    note: 'AMI-band need overview' },
+  { fixture: 'colorado-deep-dive', url: '/colorado-deep-dive.html', chart: 'concessions-chart',
+    note: 'developer concessions trend' },
+  { fixture: 'colorado-deep-dive', url: '/colorado-deep-dive.html', chart: 'foreclosure-chart',
+    note: 'foreclosure rate trend' },
+  { fixture: 'colorado-deep-dive', url: '/colorado-deep-dive.html', chart: 'confidence-chart',
+    note: 'market confidence indicator' },
+  { fixture: 'colorado-deep-dive', url: '/colorado-deep-dive.html', chart: 'chartLihtcTimeline',
+    note: 'LIHTC allocation timeline' },
+  { fixture: 'colorado-deep-dive', url: '/colorado-deep-dive.html', chart: 'comparison-chart',
+    note: 'cross-metric comparison' },
 ];
 
 function _summarize(results) {


### PR DESCRIPTION
## Summary
Extends the chart-population audit landed in #825 (and wired into CI in #826) from **17 → 24 charts** across **4 fixtures**, now covering Step 2 (HNA), Step 4 (Scenario Builder), and Colorado Deep Dive.

## New coverage
| Fixture | Charts |
|---|---|
| **hna-scenario-builder** | `sbProjectionChart` — default scenario projection line |
| **colorado-deep-dive** | `ami-need-chart`, `concessions-chart`, `foreclosure-chart`, `confidence-chart`, `chartLihtcTimeline`, `comparison-chart` |

The remaining ~9 canvases on Colorado Deep Dive are dropdown/tab-driven (only paint after interaction) — out of scope for an auto-load audit.

## Why not Market Analysis / Deal Calculator
- **MA's** `pmaRadarChart` paints only after the user picks a site on the map
- **DC's** `pf-chart` paints only after the user enters pro-forma inputs

Both intentionally skipped — they'd add a false-positive failure to the audit without a user-interaction harness, which is a bigger lift than fits this PR.

## CI workflow
Path filter extended so changes to `hna-scenario-builder.html`, `colorado-deep-dive.html`, and their JS trigger the chart-audit job.

## Local result
```
[chart-audit] 24/24 charts pass.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)