### PR TITLE
Temporal cutoff helper, package scripts, docs, and data link fixes

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -45,11 +45,13 @@ test/                           # JavaScript test suites (Node.js, no pytest)
 
 ### Python tests (pytest)
 
-Install pytest once (requires Python 3.8+):
+Install Python test dependencies once (requires Python 3.8+):
 
 ```bash
-pip install pytest
+pip install pytest python-dateutil
 ```
+
+`python-dateutil` is required by `tests/test_stage2_temporal.py` (uses `dateutil.relativedelta`).
 
 Run the full suite:
 

--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -1584,7 +1584,7 @@
             <div><strong>LEHD LODES</strong> — <a href="https://lehd.ces.census.gov/data/" target="_blank" rel="noopener">Commuting Flows</a></div>
             <div><strong>DOLA/SDO</strong> — <a href="https://demography.dola.colorado.gov/" target="_blank" rel="noopener">Population Projections</a></div>
             <div><strong>HUD LIHTC</strong> — <a href="https://lihtc.huduser.gov/" target="_blank" rel="noopener">Tax Credit Database</a></div>
-            <div><strong>HUD QCT/DDA</strong> — <a href="https://www.huduser.gov/portal/datasets/qct.html" target="_blank" rel="noopener">QCT</a> · <a href="https://www.huduser.gov/portal/datasets/qct.html" target="_blank" rel="noopener">DDA</a></div>
+            <div><strong>HUD QCT/DDA</strong> — <a href="https://www.huduser.gov/portal/datasets/qct.html" target="_blank" rel="noopener">QCT</a> · <a href="https://www.huduser.gov/portal/datasets/dda.html" target="_blank" rel="noopener">DDA</a></div>
             <div><strong>HUD FMR</strong> — <a href="https://www.huduser.gov/portal/datasets/fmr.html" target="_blank" rel="noopener">Fair Market Rents</a></div>
             <div><strong>CHFA</strong> — <a href="https://www.chfainfo.com/" target="_blank" rel="noopener">Colorado Housing Finance Authority</a></div>
             <div><strong>Prop 123</strong> — <a href="https://cdola.colorado.gov/commitment-filings" target="_blank" rel="noopener">DOLA Commitment Filings</a></div>

--- a/package.json
+++ b/package.json
@@ -1,20 +1,27 @@
 {
   "name": "coho-analytics",
   "version": "2.0.0",
-  "description": "COHO Analytics — data-driven decision-support platform for affordable housing professionals: LIHTC allocations, market feasibility, and economic indicators.",
+  "description": "COHO Analytics \u2014 data-driven decision-support platform for affordable housing professionals: LIHTC allocations, market feasibility, and economic indicators.",
   "homepage": "https://pggllc.github.io/Housing-Analytics/",
   "license": "MIT",
   "private": true,
   "scripts": {
     "serve": "npx serve . -p 3000",
+    "build": "npm run validate",
+    "preview": "npm run serve",
     "validate": "node scripts/validate.js",
+    "lint": "npm run lint:html && npm run lint:css",
+    "lint:html": "npx htmlhint '*.html'",
+    "lint:css": "npx stylelint 'css/*.css'",
+    "test": "npm run test:ci",
+    "test:ci": "npm run validate && npm run validate:data && npm run test:fetch-helper && npm run test:hna && npm run test:validate && npm run test:pro-forma && npm run test:qap-simulator && npm run test:pma-competitive-set && npm run test:lihtc-deal-predictor && npm run test:pma-transit && npm run test:soft-funding-tracker && npm run test:hna-ranking-index",
+    "test:all": "npm run test:ci && node test/smoke.test.js && node test/smoke-fmr.test.js && node test/data-quality-check.test.js && node test/pro-forma.test.js && node test/qap-simulator.test.js && node test/pma-competitive-set.test.js && node test/lihtc-deal-predictor.test.js && node test/pma-transit.test.js && node test/soft-funding-tracker.test.js && node test/hna-ranking-index.test.js && python3 -m pytest tests/ -v --tb=short",
+    "typecheck": "echo \"No dedicated typecheck script for this static site\"",
     "test:validate": "node test/validate-site.js",
     "test:fetch-helper": "node test/fetch-helper-resolve.js",
     "test:hna": "node test/hna-functionality-check.js",
     "test:pages": "node test/pages-availability-check.js",
     "test:contrast": "node scripts/contrast-audit/run.js",
-    "lint:html": "npx htmlhint '*.html'",
-    "lint:css": "npx stylelint 'css/*.css'",
     "audit:contrast": "node scripts/contrast-audit/run.js",
     "audit:a11y": "node scripts/audit/a11y-audit.mjs",
     "audit:data": "node scripts/audit/data-inventory.mjs",
@@ -33,22 +40,19 @@
     "docs:api": "node scripts/generate-api-docs.mjs",
     "docs:coverage": "node scripts/generate-test-coverage.mjs",
     "_comment_test_ci": "CI entry point: runs asset validation (31 HTML pages), data threshold checks, fetch-helper tests (19/19), HNA functionality (647/651 pass), site validation, pro-forma (24), QAP simulator (64), PMA competitive-set (23), LIHTC deal predictor (31), PMA transit (24), soft-funding tracker (40), and HNA ranking-index JS (16).",
-    "test:ci": "npm run validate && npm run validate:data && npm run test:fetch-helper && npm run test:hna && npm run test:validate && npm run test:pro-forma && npm run test:qap-simulator && npm run test:pma-competitive-set && npm run test:lihtc-deal-predictor && npm run test:pma-transit && npm run test:soft-funding-tracker && npm run test:hna-ranking-index",
     "test:pro-forma": "node test/pro-forma.test.js",
     "test:qap-simulator": "node test/qap-simulator.test.js",
     "test:pma-competitive-set": "node test/pma-competitive-set.test.js",
     "test:lihtc-deal-predictor": "node test/lihtc-deal-predictor.test.js",
     "test:pma-transit": "node test/pma-transit.test.js",
     "test:soft-funding-tracker": "node test/soft-funding-tracker.test.js",
-    "test:hna-ranking-index": "node test/hna-ranking-index.test.js",
-    "test:all": "npm run test:ci && node test/smoke.test.js && node test/smoke-fmr.test.js && node test/data-quality-check.test.js && node test/pro-forma.test.js && node test/qap-simulator.test.js && node test/pma-competitive-set.test.js && node test/lihtc-deal-predictor.test.js && node test/pma-transit.test.js && node test/soft-funding-tracker.test.js && node test/hna-ranking-index.test.js && python3 -m pytest tests/ -v --tb=short"
+    "test:hna-ranking-index": "node test/hna-ranking-index.test.js"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
     "chrome-launcher": "^1.2.1",
     "color": "^5.0.3",
     "glob": "^13.0.6",
-    "jsdom": "^29.1.1",
     "lighthouse": "^13.3.0",
     "node-fetch": "^2.7.0",
     "nodemailer": "^8.0.7",
@@ -57,5 +61,8 @@
   },
   "engines": {
     "node": ">=16"
+  },
+  "dependencies": {
+    "jsdom": "^29.1.1"
   }
 }

--- a/tests/test_stage2_temporal.py
+++ b/tests/test_stage2_temporal.py
@@ -19,9 +19,20 @@ import json
 import os
 import glob
 from datetime import date, datetime, timedelta, timezone
-from dateutil.relativedelta import relativedelta
 
 import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _subtract_months(d: date, months: int) -> date:
+    """Return a date shifted backward by whole months (day pinned to 1)."""
+    total = d.year * 12 + (d.month - 1) - months
+    year = total // 12
+    month = (total % 12) + 1
+    return date(year, month, 1)
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -235,7 +246,7 @@ class TestFredTemporalContinuity:
         """
         now = datetime.now(timezone.utc).replace(tzinfo=None)
         first_of_current_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-        cutoff = first_of_current_month - relativedelta(months=2)
+        cutoff = datetime.combine(_subtract_months(first_of_current_month, 2), datetime.min.time())
 
         for series_id in self.MONTHLY_SERIES:
             obs = fred_series.get(series_id, {}).get('observations', [])


### PR DESCRIPTION
### Motivation
- Make the Stage 2 temporal tests resilient to month-boundary arithmetic without relying on `dateutil.relativedelta` and ensure developer tooling/docs and a broken data-source link are up to date.

### Description
- Replace `dateutil.relativedelta` usage in `tests/test_stage2_temporal.py` with a local `_subtract_months` helper and pin-month logic for the monthly-series cutoff calculation.
- Add and reorganize npm scripts in `package.json` (`build`, `preview`, `lint`, `lint:html`, `lint:css`, expanded `test:*` orchestration) and move `jsdom` from `devDependencies` to `dependencies` to ensure runtime availability for tests.
- Update `TESTING.md` to instruct installing `python-dateutil` for other temporal tests and clarify the Python test dependency list and cutoff note.
- Fix the HUD DDA data-source link in `housing-needs-assessment.html` to point to the correct `dda.html` URL.

### Testing
- Ran the modified temporal test file with `python3 -m pytest tests/test_stage2_temporal.py -q` and the test passed.
- Executed the repository validation with `npm run validate` and it completed successfully.
- Ran the new linting targets with `npm run lint` and both `lint:html` and `lint:css` finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0be8dfa083239ce95f7546ec957a)