### PR TITLE
fix(hna-comparison): per-place cost-burden tiers + 2023 owner codes

### DIFF
--- a/hna-comparative-analysis.html
+++ b/hna-comparative-analysis.html
@@ -28,6 +28,11 @@
   <script defer src="js/utils/data-quality.js"></script>
   <script defer src="js/config/financial-constants.js"></script>
   <script defer src="js/hna/hna-ranking-index.js"></script>
+  <!-- TIGER place-CHAS lookup — lets the comparison panel pull
+       per-place renter cost-burden tiers instead of inheriting the
+       parent county's rates verbatim (two places in the same county
+       used to show identical 70.4/76.9/44.9 numbers). -->
+  <script defer src="js/place-chas-lookup.js"></script>
   <script defer src="js/hna/hna-comparison.js"></script>
   <script defer src="js/components/source-badge.js"></script>
   <script defer src="js/components/page-context.js"></script>

--- a/js/hna/hna-comparison.js
+++ b/js/hna/hna-comparison.js
@@ -551,19 +551,45 @@
       '</div>';
     });
 
-    // Cost burden breakdown by tier
+    // Cost burden breakdown by tier.
+    //
+    // Pre-fix: this section read pct_burdened_lte30 / 31to50 / 51to80
+    // straight off entry.metrics — which build_ranking_index populates
+    // from chas_by_county[county_fips5]. Every place inherited its
+    // county's tier burden rates verbatim, so any two places in the
+    // same county (Fruita and Clifton, both Mesa 08077) showed
+    // identical 70.4 / 76.9 / 44.9 even though their real renter mixes
+    // differ. Fix: prefer place-CHAS (TIGER-apportioned, PR #803) when
+    // available; flag county-fallback explicitly.
+    var burdenA = _deriveBurdenTiersForEntry(entryA);
+    var burdenB = _deriveBurdenTiersForEntry(entryB);
+
     html += '<div class="hca-cp-subsection">';
     html += '<div class="hca-cp-subsection__title">Renter Cost Burden by Income Tier</div>';
+
+    // Disclosure when either side falls back to the parent county's
+    // CHAS rates (the legacy behavior).
+    var anyCountyFallback = (burdenA && burdenA.source === 'county') ||
+                            (burdenB && burdenB.source === 'county');
+    if (anyCountyFallback) {
+      html += '<div class="hca-cp-burden__county-note" role="note" style="' +
+        'margin:0 0 .5rem;padding:.4rem .6rem;border-left:3px solid var(--warn,#d97706);' +
+        'border-radius:0 4px 4px 0;background:var(--warn-dim,#fef3c7);' +
+        'font-size:.76rem;line-height:1.4;color:var(--text);">' +
+        '<strong style="color:var(--warn,#d97706);">⚠ Tier burden rates are county-level.</strong> ' +
+        'At least one selection falls back to its containing county because no place-CHAS coverage is ' +
+        'available — two places in the same county will show identical tier rates.' +
+      '</div>';
+    }
+
     var burdenMetrics = [
-      { id: 'pct_burdened_lte30',  label: '≤30% AMI burdened' },
-      { id: 'pct_burdened_31to50', label: '31–50% AMI burdened' },
-      { id: 'pct_burdened_51to80', label: '51–80% AMI burdened' },
+      { id: 'lte30',  label: '≤30% AMI burdened' },
+      { id: 'tier3150', label: '31–50% AMI burdened' },
+      { id: 'tier5180', label: '51–80% AMI burdened' },
     ];
     burdenMetrics.forEach(function (bm) {
-      var bA = entryA.metrics[bm.id];
-      var bB = entryB.metrics[bm.id];
-      var numA = bA != null ? +bA : null;
-      var numB = bB != null ? +bB : null;
+      var numA = (burdenA && burdenA[bm.id] != null) ? +burdenA[bm.id] : null;
+      var numB = (burdenB && burdenB[bm.id] != null) ? +burdenB[bm.id] : null;
       var delta = _deltaText(numA, numB, 'percent', true);
       html += '<div class="hca-cp-row hca-cp-row--compact">' +
         '<div class="hca-cp-row__label">' + bm.label + '</div>' +
@@ -575,6 +601,62 @@
     html += '</div>';
     html += '</div>';
     return html;
+  }
+
+  /**
+   * Compute per-place renter cost-burden rates by AMI tier from the
+   * TIGER-apportioned place-CHAS dataset (data/hna/place-chas.json).
+   * Falls back to the entry's county-derived metrics when no place
+   * blob exists, so the section keeps working for the 31 places not
+   * in the TIGER spatial join.
+   *
+   * Output: { lte30, tier3150, tier5180, source: 'place'|'county' }
+   */
+  function _deriveBurdenTiersForEntry(entry) {
+    if (!entry) return null;
+    var m = entry.metrics || {};
+    var geoid = entry.geoid || (entry.geo && entry.geo.geoid);
+    var isPlace = entry.type === 'place' || entry.type === 'cdp';
+
+    // Place-CHAS path (preferred for places). PlaceChas.lookup handles
+    // phantom-alias redirects so the 31 places that share canonical
+    // TIGER geoids with their non-canonical registry siblings resolve.
+    if (isPlace && geoid && window.PlaceChas && typeof window.PlaceChas.lookup === 'function') {
+      var pc = window.PlaceChas.lookup(geoid);
+      var rba = pc && pc.renter_hh_by_ami;
+      if (rba) {
+        var lte30 = _tierBurdenPct(rba.lte30);
+        var t3150 = _tierBurdenPct(rba['31to50']);
+        var t5180 = _tierBurdenPct(rba['51to80']);
+        if (lte30 != null || t3150 != null || t5180 != null) {
+          return {
+            lte30:    lte30,
+            tier3150: t3150,
+            tier5180: t5180,
+            source:   'place',
+          };
+        }
+      }
+    }
+
+    // County-fallback path: reuse the pre-computed ranking-index values
+    // (which come from chas_by_county). Surface the source flag so the
+    // disclosure note fires.
+    return {
+      lte30:    m.pct_burdened_lte30,
+      tier3150: m.pct_burdened_31to50,
+      tier5180: m.pct_burdened_51to80,
+      source:   'county',
+    };
+  }
+
+  function _tierBurdenPct(tier) {
+    if (!tier) return null;
+    var total = +tier.total;
+    var cb30  = +tier.cost_burdened_30pct;
+    if (!Number.isFinite(total) || total <= 0) return null;
+    if (!Number.isFinite(cb30)) return null;
+    return +((cb30 / total) * 100).toFixed(1);
   }
 
   // ── Homeownership Affordability section builder ───────────────────
@@ -590,10 +672,13 @@
     var ownerPctA = pA.DP04_0046PE != null ? +pA.DP04_0046PE : null;
     var ownerPctB = pB.DP04_0046PE != null ? +pB.DP04_0046PE : null;
 
-    // Owner cost burden (30%+ of income): DP04_0145PE (30-34.9%) + DP04_0146PE (≥35%)
+    // Owner cost burden (30%+ of income): ACS 2023 SMOCAPI bins are
+    // DP04_0114PE (30-34.9%) + DP04_0115PE (≥35%). The legacy 2022
+    // codes (DP04_0145PE / 0146PE) don't exist in the 2023 vintage —
+    // same fix pattern as PR #816's chartOwnerCostBurden swap.
     var ownerBurdenA = null, ownerBurdenB = null;
-    if (pA.DP04_0145PE != null && pA.DP04_0146PE != null) ownerBurdenA = +pA.DP04_0145PE + +pA.DP04_0146PE;
-    if (pB.DP04_0145PE != null && pB.DP04_0146PE != null) ownerBurdenB = +pB.DP04_0145PE + +pB.DP04_0146PE;
+    if (pA.DP04_0114PE != null && pA.DP04_0115PE != null) ownerBurdenA = +pA.DP04_0114PE + +pA.DP04_0115PE;
+    if (pB.DP04_0114PE != null && pB.DP04_0115PE != null) ownerBurdenB = +pB.DP04_0114PE + +pB.DP04_0115PE;
 
     // Compute AMI required to purchase (use median HH income as AMI proxy)
     var purchaseRenter_A = _calcPurchaseAmi(homeValA, incomeA, false);
@@ -1063,6 +1148,15 @@
     if (!state || !state.allEntries.length) {
       setTimeout(init, 200);
       return;
+    }
+
+    // Kick off place-CHAS load so the renter cost-burden tier section
+    // can show per-place rates instead of falling back to county
+    // numbers by the time the user clicks Compare. Idempotent +
+    // soft-fails — _deriveBurdenTiersForEntry already falls back to
+    // entry.metrics if PlaceChas isn't ready.
+    if (window.PlaceChas && typeof window.PlaceChas.init === 'function') {
+      window.PlaceChas.init().catch(function () { /* fallback fires */ });
     }
 
     _buildCountyMap(state.allEntries);

--- a/test/hna-comparison-place-cost-burden.test.js
+++ b/test/hna-comparison-place-cost-burden.test.js
@@ -1,0 +1,80 @@
+'use strict';
+/**
+ * test/hna-comparison-place-cost-burden.test.js
+ *
+ * Regression for 2026-05-17: the Renter Cost Burden by Income Tier
+ * subsection on hna-comparative-analysis.html read
+ * pct_burdened_lte30/31to50/51to80 straight off entry.metrics — which
+ * build_ranking_index populates from CHAS county data. Every place
+ * inherited its parent county's tier burden rates verbatim, so any
+ * two places in the same county (Fruita + Clifton, both Mesa 08077)
+ * showed identical 70.4 / 76.9 / 44.9.
+ *
+ * Fix: prefer place-CHAS (TIGER-apportioned, PR #803) via PlaceChas.
+ * lookup; flag county-fallback explicitly.
+ *
+ * Also fixes the adjacent "% Owners Cost-Burdened" line in the
+ * Homeownership Affordability section, which still summed legacy 2022
+ * DP04_0145PE + 0146PE codes that don't exist in ACS 2023 (same
+ * pattern as the chartOwnerCostBurden fix in PR #816).
+ *
+ * Run: node test/hna-comparison-place-cost-burden.test.js
+ */
+
+const fs   = require('fs');
+const path = require('path');
+
+let passed = 0, failed = 0;
+function assert(cond, msg) {
+  if (cond) { console.log('  ✅ PASS:', msg); passed++; }
+  else       { console.error('  ❌ FAIL:', msg); failed++; }
+}
+
+const root = path.join(__dirname, '..');
+const comp = fs.readFileSync(path.join(root, 'js/hna/hna-comparison.js'), 'utf8');
+const html = fs.readFileSync(path.join(root, 'hna-comparative-analysis.html'), 'utf8');
+
+console.log('\n[test] place-CHAS deriver wired into renter cost-burden subsection');
+assert(/function _deriveBurdenTiersForEntry\(entry\)/.test(comp),
+  '_deriveBurdenTiersForEntry helper is defined');
+assert(/window\.PlaceChas\s*&&\s*typeof window\.PlaceChas\.lookup === 'function'/.test(comp),
+  'deriver delegates to PlaceChas.lookup when geoid is a place/cdp');
+assert(/source:\s*['"]place['"]/.test(comp) && /source:\s*['"]county['"]/.test(comp),
+  'deriver returns a source flag ("place" or "county") so the disclosure note can fire');
+// The subsection must consume the deriver output, NOT the raw
+// entry.metrics.pct_burdened_lte30 reads it used to do.
+assert(/var burdenA = _deriveBurdenTiersForEntry\(entryA\)/.test(comp),
+  'subsection invokes the deriver for side A');
+assert(/var burdenB = _deriveBurdenTiersForEntry\(entryB\)/.test(comp),
+  'subsection invokes the deriver for side B');
+
+console.log('\n[test] county-fallback disclosure exists');
+assert(/anyCountyFallback/.test(comp),
+  'subsection computes anyCountyFallback flag');
+assert(/Tier burden rates are county-level/.test(comp),
+  'disclosure text surfaces the county-fallback caveat');
+
+console.log('\n[test] init() pre-loads PlaceChas');
+assert(/window\.PlaceChas[\s\S]{0,200}\.init\(\)/.test(comp),
+  'init() kicks off PlaceChas.init() so the lookup is warm when the user clicks Compare');
+
+console.log('\n[test] HTML loads PlaceChas before hna-comparison.js');
+const scriptOrder = html.match(/<script defer src="(js\/[a-z0-9\-\/]+\.js)"><\/script>/g) || [];
+const placeIdx = scriptOrder.findIndex(s => s.includes('place-chas-lookup'));
+const compIdx  = scriptOrder.findIndex(s => s.includes('hna-comparison'));
+assert(placeIdx !== -1, 'place-chas-lookup.js script tag is in hna-comparative-analysis.html');
+assert(placeIdx < compIdx,
+  'place-chas-lookup.js loads BEFORE hna-comparison.js so window.PlaceChas exists at init time');
+
+console.log('\n[test] Homeownership Affordability owner-burden uses 2023 PE codes');
+const noComments = comp
+  .replace(/\/\/[^\n]*/g, '')
+  .replace(/\/\*[\s\S]*?\*\//g, '');
+assert(/DP04_0114PE/.test(noComments) && /DP04_0115PE/.test(noComments),
+  'owner cost-burden reads DP04_0114PE + DP04_0115PE (ACS 2023 SMOCAPI)');
+assert(!/DP04_0145PE|DP04_0146PE/.test(noComments),
+  'legacy 2022 DP04_0145PE/0146PE codes no longer referenced in executable code');
+
+console.log('\n=========================================');
+console.log('Results: ' + passed + ' passed, ' + failed + ' failed');
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary
Two related bugs in the side-by-side comparison panel on `hna-comparative-analysis.html`.

### 1. Renter Cost Burden by Income Tier — same county = same numbers
Subsection read `pct_burdened_lte30 / 31to50 / 51to80` straight off `entry.metrics`, which `build_ranking_index` populates from CHAS county data. Every place inherited its parent county's tier rates verbatim — Fruita and Clifton (both Mesa 08077) both showed identical **70.4 / 76.9 / 44.9** even though their real renter mixes differ.

**Fix:** new `_deriveBurdenTiersForEntry` helper delegates to `PlaceChas.lookup(geoid)` (the TIGER-apportioned dataset from PR #803) when the entry is a place/cdp; falls back to entry.metrics (county-derived) when no place blob exists. Returns `{lte30, tier3150, tier5180, source}` so the disclosure can fire on the county-fallback path. Matches the pattern the AMI Mix card already uses.

### 2. Owner cost-burden: legacy 2022 codes
The adjacent "% Owners Cost-Burdened" line summed `DP04_0145PE + 0146PE` (legacy 2022) that don't exist in the 2023 vintage. Switched to `DP04_0114PE + 0115PE` (ACS 2023 SMOCAPI) — same pattern as PR #816's `chartOwnerCostBurden` fix.

## Plumbing
- `init()` now pre-loads PlaceChas so the lookup is warm by the time the user clicks Compare.
- `hna-comparative-analysis.html` adds the `<script defer src="js/place-chas-lookup.js">` tag, ordered before `hna-comparison.js`.

## Verified live (Fruita 0828745 vs Clifton 0815165, both Mesa)
| Bucket | Before | After |
|---|---|---|
| ≤30% AMI burdened | A 70.4% / B 70.4% | **A 99.9% / B 71.4%** |
| 31–50% AMI burdened | A 76.9% / B 76.9% | **A 67.5% / B 90.7%** |
| 51–80% AMI burdened | A 44.9% / B 44.9% | **A 26.0% / B 35.7%** |
| County-fallback disclosure | n/a | correctly absent (both places have place-CHAS coverage) |

## Test plan
- [x] `node test/hna-comparison-place-cost-burden.test.js` — 12 assertions: deriver wired, source flag, disclosure fires, init pre-loads, HTML script ordering, owner-burden codes
- [ ] After merge, open comparative analysis, compare two same-county places (Fruita vs Clifton, or Boulder city vs Longmont), confirm the burden-tier numbers differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)