### PR TITLE
fix: LIHTC math + Data Review counters + Deal Calc H1 a11y

### DIFF
--- a/data-review-hub.html
+++ b/data-review-hub.html
@@ -641,9 +641,9 @@
       <!-- Stats bar -->
       <div class="drh-stats-bar" role="region" aria-label="Summary statistics">
         <div class="drh-stat-card">
-          <div class="drh-stat-label">Total Sources</div>
+          <div class="drh-stat-label">Registry Sources</div>
           <div class="drh-stat-value" id="drhStatTotal">—</div>
-          <div class="drh-stat-sub">in registry</div>
+          <div class="drh-stat-sub" title="Curated entries in js/data-source-inventory.js — the canonical list of upstream data feeds. Distinct from the larger 'Monitored Files' figure on the Overview tab, which also includes derived files tracked in DATA-MANIFEST.json.">in DataSourceInventory</div>
         </div>
         <div class="drh-stat-card">
           <div class="drh-stat-label">Current</div>
@@ -678,7 +678,7 @@
         <div class="drh-kpi-grid">
           <div class="drh-kpi">
             <div class="drh-kpi-val" id="drhOvTotal">—</div>
-            <div class="drh-kpi-lbl">Total Sources</div>
+            <div class="drh-kpi-lbl" title="Sources tracked by the freshness monitor — DataSourceInventory entries plus any additional file paths in DATA-MANIFEST.json. Will be greater than the 'Registry Sources' figure in the top stats bar when derived/aggregated files are tracked alongside upstream feeds.">Monitored Files</div>
           </div>
           <div class="drh-kpi drh-kpi--good">
             <div class="drh-kpi-val" id="drhOvCurrent">—</div>

--- a/js/data-freshness-monitor.js
+++ b/js/data-freshness-monitor.js
@@ -189,7 +189,7 @@
       '',
       '| Metric | Value |',
       '|---|---|',
-      '| Total Sources | ' + report.summary.total + ' |',
+      '| Monitored Files | ' + report.summary.total + ' |',
       '| Current       | ' + (report.summary.counts.current || 0) + ' |',
       '| Aging         | ' + (report.summary.counts.aging   || 0) + ' |',
       '| Stale         | ' + (report.summary.counts.stale   || 0) + ' |',

--- a/js/glossary.js
+++ b/js/glossary.js
@@ -197,6 +197,15 @@
       if (!parent) return;
       var tag = parent.tagName ? parent.tagName.toUpperCase() : '';
       if (['SCRIPT', 'STYLE', 'CODE', 'PRE', 'A', 'BUTTON', 'INPUT', 'TEXTAREA', 'SELECT'].indexOf(tag) !== -1) return;
+      // Don't wrap acronyms inside headings — the popup's full definition
+      // text bleeds into the heading's textContent / accessible name (e.g.
+      // Deal Calculator's H1 ended up with "LIHTCLow-Income Housing Tax
+      // Credit A dollar-for-dollar federal tax credit…" in textContent).
+      // Headings are shorthand by design; the body copy that follows can
+      // carry the tooltip instead. Walk ancestors so wrapping inner spans
+      // (e.g. <h1><span>LIHTC</span></h1>) is also caught.
+      var headingAncestor = parent.closest && parent.closest('h1, h2, h3, h4, h5, h6');
+      if (headingAncestor) return;
       if (parent.classList && parent.classList.contains('gl-tooltip-trigger')) return;
 
       var text = node.nodeValue;

--- a/lihtc-guide-for-stakeholders.html
+++ b/lihtc-guide-for-stakeholders.html
@@ -454,7 +454,8 @@
 <h4 style="color: var(--mcm-teal); margin: 1.5rem 0 0.75rem 0;">The pricing formula (simplified):</h4>
 <pre style="background: var(--mcm-graphite); padding: 1rem; border-radius: 4px; color: var(--mcm-beige); font-size: 0.9rem; line-height: 1.6; overflow-x: auto;">
 Equity = Annual Credit × 10 years × Price Per Credit Dollar
-        ~$9M       × 10      × $0.87  =  $78.3M (per $1M annual credit)
+         $1M       × 10      × $0.87  =  $8.7M (per $1M annual credit)
+        $1.5M      × 10      × $0.87  =  $13.05M (typical CO 9% deal)
 
 Price depends on:
   • Investor's effective tax rate (Fortune 500 at ~21% federal + state)


### PR DESCRIPTION
## Summary
Three small targeted fixes for user-flagged bugs surfaced by manual review.

### Fixes

| # | Bug | File | Fix |
|---|-----|------|-----|
| 1 | LIHTC pricing-formula example: "~\$9M × 10 × \$0.87 = \$78.3M (per \$1M annual credit)" — math was for \$9M annual but labeled "per \$1M annual" | `lihtc-guide-for-stakeholders.html:457` | Rescaled to two canonical examples: \$1M annual → \$8.7M equity (matches the per-\$1M annotation), plus \$1.5M annual → \$13.05M equity (typical CO 9% deal scale) |
| 2 | Data Review Hub shows two contradictory "Total Sources" counts (62 vs 71) at the top of the page | `data-review-hub.html` + `js/data-freshness-monitor.js` | Both counts are correct but measure different things. Relabeled: top bar → "Registry Sources" (`DataSourceInventory` entries, 62) · overview → "Monitored Files" (registry + DATA-MANIFEST, 71). Tooltips on both labels document the distinction. Markdown export aligned too. |
| 3 | Deal Calculator H1 `textContent` is polluted by the glossary tooltip — reads "LIHTCLow-Income Housing Tax CreditA dollar-for-dollar federal tax credit..." | `js/glossary.js` | Added heading-ancestor check so the auto-tooltip walker skips H1-H6. Body copy that follows the heading still gets the tooltip. Deal Calc H1 textContent now reads exactly "LIHTC Pro Forma & Capital Stack". |

## Test plan
- [x] `npm run validate` — all 40 HTML pages resolved
- [x] `npm run lint` (html + css) — clean
- [x] `npm run test:ci` — 688 + 19 + 24 + 64 + 23 + 31 + 26 + 40 + 16 pass
- [x] Browser: lihtc-guide page shows new \$8.7M/\$13.05M examples; \$78.3M is gone
- [x] Browser: data-review-hub shows "Registry Sources 62" + "Monitored Files 71" with 0 "Total Sources" labels remaining
- [x] Browser: deal-calculator H1 `textContent` is clean; 0 glossary tooltips inside any heading

## Housekeeping note (not in this PR)
Local cleanup: 43 macOS Finder-duplicate files in the main worktree were removed. **One file flagged** — `data/hna/dola_sya/08000 2.json` has `pyramidYear: 2030` while canonical `08000.json` has `pyramidYear: 2024`. Looks like accidentally-preserved newer projection data; left in place for you to triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)