### PR TITLE
fix(market-analysis): pan map to workflow jurisdiction county on load

### DIFF
--- a/market-analysis.html
+++ b/market-analysis.html
@@ -1388,13 +1388,26 @@
       try {
         var _proj = window.WorkflowState && window.WorkflowState.getActiveProject();
         var _jx   = _proj && (_proj.jurisdiction || (_proj.steps && _proj.steps.jurisdiction));
-        if (_jx && _jx.countyFips) fips = _jx.countyFips;
+        // WorkflowState / select-jurisdiction.js / HNA all write the
+        // county FIPS to `jx.fips` — the legacy `jx.countyFips` field
+        // doesn't exist anywhere in the schema. Same fix as PR #820
+        // applied to two other consumers; this inline scriptlet was
+        // missed.
+        if (_jx && _jx.fips) fips = _jx.fips;
       } catch (_) {}
       if (!fips) {
         try { var _sc = window.SiteState && window.SiteState.getCounty(); if (_sc && _sc.fips) fips = _sc.fips; } catch (_) {}
       }
       if (fips && _CO_CENTROIDS[fips] && window._cohoMap) {
-        window._cohoMap.flyTo(_CO_CENTROIDS[fips], 10, { duration: 1.2 });
+        // setView (animate:false) instead of flyTo because flyTo's
+        // animation pipeline gets interrupted by sibling map-init
+        // calls (invalidateSize / addLayer / etc.) that fire during
+        // the boot data-load chain. setView snaps the view in one
+        // tick so nothing can race ahead of it.
+        try {
+          window._cohoMap.invalidateSize(false);
+          window._cohoMap.setView(_CO_CENTROIDS[fips], 10, { animate: false });
+        } catch (_) { /* leave statewide */ }
       }
     }
     // Fly on load and whenever jurisdiction changes


### PR DESCRIPTION
## Summary
Navigating from HNA → Market Analysis didn't open the map to the chosen county — statewide every time, regardless of WorkflowState.

## Root cause
The inline `_flyToJurisdiction()` in `market-analysis.html` (comment "#13 Fly map to jurisdiction county centroid") was reading `jx.countyFips` — same non-existent field PR #820 fixed in `deal-calculator.js` + `pma-ui-controller.js`. WorkflowState writes the county FIPS to `jx.fips`; `jx.countyFips` is undefined, so `fips` stays null and the flyTo never fires.

Also swapped `flyTo` → `setView(animate:false)` + an `invalidateSize` because `flyTo`'s animation pipeline was getting interrupted by sibling map-init calls during the boot data-load chain. `setView` snaps in one tick so nothing can race ahead of it.

## Verification (live preview)
1. Cleared localStorage
2. `setJurisdiction({fips:'08097', name:'Pitkin County', type:'county'})`
3. Navigated to `/market-analysis.html`

| | Before | After |
|---|---|---|
| Map center lat | 39.04 | **38.75** |
| Map center lng | -105.56 | **-108.24** |
| Map zoom | 7 (CO statewide) | **10** (Pitkin) |

Nav pill + embedded Deal Calc were already correct (per the earlier WorkflowState fixes); this was the third copy of the `countyFips` typo and the last missing piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)