### PR TITLE
feat(build): pre-bake income / age-of-housing / bedroom-mix into summary cache

### DIFF
--- a/scripts/audit/source-url-sweep.mjs
+++ b/scripts/audit/source-url-sweep.mjs
@@ -101,10 +101,13 @@ const SKIP_PATTERNS = [
   /^https?:\/\/0\.0\.0\.0/i,
   /^\/\//,
   /\$\{/,
-  // Leaflet/Mapbox/MapLibre tile-URL templates use single-brace placeholders
-  // like {s}, {z}, {x}, {y}, {r} — these will never resolve to literal URLs
-  // (they're substituted by the tile-layer at render time).
-  /\{[a-z]\}/i,
+  // Single-brace placeholders that will never resolve to a literal URL:
+  //   - Leaflet/Mapbox/MapLibre tile templates: {s}, {z}, {x}, {y}, {r}
+  //   - Python f-string formatters in source comments / docstrings:
+  //     {acs5_year}, {qs}, {county}, etc.
+  // The pattern matches both single chars and snake/kebab/word placeholders
+  // so we don't have to chase each new f-string with a one-off allow-list.
+  /\{[a-z_][a-z_0-9-]*\}/i,
   /^https?:\/\/fonts\.googleapis\.com/i,
   /^https?:\/\/fonts\.gstatic\.com/i,
   /^https?:\/\/cdn\.jsdelivr\.net/i,

--- a/scripts/hna/build_hna_data.py
+++ b/scripts/hna/build_hna_data.py
@@ -790,7 +790,14 @@ def fetch_acs_profile(geo_type: str, geoid: str) -> dict | None:
     - GRAPI bins: DP04_0137PE (<15%) … DP04_0142PE (≥35%). DP04_0143–0146 do not exist
       in ACS 2023 and cause HTTP 400 for the entire request if included.
     """
-    vars_ = [
+    # Two batches because the Census /profile endpoint caps each request
+    # at 50 variables. Batch A is the historical bare-minimum set; batch B
+    # was added 2026-05-16 to pre-bake the income / age-of-housing /
+    # bedroom-mix codes that the JS-side fetchAcsExtended runs at page
+    # load (chartIncomeDistribution / chartHousingAge / chartBedroomMix
+    # previously rendered empty whenever the Census API was unreachable,
+    # since their fields weren't in the cached summary).
+    vars_a = [
         'DP05_0001E',   # Total population
         'DP03_0062E',   # Median household income
         'DP04_0001E',   # Total housing units
@@ -811,10 +818,27 @@ def fetch_acs_profile(geo_type: str, geoid: str) -> dict | None:
         # DP04_0141PE=30–34.9%, DP04_0142PE=35%+
         'DP04_0137PE','DP04_0138PE','DP04_0139PE','DP04_0140PE',
         'DP04_0141PE','DP04_0142PE',
-        'NAME'
+        'NAME',
     ]
+    vars_b = [
+        # Income brackets (DP03 — renderIncomeDistribution).
+        # ACS 2023: DP03_0052E (<$10k) … DP03_0060E ($200k+)
+        'DP03_0052E','DP03_0053E','DP03_0054E','DP03_0055E',
+        'DP03_0056E','DP03_0057E','DP03_0058E','DP03_0059E','DP03_0060E',
+        # Year structure built (DP04 — renderHousingAgeChart).
+        # ACS 2023: DP04_0017E (2020+) … DP04_0026E (pre-1940)
+        'DP04_0017E','DP04_0018E','DP04_0019E','DP04_0020E','DP04_0021E',
+        'DP04_0022E','DP04_0023E','DP04_0024E','DP04_0025E','DP04_0026E',
+        # Bedroom mix (DP04 — renderBedroomMixChart).
+        # ACS 2023: DP04_0039E (no BR) … DP04_0044E (5+ BR)
+        'DP04_0039E','DP04_0040E','DP04_0041E','DP04_0042E','DP04_0043E','DP04_0044E',
+        'NAME',
+    ]
+    # Single var_list kept for backward-compat with downstream call sites
+    # that still grep "vars_" — concatenated only after both batches run.
+    vars_ = vars_a + [v for v in vars_b if v not in vars_a]
 
-    def build_url(year: int, endpoint: str, series: str = 'acs1') -> str:
+    def build_url(year: int, endpoint: str, series: str, batch_vars: list[str]) -> str:
         base = f'https://api.census.gov/data/{year}/acs/{series}/{endpoint}'
         if geo_type == 'county':
             for_ = f"county:{geoid[-3:]}"
@@ -827,10 +851,23 @@ def fetch_acs_profile(geo_type: str, geoid: str) -> dict | None:
         # Census API geography parameters (for= and in=).  urllib.parse.urlencode
         # encodes ':' as '%3A', which the Census API does not decode, causing it
         # to report "ambiguous geography" errors for county-level queries.
-        qs = f"get={','.join(vars_)}&for={for_}&in=state:{STATE_FIPS_CO}"
+        qs = f"get={','.join(batch_vars)}&for={for_}&in=state:{STATE_FIPS_CO}"
         if key:
             qs += f"&key={urllib.parse.quote(key, safe='')}"
         return f"{base}?{qs}"
+
+    def _fetch_batch(batch_vars: list[str]) -> dict | None:
+        """Try ACS1/profile → ACS5/profile for each year in the fallback window.
+        Returns a {var: value} dict on first success, None if all attempts fail."""
+        for year in years_to_try:
+            for series, endpoint in [('acs1', 'profile'), ('acs5', 'profile')]:
+                url = build_url(year, endpoint, series, batch_vars)
+                result = http_get_json(url)
+                if result and len(result) > 1:
+                    if year != start_year:
+                        print(f"ℹ ACS profile {geo_type}:{geoid} batch resolved via {series}/{endpoint} year={year}", file=sys.stderr)
+                    return {result[0][i]: result[1][i] for i in range(len(result[0]))}
+        return None
 
     # Try each year from ACS_START_YEAR down, over ACS_FALLBACK_YEARS years;
     # for each year try ACS1/profile → ACS5/profile in order.
@@ -839,22 +876,30 @@ def fetch_acs_profile(geo_type: str, geoid: str) -> dict | None:
     n_fallback = int(os.environ.get('ACS_FALLBACK_YEARS', '3'))
     years_to_try = list(range(start_year, start_year - n_fallback, -1))
 
-    for year in years_to_try:
-        for series, endpoint in [('acs1', 'profile'), ('acs5', 'profile')]:
-            url = build_url(year, endpoint, series)
-            result = http_get_json(url)
-            if result and len(result) > 1:
-                if year != start_year:
-                    print(f"ℹ ACS profile {geo_type}:{geoid} resolved via {series}/{endpoint} year={year}", file=sys.stderr)
-                return {result[0][i]: result[1][i] for i in range(len(result[0]))}
+    # Batch A is the historical mandatory set; without it we can't build a
+    # useful summary at all. Batch B is the income / housing-age / bedroom-
+    # mix supplement — a partial summary (A but not B) is still valuable,
+    # so don't block on B failing.
+    merged: dict = {}
+    a = _fetch_batch(vars_a)
+    if a is None:
+        print(f"⚠ Could not fetch ACS profile (batch A) for {geo_type}:{geoid} (tried years {years_to_try})", file=sys.stderr)
+        # ACS profile/subject tables may fail for some geographies and ACS years
+        # (e.g. CDPs not in profile tables; DP variable numbering can shift between
+        # releases).  Fall back to ACS 5-year B-series which covers all geography
+        # types and uses stable variable codes.
+        print(f"ℹ {geo_type}:{geoid}: attempting ACS5 B-series fallback", file=sys.stderr)
+        return _fetch_acs5_b_series(geo_type, geoid)
+    merged.update(a)
 
-    print(f"⚠ Could not fetch ACS profile for {geo_type}:{geoid} (tried years {years_to_try})", file=sys.stderr)
-    # ACS profile/subject tables may fail for some geographies and ACS years
-    # (e.g. CDPs not in profile tables; DP variable numbering can shift between
-    # releases).  Fall back to ACS 5-year B-series which covers all geography
-    # types and uses stable variable codes.
-    print(f"ℹ {geo_type}:{geoid}: attempting ACS5 B-series fallback", file=sys.stderr)
-    return _fetch_acs5_b_series(geo_type, geoid)
+    b = _fetch_batch(vars_b)
+    if b is not None:
+        # Preserve batch-A values on conflicting keys (NAME, etc.)
+        for k, v in b.items():
+            merged.setdefault(k, v)
+    else:
+        print(f"ℹ ACS profile (batch B) for {geo_type}:{geoid} unavailable — income / housing-age / bedroom-mix cards will fall back to live fetch", file=sys.stderr)
+    return merged
 
 
 def fetch_acs_s0801(geo_type: str, geoid: str) -> dict | None:

--- a/tests/test_build_hna_data_batch_b.py
+++ b/tests/test_build_hna_data_batch_b.py
@@ -1,0 +1,123 @@
+"""tests/test_build_hna_data_batch_b.py
+
+Regression for 2026-05-16: build_hna_data.fetch_acs_profile() was
+extended to fetch batch B (income brackets + year built + bedroom
+mix codes) in addition to batch A, so that chartIncomeDistribution
+/ chartHousingAge / chartBedroomMix paint from the cached summary
+even when the live Census API is unreachable (CI, offline, network
+blip).
+
+What this asserts (source-grep style — no live network call):
+  - Batch A keeps every historical mandatory variable.
+  - Batch B adds the 25 new DP03 / DP04 codes the HNA renderers
+    consume.
+  - The fetch_acs_profile() function actually calls _fetch_batch
+    twice and merges, so a partial-data scenario (B fails, A
+    succeeds) still produces a usable summary.
+
+Run: pytest tests/test_build_hna_data_batch_b.py -v
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/hna/build_hna_data.py"
+
+# Income brackets — DP03_0052E (<$10k) … DP03_0060E ($200k+).
+INCOME_CODES = [f"DP03_{n:04d}E" for n in range(52, 61)]
+# Year structure built — DP04_0017E (2020+) … DP04_0026E (pre-1940).
+YEAR_BUILT_CODES = [f"DP04_{n:04d}E" for n in range(17, 27)]
+# Bedroom mix — DP04_0039E (no BR) … DP04_0044E (5+ BR).
+BEDROOM_CODES = [f"DP04_{n:04d}E" for n in range(39, 45)]
+
+
+def _source() -> str:
+    return SCRIPT.read_text(encoding="utf-8")
+
+
+def test_vars_a_keeps_historical_mandatory_codes():
+    """Batch A must still carry the codes the existing dashboards
+    depend on (DP04_0001E total housing, DP04_0089E median home value,
+    DP04_0134E median rent, the GRAPI bins, etc.)."""
+    src = _source()
+    for code in (
+        "DP05_0001E",
+        "DP03_0062E",
+        "DP04_0001E",
+        "DP04_0046PE",
+        "DP04_0047PE",
+        "DP04_0089E",
+        "DP04_0134E",
+        "DP04_0137PE",
+        "DP04_0142PE",
+    ):
+        assert f"'{code}'" in src, f"vars_a must still include {code}"
+
+
+def test_vars_b_adds_income_brackets():
+    src = _source()
+    for code in INCOME_CODES:
+        assert f"'{code}'" in src, f"vars_b must include income code {code}"
+
+
+def test_vars_b_adds_year_built_codes():
+    src = _source()
+    for code in YEAR_BUILT_CODES:
+        assert f"'{code}'" in src, f"vars_b must include year-built code {code}"
+
+
+def test_vars_b_adds_bedroom_mix_codes():
+    src = _source()
+    for code in BEDROOM_CODES:
+        assert f"'{code}'" in src, f"vars_b must include bedroom-mix code {code}"
+
+
+def test_fetch_acs_profile_runs_both_batches_and_merges():
+    """The function must run _fetch_batch twice (once per vars_*) and
+    fall through cleanly if batch B fails — otherwise the supplement
+    would silently drop the historical fields."""
+    src = _source()
+    assert "_fetch_batch(vars_a)" in src, \
+        "fetch_acs_profile must call _fetch_batch with vars_a"
+    assert "_fetch_batch(vars_b)" in src, \
+        "fetch_acs_profile must call _fetch_batch with vars_b"
+    # When B fails, A's data should still be returned (i.e. there's a
+    # 'b is None' branch that doesn't abort the whole function).
+    assert "if b is not None:" in src, \
+        "must keep batch-A data when batch-B fetch fails"
+
+
+def test_each_batch_stays_within_census_api_50_var_cap():
+    """Census /profile endpoint refuses requests with >50 variables.
+    Count the unique 'DP\\d\\d_\\d{4}P?E' identifiers inside each
+    vars_* list block to make sure neither batch exceeds the cap."""
+    import re
+    src = _source()
+
+    def _block(label: str) -> str:
+        # Capture from 'label = [' to the matching closing ']'.
+        m = re.search(label + r"\s*=\s*\[(.*?)\n    \]", src, re.DOTALL)
+        assert m, f"could not locate {label} block in source"
+        return m.group(1)
+
+    def _codes(block: str) -> set[str]:
+        return set(re.findall(r"'(DP0\d_\d{4}P?E)'", block))
+
+    a = _codes(_block("vars_a"))
+    b = _codes(_block("vars_b"))
+    # +1 for NAME; Census counts NAME against the cap.
+    assert len(a) + 1 <= 50, f"batch A has {len(a) + 1} vars (cap 50)"
+    assert len(b) + 1 <= 50, f"batch B has {len(b) + 1} vars (cap 50)"
+
+
+def test_batch_b_codes_match_renderer_expectations():
+    """Sanity: each code in the new batch is what the corresponding
+    renderer reads from `profile` at runtime."""
+    src = _source()
+    # Renderer probes (assert the new codes the HNA renderers actually use):
+    # - chartIncomeDistribution → DP03_0052E..0060E
+    # - chartHousingAge         → DP04_0017E..0026E
+    # - chartBedroomMix         → DP04_0039E..0044E
+    expected = set(INCOME_CODES + YEAR_BUILT_CODES + BEDROOM_CODES)
+    missing = [c for c in expected if f"'{c}'" not in src]
+    assert not missing, f"missing from build_hna_data.py: {missing}"


### PR DESCRIPTION
## Summary
`scripts/hna/build_hna_data.fetch_acs_profile()` now hits the Census `/profile` endpoint in **two batches** and merges, so the summary cache files (`data/hna/summary/*.json`) carry the income brackets (DP03_0052E..0060E), year-built codes (DP04_0017E..0026E), and bedroom-mix codes (DP04_0039E..0044E) the HNA renderers consume.

## Why
`chartIncomeDistribution`, `chartHousingAge`, and `chartBedroomMix` were the only three HNA charts the new chart-population audit (#825, #827) excluded — they always rendered empty whenever the live Census API was unreachable (CI, offline preview, transient network blip). The runtime fallback (`fetchAcsExtended.batchA` in `hna-controller.js`) still works, but cache parity means the charts paint immediately on every load instead of waiting for the live request to come back.

## Method
- Original `vars_` split into:
  - `vars_a` — the historical mandatory set (24 codes + NAME)
  - `vars_b` — the new 25-code supplement (income / year built / bedroom mix)
- New `_fetch_batch` helper runs the ACS1→ACS5 profile fallback chain for a given batch
- `fetch_acs_profile()` calls `_fetch_batch(vars_a)` first (still falls through to B-series when batch A is unreachable — existing behavior). Then `_fetch_batch(vars_b)`; if B fails, the partial summary (A only) is still returned — supplement is best-effort

Each batch stays under the Census `/profile` 50-variable cap.

## Cache regeneration
**Not regenerated in this PR.** The cron data-refresh workflow will pick it up on the next scheduled run. Until then, the runtime `fetchAcsExtended` path keeps the three charts working when the Census API is reachable; once the cron runs, they'll paint immediately from cache too.

**Follow-up:** add the three chart IDs to the chart-population audit's `EXPECTED` list once a regenerated summary lands in main.

## Test plan
- [x] `pytest tests/test_build_hna_data_batch_b.py -v` — 7 assertions covering batch A preservation, batch B addition, two-batch + merge invocation, 50-var cap, renderer-expectation match
- [ ] After merge, watch the next data-refresh cron run and confirm the regenerated `data/hna/summary/08001.json` carries the new fields
- [ ] Then a follow-up tiny PR extends `chart-population-audit.mjs` to assert all 3 new charts populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)