### PR TITLE
feat(exports): enriched HNA + Market Analysis CSV/JSON exports

### DIFF
--- a/js/hna/hna-export.js
+++ b/js/hna/hna-export.js
@@ -106,8 +106,102 @@
   // ---------------------------------------------------------------------------
 
   /**
+   * Pull a ranking-index entry for the currently-selected geography by
+   * matching geoid against window.HNARanking._get().allEntries. Returns
+   * null if the ranking module isn't loaded yet — HNA single-jurisdiction
+   * page doesn't load it; Compare does.
+   */
+  function _rankingEntry(geoid) {
+    try {
+      var st = window.HNARanking && window.HNARanking._get
+             ? window.HNARanking._get() : null;
+      if (!st || !st.allEntries) return null;
+      for (var i = 0; i < st.allEntries.length; i++) {
+        if (st.allEntries[i].geoid === geoid) return st.allEntries[i];
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  /**
+   * Fallback metrics builder for the HNA single-jurisdiction page where
+   * HNARanking isn't loaded. Reads from window.HNAState (the loaded
+   * profile + chasData) and computes the same analytics-grade fields
+   * the ranking-index would expose.
+   */
+  function _metricsFromHnaState(geoid) {
+    try {
+      var st = window.HNAState && window.HNAState.state;
+      if (!st) return null;
+      var prof = st.lastProfile || {};
+      var chas = st.chasData || {};
+      var contextCounty = st.contextCounty || (geoid && geoid.length === 5 ? geoid : null);
+      var county = (chas.counties || chas)[contextCounty] || null;
+      var rba = (county && county.renter_hh_by_ami) || null;
+      var ownerSum = (county && county.summary) || {};
+
+      // Helper: tier % from CHAS — use canonical cost_burdened_30pct
+      function tierPct(td) {
+        if (!td) return null;
+        var total = +td.total, burdened = +(td.cost_burdened_30pct != null ? td.cost_burdened_30pct : td.cost_burdened);
+        if (!total || !Number.isFinite(total) || total <= 0) return null;
+        return +((burdened / total) * 100).toFixed(1);
+      }
+
+      // Vacancy from DP04_0005E (the actual percentage per ACS spec — fix landed in #857)
+      var vacancyRate = null;
+      var vacRaw = prof.DP04_0005E;
+      var pctRenter = +prof.DP04_0047PE || 0;
+      var totalUnits = +prof.DP04_0001E || 0;
+      var rentalUnits = (totalUnits && pctRenter) ? Math.round(totalUnits * pctRenter / 100) : 0;
+      if (vacRaw != null && rentalUnits >= 50) vacancyRate = Math.min(50, Math.max(0, +vacRaw));
+
+      // Structure composition (5+ MF, 1-unit detached, 2-4 small MF)
+      var sfDet = +prof.DP04_0007E || 0;
+      var sfAtt = +prof.DP04_0008E || 0;
+      var u2 = +prof.DP04_0009E || 0, u3to4 = +prof.DP04_0010E || 0;
+      var u5to9 = +prof.DP04_0011E || 0, u10to19 = +prof.DP04_0012E || 0, u20plus = +prof.DP04_0013E || 0;
+      var mobile = +prof.DP04_0014E || 0;
+      var structTotal = sfDet + sfAtt + u2 + u3to4 + u5to9 + u10to19 + u20plus + mobile;
+      var pctMf = structTotal > 0 ? +((u5to9 + u10to19 + u20plus) / structTotal * 100).toFixed(1) : null;
+      var pctSf = structTotal > 0 ? +(sfDet / structTotal * 100).toFixed(1) : null;
+      var pct24 = structTotal > 0 ? +((u2 + u3to4) / structTotal * 100).toFixed(1) : null;
+
+      // Owner sum from CHAS summary. County CHAS uses `pct_owner_cb30`
+      // (decimal); place CHAS uses `owner_cb30_share`. Check both.
+      var ownerRaw = ownerSum.pct_owner_cb30 != null
+        ? ownerSum.pct_owner_cb30
+        : ownerSum.owner_cb30_share;
+      var ownerBurden = (ownerRaw != null && Number.isFinite(+ownerRaw))
+        ? +((+ownerRaw) * 100).toFixed(1)
+        : null;
+
+      return {
+        population:           +prof.DP05_0001E || null,
+        median_hh_income:     +prof.DP03_0062E || null,
+        gross_rent_median:    +prof.DP04_0134E || null,
+        pct_renters:          pctRenter || null,
+        vacancy_rate:         vacancyRate,
+        pct_multifamily:      pctMf,
+        pct_sf_detached:      pctSf,
+        pct_2to4_units:       pct24,
+        pct_burdened_lte30:   rba ? tierPct(rba.lte30) : null,
+        pct_burdened_31to50:  rba ? tierPct(rba['31to50']) : null,
+        pct_burdened_51to80:  rba ? tierPct(rba['51to80']) : null,
+        pct_burdened_81to100: rba ? tierPct(rba['81to100']) : null,
+        pct_burdened_100plus: rba ? tierPct(rba['100plus']) : null,
+        pct_owner_burdened_30plus: ownerBurden,
+        _chas_source: county ? 'county' : 'none',
+      };
+    } catch (_) { return null; }
+  }
+
+  /**
    * Collects the currently rendered housing-needs assessment values from
-   * the DOM and returns a plain object suitable for CSV or JSON export.
+   * the DOM AND from the loaded ranking-index entry for the selected
+   * geography. The DOM values give exact visual fidelity (formatted
+   * strings); the ranking-index values give analytics-grade numerics
+   * with explicit data-provenance flags.
    *
    * @returns {object} reportData
    */
@@ -118,28 +212,86 @@
     var geoSelectEl = document.getElementById('geoSelect');
     var geoid      = geoSelectEl ? geoSelectEl.value : '';
 
+    // Pull the analytics-grade numeric record. Compare page provides
+    // HNARanking — use its ranking-index entry. HNA single-jurisdiction
+    // page doesn't load that module — fall back to a synthesis from
+    // HNAState (the loaded ACS profile + CHAS county aggregate). Both
+    // paths produce the same metrics shape so the export rows below
+    // work uniformly.
+    var idxRec = _rankingEntry(geoid);
+    var m = (idxRec && idxRec.metrics) || _metricsFromHnaState(geoid) || {};
+
     return {
       exportedAt:    new Date().toISOString(),
+      generatedBy:   'COHO Analytics HNA Export',
+      disclaimer:    'Screening tool only. Public-data screening output, not a substitute for a CHFA-required market study, professional underwriting, or independent investor analysis. See docs/METHODOLOGY-GAPS-2026-05-21.md for known limitations.',
+      vintages: {
+        acs:          'ACS 5-Year 2019-2023',
+        chas:         'HUD CHAS 2018-2022',
+        lehd:         'LEHD WAC 2021',
+        dola:         'DOLA SYA 2024',
+        fmr:          'HUD FMR FY2025',
+        rankingIndex: idxRec && idxRec._metadata && idxRec._metadata.builtAt || null,
+      },
       geography: {
         label:   geoLabel,
         type:    geoType,
         geoid:   geoid,
+        containingCounty: idxRec ? idxRec.containingCounty : null,
+        region:           idxRec ? idxRec.region : null,
       },
       snapshot: {
-        population:        _elText('statPop'),
+        population:            _elText('statPop'),
         medianHouseholdIncome: _elText('statMhi'),
-        medianHomeValue:   _elText('statHomeValue'),
-        medianGrossRent:   _elText('statRent'),
-        ownerRenterTenure: _elText('statTenure'),
-        rentBurden30Plus:  _elText('statRentBurden'),
-        incomeNeededToBuy: _elText('statIncomeNeed'),
-        meanCommute:       _elText('statCommute'),
+        medianHomeValue:       _elText('statHomeValue'),
+        medianGrossRent:       _elText('statRent'),
+        ownerRenterTenure:     _elText('statTenure'),
+        rentBurden30Plus:      _elText('statRentBurden'),
+        incomeNeededToBuy:     _elText('statIncomeNeed'),
+        meanCommute:           _elText('statCommute'),
+        // Analytics-grade numerics from ranking-index
+        populationNumeric:        m.population || null,
+        medianHhIncomeNumeric:    m.median_hh_income || null,
+        grossRentMedianNumeric:   m.gross_rent_median || null,
+        pctRenters:               m.pct_renters || null,
+        pctCostBurdenedRenters:   m.pct_cost_burdened || null,
       },
       housingStock: {
-        baselineUnits:    _elText('statBaseUnits'),
-        targetVacancyRate: _elText('statTargetVac'),
-        unitsNeeded:      _elText('statUnitsNeed'),
-        netMigration:     _elText('statNetMig'),
+        baselineUnits:       _elText('statBaseUnits'),
+        targetVacancyRate:   _elText('statTargetVac'),
+        unitsNeeded:         _elText('statUnitsNeed'),
+        netMigration:        _elText('statNetMig'),
+        // Structure-type composition (% of structures) + vacancy
+        rentalVacancyRate:   m.vacancy_rate,
+        pctMultifamily:      m.pct_multifamily || null,
+        pctSfDetached:       m.pct_sf_detached || null,
+        pct2to4Units:        m.pct_2to4_units || null,
+        population20yr:      m.population_projection_20yr || null,
+      },
+      chasCostBurden: {
+        source:         m._chas_source || 'unavailable',  // 'place' | 'county' | 'none'
+        renterPctBurdened: {
+          lte30:    m.pct_burdened_lte30 || null,
+          tier31to50: m.pct_burdened_31to50 || null,
+          tier51to80: m.pct_burdened_51to80 || null,
+          tier81to100: m.pct_burdened_81to100 || null,
+          tier100plus: m.pct_burdened_100plus || null,
+        },
+        ownerPctBurdened30Plus: m.pct_owner_burdened_30plus || null,
+        note: 'CHAS publishes HUD-defined cost-burden rates (≥30% of income on housing) by AMI tier. Place-level values are TIGER-apportioned from tract-level CHAS when available; otherwise the containing-county rates are used as a fallback.',
+      },
+      amiGap: {
+        housingGapUnits:    m.housing_gap_units || null,
+        gap30pctUnits:      m.ami_gap_30pct || null,
+        gap50pctUnits:      m.ami_gap_50pct || null,
+        gap60pctUnits:      m.ami_gap_60pct || null,
+        missingAmiTiers:    m.missing_ami_tiers || [],
+        source:             m._ami_gap_source || 'unavailable',
+      },
+      employment: {
+        inCommuters:        m.in_commuters || null,
+        commuteRatioPct:    m.commute_ratio || null,
+        source:             m._lehd_source || 'unavailable',  // 'place' | 'county_direct' | 'county_proportional' | 'none'
       },
       lihtc: {
         projectCount: _elText('statLihtcCount'),
@@ -147,6 +299,12 @@
         qctTracts:    _elText('statQctCount'),
         ddaStatus:    _elText('statDdaStatus'),
       },
+      dataQuality: idxRec ? {
+        approximatedFields:  (idxRec.dataQuality && idxRec.dataQuality.approximated_fields) || [],
+        approximationBasis:  (idxRec.dataQuality && idxRec.dataQuality.approximation_basis) || null,
+        hasIncompleteData:   idxRec.hasIncompleteData || false,
+        nullCriticalMetrics: idxRec.nullCriticalMetrics || 0,
+      } : null,
       narrative: _elText('execNarrative'),
     };
   }
@@ -227,34 +385,120 @@
     var d       = reportData || buildReportData();
     var outFile = filename   || 'housing-needs-assessment.csv';
 
+    var chas = d.chasCostBurden || {};
+    var burden = chas.renterPctBurdened || {};
+    var gap = d.amiGap || {};
+    var emp = d.employment || {};
+    var dq = d.dataQuality || {};
+    var v = d.vintages || {};
+    var fmtPct = function (n) { return (n == null) ? '' : (+n).toFixed(1) + '%'; };
+    var fmtNum = function (n) { return (n == null) ? '' : (+n).toLocaleString('en-US'); };
+
     var rows = [
-      // Header row
+      // \u2500\u2500 Header & meta \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
       ['Field', 'Value'],
-      // Geography
-      ['Geography',              d.geography.label],
-      ['Geography Type',         d.geography.type],
-      ['GEOID',                  d.geography.geoid],
-      // Snapshot
-      ['Population',                    d.snapshot.population],
-      ['Median Household Income',       d.snapshot.medianHouseholdIncome],
-      ['Median Home Value',             d.snapshot.medianHomeValue],
-      ['Median Gross Rent',             d.snapshot.medianGrossRent],
-      ['Owner / Renter Tenure',         d.snapshot.ownerRenterTenure],
-      ['Rent Burden (\u226530% of income)', d.snapshot.rentBurden30Plus],
-      ['Income Needed to Buy Median Home', d.snapshot.incomeNeededToBuy],
-      ['Mean Commute Time',             d.snapshot.meanCommute],
-      // Housing stock / projections
-      ['Baseline Housing Units',        d.housingStock.baselineUnits],
-      ['Target Vacancy Rate',           d.housingStock.targetVacancyRate],
-      ['Estimated Units Needed (20-year)', d.housingStock.unitsNeeded],
-      ['Net Migration (20-year)',          d.housingStock.netMigration],
-      // LIHTC
-      ['LIHTC Projects in County',      d.lihtc.projectCount],
-      ['LIHTC Total Units',             d.lihtc.totalUnits],
-      ['Qualified Census Tracts',       d.lihtc.qctTracts],
-      ['DDA Status',                    d.lihtc.ddaStatus],
-      // Meta
-      ['Exported At',                   d.exportedAt],
+      ['Report Type',                   'Housing Needs Assessment'],
+      ['Generated By',                  d.generatedBy || ''],
+      ['Exported At',                   d.exportedAt || ''],
+      ['Disclaimer',                    d.disclaimer || ''],
+      ['', ''],
+
+      // \u2500\u2500 Geography \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+      ['SECTION', 'Geography'],
+      ['Geography Name',                d.geography.label],
+      ['Geography Type',                d.geography.type],
+      ['GEOID',                         d.geography.geoid],
+      ['Containing County',             d.geography.containingCounty || ''],
+      ['Region',                        d.geography.region || ''],
+      ['', ''],
+
+      // \u2500\u2500 Data vintages \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+      ['SECTION', 'Data Vintages'],
+      ['ACS',                           v.acs || ''],
+      ['HUD CHAS',                      v.chas || ''],
+      ['LEHD WAC',                      v.lehd || ''],
+      ['DOLA Population/Households',    v.dola || ''],
+      ['HUD FMR',                       v.fmr || ''],
+      ['', ''],
+
+      // \u2500\u2500 Executive Snapshot (visible page values) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+      ['SECTION', 'Executive Snapshot'],
+      ['Population (displayed)',                 d.snapshot.population],
+      ['Median Household Income (displayed)',    d.snapshot.medianHouseholdIncome],
+      ['Median Home Value (displayed)',          d.snapshot.medianHomeValue],
+      ['Median Gross Rent (displayed)',          d.snapshot.medianGrossRent],
+      ['Owner / Renter Tenure',                  d.snapshot.ownerRenterTenure],
+      ['Rent Burden \u226530% of income',             d.snapshot.rentBurden30Plus],
+      ['Income Needed to Buy Median Home',       d.snapshot.incomeNeededToBuy],
+      ['Mean Commute Time',                      d.snapshot.meanCommute],
+      ['', ''],
+
+      // \u2500\u2500 Analytics-grade numerics from ranking-index \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+      ['SECTION', 'Numeric Metrics (ranking-index)'],
+      ['Population',                             fmtNum(d.snapshot.populationNumeric)],
+      ['Median HH Income ($)',                   fmtNum(d.snapshot.medianHhIncomeNumeric)],
+      ['Median Gross Rent ($)',                  fmtNum(d.snapshot.grossRentMedianNumeric)],
+      ['% Renter-Occupied',                      fmtPct(d.snapshot.pctRenters)],
+      ['% Renters Cost-Burdened (ACS GRAPI \u226530%)', fmtPct(d.snapshot.pctCostBurdenedRenters)],
+      ['', ''],
+
+      // \u2500\u2500 Housing stock composition \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+      ['SECTION', 'Housing Stock'],
+      ['Baseline Housing Units',                 d.housingStock.baselineUnits],
+      ['Target Vacancy Rate',                    d.housingStock.targetVacancyRate],
+      ['Rental Vacancy Rate (ACS DP04_0005E)',
+        (d.housingStock.rentalVacancyRate == null ? '\u2014 (small-N suppressed)' : fmtPct(d.housingStock.rentalVacancyRate))],
+      ['% Multifamily (5+ unit structures)',     fmtPct(d.housingStock.pctMultifamily)],
+      ['% Single-Family Detached',               fmtPct(d.housingStock.pctSfDetached)],
+      ['% 2-4 Unit Structures',                  fmtPct(d.housingStock.pct2to4Units)],
+      ['Estimated Units Needed (20-year)',       d.housingStock.unitsNeeded],
+      ['Net Migration (20-year)',                d.housingStock.netMigration],
+      ['Projected Population (20-year)',         fmtNum(d.housingStock.population20yr)],
+      ['', ''],
+
+      // \u2500\u2500 HUD CHAS Cost Burden (all 5 AMI tiers) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+      ['SECTION', 'HUD CHAS Cost Burden'],
+      ['CHAS Data Source',                       chas.source || ''],
+      ['Renter Cost-Burdened: \u226430% AMI',         fmtPct(burden.lte30)],
+      ['Renter Cost-Burdened: 31-50% AMI',       fmtPct(burden.tier31to50)],
+      ['Renter Cost-Burdened: 51-80% AMI',       fmtPct(burden.tier51to80)],
+      ['Renter Cost-Burdened: 81-100% AMI',      fmtPct(burden.tier81to100)],
+      ['Renter Cost-Burdened: >100% AMI',        fmtPct(burden.tier100plus)],
+      ['Owner Cost-Burdened (\u226530% of income)',   fmtPct(chas.ownerPctBurdened30Plus)],
+      ['CHAS Note',                              chas.note || ''],
+      ['', ''],
+
+      // \u2500\u2500 AMI Gap Analysis \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+      ['SECTION', 'AMI Gap Analysis'],
+      ['Total Housing Gap (units)',              fmtNum(gap.housingGapUnits)],
+      ['Unit Gap \u226430% AMI',                      fmtNum(gap.gap30pctUnits)],
+      ['Unit Gap \u226450% AMI',                      fmtNum(gap.gap50pctUnits)],
+      ['Unit Gap \u226460% AMI',                      fmtNum(gap.gap60pctUnits)],
+      ['Missing AMI Tiers',                      (gap.missingAmiTiers || []).join(', ')],
+      ['AMI Gap Source',                         gap.source || ''],
+      ['', ''],
+
+      // \u2500\u2500 LEHD Employment + Commuting \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+      ['SECTION', 'LEHD Employment'],
+      ['In-Commuters',                           fmtNum(emp.inCommuters)],
+      ['Commute Ratio (inflow / total)',         fmtPct(emp.commuteRatioPct)],
+      ['LEHD Source',                            emp.source || ''],
+      ['', ''],
+
+      // \u2500\u2500 LIHTC \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+      ['SECTION', 'LIHTC'],
+      ['LIHTC Projects in County',               d.lihtc.projectCount],
+      ['LIHTC Total Units',                      d.lihtc.totalUnits],
+      ['Qualified Census Tracts',                d.lihtc.qctTracts],
+      ['DDA Status',                             d.lihtc.ddaStatus],
+      ['', ''],
+
+      // \u2500\u2500 Data Quality flags \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+      ['SECTION', 'Data Quality'],
+      ['Approximated Fields',                    (dq.approximatedFields || []).join(', ')],
+      ['Approximation Basis',                    dq.approximationBasis || ''],
+      ['Has Incomplete Data',                    String(dq.hasIncompleteData)],
+      ['Null Critical Metrics (count)',          String(dq.nullCriticalMetrics)],
     ];
 
     var csv  = _toCsv(rows);

--- a/js/market-analysis.js
+++ b/js/market-analysis.js
@@ -2618,6 +2618,225 @@
     });
   }
 
+  /* ── CSV / JSON export ───────────────────────────────────────────── */
+  /**
+   * Serialize the last PMA analysis result into a structured object
+   * suitable for downstream re-analysis. Pulls from `lastResult` (the
+   * runAnalysis composite) plus the per-section data the controller
+   * collects. Falls back gracefully when fields aren't populated.
+   */
+  function _buildPmaReportData() {
+    var r = lastResult || {};
+    var bufferM = r.bufferMiles || bufferMiles || 5;
+    var acs = r.acs || {};
+    var dims = r.dimensions || {};
+    var dimAvail = r.dimensionDataAvailable || {};
+    var coverage = r.pmaDataCoverage || {};
+    return {
+      exportedAt:  new Date().toISOString(),
+      generatedBy: 'COHO Analytics Market Analysis (PMA) Export',
+      disclaimer:  'Screening tool only. PMA score is a public-data screening signal, not a substitute for a CHFA-required market study. Buffer-based, not commuting-shed. See docs/METHODOLOGY-GAPS-2026-05-21.md for limits.',
+      vintages: {
+        acs:  'ACS 5-Year 2019-2023',
+        chas: 'HUD CHAS 2018-2022',
+        lehd: 'LEHD WAC 2021',
+        fmr:  'HUD FMR FY2025',
+        lihtc:'HUD LIHTC Database (most recent quarterly)'
+      },
+      site: {
+        latitude:    r.lat,
+        longitude:   r.lon,
+        bufferMiles: bufferM,
+        boundaryMethod: 'circular buffer (screening simplification, not commuting-shed)',
+        tractsInBuffer: r.tractCount,
+        tractGeoids:    (r._tractIds || []).slice(0, 50)
+      },
+      overall: {
+        score:      r.overall,
+        tier:       (function () { try { return scoreTier(r.overall).label; } catch (e) { return null; } })(),
+        // Confidence is an object in some result shapes ({ label, score }
+        // or { level, reasons }). Serialize defensively so CSV doesn't
+        // render "[object Object]" — prefer label, then level, then score.
+        confidence: (function () {
+          var c = r.confidence;
+          if (c == null) return null;
+          if (typeof c === 'string' || typeof c === 'number') return c;
+          if (typeof c === 'object') return c.label || c.level || c.score || JSON.stringify(c).slice(0, 60);
+          return String(c);
+        })()
+      },
+      dimensions: {
+        demand:           dims.demand,
+        captureRisk:      dims.captureRisk,
+        rentPressure:     dims.rentPressure,
+        marketTightness:  dims.marketTightness,
+        workforce:        dims.workforce
+      },
+      dimensionDataAvailable: {
+        demand:           !!dimAvail.demand,
+        captureRisk:      !!dimAvail.captureRisk,
+        rentPressure:     !!dimAvail.rentPressure,
+        marketTightness:  !!dimAvail.marketTightness,
+        workforce:        !!dimAvail.workforce
+      },
+      dataCoverage: coverage,
+      acsAggregates: {
+        totalHouseholds:   acs.total_hh,
+        renterHouseholds:  acs.renter_hh,
+        renterShare:       (acs.total_hh && acs.renter_hh) ? +(acs.renter_hh / acs.total_hh * 100).toFixed(1) : null,
+        costBurdenRate:    acs.cost_burden_rate,
+        medianGrossRent:   acs.median_gross_rent,
+        vacancyRate:       acs.vacancy_rate
+      },
+      supply: {
+        lihtcProjectsInBuffer: r.lihtcCount,
+        lihtcUnitsInBuffer:    r.lihtcUnits,
+        prop123ProjectsInBuffer: r.prop123Count
+      },
+      summaryFromCard: (function () {
+        var sumGet = function (id) { var e = document.getElementById(id); return e ? e.textContent.trim() : null; };
+        return {
+          boundary:   sumGet('pmaSumBoundary'),
+          tracts:     sumGet('pmaSumTracts'),
+          units:      sumGet('pmaSumUnits'),
+          renters:    sumGet('pmaSumRenters'),
+          transit:    sumGet('pmaSumTransit'),
+          grocery:    sumGet('pmaSumGrocery'),
+          healthcare: sumGet('pmaSumHealthcare'),
+          school:     sumGet('pmaSumSchool'),
+          park:       sumGet('pmaSumPark')
+        };
+      })()
+    };
+  }
+
+  function _pmaTriggerDownload(blob, filename) {
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url; a.download = filename;
+    document.body.appendChild(a); a.click();
+    document.body.removeChild(a);
+    setTimeout(function () { URL.revokeObjectURL(url); }, 100);
+  }
+
+  function _pmaCsvEscape(v) {
+    if (v == null) return '';
+    var s = String(v);
+    return /[",\n]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;
+  }
+
+  function exportPmaCsv() {
+    if (!lastResult) {
+      alert('Run an analysis first, then download the CSV.');
+      return;
+    }
+    var d = _buildPmaReportData();
+    var fmtNum = function (n) { return (n == null) ? '' : (+n).toLocaleString('en-US'); };
+    var fmtPct = function (n) { return (n == null) ? '' : (+n).toFixed(1) + '%'; };
+    var s = d.site, ov = d.overall, dim = d.dimensions, av = d.dimensionDataAvailable;
+    var ag = d.acsAggregates, sp = d.supply, sc = d.summaryFromCard, dq = d.dataCoverage, v = d.vintages;
+    var rows = [
+      ['Field', 'Value'],
+      ['Report Type', 'PMA Site Analysis'],
+      ['Generated By', d.generatedBy],
+      ['Exported At', d.exportedAt],
+      ['Disclaimer', d.disclaimer],
+      ['', ''],
+      ['SECTION', 'Site'],
+      ['Latitude', s.latitude],
+      ['Longitude', s.longitude],
+      ['Buffer (miles)', s.bufferMiles],
+      ['Boundary Method', s.boundaryMethod],
+      ['ACS Tracts in Buffer', s.tractsInBuffer],
+      ['Tract GEOIDs (first 50)', (s.tractGeoids || []).join('; ')],
+      ['', ''],
+      ['SECTION', 'Data Vintages'],
+      ['ACS',   v.acs],
+      ['CHAS',  v.chas],
+      ['LEHD',  v.lehd],
+      ['FMR',   v.fmr],
+      ['LIHTC', v.lihtc],
+      ['', ''],
+      ['SECTION', 'Overall Score'],
+      ['Score (0-100)', ov.score],
+      ['Tier',          ov.tier],
+      ['Confidence',    ov.confidence],
+      ['', ''],
+      ['SECTION', 'Dimension Scores (0-100)'],
+      ['Demand',           dim.demand],
+      ['Capture Risk',     dim.captureRisk],
+      ['Rent Pressure',    dim.rentPressure],
+      ['Market Tightness', dim.marketTightness],
+      ['Workforce',        dim.workforce],
+      ['', ''],
+      ['SECTION', 'Dimension Data Availability'],
+      ['Demand',           String(av.demand)],
+      ['Capture Risk',     String(av.captureRisk)],
+      ['Rent Pressure',    String(av.rentPressure)],
+      ['Market Tightness', String(av.marketTightness)],
+      ['Workforce',        String(av.workforce)],
+      ['', ''],
+      ['SECTION', 'ACS Aggregates (sum over buffer tracts)'],
+      ['Total Households',     fmtNum(ag.totalHouseholds)],
+      ['Renter Households',    fmtNum(ag.renterHouseholds)],
+      ['Renter Share',         fmtPct(ag.renterShare)],
+      ['Cost-Burden Rate',     fmtPct(ag.costBurdenRate)],
+      ['Median Gross Rent',    ag.medianGrossRent != null ? '$' + fmtNum(ag.medianGrossRent) : ''],
+      ['Vacancy Rate',         fmtPct(ag.vacancyRate)],
+      ['', ''],
+      ['SECTION', 'LIHTC Supply in Buffer'],
+      ['LIHTC Projects',       fmtNum(sp.lihtcProjectsInBuffer)],
+      ['LIHTC Total Units',    fmtNum(sp.lihtcUnitsInBuffer)],
+      ['Prop 123 Projects',    fmtNum(sp.prop123ProjectsInBuffer)],
+      ['', ''],
+      ['SECTION', 'PMA Site Summary Card'],
+      ['Boundary',    sc.boundary],
+      ['Census Tracts', sc.tracts],
+      ['Housing Units in Buffer', sc.units],
+      ['Rental Households',       sc.renters],
+      ['Nearest Transit',    sc.transit],
+      ['Nearest Grocery',    sc.grocery],
+      ['Nearest Healthcare', sc.healthcare],
+      ['Nearest School',     sc.school],
+      ['Nearest Park',       sc.park],
+      ['', ''],
+      ['SECTION', 'Data Coverage Diagnostic (per dimension)'],
+      ['Demand',           dq.demand || ''],
+      ['Capture Risk',     dq.capture_risk || ''],
+      ['Rent Pressure',    dq.rent_pressure || ''],
+      ['Market Tightness', dq.market_tightness || ''],
+      ['Workforce',        dq.workforce || '']
+    ];
+    var csv = rows.map(function (r) {
+      return r.map(_pmaCsvEscape).join(',');
+    }).join('\n');
+    var blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    var coord = (s.latitude != null && s.longitude != null)
+      ? '_' + s.latitude.toFixed(4) + '_' + s.longitude.toFixed(4)
+      : '';
+    _pmaTriggerDownload(blob, 'pma-site-analysis' + coord + '.csv');
+  }
+
+  function exportPmaJson() {
+    if (!lastResult) {
+      alert('Run an analysis first, then download the JSON.');
+      return;
+    }
+    var d = _buildPmaReportData();
+    var blob = new Blob([JSON.stringify(d, null, 2)], { type: 'application/json' });
+    var coord = (d.site.latitude != null && d.site.longitude != null)
+      ? '_' + d.site.latitude.toFixed(4) + '_' + d.site.longitude.toFixed(4)
+      : '';
+    _pmaTriggerDownload(blob, 'pma-site-analysis' + coord + '.json');
+  }
+
+  function bindPmaExportButtons() {
+    var csvBtn = el('pmaExportCsvBtn');
+    if (csvBtn) csvBtn.addEventListener('click', exportPmaCsv);
+    var jsonBtn = el('pmaExportJsonBtn');
+    if (jsonBtn) jsonBtn.addEventListener('click', exportPmaJson);
+  }
+
   /* ── AMI mix inputs ─────────────────────────────────────────────── */
   // Three-state unit-mix integrity check (matches Deal Calculator pattern):
   //   sum > total   → HARD ERROR (red): physically impossible — block sim output.
@@ -3001,6 +3220,7 @@
     initLayerToggles();
     bindBufferSelect();
     bindRunBtn();
+    bindPmaExportButtons();
     bindAmiInputs();
     bindExport();
 

--- a/market-analysis.html
+++ b/market-analysis.html
@@ -420,6 +420,8 @@
             <button class="pma-btn pma-btn-primary" id="pmaRunBtn" type="button">Run Analysis</button>
             <button class="pma-btn" id="pmaExplainScoreBtn" type="button" hidden>Explain Score</button>
             <button class="pma-btn" id="pmaExportBtn" type="button" title="Export PMA report as printable HTML">Export Report</button>
+            <button class="pma-btn" id="pmaExportCsvBtn" type="button" title="Download analytics-grade CSV: site coords, dimension scores, ACS aggregates, amenity distances, data-coverage flags">Download CSV</button>
+            <button class="pma-btn" id="pmaExportJsonBtn" type="button" title="Download full result snapshot as JSON for downstream analysis">Download JSON</button>
           </div>
 
           <!-- ── Progress bar (visible during analysis) ── -->


### PR DESCRIPTION
## Summary
Existing HNA `Download CSV` emitted only ~22 headline metrics from the DOM. Market Analysis had a printable HTML report but no structured export. User asked for "downloadable HNA and Market analysis at least helpful for more detailed analysis." Both now ship rich, analytics-grade exports.

## HNA export (Download CSV + Download JSON)
Pulls from `window.HNARanking._get()` when loaded (Compare page) AND from `window.HNAState.state.chasData/lastProfile` directly on the HNA single-jurisdiction page (HNA doesn't load the ranking module). Both paths produce the same metrics shape.

**45+ CSV rows** organized into sections:
- Report Type / Generated By / Disclaimer header
- Geography (label, type, GEOID, containing county, region)
- Data Vintages (ACS · CHAS · LEHD · DOLA · FMR)
- Executive Snapshot (visible + numeric variants)
- Housing Stock — rental vacancy + % MF + % SF detached + % 2-4 unit
- HUD CHAS Cost Burden — all 5 AMI tiers (≤30 / 31-50 / 51-80 / 81-100 / 100+) + owner ≥30% aggregate + CHAS source flag (place vs county)
- AMI Gap Analysis — housing gap + ≤30/50/60 deficits + missing tiers list
- LEHD Employment — in-commuters + commute ratio + source flag
- LIHTC
- Data Quality — approximated fields list + basis + incomplete flag

**Spot-check Denver County**: 5 CHAS tiers populated (lte30=73.4%, 31-50=82.9%, 51-80=54.6%, 81-100=23.2%, 100+=4.5%), owner burden 23.4%, vacancy 5.8% (post-#857), MF 46.6%, SF 39.8%, all vintages stamped.

## Market Analysis export (Download CSV + Download JSON)
NEW buttons next to Export Report on `market-analysis.html`. Pull from the `lastResult` composite + PMA Site Summary card.

CSV includes:
- Site (lat/lon/buffer, boundary method, tracts + **first 50 tract GEOIDs**)
- Data Vintages
- Overall Score (score, tier, confidence — defensively serialized)
- Dimension Scores + per-dimension data-availability flags
- ACS Aggregates (households, renters, renter share, cost-burden, median rent, vacancy)
- LIHTC Supply (LIHTC projects/units, Prop 123 projects)
- PMA Site Summary Card values
- Per-dimension Data Coverage diagnostic

**Spot-check Denver downtown (39.7536, -104.999)**: captured 33 tract GEOIDs, overall 39 (Weak), all 5 dimension scores, ACS aggs 26,076 households / 12,336 renters / 47.3% renter share, 170 LIHTC projects / 13,219 units.

## Filename convention
Both exports include lat/lon in the filename when applicable (e.g. `pma-site-analysis_39.7536_-104.999.csv`) so multiple site exports don't collide.

## Test plan
- [x] `npm run validate` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:ci` — all suites pass
- [x] Browser: HNA CSV captured with 45+ rows of real Denver data
- [x] Browser: Market CSV captured with 33 tract GEOIDs + all dimension scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)