### PR TITLE
feat: Compare CHAS provenance badge + data-source attrs on 16 charts

### DIFF
--- a/colorado-deep-dive.html
+++ b/colorado-deep-dive.html
@@ -641,7 +641,7 @@ document.addEventListener('DOMContentLoaded', function () {
 <h3 class="chart-title">Colorado Housing Need by AMI Level</h3>
 <p class="chart-subtitle">Estimated households vs. available units</p>
 </div>
-<div style="height: 300px; position: relative;">
+<div style="height: 300px; position: relative;" data-source="HUD FY2025 Income Limits + ACS B25063" data-source-url="https://www.huduser.gov/portal/datasets/il.html" data-vintage="HUD FY2025 · ACS 2019–2023" data-source-type="raw">
 <canvas id="ami-need-chart" role="img" aria-label="Bar chart: Colorado housing need versus available affordable units by AMI level"></canvas><p class="sr-only" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0">Chart data is available in the surrounding text and data tables on this page.</p>
 </div>
 <p class="chart-source">Source: <a href="https://www.huduser.gov/portal/datasets/il.html" target="_blank" rel="noopener">HUD FY2025 Income Limits</a> · <a href="https://www.census.gov/programs-surveys/acs/" target="_blank" rel="noopener">ACS B25063</a> | Units: households &amp; affordable units by AMI band</p>
@@ -759,7 +759,7 @@ document.addEventListener('DOMContentLoaded', function () {
       <h3 class="chart-title">Households vs. Priced-Affordable Units by AMI Level</h3>
       <p class="chart-subtitle">Blue = households with income at or below threshold · Green = rental units with rent at or below affordable threshold</p>
     </div>
-    <div style="height:340px; position:relative; padding:.5rem 1rem 1rem;">
+    <div style="height:340px; position:relative; padding:.5rem 1rem 1rem;" data-source="HUD CHAS + ACS B25074 (income × rent-burden cross-tab)" data-source-url="https://www.huduser.gov/portal/datasets/cp.html" data-vintage="CHAS 2018–2022 · ACS 2019–2023" data-source-type="modeled">
       <canvas id="amiGapComparisonChart" role="img" aria-label="Interactive chart: amiGapComparisonChart"></canvas><p class="sr-only" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0">Chart data is available in the surrounding text and data tables on this page.</p>
     </div>
   </div>
@@ -771,7 +771,7 @@ document.addEventListener('DOMContentLoaded', function () {
         <h3 class="chart-title">Affordability Gap</h3>
         <p class="chart-subtitle">Units minus households at each AMI level · Red = deficit · Green = surplus</p>
       </div>
-      <div style="height:260px; position:relative; padding:.5rem 1rem 1rem;">
+      <div style="height:260px; position:relative; padding:.5rem 1rem 1rem;" data-source="HUD CHAS + ACS B25074 (units minus households at each AMI level)" data-source-url="https://www.huduser.gov/portal/datasets/cp.html" data-vintage="CHAS 2018–2022 · ACS 2019–2023" data-source-type="modeled">
         <canvas id="amiGapChart" role="img" aria-label="Interactive chart: amiGapChart"></canvas><p class="sr-only" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0">Chart data is available in the surrounding text and data tables on this page.</p>
       </div>
     </div>
@@ -857,7 +857,7 @@ document.addEventListener('DOMContentLoaded', function () {
 <p class="chart-subtitle">Average monthly concession value 2022-2025</p>
 </div>
 <div style="height: 300px; position: relative;">
-<canvas id="concessions-chart" role="img" aria-label="Line chart: Denver Metro average monthly rental concession value 2022–2025"></canvas><p class="sr-only" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0">Chart data is available in the surrounding text and data tables on this page.</p>
+<canvas id="concessions-chart" role="img" aria-label="Line chart: Denver Metro average monthly rental concession value 2022–2025" data-source="CBRE Multifamily Outlook 2025" data-source-url="https://www.cbre.com/insights/books/us-real-estate-market-outlook-2025/multifamily" data-vintage="CBRE 2022–2025" data-source-type="raw"></canvas><p class="sr-only" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0">Chart data is available in the surrounding text and data tables on this page.</p>
 </div>
 <p class="chart-source">Source: <a href="https://www.cbre.com/insights/books/us-real-estate-market-outlook-2025/multifamily" target="_blank" rel="noopener">CBRE Multifamily Outlook 2025</a> | Units: USD/month average concession value</p>
 </div>
@@ -961,7 +961,7 @@ document.addEventListener('DOMContentLoaded', function () {
 <p class="chart-subtitle">Monthly foreclosure filings 2023-2026</p>
 </div>
 <div style="height: 300px; position: relative;">
-<canvas id="foreclosure-chart" role="img" aria-label="Bar chart: Colorado foreclosure filing trends by quarter"></canvas><p class="sr-only" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0">Chart data is available in the surrounding text and data tables on this page.</p>
+<canvas id="foreclosure-chart" role="img" aria-label="Bar chart: Colorado foreclosure filing trends by quarter" data-source="ATTOM Foreclosure Data" data-source-url="https://www.attomdata.com/solutions/market-trends-data/foreclosure-activity-report/" data-vintage="ATTOM 2023–2026" data-source-type="raw"></canvas><p class="sr-only" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0">Chart data is available in the surrounding text and data tables on this page.</p>
 </div>
 <p class="chart-source">Source: <a href="https://www.attomdata.com/solutions/market-trends-data/foreclosure-activity-report/" target="_blank" rel="noopener">ATTOM Foreclosure Data</a> | Units: monthly filing count, Colorado statewide</p>
 </div>
@@ -1008,7 +1008,7 @@ document.addEventListener('DOMContentLoaded', function () {
 <p class="chart-subtitle">Buyer and seller sentiment index</p>
 </div>
 <div style="height: 300px; position: relative;">
-<canvas id="confidence-chart" role="img" aria-label="Line chart: NAHB builder confidence index for Colorado housing market"></canvas><p class="sr-only" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0">Chart data is available in the surrounding text and data tables on this page.</p>
+<canvas id="confidence-chart" role="img" aria-label="Line chart: NAHB builder confidence index for Colorado housing market" data-source="NAHB Housing Market Index" data-source-url="https://www.nahb.org/news-and-economics/housing-economics/indices/housing-market-index" data-vintage="NAHB HMI — monthly" data-source-type="raw"></canvas><p class="sr-only" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0">Chart data is available in the surrounding text and data tables on this page.</p>
 </div>
 <p class="chart-source">Source: <a href="https://www.nahb.org/news-and-economics/housing-economics/indices/housing-market-index" target="_blank" rel="noopener">NAHB Housing Market Index</a> | Units: index score, 50 = neutral, above = more builders positive than negative</p>
 </div>
@@ -1047,7 +1047,7 @@ document.addEventListener('DOMContentLoaded', function () {
         <p class="chart-subtitle">Annual low-income housing tax credit units placed in service — Colorado</p>
       </div>
       <div style="height:280px;position:relative;">
-        <canvas id="chartLihtcTimeline" role="img" aria-label="Bar chart: LIHTC units allocated in Colorado per year 2010–2026"></canvas>
+        <canvas id="chartLihtcTimeline" role="img" aria-label="Bar chart: LIHTC units allocated in Colorado per year 2010–2026" data-source="HUD LIHTC Database (LI_UNITS by YEAR_ALLOC)" data-source-url="https://www.huduser.gov/portal/datasets/lihtc.html" data-vintage="LIHTC 2010–2026" data-source-type="raw"></canvas>
         <p class="sr-only" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0">Annual LIHTC allocation counts are shown in the bar chart above.</p>
       </div>
       <p style="font-size:.75rem;color:var(--muted);margin-top:.5rem;">
@@ -1272,7 +1272,7 @@ document.addEventListener('DOMContentLoaded', function () {
 <p class="chart-subtitle">Colorado metrics vs dashboard trends</p>
 </div>
 <div style="height: 400px; position: relative;">
-<canvas id="comparison-chart" role="img" aria-label="Bar chart: Colorado housing market metrics compared with national averages"></canvas><p class="sr-only" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0">Chart data is available in the surrounding text and data tables on this page.</p>
+<canvas id="comparison-chart" role="img" aria-label="Bar chart: Colorado housing market metrics compared with national averages" data-source="Colorado ACS DP04 + national benchmarks (FRED, NAR, U.S. Census)" data-source-url="https://fred.stlouisfed.org/" data-vintage="Composite — see chart-source caption" data-source-type="transformed"></canvas><p class="sr-only" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0">Chart data is available in the surrounding text and data tables on this page.</p>
 </div>
 </div>
 <h2>Market Outlook &amp; Strategic Implications</h2>
@@ -1772,7 +1772,7 @@ document.addEventListener('DOMContentLoaded', function () {
         <p class="chart-subtitle">Projected 9% credit pricing with 95% confidence intervals</p>
       </div>
       <div style="height:280px;position:relative;">
-        <canvas id="mo-pricing-forecast" role="img" aria-label="Line chart: Colorado LIHTC credit pricing forecast through 2027"></canvas>
+        <canvas id="mo-pricing-forecast" role="img" aria-label="Line chart: Colorado LIHTC credit pricing forecast through 2027" data-source="Modeled — CHFA historical pricing + Novogradac investor benchmark trend" data-source-url="https://www.novoco.com/resource-center/lihtc-pricing" data-vintage="CHFA + Novogradac through 2027" data-source-type="modeled"></canvas>
         <p class="sr-only">Chart data is available in the surrounding text and data tables on this page.</p>
       </div>
     </div>
@@ -1783,7 +1783,7 @@ document.addEventListener('DOMContentLoaded', function () {
         <p class="chart-subtitle">Quarterly multifamily housing starts projection</p>
       </div>
       <div style="height:280px;position:relative;">
-        <canvas id="mo-starts-forecast" role="img" aria-label="Line chart: Colorado housing starts forecast through 2027"></canvas>
+        <canvas id="mo-starts-forecast" role="img" aria-label="Line chart: Colorado housing starts forecast through 2027" data-source="Modeled — Census BPS multifamily permits + DOLA population growth" data-source-url="https://www.census.gov/construction/bps/" data-vintage="Census BPS + DOLA 2024 through 2027" data-source-type="modeled"></canvas>
         <p class="sr-only">Chart data is available in the surrounding text and data tables on this page.</p>
       </div>
     </div>

--- a/economic-dashboard.html
+++ b/economic-dashboard.html
@@ -308,19 +308,19 @@ document.addEventListener('DOMContentLoaded', function () {
             </div>
           </div>
           <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem;">
-            <div class="chart-wrap" style="position:relative;height:240px;">
+            <div class="chart-wrap" style="position:relative;height:240px;" data-source="CFPB HMDA Data Browser" data-source-url="https://ffiec.cfpb.gov/data-browser/" data-vintage="HMDA 2018–current" data-source-type="raw">
               <canvas id="hmdaTrendOriginationsChart"
                       aria-label="HMDA originations time series chart"></canvas>
             </div>
-            <div class="chart-wrap" style="position:relative;height:240px;">
+            <div class="chart-wrap" style="position:relative;height:240px;" data-source="CFPB HMDA Data Browser" data-source-url="https://ffiec.cfpb.gov/data-browser/" data-vintage="HMDA 2018–current" data-source-type="raw">
               <canvas id="hmdaTrendDenialChart"
                       aria-label="HMDA denial rate time series chart"></canvas>
             </div>
-            <div class="chart-wrap" style="position:relative;height:240px;">
+            <div class="chart-wrap" style="position:relative;height:240px;" data-source="CFPB HMDA Data Browser" data-source-url="https://ffiec.cfpb.gov/data-browser/" data-vintage="HMDA 2018–current" data-source-type="raw">
               <canvas id="hmdaTrendMeanLoanChart"
                       aria-label="HMDA mean loan amount time series chart"></canvas>
             </div>
-            <div class="chart-wrap" style="position:relative;height:240px;">
+            <div class="chart-wrap" style="position:relative;height:240px;" data-source="CFPB HMDA Data Browser" data-source-url="https://ffiec.cfpb.gov/data-browser/" data-vintage="HMDA 2018–current" data-source-type="raw">
               <canvas id="hmdaTrendMultifamilyChart"
                       aria-label="HMDA multifamily originations time series chart"></canvas>
             </div>
@@ -725,7 +725,7 @@ function getKey(){ return CONFIG_KEY || ""; }
         <span class="meta-currency" id="currency-${idSafe}" aria-label="Data currency">—</span>
         <span class="delta flat" id="delta-${idSafe}">—</span>
       </div>
-      <div class="chart-wrap">
+      <div class="chart-wrap" data-source="FRED Economic Data (Federal Reserve Bank of St. Louis)" data-source-url="https://fred.stlouisfed.org/series/${encodeURIComponent(ind.id)}" data-vintage="FRED — live API" data-source-type="raw">
         <canvas id="ch-${idSafe}" aria-label="${ind.title} chart"></canvas>
         <div class="small" id="err-${idSafe}" style="margin-top:8px;"></div>
       </div>

--- a/hna-scenario-builder.html
+++ b/hna-scenario-builder.html
@@ -329,7 +329,7 @@
         <!-- Chart panel -->
         <div class="sb-chart-panel">
           <h2 class="sb-chart-title" data-i18n="scenarios.results.title">Projection Results: Housing Units Needed (2024–2050)</h2>
-          <div class="sb-chart-wrap">
+          <div class="sb-chart-wrap" data-source="DOLA SYA + Cohort-Component Scenarios (Headship 0.38, Vacancy 5%)" data-source-url="https://demography.dola.colorado.gov/assets/html/sdodata.html" data-vintage="DOLA 2024" data-source-type="modeled">
             <canvas id="sbProjectionChart"
               role="img"
               aria-label="Line chart showing projected housing units needed under baseline, low-growth, high-growth, and custom scenarios from 2024 to 2050">

--- a/js/hna/hna-comparison.js
+++ b/js/hna/hna-comparison.js
@@ -567,18 +567,35 @@
     html += '<div class="hca-cp-subsection">';
     html += '<div class="hca-cp-subsection__title">Renter Cost Burden by Income Tier</div>';
 
+    // Per-side CHAS source pills (Place vs County) — makes the underlying
+    // data layer visible without forcing the user to compare numbers to
+    // infer it. Renders as a single row matching the side-by-side layout
+    // of the burden tier rows below.
+    var srcA = (burdenA && burdenA.source) || 'none';
+    var srcB = (burdenB && burdenB.source) || 'none';
+    html += '<div class="hca-cp-row hca-cp-row--compact" style="margin-bottom:.4rem;align-items:center;">' +
+      '<div class="hca-cp-row__label" style="font-size:.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.04em;">Data source</div>' +
+      '<div class="hca-cp-row__val">' + _chasSourcePill(srcA) + '</div>' +
+      '<div class="hca-cp-row__delta"></div>' +
+      '<div class="hca-cp-row__val">' + _chasSourcePill(srcB) + '</div>' +
+    '</div>';
+
     // Disclosure when either side falls back to the parent county's
-    // CHAS rates (the legacy behavior).
-    var anyCountyFallback = (burdenA && burdenA.source === 'county') ||
-                            (burdenB && burdenB.source === 'county');
+    // CHAS rates. With the per-side pills above, this becomes a more
+    // detailed callout — kept for screen-reader users and to explain
+    // why two places in the same county can show identical rates.
+    var anyCountyFallback = srcA === 'county' || srcB === 'county';
     if (anyCountyFallback) {
+      var fallbackSummary = (srcA === 'county' && srcB === 'county')
+        ? 'Both selections use their containing county’s CHAS rates'
+        : 'One selection uses its containing county’s CHAS rates';
       html += '<div class="hca-cp-burden__county-note" role="note" style="' +
         'margin:0 0 .5rem;padding:.4rem .6rem;border-left:3px solid var(--warn,#d97706);' +
         'border-radius:0 4px 4px 0;background:var(--warn-dim,#fef3c7);' +
         'font-size:.76rem;line-height:1.4;color:var(--text);">' +
         '<strong style="color:var(--warn,#d97706);">⚠ Tier burden rates are county-level.</strong> ' +
-        'At least one selection falls back to its containing county because no place-CHAS coverage is ' +
-        'available — two places in the same county will show identical tier rates.' +
+        fallbackSummary + ' because no place-CHAS coverage is available ' +
+        '— two places in the same county will show identical tier rates.' +
       '</div>';
     }
 
@@ -601,6 +618,27 @@
     html += '</div>';
     html += '</div>';
     return html;
+  }
+
+  /**
+   * Small pill rendering the data source for a CHAS column.
+   * Mirrors the three-state machine on the single-jurisdiction HNA
+   * page's chasProvenanceBadge:
+   *   'place'  → green "Place" (TIGER 2024 place-level apportionment)
+   *   'county' → amber "County" (parent county fallback)
+   *   'none'   → muted "—" (no CHAS data)
+   */
+  function _chasSourcePill(source) {
+    var cfg = {
+      place:  { text: 'Place',  bg: 'rgba(4,120,87,.12)',   border: 'rgba(4,120,87,.45)',   color: 'var(--good,#047857)', title: 'TIGER 2024 place-level CHAS (apportioned from tract-level HUD CHAS 2018-2022).' },
+      county: { text: 'County', bg: 'rgba(217,119,6,.12)',  border: 'rgba(217,119,6,.45)',  color: 'var(--warn,#d97706)', title: 'Containing-county CHAS used as fallback — no place-level coverage for this geography.' },
+      none:   { text: '—',      bg: 'transparent',          border: 'transparent',          color: 'var(--muted,#6b7280)', title: 'No CHAS data available for this geography.' },
+    };
+    var c = cfg[source] || cfg.none;
+    return '<span class="hca-cp-source-pill" title="' + c.title + '" ' +
+      'style="display:inline-block;padding:1px 8px;border-radius:999px;font-size:.7rem;font-weight:700;' +
+      'background:' + c.bg + ';border:1px solid ' + c.border + ';color:' + c.color + ';">' +
+      c.text + '</span>';
   }
 
   /**


### PR DESCRIPTION
## Summary
Closes the last two consistency gaps from the cross-page one-sided-fix audit.

### (H) Compare CHAS provenance badge
The burden-tier subsection on `hna-comparative-analysis.html` now renders a small **"Place"** or **"County"** pill under each jurisdiction's column, mirroring the three-state machine the single-jurisdiction HNA page's `chasProvenanceBadge` already uses (green = TIGER place-level, amber = county fallback, muted = none).

The existing county-fallback warning text now adapts to whether one or both selections fall back, so it reads accurately instead of saying "at least one selection" when both are county-level.

### (G) `data-source` attrs on 16 chart wrappers
Added to containers the audit flagged as missing the structured attrs. [source-badge.js](js/components/source-badge.js) auto-attaches visible badges to any `[data-source]` element so this propagates without further wiring:

| File | Charts | Sources |
|---|---|---|
| `hna-scenario-builder.html:333` | `sbProjectionChart` | DOLA SYA + Cohort-Component Scenarios |
| `economic-dashboard.html:311–324` | HMDA quad-chart (4) | CFPB HMDA Data Browser |
| `economic-dashboard.html:728` | dynamic FRED template | FRED Economic Data |
| `colorado-deep-dive.html` (10 charts) | `ami-need-chart`, `amiGapComparisonChart`, `amiGapChart`, `concessions-chart`, `foreclosure-chart`, `confidence-chart`, `chartLihtcTimeline`, `comparison-chart`, `mo-pricing-forecast`, `mo-starts-forecast` | HUD CHAS / ACS / CBRE / ATTOM / NAHB / HUD LIHTC / Novogradac / Census BPS |

## Test plan
- [x] Compare: pills render "Place" green for Fruita+Clifton
- [x] `npm run lint` — clean
- [x] `npm run test:ci` — 688 + 19 + 24 + 64 + 23 + 31 + 26 + 40 + 16 pass
- [x] Iframe spot-check confirms `[data-source]` attrs resolve correctly on Scenario Builder + 5 of 10 Colorado Deep Dive charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)