### PR TITLE
fix: cross-page consistency sweep — bugs found by one-sided-fix audit

### DIFF
--- a/hna-comparative-analysis.html
+++ b/hna-comparative-analysis.html
@@ -333,7 +333,7 @@ document.addEventListener('DOMContentLoaded', function () {
     var hasJurisdiction = false;
     try {
       var proj = window.WorkflowState && window.WorkflowState.getActiveProject();
-      if (proj && proj.steps && proj.steps.jurisdiction && proj.steps.jurisdiction.countyFips) {
+      if (proj && proj.steps && proj.steps.jurisdiction && (proj.steps.jurisdiction.fips || proj.steps.jurisdiction.countyFips)) {
         hasJurisdiction = true;
       }
     } catch (_) {}

--- a/hna-scenario-builder.html
+++ b/hna-scenario-builder.html
@@ -515,7 +515,7 @@
       try {
         var _proj = window.WorkflowState && window.WorkflowState.getActiveProject();
         var _jx   = _proj && (_proj.jurisdiction || (_proj.steps && _proj.steps.jurisdiction));
-        if (_jx && _jx.countyFips) _jxFips = _jx.countyFips;
+        if (_jx && (_jx.fips || _jx.countyFips)) _jxFips = _jx.fips || _jx.countyFips;
       } catch (_) {}
       if (!_jxFips) {
         try {

--- a/js/colorado-deep-dive.js
+++ b/js/colorado-deep-dive.js
@@ -555,7 +555,10 @@ function initPolicyPanel(panelId) {
         DataService.getJSON('data/hna/chas_affordability_gap.json')
       ]).then(function (res) {
         var geojson  = res[0];
-        var chasData = res[1].counties || {};
+        // Older CHAS vintages shipped counties at top level; 2026 ships
+        // them nested under `.counties`. Support both shapes so the map
+        // doesn't break silently when the file format moves.
+        var chasData = (res[1] && res[1].counties) || res[1] || {};
 
         L.geoJSON(geojson, {
           style: function (feat) {

--- a/js/deal-comparison.js
+++ b/js/deal-comparison.js
@@ -273,8 +273,8 @@
       // Try to get active jurisdiction from WorkflowState
       var proj = window.WorkflowState && WorkflowState.getActiveProject();
       var fips = null;
-      if (proj && proj.jurisdiction && proj.jurisdiction.countyFips) {
-        fips = proj.jurisdiction.countyFips;
+      if (proj && proj.jurisdiction && (proj.jurisdiction.fips || proj.jurisdiction.countyFips)) {
+        fips = proj.jurisdiction.fips || proj.jurisdiction.countyFips;
       }
       if (!fips && window.SiteState) {
         var sc = SiteState.getCounty();

--- a/js/hna/hna-comparison.js
+++ b/js/hna/hna-comparison.js
@@ -1173,8 +1173,14 @@
     // numbers by the time the user clicks Compare. Idempotent +
     // soft-fails — _deriveBurdenTiersForEntry already falls back to
     // entry.metrics if PlaceChas isn't ready.
+    // When init resolves AFTER the first comparison render (slow network
+    // or persisted A/B from a prior session), force a refresh so the
+    // burden-tier section swaps county-fallback for per-place rates
+    // without requiring a user action.
     if (window.PlaceChas && typeof window.PlaceChas.init === 'function') {
-      window.PlaceChas.init().catch(function () { /* fallback fires */ });
+      window.PlaceChas.init().then(function () {
+        if (_compA && _compB) _renderComparisonPanel();
+      }).catch(function () { /* fallback already in DOM */ });
     }
 
     _buildCountyMap(state.allEntries);

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -1766,13 +1766,18 @@
       }
     }
 
-    // CHAS-derived ≤60% AMI deficit (county-level only).
-    if (county && county.tiers && Array.isArray(county.tiers)) {
-      const lte60Tiers = county.tiers.filter(t => t.ami_tier && /≤30|31[-–]50|51[-–]60/.test(t.ami_tier));
-      const totalLte60 = lte60Tiers.reduce((sum, t) => sum + (Number(t.burden_30_50) || 0) + (Number(t.burden_50plus) || 0), 0);
-      if (totalLte60 > 0) {
+    // CHAS-derived ≤50% AMI deficit (county-level only).
+    // 2026 vintage ships renter_hh_by_ami keyed by AMI bucket; legacy
+    // `tiers` array was removed. Read counts straight off lte30 +
+    // 31to50 (the buckets that fully fit under the LIHTC 60% AMI cap).
+    const _rba = county && county.renter_hh_by_ami;
+    if (_rba) {
+      const lte30Cb = (_rba.lte30 && Number(_rba.lte30.cost_burdened_30pct)) || 0;
+      const t3150Cb = (_rba['31to50'] && Number(_rba['31to50'].cost_burdened_30pct)) || 0;
+      const lte50Total = lte30Cb + t3150Cb;
+      if (lte50Total > 0) {
         bullets.push(
-          'HUD CHAS county data flags <strong>' + fmtNum(Math.round(totalLte60)) + '</strong> renter households at ≤60% AMI ' +
+          'HUD CHAS county data flags <strong>' + fmtNum(Math.round(lte50Total)) + '</strong> renter households at ≤50% AMI ' +
           'paying ≥30% of income on housing — the cohort LIHTC at 60% AMI rents most directly serves. ' +
           'Use the AMI tier chart below for the per-tier breakdown.'
         );

--- a/js/housing-need-projector.js
+++ b/js/housing-need-projector.js
@@ -282,7 +282,10 @@
   function _buildRationale(priority, cd) {
     var inc = cd.median_household_income || 0;
     var cb  = cd.cost_burdened_pct || 0;
-    var vr  = cd.vacancy_rate || 0;
+    // vr may legitimately be null when ACS small-N suppression hides
+    // the rate; treat null as unknown rather than coercing to 0 (which
+    // would put "vacancy rate (0%)" into user-facing rationale text).
+    var vr  = (cd.vacancy_rate == null) ? null : cd.vacancy_rate;
     var rationale = [];
 
     if (priority === 'deeply_affordable') {
@@ -319,11 +322,13 @@
         'the local market without sacrificing affordability depth.'
       );
     } else if (priority === 'workforce') {
+      var _vacancyClause = (vr == null)
+        ? ''
+        : ', and/or the vacancy rate (' + vr + '%) suggests market conditions are relatively functional at lower tiers';
       rationale.push(
         '30–40% AMI (Deeply Affordable): Minimal weighting because the county ' +
         'median income (' + _fmtDollar(inc) + ') indicates most renter ' +
-        'households earn above 50% AMI, and/or the vacancy rate (' + vr + '%) ' +
-        'suggests market conditions are relatively functional at lower tiers.'
+        'households earn above 50% AMI' + _vacancyClause + '.'
       );
       rationale.push(
         '50–60% AMI (Transitional Workforce): Moderate allocation bridges the ' +
@@ -367,6 +372,10 @@
     var cd  = countyData || {};
     var cb  = cd.cost_burdened_pct || 0;
     var inc = cd.median_household_income || 0;
+    // Coerce null to 0 only for the priority threshold below; the
+    // rationale builder reads the raw cd.vacancy_rate to suppress
+    // misleading "vacancy rate (0%)" text when small-N suppression hides
+    // the real value.
     var vr  = cd.vacancy_rate || 0;
 
     var priority;

--- a/js/market-analysis.js
+++ b/js/market-analysis.js
@@ -295,7 +295,14 @@
    * @returns {number} 0-100 score
    */
   function scoreMarketTightness(acs) {
-    var vac = acs.vacancy_rate || 0;
+    // ACS small-N suppression now emits null for vacancy_rate. The old
+    // `acs.vacancy_rate || 0` coerce produced a max-tight score (100)
+    // for every suppressed place — a false "tight market" signal that
+    // pollutes the composite. Default to 0.05 (~CO statewide vacancy)
+    // to match site-selection-score.js's `_safe(acs.vacancy_rate, 0.05)`,
+    // yielding a neutral ~58 instead of a misleading 100. Coverage
+    // metadata still flags the underlying suppression in fallbackReasons.
+    var vac = (acs && acs.vacancy_rate != null) ? acs.vacancy_rate : 0.05;
     // Very low vacancy → tight market → strong demand signal
     var score = Math.max(0, Math.min(100, (1 - vac / 0.12) * 100));
     return Math.round(score);
@@ -612,7 +619,7 @@
     var marketTightnessCoverage;
     if (!acs || acs.vacancy_rate == null) {
       marketTightnessCoverage = 'fallback';
-      fallbackReasons.market_tightness = 'ACS vacancy_rate missing; defaulted to 0';
+      fallbackReasons.market_tightness = 'ACS vacancy_rate missing or small-N suppressed; defaulted to 0.05 (neutral) — score does not reflect actual market tightness';
     } else {
       marketTightnessCoverage = 'full';
     }

--- a/js/market-analysis/market-report-renderers.js
+++ b/js/market-analysis/market-report-renderers.js
@@ -809,7 +809,7 @@
           'h2 { font-size: 1.15rem; color: #1e3a5f; margin: 1.5rem 0 0.75rem; padding-bottom: 0.35rem; border-bottom: 1px solid #ddd; }' +
           '.report-header { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 0.5rem; }' +
           '.report-score { font-size: 2.5rem; font-weight: 800; color: #1e3a5f; }' +
-          '.report-section { page-break-inside: avoid; margin-bottom: 0.5rem; }' +
+          '.report-section { break-inside: avoid; margin-bottom: 0.5rem; }' +
           '.badge, .pill { display: inline-block; padding: 2px 10px; border-radius: 999px; font-size: 0.8rem; font-weight: 600; }' +
           '.pill.good { background: #22c55e; color: #fff; }' +
           '.pill.warn { background: #f59e0b; color: #fff; }' +
@@ -817,7 +817,7 @@
           'td, th { padding: 4px 8px; border-bottom: 1px solid #eee; font-size: 0.85rem; }' +
           '.callout { border-left: 3px solid #ddd; padding: 0.5rem 0.75rem; margin: 0.5rem 0; background: #f8f9fa; }' +
           '@media print { body { padding: 0.5in; } .no-print { display: none !important; } ' +
-          '  .report-section { page-break-inside: avoid; } ' +
+          '  .report-section { break-inside: avoid; } ' +
           '  img { max-height: 400px; } }' +
           '@page { margin: 0.75in; size: letter; }' +
         '</style></head><body>' +

--- a/js/market-analysis/site-selection-score.js
+++ b/js/market-analysis/site-selection-score.js
@@ -603,6 +603,16 @@
         reason: 'ACS vacancy data unavailable'
       };
     }
+    // ACS small-N suppression now emits null for vacancy_rate. Treat
+    // null as unavailable rather than silently defaulting to 5% — the
+    // composite redistributes the weight via `unavailable: true`.
+    if (acs.vacancy_rate == null) {
+      return {
+        score: null,
+        unavailable: true,
+        reason: 'ACS vacancy_rate small-N suppressed'
+      };
+    }
     var vac = _safe(acs.vacancy_rate, 0.05);
     // Very low vacancy (<1%) → score ≈ 90; at 10%+ vacancy → score ≈ 0.
     // 10% is the threshold where lease-up risk and absorption pace begin to


### PR DESCRIPTION
## Summary
A deep-dive audit ran across the codebase looking for improvements that landed in one place but hadn't propagated to siblings. This PR fixes the real bugs and small inconsistencies surfaced — every change is minimal and targeted.

### The bugs

- **Compare page place-CHAS race** — `js/hna/hna-comparison.js`. The page was wired to use place-CHAS via `_deriveBurdenTiersForEntry`, but `PlaceChas.init()` was fire-and-forget. If init resolved AFTER the first render (slow network, or persisted A/B from a prior session), the burden-tier section showed county-fallback with no follow-up refresh. Chained a re-render onto the init promise. **Verified Fruita 99.9/67.5/26.0 vs Clifton 71.4/90.7/35.7 (was identical Mesa county values 70.4/76.9/44.9).**
- **`jx.fips` vs `jx.countyFips` typo trio (BUG ×3)** — three sites silently missed the active jurisdiction:
  - `js/deal-comparison.js:276` — community-need lookup never resolved → always fell through to SiteState
  - `hna-comparative-analysis.html:336` — explore banner never hid for users with an active jurisdiction
  - `hna-scenario-builder.html:518` — county select never auto-pinned
  All three now read `jx.fips || jx.countyFips`.
- **`county.tiers` reader without adapter (BUG)** — `js/hna/hna-renderers.js:1770`. `_buildGapBullets` read `county.tiers` directly; 2026 CHAS vintage ships `renter_hh_by_ami` instead, so the ≤60% AMI deficit bullet silently disappeared from the gap-analysis prose. Now derives lte30 + 31to50 cost-burdened counts straight off `renter_hh_by_ami`. (Also tightened wording to "≤50% AMI" since `51to80` doesn't fit under LIHTC 60%.)
- **`vacancy_rate` 0-coerce dishonesty** — three call sites coerced null small-N-suppressed `vacancy_rate` to 0:
  - `js/market-analysis.js:298` — `scoreMarketTightness` yielded 100 (max-tight market) for every suppressed place, polluting the composite. Now defaults to 0.05 matching siblings; coverage metadata flags the suppression.
  - `js/housing-need-projector.js:285` — `_buildRationale` literally quoted *"the vacancy rate (0%) suggests market conditions are relatively functional"* as user-facing text. Suppresses the clause when vr is null.
  - `js/market-analysis/site-selection-score.js:606` — `scoreLandSupply` fell through to `_safe(vacancy_rate, 0.05)` instead of returning `unavailable`. Now mirrors the `!acs` short-circuit.
- **`colorado-deep-dive.js:558` asymmetric CHAS guard** — read `res[1].counties || {}` with no fallback to top-level. Symmetric guard so the choropleth doesn't break on older vintage files.
- **`page-break-*` in `market-report-renderers.js`** — modernized to `break-inside` to match the css/print.css sweep in #847.

### Out of scope (separate PRs)

- `scripts/hna/build_ranking_index.py:419-461` — places get county-approx CHAS + LEHD in the ranking index, even when place-level data files exist. Affects all places in Compare. Requires Python edits + data regeneration; larger scope.
- Missing `data-source` attrs on Scenario Builder + Economic Dashboard + Colorado Deep Dive charts.
- Compare page lacks per-side CHAS provenance badge.

## Test plan
- [x] `npm run lint` (html + css) — clean
- [x] `npm run test:ci` — 688 + 19 + 24 + 64 + 23 + 31 + 26 + 40 + 16 all pass
- [x] Compare page: Fruita + Clifton render distinct place-level CHAS values
- [x] HNA page: 27/27 charts attach, ≤50% AMI bullet renders in gap-analysis prose
- [x] No preview regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)