### PR TITLE
feat(ux): Tier A — owner-burden vintage pill + PMA escalation card + Deal Calc disclaimer

### DIFF
--- a/js/deal-calculator.js
+++ b/js/deal-calculator.js
@@ -832,6 +832,16 @@
 
       <fieldset style="border:1px solid var(--border);border-radius:var(--radius);padding:var(--sp3);margin-bottom:var(--sp3);">
         <legend style="font-size:var(--small);font-weight:700;padding:0 0.4rem;">LIHTC Credit Estimates <span style="font-weight:400;font-size:var(--tiny);color:var(--muted);">(screening-level)</span></legend>
+
+        <!-- Adjacent-to-headline disclaimer (per methodology-gaps deep-dive):
+             the "Screening tool only" note in the page intro is easy to miss
+             once a user is staring at a 7-figure equity number. Repeat the
+             framing right next to the headline outputs so it stays in view. -->
+        <p role="note" style="margin:0 0 var(--sp2);padding:0.4rem 0.6rem;font-size:var(--tiny);background:rgba(217,119,6,.08);border-left:3px solid var(--warn,#d97706);border-radius:0 4px 4px 0;color:var(--text);line-height:1.45;">
+          <strong style="color:var(--warn,#d97706);">⚠ Screening estimate, not underwriting.</strong>
+          The equity figure below uses public assumptions for hard costs, equity pricing, and applicable fraction. Real syndicator pricing varies ±3-8¢/credit by deal characteristics — confirm with your investor before relying on this number for site control or capital-stack decisions.
+        </p>
+
         <dl id="dc-results" style="display:grid;grid-template-columns:1fr auto;gap:0.5rem 1rem;font-size:var(--small);">
           <dt style="color:var(--muted);">Eligible Basis</dt>
           <dd id="dc-r-basis" style="font-weight:700;text-align:right;">—</dd>

--- a/js/hna/hna-comparison.js
+++ b/js/hna/hna-comparison.js
@@ -795,25 +795,52 @@
 
     // If owner cost burden fell back to CHAS for either side (because
     // ACS SMOCAPI bins are suppressed for small places/CDPs), surface
-    // a small note so users know the value isn't ACS-direct. Same
-    // pattern as the renter-burden Place/County pill.
+    // a small note so users know the value isn't ACS-direct. Matches
+    // the renter-burden Place/County pill pattern, with explicit
+    // vintage stamps (ACS 2019-2023 vs CHAS 2018-2022) so the user
+    // can see which side's number is fresher.
+    var ownerSrcLabel = function (s) {
+      if (s === 'acs')         return 'ACS 2019–2023 DP04 SMOCAPI';
+      if (s === 'place_chas')  return 'HUD CHAS 2018–2022 (place-level, TIGER-apportioned)';
+      if (s === 'county_chas') return 'HUD CHAS 2018–2022 (containing county)';
+      return 'unavailable';
+    };
+    var ownerSrcPill = function (s) {
+      var cfg = {
+        acs:         { text: 'ACS 2019–23', bg: 'rgba(4,120,87,.12)',   border: 'rgba(4,120,87,.45)',   color: 'var(--good,#047857)', title: 'ACS 2019-2023 DP04 SMOCAPI (Selected Monthly Owner Costs as % of household income).' },
+        place_chas:  { text: 'CHAS 2018–22 · Place',  bg: 'rgba(217,119,6,.12)',  border: 'rgba(217,119,6,.45)',  color: 'var(--warn,#d97706)', title: 'HUD CHAS 2018-2022 place-level TIGER-apportioned (fallback when ACS SMOCAPI is small-N suppressed).' },
+        county_chas: { text: 'CHAS 2018–22 · County', bg: 'rgba(217,119,6,.12)',  border: 'rgba(217,119,6,.45)',  color: 'var(--warn,#d97706)', title: 'HUD CHAS 2018-2022 containing-county aggregate (fallback when ACS SMOCAPI is suppressed and no place-CHAS coverage).' },
+        none:        { text: '—', bg: 'transparent', border: 'transparent', color: 'var(--muted,#6b7280)', title: 'No owner cost-burden data available.' },
+      };
+      var c = cfg[s] || cfg.none;
+      return '<span class="hca-cp-source-pill" title="' + c.title + '" ' +
+        'style="display:inline-block;padding:1px 8px;border-radius:999px;font-size:.7rem;font-weight:700;' +
+        'background:' + c.bg + ';border:1px solid ' + c.border + ';color:' + c.color + ';">' +
+        c.text + '</span>';
+    };
+    // Per-side source pills row — mirrors the renter-burden Data Source row
+    // so users see at a glance whether each owner figure is ACS-direct or
+    // a CHAS fallback, AND which CHAS vintage backs it. Always render so
+    // even ACS-direct pairs get the vintage label visible.
+    html += '<div class="hca-cp-row hca-cp-row--compact" style="margin-bottom:.4rem;align-items:center;">' +
+      '<div class="hca-cp-row__label" style="font-size:.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.04em;">Owner-burden source</div>' +
+      '<div class="hca-cp-row__val">' + ownerSrcPill(ownerA.source) + '</div>' +
+      '<div class="hca-cp-row__delta"></div>' +
+      '<div class="hca-cp-row__val">' + ownerSrcPill(ownerB.source) + '</div>' +
+    '</div>';
     if (ownerA.source === 'place_chas' || ownerA.source === 'county_chas' ||
         ownerB.source === 'place_chas' || ownerB.source === 'county_chas') {
-      var srcLabel = function (s) {
-        if (s === 'acs') return 'ACS DP04';
-        if (s === 'place_chas') return 'HUD CHAS (place-level, TIGER-apportioned)';
-        if (s === 'county_chas') return 'HUD CHAS (containing county)';
-        return 'unavailable';
-      };
       html += '<div class="hca-cp-owner-fallback-note" role="note" style="' +
         'margin:0 0 .5rem;padding:.4rem .6rem;border-left:3px solid var(--accent);' +
         'border-radius:0 4px 4px 0;background:color-mix(in oklab,var(--card) 80%,var(--accent) 20%);' +
         'font-size:.76rem;line-height:1.4;color:var(--text);">' +
         '<strong>% Owners Cost-Burdened source:</strong> ' +
-        'A=' + srcLabel(ownerA.source) + ' · B=' + srcLabel(ownerB.source) + '. ' +
+        'A=' + ownerSrcLabel(ownerA.source) + ' · B=' + ownerSrcLabel(ownerB.source) + '. ' +
         'CHAS fallback fires when ACS DP04 SMOCAPI bins are suppressed ' +
         '(common for CDPs and small places). CHAS measures ≥30% of income spent on housing costs ' +
-        'across all owner households — broadly comparable to ACS SMOCAPI but uses HUD\'s tabulation.' +
+        'across all owner households — broadly comparable to ACS SMOCAPI but uses HUD\'s tabulation. ' +
+        'Note: CHAS 2018–2022 is 3 years older than ACS 2019–2023; cross-side comparisons aren\'t ' +
+        'strictly apples-to-apples when one column is ACS and the other is CHAS.' +
       '</div>';
     }
 

--- a/market-analysis.html
+++ b/market-analysis.html
@@ -737,6 +737,39 @@
           </div>
         </div>
 
+        <!-- ── When to escalate beyond this screening tool ──────────────────
+             User-trust intervention from the methodology-gaps deep dive.
+             Public-data screening reaches diminishing returns at certain
+             deal sizes / risk levels — this card tells users WHERE that
+             boundary is so they don't mistake screening output for a
+             market study.
+        -->
+        <div class="pma-card" style="border:1px solid color-mix(in oklab,var(--border) 50%,var(--accent) 50%);">
+          <h2 style="display:flex;align-items:center;gap:8px;">
+            When to commission a professional market study
+            <small style="font-size:.65em;font-weight:400;color:var(--muted);background:var(--surface);padding:2px 8px;border-radius:4px">Beyond screening</small>
+          </h2>
+          <p style="font-size:.85rem;color:var(--text);margin:0 0 .6rem;line-height:1.5;">
+            This page is a <strong>screening tool</strong>. The public data it reads (ACS, HUD CHAS, LIHTC database, LEHD, FRED) is broad-coverage but lags 1-5 years and isn't structured for deal-level underwriting. At certain deal sizes, AMI depths, or competitive contexts, the screening reaches diminishing returns. The thresholds below are guidance, not policy.
+          </p>
+          <details style="font-size:.82rem;color:var(--text);line-height:1.55;">
+            <summary style="cursor:pointer;font-weight:600;color:var(--text);padding:.25rem 0;">Suggested escalation triggers →</summary>
+            <ul style="margin:.5rem 0 0 1.25rem;padding:0;">
+              <li><strong>Deal size ≥ 60 units:</strong> CHFA generally requires a third-party market study at the application stage. Don't wait until the application deadline to commission it.</li>
+              <li><strong>Deep affordability (&gt;50% of units below 50% AMI):</strong> Capture-rate sensitivity matters more — public-data ratios understate competitive pressure in tight income bands.</li>
+              <li><strong>Tight market (vacancy &lt; 3% AND existing LIHTC saturation in buffer):</strong> Absorption forecasting needs lease-up data from comparable nearby projects, not ACS snapshots.</li>
+              <li><strong>Rural / mountain markets:</strong> ACS small-sample noise + 2nd-home inventory distortion make public data unreliable. CoStar / Yardi don't cover these well either — a local broker or appraiser tour is usually the right next step.</li>
+              <li><strong>First-time developer in this submarket:</strong> Investor pricing premium without a third-party study can be 3-5¢/credit — easily worth the study cost on a deal over ~$1M annual credit.</li>
+            </ul>
+            <p style="margin:.65rem 0 0;color:var(--muted);">
+              <strong>Typical market-study providers in CO:</strong> Allen &amp; Associates, Capital Markets Group, Novogradac, RKG Associates. CHFA maintains an approved-vendor list. Expect $15K–$40K depending on submarket complexity and units.
+            </p>
+            <p style="margin:.65rem 0 0;color:var(--muted);">
+              <strong>Subscription data:</strong> CoStar MultifamilyTrack, Yardi Matrix, and RealPage MTM cover urban/suburban CO down to submarket level ($5K-$25K/year per market). Not useful for rural sites.
+            </p>
+          </details>
+        </div>
+
       </div><!-- /.pma-panel -->
     </div><!-- /.pma-layout -->
     </section><!-- /#maPmaTool -->


### PR DESCRIPTION
## Summary
Three small UX consistency fixes from the methodology-gaps deep-dive (#860 Tier A). Each is small but high-value for user trust.

### 1. Compare owner-burden vintage pill (`js/hna/hna-comparison.js`)
Renter-burden subsection has a per-side Place/County pill (shipped in #851). Owner-burden had a narrative disclosure note but no visual pill, AND the source labels lacked vintage stamps. Now:
- New **"Owner-burden source"** row mirroring the renter-burden Data Source row pattern (always renders, even for ACS-direct pairs).
- Pills include vintage: "ACS 2019–23" (green), "CHAS 2018–22 · Place" (amber), "CHAS 2018–22 · County" (amber).
- Disclosure note flags the vintage gap: "CHAS 2018-2022 is 3 years older than ACS 2019-2023; cross-side comparisons aren't strictly apples-to-apples."
- **Verified Fruita + Clifton**: both pills render "CHAS 2018–22 · Place" with hover-explained tooltips.

### 2. PMA escalation card (`market-analysis.html`)
New card at the bottom of the PMA right panel: **"When to commission a professional market study"**. Closes the user-trust gap by telling users WHERE the screening tool reaches diminishing returns.

Inside a `<details>` — 5 escalation triggers:
- Deal size ≥ 60 units (CHFA generally requires a third-party study)
- Deep affordability (>50% units below 50% AMI)
- Tight market + LIHTC saturation in buffer
- Rural / mountain markets (ACS small-sample + 2nd-home inventory)
- First-time developer in submarket (3-5¢/credit pricing premium)

Lists named CO providers (Allen & Associates, Capital Markets Group, Novogradac, RKG) + subscription data products (CoStar MultifamilyTrack, Yardi Matrix, RealPage MTM). Cost ranges quoted.

### 3. Deal Calc screening disclaimer adjacent to equity output (`js/deal-calculator.js`)
The "Screening tool only" note in the page intro is easy to miss once a user is staring at a 7-figure equity number. Added a warning note **inside** the LIHTC Credit Estimates fieldset, above the equity output rows. Calls out that real syndicator pricing varies ±3-8¢/credit.

**Verified live** for Denver site ($12.96M equity): disclaimer renders with amber border-left adjacent to the equity row.

## Test plan
- [x] `npm run validate` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:ci` — all suites pass
- [x] Browser spot-check: all 3 changes render correctly with real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)