### PR TITLE
fix: 3 small follow-ups from Codex #836 audit

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -45,13 +45,14 @@ test/                           # JavaScript test suites (Node.js, no pytest)
 
 ### Python tests (pytest)
 
-Install Python test dependencies once (requires Python 3.8+):
+Install pytest once (requires Python 3.8+):
 
 ```bash
-pip install pytest python-dateutil
+pip install pytest
 ```
 
-`python-dateutil` is required by `tests/test_stage2_temporal.py` (uses `dateutil.relativedelta`).
+No third-party Python deps are required — `tests/test_stage2_temporal.py`
+uses a small stdlib helper instead of `dateutil.relativedelta`.
 
 Run the full suite:
 

--- a/js/hna/hna-utils.js
+++ b/js/hna/hna-utils.js
@@ -100,7 +100,7 @@
     prop123Commitments: 'https://cdola.colorado.gov/commitment-filings',
     lihtcDb: 'https://lihtc.huduser.gov/',
     hudQct: 'https://www.huduser.gov/portal/datasets/qct.html',
-    hudDda: 'https://www.huduser.gov/portal/datasets/qct.html',
+    hudDda: 'https://www.huduser.gov/portal/datasets/dda.html',
     chfaLihtcQuery: 'https://services.arcgis.com/VTyQ9soqVukalItT/arcgis/rest/services/LIHTC/FeatureServer/0',
     hudLihtcQuery: 'https://services.arcgis.com/VTyQ9soqVukalItT/arcgis/rest/services/LIHTC_Properties/FeatureServer/0',
     hudQctQuery: 'https://services.arcgis.com/VTyQ9soqVukalItT/arcgis/rest/services/Qualified_Census_Tracts_2026/FeatureServer/0', // Update year annually (e.g. Qualified_Census_Tracts_2027 when HUD publishes next cycle)

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "chrome-launcher": "^1.2.1",
     "color": "^5.0.3",
     "glob": "^13.0.6",
+    "jsdom": "^29.1.1",
     "lighthouse": "^13.3.0",
     "node-fetch": "^2.7.0",
     "nodemailer": "^8.0.7",
@@ -61,8 +62,5 @@
   },
   "engines": {
     "node": ">=16"
-  },
-  "dependencies": {
-    "jsdom": "^29.1.1"
   }
 }


### PR DESCRIPTION
## Summary
Three small fixes flagged by the independent audit of Codex's #836 work. All <20 LOC total, no new tests, no new deps.

| # | What | Why |
|---|---|---|
| 1 | `js/hna/hna-utils.js`: `SOURCES.hudDda` → `dda.html` | Same bug Codex fixed in `housing-needs-assessment.html`, missed in the renderer-side constant |
| 2 | `TESTING.md`: revert "install `python-dateutil`" paragraph | #836 simultaneously removed dateutil from `tests/test_stage2_temporal.py` and added doc saying to install it — pure doc/code drift |
| 3 | `package.json`: jsdom back to `devDependencies` | jsdom is only used by test/ files; putting it under `dependencies` was the wrong shape |

## Verification
- `npm run test` → HNARanking 16/16 ✓
- `python3 -m pytest tests/test_stage2_temporal.py -q` → 57/57 ✓
- `fetch('/js/hna/hna-utils.js').then(...)` confirms `hudDda` now resolves to `/portal/datasets/dda.html` ✓

## Not in scope
Pre-existing lint debt (`market-analysis.html`, `insights.html`, `hna-comparative-analysis.html` — all from 2026-03-22 copilot-swe-agent commits). Separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)