### PR TITLE
chore(qa): targeted content + layout pass per QA notes

### DIFF
--- a/css/pages/hna-comparative-analysis.css
+++ b/css/pages/hna-comparative-analysis.css
@@ -29,8 +29,12 @@
   color: var(--muted);
   font-size: 0.9rem;
   margin: 0 0 0.75rem;
-  max-width: 720px;
+  max-width: 780px;
   line-height: 1.55;
+  /* Browser-balanced wrapping prevents the orphan/widow lines the
+     previous fixed max-width produced (last word on a line by
+     itself, or a stray short final line). */
+  text-wrap: pretty;
 }
 /* Body-copy link inside the hero sub-paragraph needs a non-color cue
    per WCAG 1.4.1 (link-in-text-block). Accent-colored underline at
@@ -247,9 +251,18 @@
 }
 .hca-table thead {
   position: sticky;
-  top: 58px; /* below site header */
+  /* Sticky inside .hca-table-wrap (which is the scroll viewport via
+     overflow-y:auto + max-height:70vh) — top is relative to the wrap,
+     not the page. The previous 58px value left a 58px gap inside the
+     wrap and the header would stick partway down, visually covering
+     the #1 row. Use 0 so the header pins to the top of the scroll
+     viewport. */
+  top: 0;
   z-index: 2;
   background: var(--card);
+  /* A soft inset shadow below the sticky header so users can tell it
+     is floating above the rows when they scroll. */
+  box-shadow: 0 1px 0 var(--border);
 }
 .hca-th {
   padding: 9px 10px;

--- a/deal-calculator.html
+++ b/deal-calculator.html
@@ -664,8 +664,9 @@
     /* ── Inject workflow progress bar styles ─────────────────────────── */
     var s = document.createElement('style');
     s.textContent = [
-      '.wf-progress-wrap{max-width:1200px;margin:0 auto;padding:14px 18px 0;}',
-      '.wf-progress-steps{display:flex;align-items:center;gap:0;}',
+      /* Sticky below the site header — see housing-needs-assessment.html. */
+      '.wf-progress-wrap{max-width:1200px;margin:0 auto;padding:10px 18px;position:sticky;top:58px;z-index:900;background:var(--bg);border-bottom:1px solid var(--border);}',
+      '.wf-progress-steps{display:flex;align-items:center;gap:0;max-width:1200px;margin:0 auto;}',
       '.wf-step{display:flex;flex-direction:column;align-items:center;text-align:center;text-decoration:none;color:var(--muted);min-width:80px;}',
       '.wf-step__num{width:30px;height:30px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:.78rem;font-weight:700;background:var(--bg2);color:var(--muted);border:2px solid var(--border);z-index:1;}',
       '.wf-step__label{font-size:.68rem;color:var(--muted);margin-top:4px;line-height:1.2;font-weight:600;}',

--- a/hna-scenario-builder.html
+++ b/hna-scenario-builder.html
@@ -446,8 +446,9 @@
     var s = document.createElement('style');
     s.id = 'wf-progress-styles';
     s.textContent = [
-      '.wf-progress-wrap{max-width:1200px;margin:0 auto;padding:14px 18px 0;}',
-      '.wf-progress-steps{display:flex;align-items:center;gap:0;}',
+      /* Sticky below the site header — see housing-needs-assessment.html. */
+      '.wf-progress-wrap{max-width:1200px;margin:0 auto;padding:10px 18px;position:sticky;top:58px;z-index:900;background:var(--bg);border-bottom:1px solid var(--border);}',
+      '.wf-progress-steps{display:flex;align-items:center;gap:0;max-width:1200px;margin:0 auto;}',
       '.wf-step{display:flex;flex-direction:column;align-items:center;text-align:center;text-decoration:none;color:var(--muted);min-width:80px;}',
       '.wf-step__num{width:30px;height:30px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:.78rem;font-weight:700;background:var(--bg2);color:var(--muted);border:2px solid var(--border);z-index:1;}',
       '.wf-step__label{font-size:.68rem;color:var(--muted);margin-top:4px;line-height:1.2;font-weight:600;}',

--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -233,10 +233,10 @@
           <div class="stat"><div class="k">Median home value</div><div class="v" id="statHomeValue">—</div><div id="statHomeValueYoy" class="yoy"></div><div class="s" id="statHomeValueSrc">—</div></div>
           <div class="stat"><div class="k">Median gross rent</div><div class="v" id="statRent">—</div><div id="statRentYoy" class="yoy"></div><div class="s" id="statRentSrc">—</div></div>
 
-          <div class="stat"><div class="k">Tenure</div><div class="v" id="statTenure">—</div><div class="s" id="statTenureSrc">Owner vs renter</div></div>
-          <div class="stat"><div class="k">Rent burdened (≥30%)</div><div class="v" id="statRentBurden">—</div><div class="s" id="statRentBurdenSrc">ACS GRAPI bins</div></div>
-          <div class="stat"><div class="k">Income needed to buy (est.)</div><div class="v" id="statIncomeNeed">—</div><div class="s" id="statIncomeNeedNote">30% of income rule</div></div>
-          <div class="stat"><div class="k">Mean commute time</div><div class="v" id="statCommute">—</div><div class="s" id="statCommuteSrc">ACS S0801</div></div>
+          <div class="stat"><div class="k">Tenure</div><div class="v" id="statTenure">—</div><div class="s" id="statTenureSrc">ACS DP04 0046/0047 · <a href="https://data.census.gov/table/ACSDP5Y2023.DP04" target="_blank" rel="noopener">data.census.gov</a></div></div>
+          <div class="stat"><div class="k">Rent burdened (≥30%)</div><div class="v" id="statRentBurden">—</div><div class="s" id="statRentBurdenSrc">ACS DP04 GRAPI bins · <a href="https://data.census.gov/table/ACSDP5Y2023.DP04" target="_blank" rel="noopener">data.census.gov</a></div></div>
+          <div class="stat"><div class="k">Income needed to buy (est.)</div><div class="v" id="statIncomeNeed">—</div><div class="s" id="statIncomeNeedNote">30% of income rule</div><div class="s" style="font-size:.68rem;opacity:.85">ACS DP04_0089E median home value · <a href="https://www.freddiemac.com/pmms" target="_blank" rel="noopener">Freddie Mac PMMS</a></div></div>
+          <div class="stat"><div class="k">Mean commute time</div><div class="v" id="statCommute">—</div><div class="s" id="statCommuteSrc">ACS S0801_C01_002E · <a href="https://data.census.gov/table/ACSST5Y2023.S0801" target="_blank" rel="noopener">data.census.gov</a></div></div>
         </div>
         <!-- Affordability Gap Coverage — named metric from CHAS data -->
         <div id="hnaGapCoveragePanel" class="hna-gap-coverage" hidden>
@@ -342,11 +342,20 @@
           <div class="stat"><div class="k">QCT tracts</div><div class="v" id="statQctCount">—</div><div class="s">HUD annual list</div></div>
           <div class="stat"><div class="k">DDA status</div><div class="v" id="statDdaStatus">—</div><div class="s" id="statDdaNote">HUD designation</div></div>
         </div>
-        <div id="lihtcInfoPanel" style="margin-top:10px"></div>
+        <!-- Cap the list height + add internal scroll so a long LIHTC
+             project list (50+ items for Adams) doesn't push the card
+             much taller than the adjacent map and break the row's
+             vertical balance. -->
+        <div id="lihtcInfoPanel" style="margin-top:10px;max-height:340px;overflow-y:auto;border-top:1px solid var(--border);padding-top:.5rem;"></div>
       </div>
 
-      <!-- ── HUD FMR & Income Limits panel ─────────────────────── -->
-      <div class="chart-card span-8" id="hudFmrPanel">
+      <!-- ── HUD FMR & Income Limits panel ───────────────────────
+           Was span-8; next card was span-6 (8+6=14 > 12) which forced
+           a wrap and left 4 columns of empty space to the right. The
+           inner content is already a 2-column grid that uses width
+           well at full row span — so going span-12 fills the row and
+           gives the tables more breathing room. -->
+      <div class="chart-card span-12" id="hudFmrPanel">
         <h2>HUD Fair Market Rents &amp; Income Limits</h2>
         <p>FY2025 HUD Fair Market Rents by bedroom size and Income Limits by household size for the selected county. Source: <a href="https://www.huduser.gov/portal/datasets/fmr.html" target="_blank" rel="noopener">HUD User</a>.</p>
         <div id="hudFmrAreaName" style="margin:6px 0;font-size:var(--small);color:var(--muted)">Select a geography to view FMR data.</div>
@@ -2255,8 +2264,12 @@
   var s = document.createElement('style');
   s.textContent = [
     /* Progress bar */
-    '.wf-progress-wrap{max-width:1200px;margin:0 auto;padding:14px 18px 0;}',
-    '.wf-progress-steps{display:flex;align-items:center;gap:0;}',
+    /* Sticky below the site header (which is z-index:1000, top:0) so
+       users keep their 5-step orientation while scrolling deep into
+       the page. Padding tightened from 14px → 10px since the bar is
+       now persistent and shouldn't eat scroll real estate. */
+    '.wf-progress-wrap{max-width:1200px;margin:0 auto;padding:10px 18px;position:sticky;top:58px;z-index:900;background:var(--bg);border-bottom:1px solid var(--border);}',
+    '.wf-progress-steps{display:flex;align-items:center;gap:0;max-width:1200px;margin:0 auto;}',
     '.wf-step{display:flex;flex-direction:column;align-items:center;text-align:center;text-decoration:none;color:var(--muted);min-width:80px;}',
     '.wf-step__num{width:30px;height:30px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:.78rem;font-weight:700;background:var(--bg2);color:var(--muted);border:2px solid var(--border);z-index:1;}',
     '.wf-step__label{font-size:.68rem;color:var(--muted);margin-top:4px;line-height:1.2;font-weight:600;}',

--- a/js/components/workflow-progress.js
+++ b/js/components/workflow-progress.js
@@ -40,8 +40,16 @@
     var s = document.createElement('style');
     s.id = 'wf-progress-styles';
     s.textContent = [
-      '.wf-progress-wrap{max-width:1200px;margin:0 auto;padding:14px 18px 0;}',
-      '.wf-progress-steps{display:flex;align-items:center;gap:0;}',
+      /* Workflow stepper sits BELOW the sticky site header (which is
+         z-index:1000, top:0) but ABOVE the page content. Make it
+         stick too so it stays visible on scroll — previously it
+         scrolled away with the rest of the page, which left users
+         wondering where they were in the 5-step flow once they
+         started reading mid-page. */
+      '.wf-progress-wrap{max-width:1200px;margin:0 auto;padding:10px 18px;' +
+        'position:sticky;top:58px;z-index:900;background:var(--bg);' +
+        'border-bottom:1px solid var(--border);}',
+      '.wf-progress-steps{display:flex;align-items:center;gap:0;max-width:1200px;margin:0 auto;}',
       '.wf-step{display:flex;flex-direction:column;align-items:center;text-align:center;',
         'text-decoration:none;color:var(--muted);min-width:80px;}',
       '.wf-step__num{width:30px;height:30px;border-radius:50%;display:flex;align-items:center;',

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -1707,7 +1707,103 @@
   function renderHousingGapSummary(profile, geoType) {
     const container = document.getElementById('housingGapSummary');
     if (!container || !profile) return;
-    container.textContent = 'Housing gap analysis available for county geographies.';
+    // Pre-fix: this was a one-line stub. Compute a plain-English
+    // interpretation of the housing gap from the cached ACS profile +
+    // CHAS county data when available, so the section earns its name.
+    const safeNum = U().safeNum;
+    const fmtNum  = U().fmtNum;
+    const fmtPct  = U().fmtPct;
+
+    const totalUnits   = safeNum(profile.DP04_0001E) || 0;
+    const renterTotal  = safeNum(profile.DP04_0047E);
+    const renterPct    = safeNum(profile.DP04_0047PE);
+    const burden30_35  = safeNum(profile.DP04_0141PE) || 0;  // 30-34.9%
+    const burden35plus = safeNum(profile.DP04_0142PE) || 0;  // 35%+
+    const burden30plus = burden30_35 + burden35plus;          // cost-burdened
+    const burden50plus = burden35plus * 0.65;                  // rough severe estimate
+    const medianRent   = safeNum(profile.DP04_0134E);
+    const medianHomeVal = safeNum(profile.DP04_0089E);
+
+    // CHAS county aggregates, if loaded.
+    const chasData = S().state && S().state.chasData;
+    const countyFips = U().countyFromGeoid && U().countyFromGeoid(geoType, profile._geoid || '');
+    const county = (chasData && countyFips) ? chasData[countyFips] : null;
+
+    const bullets = [];
+
+    // Renter cost-burden — from ACS GRAPI bins.
+    if (Number.isFinite(burden30plus) && burden30plus > 0 && Number.isFinite(renterTotal) && renterTotal > 0) {
+      const burdenedHH = Math.round(renterTotal * burden30plus / 100);
+      bullets.push(
+        '<strong>' + fmtPct(burden30plus) + '</strong> of renter households are <strong>cost-burdened</strong> ' +
+        '(paying ≥30% of income on rent) — roughly <strong>' + fmtNum(burdenedHH) + '</strong> households. ' +
+        (burden35plus >= 20
+          ? 'A meaningful share (' + fmtPct(burden35plus) + ') are severely burdened (≥35%), which signals immediate rental-affordability stress.'
+          : 'Severe burden (≥35%) is moderate at ' + fmtPct(burden35plus) + '.')
+      );
+    } else if (geoType === 'state') {
+      bullets.push('Statewide ACS GRAPI bins suppress at this granularity — pick a county or place for cost-burden detail.');
+    }
+
+    // Affordability gap from rent vs income.
+    if (medianRent && profile.DP03_0062E) {
+      const mhi = safeNum(profile.DP03_0062E);
+      const incomeNeededRent = (medianRent * 12) / 0.30;
+      const gapDollars = incomeNeededRent - mhi;
+      if (gapDollars > 0) {
+        bullets.push(
+          'Median rent of <strong>$' + fmtNum(medianRent) + '/mo</strong> needs ' +
+          '<strong>$' + fmtNum(Math.round(incomeNeededRent)) + '/yr</strong> at the 30%-of-income rule — ' +
+          '<strong>$' + fmtNum(Math.round(gapDollars)) + '</strong> above the median household income (' +
+          '$' + fmtNum(mhi) + '). Median renters cannot comfortably afford the median rent here.'
+        );
+      } else {
+        bullets.push(
+          'Median rent ($' + fmtNum(medianRent) + '/mo) is within the 30%-of-income window for the median household ' +
+          '(income $' + fmtNum(mhi) + ' vs $' + fmtNum(Math.round(incomeNeededRent)) + ' needed). ' +
+          'Affordability stress is concentrated below the median income.'
+        );
+      }
+    }
+
+    // CHAS-derived ≤60% AMI deficit (county-level only).
+    if (county && county.tiers && Array.isArray(county.tiers)) {
+      const lte60Tiers = county.tiers.filter(t => t.ami_tier && /≤30|31[-–]50|51[-–]60/.test(t.ami_tier));
+      const totalLte60 = lte60Tiers.reduce((sum, t) => sum + (Number(t.burden_30_50) || 0) + (Number(t.burden_50plus) || 0), 0);
+      if (totalLte60 > 0) {
+        bullets.push(
+          'HUD CHAS county data flags <strong>' + fmtNum(Math.round(totalLte60)) + '</strong> renter households at ≤60% AMI ' +
+          'paying ≥30% of income on housing — the cohort LIHTC at 60% AMI rents most directly serves. ' +
+          'Use the AMI tier chart below for the per-tier breakdown.'
+        );
+      }
+    }
+
+    // Tenure context closer.
+    if (renterPct != null) {
+      bullets.push(
+        'Renters make up <strong>' + fmtPct(renterPct) + '</strong> of occupied housing ' +
+        (renterPct >= 40
+          ? '— a meaningful renter base, so rental supply expansion has direct demand.'
+          : '— a smaller renter base; affordable rental projects may face longer absorption timelines.')
+      );
+    }
+
+    if (!bullets.length) {
+      container.innerHTML = '<p style="color:var(--muted);">' +
+        'Housing gap analysis becomes available once ACS profile + CHAS data load. ' +
+        'Try selecting a county.</p>';
+      return;
+    }
+
+    container.innerHTML =
+      '<ul style="margin:0 0 .5rem;padding-left:1.25rem;font-size:.9rem;line-height:1.55;color:var(--text);">' +
+        bullets.map(b => '<li style="margin:.35rem 0;">' + b + '</li>').join('') +
+      '</ul>' +
+      '<p style="margin:.5rem 0 0;font-size:.78rem;color:var(--muted);">' +
+        'Source: ACS 5-year DP03/DP04 (vintage 2019–2023) · HUD CHAS Table 7. ' +
+        'See the AMI Tier and Rent Burden charts below for the underlying numbers.' +
+      '</p>';
   }
 
   function renderSpecialNeedsPanel(profile) {

--- a/lihtc-guide-for-stakeholders.html
+++ b/lihtc-guide-for-stakeholders.html
@@ -29,9 +29,9 @@
 <main id="main-content" style="max-width: 1200px; margin: 0 auto; padding: 1.5rem 2rem 2rem;">
 <div class="hero" style="margin: -1.5rem -2rem 1.25rem; padding: 1.5rem 2rem;">
 <h1 style="margin-bottom: 1rem;">LIHTC Basics</h1>
-<p style="font-size: 1.5rem; color: var(--mcm-beige); max-width: 800px;">
-                An educational resource for new developers, housing authorities, and investors navigating LIHTC program requirements, financing structures, and market dynamics.
-            </p>
+<p style="font-size: 1.05rem; color: var(--mcm-beige); max-width: 720px; line-height: 1.55;">
+  Affordable housing 101 — how Low-Income Housing Tax Credits actually work, and who plays which role.
+</p>
 <div style="margin-top:1.25rem;display:flex;gap:12px;flex-wrap:wrap;align-items:center;">
   <a href="select-jurisdiction.html"
      style="display:inline-block;padding:12px 22px;background:var(--accent,#096e65);color:#fff;
@@ -43,25 +43,59 @@
   </span>
 </div>
 </div>
+
+<!-- Plain-English explainer — long-form sits BELOW the hero in body
+     size so the page wraps cleanly inside the content container. The
+     three roles render as three cards so a novice reader can scan
+     them at a glance. -->
+<section class="lihtc-explainer" style="max-width: 880px; margin: 0 auto 2rem; font-size: 1rem; line-height: 1.65; color: var(--text);">
+  <p>Low-Income Housing Tax Credits are one of the main ways affordable rental housing gets built in the United States. The program can feel complicated, but the basic idea is pretty simple: tax credits are awarded to affordable housing projects, and those credits are turned into cash that helps pay for construction.</p>
+
+  <p style="margin-top:1rem;">A LIHTC deal usually comes down to three main groups:</p>
+
+  <div class="lihtc-roles-grid" style="display:grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; margin: 1.25rem 0;">
+    <div class="lihtc-role-card" style="background: var(--mcm-slate, var(--card)); border-left: 4px solid var(--mcm-burnt-orange, var(--accent)); border-radius: 6px; padding: 1.1rem 1.25rem;">
+      <h3 style="margin: 0 0 .55rem; font-size: 1.05rem; color: var(--mcm-burnt-orange, var(--accent));">The developer</h3>
+      <p style="margin: 0; font-size: .95rem; line-height: 1.55; color: var(--mcm-beige, var(--text));">The group trying to make the project happen. They find the site, design the housing, apply for funding, pull the financing together, manage construction, and ultimately have to make sure the property works financially while still offering affordable rents.</p>
+    </div>
+    <div class="lihtc-role-card" style="background: var(--mcm-slate, var(--card)); border-left: 4px solid var(--mcm-teal, var(--info)); border-radius: 6px; padding: 1.1rem 1.25rem;">
+      <h3 style="margin: 0 0 .55rem; font-size: 1.05rem; color: var(--mcm-teal, var(--info));">The housing agency</h3>
+      <p style="margin: 0; font-size: .95rem; line-height: 1.55; color: var(--mcm-beige, var(--text));">The group that decides which projects receive tax credits. In Colorado, that is CHFA. Because there are always more good projects than available credits, the agency uses a competitive process to decide which developments best match public goals like affordability, location, rural housing, preservation, or serving specific community needs.</p>
+    </div>
+    <div class="lihtc-role-card" style="background: var(--mcm-slate, var(--card)); border-left: 4px solid var(--mcm-mustard, var(--accent2)); border-radius: 6px; padding: 1.1rem 1.25rem;">
+      <h3 style="margin: 0 0 .55rem; font-size: 1.05rem; color: var(--mcm-mustard, var(--accent2));">The investor</h3>
+      <p style="margin: 0; font-size: .95rem; line-height: 1.55; color: var(--mcm-beige, var(--text));">Usually a bank, insurance company, or large business that can use the tax credits. The investor puts cash into the project in exchange for receiving those credits over time. That cash helps reduce the amount of debt the project has to carry, which is what makes lower rents possible.</p>
+    </div>
+  </div>
+
+  <p style="margin-top:.5rem;">So, in simple terms:</p>
+  <ul style="margin: .35rem 0 1rem 1.25rem; padding: 0;">
+    <li>The <strong>housing agency</strong> awards the credits.</li>
+    <li>The <strong>developer</strong> builds and operates the housing.</li>
+    <li>The <strong>investor</strong> turns the credits into upfront money.</li>
+  </ul>
+
+  <p>That partnership is what makes LIHTC work. It is not just a government program, and it is not just private development. It is a public-private financing system where each party plays a different role in getting affordable homes built.</p>
+</section>
 <!-- Quick Navigation -->
 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin-bottom: 1.25rem;">
 <a href="#developers" style="padding: 1.5rem; background: var(--mcm-slate); text-decoration: none; border-left: 4px solid var(--mcm-burnt-orange); border-radius: 4px;">
-<h3 style="color: var(--mcm-burnt-orange); margin: 0 0 0.5rem 0; font-size: 1.25rem;">For Developers</h3>
+<h3 style="color: var(--mcm-burnt-orange); margin: 0 0 0.5rem 0; font-size: 1.25rem;">LIHTC Developer</h3>
 <p style="margin: 0; color: var(--mcm-beige); font-size: 0.875rem;">Project structuring &amp; feasibility</p>
 </a>
 <a href="#housing-authorities" style="padding: 1.5rem; background: var(--mcm-slate); text-decoration: none; border-left: 4px solid var(--mcm-teal); border-radius: 4px;">
-<h3 style="color: var(--mcm-teal); margin: 0 0 0.5rem 0; font-size: 1.25rem;">For Housing Authorities</h3>
-<p style="margin: 0; color: var(--mcm-beige); font-size: 0.875rem;">QAP design &amp; allocation strategy</p>
+<h3 style="color: var(--mcm-teal); margin: 0 0 0.5rem 0; font-size: 1.25rem;">Housing Agency</h3>
+<p style="margin: 0; color: var(--mcm-beige); font-size: 0.875rem;">QAP Design &amp; Allocation Strategy</p>
 </a>
 <a href="#investors" style="padding: 1.5rem; background: var(--mcm-slate); text-decoration: none; border-left: 4px solid var(--mcm-mustard); border-radius: 4px;">
-<h3 style="color: var(--mcm-mustard); margin: 0 0 0.5rem 0; font-size: 1.25rem;">For Investors</h3>
-<p style="margin: 0; color: var(--mcm-beige); font-size: 0.875rem;">Due diligence &amp; portfolio strategy</p>
+<h3 style="color: var(--mcm-mustard); margin: 0 0 0.5rem 0; font-size: 1.25rem;">Investor</h3>
+<p style="margin: 0; color: var(--mcm-beige); font-size: 0.875rem;">Due Diligence &amp; Portfolio Strategy</p>
 </a>
 </div>
 <div class="accent-bar"></div>
 <!-- FOR DEVELOPERS -->
 <section id="developers" style="margin-bottom: 4rem;">
-<h2 style="color: var(--mcm-burnt-orange);">For Developers: LIHTC Project Development</h2>
+<h2 style="color: var(--mcm-burnt-orange);">LIHTC Development: Project Structuring &amp; Feasibility</h2>
 <div class="chart-card" style="margin: 2rem 0;">
 <h3>The LIHTC Development Process</h3>
 <p style="line-height: 1.8; color: var(--mcm-beige); margin-bottom: 1.5rem;">
@@ -533,7 +567,7 @@ Price depends on:
 <div class="accent-bar"></div>
 <!-- FOR HOUSING AUTHORITIES -->
 <section id="housing-authorities" style="margin-bottom: 4rem;">
-<h2 style="color: var(--mcm-teal);">For Housing Authorities: QAP Design &amp; Allocation Strategy</h2>
+<h2 style="color: var(--mcm-teal);">Housing Agency: QAP Design &amp; Allocation Strategy</h2>
 <div class="chart-card" style="margin: 2rem 0;">
 <h3>Role of State Housing Finance Agencies</h3>
 <p style="line-height: 1.8; color: var(--mcm-beige);">
@@ -638,7 +672,7 @@ Price depends on:
 <div class="accent-bar"></div>
 <!-- FOR INVESTORS -->
 <section id="investors" style="margin-bottom: 4rem;">
-<h2 style="color: var(--mcm-mustard);">For Investors: Due Diligence &amp; Portfolio Strategy</h2>
+<h2 style="color: var(--mcm-mustard);">Investors: Due Diligence &amp; Portfolio Strategy</h2>
 <div class="chart-card" style="margin: 2rem 0;">
 <h3>Understanding LIHTC as an Investment</h3>
 <p style="line-height: 1.8; color: var(--mcm-beige); margin-bottom: 1.5rem;">

--- a/market-analysis.html
+++ b/market-analysis.html
@@ -1256,8 +1256,9 @@
     var s = document.createElement('style');
     s.id = 'wf-progress-styles';
     s.textContent = [
-      '.wf-progress-wrap{max-width:1200px;margin:0 auto;padding:14px 18px 0;}',
-      '.wf-progress-steps{display:flex;align-items:center;gap:0;}',
+      /* Sticky below the site header — see housing-needs-assessment.html. */
+      '.wf-progress-wrap{max-width:1200px;margin:0 auto;padding:10px 18px;position:sticky;top:58px;z-index:900;background:var(--bg);border-bottom:1px solid var(--border);}',
+      '.wf-progress-steps{display:flex;align-items:center;gap:0;max-width:1200px;margin:0 auto;}',
       '.wf-step{display:flex;flex-direction:column;align-items:center;text-align:center;text-decoration:none;color:var(--muted);min-width:80px;}',
       '.wf-step__num{width:30px;height:30px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:.78rem;font-weight:700;background:var(--bg2);color:var(--muted);border:2px solid var(--border);z-index:1;}',
       '.wf-step__label{font-size:.68rem;color:var(--muted);margin-top:4px;line-height:1.2;font-weight:600;}',

--- a/select-jurisdiction.html
+++ b/select-jurisdiction.html
@@ -67,16 +67,16 @@
     <!-- Page header -->
     <div class="sj-header">
       <h1>Where are you working?</h1>
-      <p class="sj-lead">Select a Colorado county to begin your housing needs assessment and LIHTC feasibility analysis. Your jurisdiction choice shapes every piece of data that follows — AMI limits, market conditions, allocation history, and comparable projects.</p>
+      <p class="sj-lead">Start by choosing the Colorado community you want to study. This selection sets the geography for the rest of the project scoping process. The tool will use this location to review housing need, market conditions, affordability gaps, comparable projects, and LIHTC feasibility. You can start broad by choosing a county, or narrow the analysis by selecting a city or CDP when available.</p>
     </div>
 
     <div id="pageContext"></div>
     <script>
     document.addEventListener('DOMContentLoaded', function () {
       if (window.PageContext) PageContext.render('pageContext', {
-        what: 'Choose the Colorado geography (county, incorporated place, or CDP) you want to analyze. This selection carries forward through all 5 workflow steps.',
-        why: 'LIHTC development is hyper-local. The same project concept can score differently depending on county AMI limits, QAP geography preferences, local policy environment, and competitive landscape. Starting with the right geography anchors your entire analysis.',
-        not: 'This page does not evaluate or rank geographies. To compare jurisdictions by housing need before choosing, use the Compare Jurisdictions page under Explore.',
+        what: 'Your selection here informs the subsequent analysis. The selected geography carries forward through the full scoping workflow: Housing Needs Assessment (what housing gaps exist here?), Market Analysis (what do rents, vacancy, demand, and comparable projects suggest?), Scenarios (what project types might make sense?), and Deal / LIHTC Feasibility (how might the project fit within LIHTC funding, AMI limits, QAP priorities, and recent allocation history?).',
+        why: 'Affordable housing development is local. The same project can look very different depending on where it is located. A county or city can affect income limits, achievable rents, demand, scoring competitiveness, nearby projects, local policy support, and whether a LIHTC deal is likely to be feasible.',
+        not: 'This page does not tell you which community is the best place to build. If you are still deciding where to focus, use the Compare Jurisdictions page first. That page helps compare communities by housing need, cost burden, vacancy, and affordability gaps.',
         nextSteps: [
           { label: 'Compare Jurisdictions', href: 'hna-comparative-analysis.html', desc: 'Rank all 546 geographies by need' },
           { label: 'LIHTC Guide', href: 'lihtc-guide-for-stakeholders.html', desc: 'New to LIHTC? Start here' }


### PR DESCRIPTION
## Summary
Multi-cluster QA/QC sweep — content rewrites, layout fixes, and missing-narrative additions per the QA notes. Each cluster is small + localized; **no broad styling changes, no data-schema changes, no route changes.**

## Clusters shipped

### Content
1. **Additional Resources cards** (`lihtc-guide-for-stakeholders.html`) — "For Developers" → "LIHTC Developer", "For Housing Authorities" → "Housing Agency", "For Investors" → "Investor"; matching H2 renames.
2. **LIHTC Basics intro** — replaced the 1.5rem hero paragraph (wrapped awkwardly) with a short hero subhead + plain-English long-form explainer below; three roles as three side-by-side cards.
3. **Select Jurisdiction copy** — lead + PageContext what/why/not rewritten to novice voice per the notes.

### Layout
4. **Compare Jurisdictions hero wrap** — `.hca-hero-sub` max-width 720 → 780px + `text-wrap: pretty`.
5. **547 table sticky header** — `.hca-table thead` was `top: 58px` inside an `overflow-y: auto` scroll viewport, so the header sat partway down + covered the #1 row. Set `top: 0` + hairline shadow.
6. **Workflow progress stepper** — was in normal flow despite the "sticks independently" comment. Now `position: sticky; top: 58px` (under the sticky site header at z:1000); applied to HNA, Deal Calc, Scenario Builder, Market Analysis.

### HNA-specific
7. **Executive Snapshot source links** — Tenure, Rent burdened, Income needed, Mean commute now carry source anchors to `data.census.gov` / Freddie Mac.
8. **Housing Gap & Affordability Analysis narrative** — `renderHousingGapSummary` was a one-liner stub. Now produces a plain-English bulleted interpretation: % cost-burdened renters + count, median-rent-vs-income gap at the 30%-rule, CHAS county ≤60% AMI deficit, tenure context.
9. **HUD FMR panel** — span-8 → span-12 (fixes the 4-col empty space on the right).
10. **LIHTC info-panel** — added `max-height: 340px; overflow-y: auto` so a long LIHTC list doesn't push the card much taller than the adjacent map.

## Deliberately NOT in this PR
- **Repo-wide typography standardization.** QA notes asked for it but also warned against broad style changes. Recommend after this PR is reviewed for visual surprises.
- **Vacancy rate column on Compare Jurisdictions Demographics & Market.** Need to confirm `vacancy_rate` is in `ranking-index` for every entry before wiring.
- **AMI Unit Mix "same for both jurisdictions."** Verified earlier that `ranking-index.json` has `_ami_gap_source: 'place_acs_direct'` for both Fruita + Clifton with materially different gaps (609/941/1219 vs 1814/2046/2426). The percentages will differ. The 48/36/17 numbers you saw were from the pre-PR #768 county-proportional path — likely a stale-cache view, not a current bug. Worth a hard-refresh re-check.
- **Owner Housing Cost Burden "missing chart."** Implemented in #816 via `renderOwnerCostBurdenChart`. When ACS suppresses `DP04_0111PE..0115PE` for tiny places the chart shows a "data not available" placeholder — that's correct, not missing.

## QA/QC results
| Check | Result |
|---|---|
| `grep` for replaced strings | old strings gone; new strings present |
| Console errors on HNA | none |
| Console errors on Compare Jurisdictions | none |
| Console errors on Select Jurisdiction | none |
| Console errors on LIHTC Basics | none |
| Routes / navigation | unchanged |
| Sticky header overlap on `.hca-table` | resolved (top: 0px inside scroll viewport) |
| Workflow stepper sticky | resolved (top: 58px below site header) |
| FMR card empty space | resolved (span-12) |
| LIHTC list overflow | resolved (340px max + scroll) |
| All 4 Exec Snapshot stats have source anchor | yes (verified via `querySelector('a').href`) |
| Housing Gap renders narrative bullets | yes when geo loads; falls back gracefully at state level |
| Chart rendering / map rendering | unchanged |
| Workflow data flow | unchanged |
| Pro-forma / QAP / pf-chart tests | not exercised — no JS schema changes |

## Remaining TODOs needing human judgment
- Repo-wide typography pass: requires design call (which sizes are "right") before code.
- Vacancy rate column wire-up: needs data audit of `ranking-index` to confirm field coverage.
- AMI Unit Mix re-verify after hard refresh: confirm 48/36/17 doesn't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)