### PR TITLE
fix(hna): close CHAS chart + chart provenance gap + page lint hygiene

### DIFF
--- a/css/scenario-builder.css
+++ b/css/scenario-builder.css
@@ -40,6 +40,10 @@
   align-items: start;
 }
 
+.sb-layout > * {
+  min-width: 0;
+}
+
 @media (max-width: 768px) {
   .sb-layout {
     grid-template-columns: 1fr;

--- a/hna-comparative-analysis.html
+++ b/hna-comparative-analysis.html
@@ -157,7 +157,7 @@ document.addEventListener('DOMContentLoaded', function () {
       <button class="hca-quick-btn"        data-preset="cdps"        type="button">CDPs Only</button>
       <button class="hca-quick-btn"        data-preset="frontRange"  type="button">Front Range</button>
       <button class="hca-quick-btn"        data-preset="mountains"   type="button">Mountains</button>
-      <button class="hca-quick-btn"        data-preset="westernSlope"type="button">Western Slope</button>
+      <button class="hca-quick-btn"        data-preset="westernSlope" type="button">Western Slope</button>
     </div>
 
     <!-- Search & filter controls -->

--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -510,7 +510,7 @@
         <div class="hna-grid" style="margin-top:0">
           <div class="chart-card span-6" style="margin:0">
             <h2 style="font-size:1rem">Age pyramid</h2>
-            <div class="chart-box tall"><canvas id="chartPyramid" role="img" aria-label="Population age pyramid chart"></canvas></div>
+            <div class="chart-box tall" data-source="DOLA Single-Year-of-Age Projections" data-source-url="https://demography.dola.colorado.gov/assets/html/sdodata.html" data-vintage="DOLA 2024" data-source-type="raw"><canvas id="chartPyramid" role="img" aria-label="Population age pyramid chart"></canvas></div>
           </div>
           <div class="chart-card span-6" style="margin:0">
             <h2 style="font-size:1rem">Senior growth pressure</h2>
@@ -530,7 +530,7 @@
         <div class="hna-grid" style="margin-top:0">
           <div class="chart-card span-8" style="margin:0">
             <h2 style="font-size:1rem">Population: DOLA forecast vs historic-trend sensitivity</h2>
-            <div class="chart-box tall"><canvas id="chartPopProj" role="img" aria-label="Population projection and DOLA forecast chart"></canvas></div>
+            <div class="chart-box tall" data-source="DOLA Components-of-Change + Historic-Trend Sensitivity" data-source-url="https://demography.dola.colorado.gov/assets/html/sdodata.html" data-vintage="DOLA 2024" data-source-type="modeled"><canvas id="chartPopProj" role="img" aria-label="Population projection and DOLA forecast chart"></canvas></div>
           </div>
           <div class="chart-card span-4" style="margin:0">
             <h2 style="font-size:1rem">Housing need summary</h2>
@@ -606,7 +606,7 @@
       <div class="chart-card span-4">
         <h2>Bedroom Mix</h2>
         <p>Unit mix by bedroom count — key indicator of whether existing stock meets household composition needs. Source: ACS DP04.</p>
-        <div class="chart-box"><canvas id="chartBedroomMix" role="img" aria-label="Housing units by bedroom count chart"></canvas></div>
+        <div class="chart-box" data-source="ACS 5-Year DP04" data-source-url="https://data.census.gov/table/ACSDP5Y2023.DP04" data-vintage="ACS 2019–2023" data-source-type="raw"><canvas id="chartBedroomMix" role="img" aria-label="Housing units by bedroom count chart"></canvas></div>
       </div>
 
       <!-- Owner Cost Burden -->
@@ -718,12 +718,12 @@
             <div class="chart-card span-8" style="margin:0">
               <h3 style="font-size:.95rem;margin:0 0 4px">Population projection by scenario</h3>
               <p style="font-size:.82rem;color:var(--muted);margin:0 0 8px">Baseline, low, and high growth trajectories from DOLA SYA data.</p>
-              <div class="chart-box tall"><canvas id="chartScenarioComparison" role="img" aria-label="Scenario comparison chart"></canvas></div>
+              <div class="chart-box tall" data-source="DOLA SYA + Cohort-Component Scenarios" data-source-url="https://demography.dola.colorado.gov/assets/html/sdodata.html" data-vintage="DOLA 2024" data-source-type="modeled"><canvas id="chartScenarioComparison" role="img" aria-label="Scenario comparison chart"></canvas></div>
             </div>
             <div class="chart-card span-4" style="margin:0">
               <h3 style="font-size:.95rem;margin:0 0 4px">Selected scenario detail</h3>
               <p id="scenarioDetailDesc" style="font-size:.82rem;color:var(--muted);margin:0 0 8px">Single-scenario population trend over the 10-year horizon.</p>
-              <div class="chart-box tall"><canvas id="chartProjectionDetail" role="img" aria-label="Single-scenario population projection detail chart"></canvas></div>
+              <div class="chart-box tall" data-source="DOLA SYA + Cohort-Component Scenarios" data-source-url="https://demography.dola.colorado.gov/assets/html/sdodata.html" data-vintage="DOLA 2024" data-source-type="modeled"><canvas id="chartProjectionDetail" role="img" aria-label="Single-scenario population projection detail chart"></canvas></div>
             </div>
           </div>
         </div>
@@ -733,7 +733,7 @@
           <div class="chart-card" style="margin:0">
             <h3 style="font-size:.95rem;margin:0 0 4px">Projected households over time</h3>
             <p style="font-size:.82rem;color:var(--muted);margin:0 0 8px">DOLA household formation forecast — drives housing unit demand calculations per DLG methodology.</p>
-            <div class="chart-box tall"><canvas id="chartProjectedHH" role="img" aria-label="Household projection chart"></canvas></div>
+            <div class="chart-box tall" data-source="DOLA Population + Headship Rate Conversion" data-source-url="https://demography.dola.colorado.gov/assets/html/sdodata.html" data-vintage="DOLA 2024" data-source-type="modeled"><canvas id="chartProjectedHH" role="img" aria-label="Household projection chart"></canvas></div>
           </div>
         </div>
 
@@ -742,7 +742,7 @@
           <div class="chart-card" style="margin:0">
             <h3 style="font-size:.95rem;margin:0 0 4px">Projected housing demand by affordability tier (renter households)</h3>
             <p id="demandTierDesc" style="font-size:.82rem;color:var(--muted);margin:0 0 8px">Estimated renter households by AMI tier over the 10-year horizon. Used to identify missing AMI tiers for LIHTC applications. Based on statewide CO income distributions (ACS CHAS).</p>
-            <div class="chart-box tall"><canvas id="chartHouseholdDemand" role="img" aria-label="Housing demand by AMI affordability tier chart showing projected renter households at each income tier"></canvas></div>
+            <div class="chart-box tall" data-source="DOLA Households + HUD CHAS AMI Tier Shares" data-source-url="https://www.huduser.gov/portal/datasets/cp.html" data-vintage="DOLA 2024 · CHAS 2018–2022" data-source-type="modeled"><canvas id="chartHouseholdDemand" role="img" aria-label="Housing demand by AMI affordability tier chart showing projected renter households at each income tier"></canvas></div>
           </div>
         </div>
 
@@ -871,20 +871,20 @@
             <h2 style="font-size:1rem">Wage Trend</h2>
             <p style="color:var(--muted);font-size:.88rem">Average wages over time (BLS QCEW).</p>
             <div class="chart-container">
-              <div class="chart-box"><canvas id="chartWageTrend" role="img" aria-label="Average wage trend over time chart"></canvas></div>
+              <div class="chart-box" data-source="BLS QCEW (Quarterly Census of Employment and Wages)" data-source-url="https://www.bls.gov/cew/" data-vintage="QCEW 2024" data-source-type="raw"><canvas id="chartWageTrend" role="img" aria-label="Average wage trend over time chart"></canvas></div>
             </div>
           </div>
           <div id="industryAnalysisContainer" class="chart-card span-6" style="margin:0">
             <h2 style="font-size:1rem">Industry Analysis</h2>
             <p style="color:var(--muted);font-size:.88rem">Employment share by NAICS sector.</p>
             <div class="chart-container">
-              <div class="chart-box"><canvas id="chartIndustryAnalysis" role="img" aria-label="Industry employment share by NAICS sector chart"></canvas></div>
+              <div class="chart-box" data-source="BLS QCEW Industry Share by NAICS" data-source-url="https://www.bls.gov/cew/" data-vintage="QCEW 2024" data-source-type="raw"><canvas id="chartIndustryAnalysis" role="img" aria-label="Industry employment share by NAICS sector chart"></canvas></div>
             </div>
           </div>
           <div id="wageGapsContainer" class="chart-card span-6" style="margin:0">
             <h2 style="font-size:1rem">Wage Gaps</h2>
             <p style="color:var(--muted);font-size:.88rem">High / medium / low wage job distribution (LEHD CE01–CE03).</p>
-            <div class="chart-container chart-container--bar"></div>
+            <div class="chart-container chart-container--bar" data-source="LEHD LODES Wage Bands (CE01–CE03)" data-source-url="https://lehd.ces.census.gov/data/lodes/LODES8/" data-vintage="LODES 2021" data-source-type="raw"></div>
           </div>
         </div>
       </section>
@@ -912,7 +912,7 @@
             <h3>3% Annual Growth Target</h3>
             <div id="prop123GrowthContent">
               <p style="color:var(--muted);font-size:.9rem">Baseline required before growth targets can be set.</p>
-              <div class="timeline-chart"><canvas id="chartProp123Growth" role="img" aria-label="Proposition 123 annual growth target tracking chart"></canvas></div>
+              <div class="timeline-chart" data-source="DOLA Prop 123 Baseline + 3% Growth Target" data-source-url="https://cdola.colorado.gov/prop123" data-vintage="Prop 123 2024" data-source-type="transformed"><canvas id="chartProp123Growth" role="img" aria-label="Proposition 123 annual growth target tracking chart"></canvas></div>
             </div>
           </div>
 
@@ -934,7 +934,7 @@
           <div id="prop123HistoricalStatus" class="compliance-status" style="margin-bottom:10px;">
             Select a geography to view compliance status.
           </div>
-          <div class="timeline-chart" style="height:220px;">
+          <div class="timeline-chart" style="height:220px;" data-source="DOLA Prop 123 Annual Filings" data-source-url="https://cdola.colorado.gov/prop123" data-vintage="Prop 123 2024" data-source-type="raw">
             <canvas id="chartProp123Historical" role="img" aria-label="Proposition 123 historical compliance tracking chart"></canvas>
           </div>
           <div id="prop123HistoricalContent" style="margin-top:12px;overflow-x:auto;"></div>
@@ -1164,8 +1164,8 @@
           <p style="color:var(--muted);font-size:.88rem;font-style:italic">Select a geography above to load housing type analysis.</p>
         </div>
         <div class="grid-row" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:1rem;margin-top:1rem">
-          <div class="chart-box"><canvas id="chartHousingTypeComposition" role="img" aria-label="Housing units by structure type"></canvas></div>
-          <div class="chart-box"><canvas id="chartConstructionEra" role="img" aria-label="Construction era trend by housing type"></canvas></div>
+          <div class="chart-box" data-source="ACS 5-Year DP04 (Structure Type)" data-source-url="https://data.census.gov/table/ACSDP5Y2023.DP04" data-vintage="ACS 2019–2023" data-source-type="raw"><canvas id="chartHousingTypeComposition" role="img" aria-label="Housing units by structure type"></canvas></div>
+          <div class="chart-box" data-source="ACS 5-Year DP04 (Year Structure Built)" data-source-url="https://data.census.gov/table/ACSDP5Y2023.DP04" data-vintage="ACS 2019–2023" data-source-type="raw"><canvas id="chartConstructionEra" role="img" aria-label="Construction era trend by housing type"></canvas></div>
         </div>
         <div id="htfFeasibilityMatrix" style="margin-top:1.5rem"></div>
       </section>

--- a/insights.html
+++ b/insights.html
@@ -364,3 +364,5 @@
       .catch(function () { badge.textContent = 'Verification status unavailable'; });
   }());
   </script>
+</body>
+</html>

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -1727,7 +1727,7 @@
     // CHAS county aggregates, if loaded.
     const chasData = S().state && S().state.chasData;
     const countyFips = U().countyFromGeoid && U().countyFromGeoid(geoType, profile._geoid || '');
-    const county = (chasData && countyFips) ? chasData[countyFips] : null;
+    const county = (chasData && countyFips) ? ((chasData.counties || chasData)[countyFips] || null) : null;
 
     const bullets = [];
 
@@ -3026,7 +3026,8 @@
       return;
     }
 
-    const county = chasData[countyFips5] || chasData['statewide'] || null;
+    const _chasIndex = (chasData && chasData.counties) || chasData;
+    const county = _chasIndex[countyFips5] || _chasIndex['statewide'] || null;
     if (!county) {
       if (statusEl) statusEl.textContent = `No CHAS data for FIPS ${countyFips5}.`;
       _setProvenanceBadge('none');
@@ -3041,7 +3042,34 @@
       (selectedGeo.type === 'place' || selectedGeo.type === 'cdp') &&
       selectedGeo.geoid && selectedGeo.geoid !== countyFips5 && countyFips5;
     _setProvenanceBadge(isPlaceProxy ? 'county-approx' : 'county');
-    _renderTiers(county.tiers || [], county.name || countyFips5, /* tigerSource */ false);
+    // Adapter: 2026 CHAS data ships renter_hh_by_ami keyed by AMI bucket;
+    // legacy `tiers` array is no longer emitted. Derive it on the fly so
+    // the existing chart code keeps working.
+    let tiers = county.tiers;
+    if ((!tiers || !tiers.length) && county.renter_hh_by_ami) {
+      const TIER_ORDER = ['lte30','31to50','51to80','81to100','100plus'];
+      const TIER_LABEL = {
+        lte30:    '≤30% AMI',
+        '31to50': '31–50% AMI',
+        '51to80': '51–80% AMI',
+        '81to100':'81–100% AMI',
+        '100plus':'>100% AMI',
+      };
+      tiers = TIER_ORDER
+        .map(k => {
+          const row = county.renter_hh_by_ami[k];
+          if (!row) return null;
+          const p30 = (row.pct_cost_burdened_30 || 0) * 100;
+          const p50 = (row.pct_cost_burdened_50 || 0) * 100;
+          return {
+            ami_tier:     TIER_LABEL[k] || k,
+            burden_30_50: Math.max(0, p30 - p50),
+            burden_50plus: p50,
+          };
+        })
+        .filter(Boolean);
+    }
+    _renderTiers(tiers || [], county.name || countyFips5, /* tigerSource */ false);
   }
 
   /**

--- a/market-analysis.html
+++ b/market-analysis.html
@@ -54,8 +54,8 @@
   <script defer src="js/components/workflow-next-action.js"></script>
   <script defer src="js/components/development-realism.js"></script>
 </head>
-<body data-page-last-updated="2026-03-22"
-      data-page-source="Census ACS · HUD LIHTC · FRED · CoStar (public)">  <a class="skip-link" href="#main-content">Skip to main content</a>
+<body data-page-last-updated="2026-03-22" data-page-source="Census ACS · HUD LIHTC · FRED · CoStar (public)">
+  <a class="skip-link" href="#main-content">Skip to main content</a>
 
   <header class="site-header">
     <!-- Injected by navigation.js -->
@@ -1441,4 +1441,5 @@
   });
 }());
 </script>
+</body>
 </html>


### PR DESCRIPTION
## Summary
Comprehensive QA pass surface findings — all minimal, targeted fixes verified in real preview with full test suite green.

- **`chartChasGap` rendered blank for every county** — renderer was reaching `chasData[fips]` while 2026 vintage ships data under `chasData.counties[fips]`, and the inner `tiers` array was replaced with `renter_hh_by_ami` keyed by AMI bucket. Two-line lookup guard + adapter that derives the legacy tier-array shape on the fly so the existing chart code keeps working. Verified 27/27 charts attach with correct % values matching raw JSON.
- **Scenario Builder horizontal scroll at desktop (+109px)** — `.sb-layout` grid items had default `min-width: auto`, so long URLs in the model-assumptions `<dl>` forced the right column past its `1fr` share. One-line `min-width: 0` on grid children. Mobile single-column layout still works.
- **14 HNA chart containers lacked `[data-source]` provenance** — added DOLA / ACS DP04 / BLS QCEW / LEHD / CHAS / Prop 123 attribution to: chartPyramid, chartPopProj, chartBedroomMix, chartScenarioComparison, chartProjectionDetail, chartProjectedHH, chartHouseholdDemand, chartWageTrend, chartIndustryAnalysis, chartWageGaps, chartProp123Growth, chartProp123Historical, chartHousingTypeComposition, chartConstructionEra. Now 0/27 unsourced.
- **htmlhint failed pre-pass on 3 files** from `copilot-swe-agent[bot]` commits (2026-03-22):
  - `market-analysis.html` was missing `</body>`
  - `insights.html` was missing `</body></html>`
  - A button in `hna-comparative-analysis.html` had two attributes glued together

## Out of scope (documented, not addressed)
- `lint:css` (stylelint) fails because no stylelint config has ever existed in the repo. Adding one is net-new tooling infra, not in scope for this QA-driven fix PR.
- The daily-chore `data/fred-data.json` update (123K-line auto-data refresh) was excluded — it belongs in a separate chore commit.

## Test plan
- [x] `npm run validate` — all 40 HTML pages resolved
- [x] `npm run lint:html` — clean (was 5 errors in 3 files pre-pass)
- [x] `npm run test:ci` — 688 + 19 + 24 + 64 + 23 + 31 + 26 + 40 + 16 all pass
- [x] `npm run test:all` — 482 pytest pass, WCAG 100%
- [x] Real preview: HNA loads with Denver County, all 27 charts attach, CHAS chart shows correct tier values matching raw JSON
- [x] Real preview: Scenario Builder desktop layout has 0 horizontal overflow (was 109px)
- [x] Real preview: Mobile layouts still work (Scenario Builder single-column at <=768px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)