### PR TITLE
chore(qa): remaining TODOs — typography scale + vacancy honesty

### DIFF
--- a/article-co-housing-costs.html
+++ b/article-co-housing-costs.html
@@ -78,7 +78,7 @@
         </nav>
         <span class="tag tag-orange" style="margin:var(--sp3) 0 var(--sp2);display:inline-block;">Regional Focus</span>
         <span class="kicker">Data Analysis</span>
-        <h1 style="font-size:clamp(1.8rem,4vw,2.8rem);font-weight:800;color:var(--text-strong);letter-spacing:-0.02em;line-height:1.2;margin-bottom:var(--sp3);">Colorado Housing Costs: County-Level Analysis</h1>
+        <h1 style="font-size:var(--h1);font-weight:800;color:var(--text-strong);letter-spacing:-0.02em;line-height:1.2;margin-bottom:var(--sp3);">Colorado Housing Costs: County-Level Analysis</h1>
         <div class="page-meta">
           <span>📅 March 27, 2026</span>
           <span>📖 10 min read</span>

--- a/article-pricing.html
+++ b/article-pricing.html
@@ -44,7 +44,7 @@
         </nav>
         <span class="tag tag-red" style="margin:var(--sp3) 0 var(--sp2);display:inline-block;">Q1 2026 Market Report</span>
         <span class="kicker">Analysis</span>
-<h1 style="font-size:clamp(1.8rem,4vw,2.8rem);font-weight:800;color:var(--text-strong);letter-spacing:-0.02em;line-height:1.2;margin-bottom:var(--sp3);">Tax Credit Pricing Reaches Historic Lows</h1>
+<h1 style="font-size:var(--h1);font-weight:800;color:var(--text-strong);letter-spacing:-0.02em;line-height:1.2;margin-bottom:var(--sp3);">Tax Credit Pricing Reaches Historic Lows</h1>
         <div class="page-meta">
           <span>📅 February 8, 2026</span>
           <span>📖 6 min read</span>

--- a/cra-expansion-analysis.html
+++ b/cra-expansion-analysis.html
@@ -32,7 +32,7 @@
             Policy Analysis
         </div>
 <span class="kicker">Analysis</span>
-<h1 style="font-size: 3rem; margin-bottom: 1rem;">CRA Expansion Impact on LIHTC Pricing</h1>
+<h1 style="font-size: var(--h1); margin-bottom: 1rem;">CRA Expansion Impact on LIHTC Pricing</h1>
 <p style="font-size: 1.25rem; color: var(--color-text-light); line-height: 1.7; margin-bottom: 1.25rem;">
             Predictive modeling of tax credit pricing scenarios if pending housing legislation expands Community Reinvestment Act credit to additional institutions.
         </p>

--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -137,9 +137,13 @@
   /* Typography */
   --font-sans: 'Plus Jakarta Sans', system-ui, -apple-system, sans-serif;
   --font-mono: 'DM Mono', 'Fira Code', monospace;
-  --h1:  clamp(1.7rem, 3.5vw, 2.6rem);
-  --h2:  clamp(1.15rem, 2vw, 1.4rem);
-  --h3:  1.05rem;
+  /* Typography scale — Compare Jurisdictions page H1 sizing is the
+     site-wide standard for major page titles (clamp 1.4rem → 1.9rem).
+     Previously --h1 went up to 2.6rem which made article + landing
+     headings tower over other pages. Calmer scale = less "AI-busy". */
+  --h1:  clamp(1.4rem, 3vw, 1.9rem);
+  --h2:  clamp(1.05rem, 1.6vw, 1.25rem);
+  --h3:  1rem;
   --body: 0.938rem;
   --small: 0.875rem;
   --tiny: 0.75rem;

--- a/housing-legislation-2026.html
+++ b/housing-legislation-2026.html
@@ -45,7 +45,7 @@
       </nav>
 
       <span class="tag tag-green" style="margin:var(--sp3) 0 var(--sp2);display:inline-block;">Legislative Analysis</span>
-      <h1 style="font-size:clamp(1.8rem,4vw,2.8rem);font-weight:800;color:var(--text-strong);letter-spacing:-0.02em;line-height:1.2;margin-bottom:var(--sp2);">Housing for the 21st Century Act</h1>
+      <h1 style="font-size:var(--h1);font-weight:800;color:var(--text-strong);letter-spacing:-0.02em;line-height:1.2;margin-bottom:var(--sp2);">Housing for the 21st Century Act</h1>
       <p style="font-size:1.1rem;color:var(--muted);line-height:1.7;margin-bottom:var(--sp2);">House passes sweeping bipartisan housing reform 390-9, advancing to conference with Senate ROAD Act</p>
       <div class="page-meta"><span>Published: February 13, 2026</span><span>H.R. 6644 Status: Passed House | Conference Committee Next</span></div>
 

--- a/js/hna/hna-comparison.js
+++ b/js/hna/hna-comparison.js
@@ -1008,11 +1008,22 @@
     '</div>';
 
     // ── Core Demographics ──
+    // Some metrics use 0 as a small-N suppression sentinel rather than a
+    // genuine zero. vacancy_rate in particular: build_ranking_index.py
+    // clamps to 0.0 when rental_units < 10, so 357/547 entries carry a
+    // misleading "0.0%". Treat those as null so _fmtVal renders "—" and
+    // surface a footnote at the bottom of the section.
+    var SMALL_N_ZERO_AS_NULL = { vacancy_rate: true };
+    var sawSuppressedVacancy = false;
     html += '<div class="hca-cp-metrics">';
     html += '<h4 class="hca-cp-section__title">Demographics & Market <span class="hca-cp-source">ACS 2024 · DOLA · LEHD LODES</span></h4>';
     COMPARISON_METRICS.forEach(function (m) {
       var valA = entryA.metrics[m.id];
       var valB = entryB.metrics[m.id];
+      if (SMALL_N_ZERO_AS_NULL[m.id]) {
+        if (valA === 0 || valA === '0' || valA === 0.0) { valA = null; sawSuppressedVacancy = true; }
+        if (valB === 0 || valB === '0' || valB === 0.0) { valB = null; sawSuppressedVacancy = true; }
+      }
       var numA = (valA !== null && valA !== undefined) ? +valA : null;
       var numB = (valB !== null && valB !== undefined) ? +valB : null;
 
@@ -1035,6 +1046,13 @@
         '</div>' +
       '</div>';
     });
+    if (sawSuppressedVacancy) {
+      html += '<p style="margin:.4rem 0 0;font-size:.74rem;color:var(--muted);">' +
+        '<strong>Vacancy Rate "—":</strong> ACS rental-vacancy is suppressed when ' +
+        'estimated rental units < 10 for the geography (small-N artifact). ' +
+        'Counties have the most reliable vacancy figures; CDPs are sparsely populated.' +
+      '</p>';
+    }
     html += '</div>';
 
     // ── Housing Gap Analysis ──

--- a/scripts/hna/build_ranking_index.py
+++ b/scripts/hna/build_ranking_index.py
@@ -274,7 +274,11 @@ def compute_metrics(
         # Clamp to [0, 50]. Anything higher is a small-N artifact, not real.
         vacancy_rate = round(min(50.0, (vacant_for_rent / rental_units) * 100), 1)
     else:
-        vacancy_rate = 0.0
+        # Small-N suppression: don't fabricate a "0.0%" that downstream
+        # consumers (Compare Jurisdictions Demographics row) would
+        # render as if it were a real measurement. Emit null so the
+        # UI renders "—" and footnotes the suppression.
+        vacancy_rate = None
 
     # Cost burden:
     #   Primary: ACS DP04 GRAPI bins (DP04_0141PE + DP04_0142PE) = share of


### PR DESCRIPTION
## Summary
Wraps the three remaining QA-pass items flagged in #834:

| TODO | Verdict |
|---|---|
| Typography standardization | Shipped — `--h1` token re-aligned to Compare Jurisdictions sizing; 4 article pages re-pointed at the token |
| Vacancy rate column on Demographics & Market | Shipped — value already existed; data was lying (357 of 547 entries carried `0.0` as a small-N suppression sentinel). Fixed two layers |
| AMI Mix re-check | Verified — data is correct; 48/36/17 was stale cache. No code change |

## 1. Typography
QA notes asked for site-wide standardization with Compare Jurisdictions H1 sizing as the reference. Doing this via the global `--h1` design token rather than touching every CSS rule:

```css
--h1: clamp(1.7rem, 3.5vw, 2.6rem)   →   clamp(1.4rem, 3vw, 1.9rem)
--h2: clamp(1.15rem, 2vw, 1.4rem)    →   clamp(1.05rem, 1.6vw, 1.25rem)
--h3: 1.05rem                         →   1rem
```

Three article pages that hard-coded `clamp(1.8rem, 4vw, 2.8rem)` inline + one with a flat `3rem` re-pointed at `var(--h1)` so they ride the new scale: `article-pricing.html`, `article-co-housing-costs.html`, `housing-legislation-2026.html`, `cra-expansion-analysis.html`.

Pages with scoped H1 rules (HNA hero, Compare hero, Scenario Builder hero) unchanged — they already sit at or below the new standard.

## 2. Vacancy rate honesty
Audit of `ranking-index.json`:
- 547 total entries
- **190 have non-zero `vacancy_rate`** (real measurements)
- **357 carry `vacancy_rate: 0.0`** (small-N suppression sentinel — `build_ranking_index.py` clamps to 0 when `rental_units < 10`)

So `_fmtVal` was rendering "0.0%" for the 357 suppressed cases as if it were a real measurement — and that's why you reported "vacancy rate missing".

**Two-layer fix:**
- `scripts/hna/build_ranking_index.py` — emit `None` (→ JSON null) instead of `0.0`. Future regenerations honest at the data layer.
- `js/hna/hna-comparison.js` — until the next cron regenerates, defensive coercion maps `vacancy_rate === 0 → null` so `_fmtVal` renders `"—"`. Footnote at the section bottom explains the suppression when either side surfaces it.

Verified live with Columbine (vacancy 0.5) vs Welby (vacancy 0): A → `0.5%`, B → `—`, footnote present.

## 3. AMI Mix re-check
Direct audit confirmed `_ami_gap_source: 'place_acs_direct'` for all sample pairs (Fruita / Clifton / Boulder city / Longmont) with materially different gaps. The 48/36/17 you originally saw matched the pre-PR-#768 county-proportional values — **stale cache, not a current bug.** Hard refresh in your browser to confirm.

## QA/QC
- No console errors after typography change ✓
- Compare H1 computed font-size: 28.5px (clamp upper bound) ✓
- Vacancy renders `0.5%` / `—` per data; footnote fires when null seen ✓
- Article page H1s now use `var(--h1)` ✓
- All other pages with `var(--h1)` automatically inherit the new scale ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)