### PR TITLE
docs(hna): explain CHAS chart's 4-tier limit, link to 7-band gap panel

### DIFF
--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -478,7 +478,9 @@
                panel; new provenance badge above is the preferred surface. -->
           <span id="chasApproxHint" class="data-approx-hint" hidden title="When a place or CDP is selected, CHAS tiers are scaled from the containing county — the selected geography may not have its own CHAS breakdown. See comparative-analysis detail panel for full disclaimer.">(county-approx)</span>
         </h2>
-        <p>Renter households by income tier (% of Area Median Income) showing not-burdened, moderately burdened (30–50% of income), and severely burdened (&gt;50%) households. Source: HUD Comprehensive Housing Affordability Strategy (CHAS).</p>
+        <p>Renter households by income tier (% of Area Median Income) showing not-burdened, moderately burdened (30–50% of income), and severely burdened (&gt;50%) households. Source: HUD Comprehensive Housing Affordability Strategy (CHAS).
+          <br><span style="font-size:var(--tiny);color:var(--muted)"><strong>Why only 4 tiers?</strong> HUD CHAS Table 9 publishes income at four bands only (≤30 / 31–50 / 51–80 / 81–100% AMI) — finer 10% increments aren't in the source dataset. For a 7-band breakdown of <em>unit shortfall</em> (households needing vs. units available at each tier), see the <a href="#hnaGapCoveragePanel" style="color:var(--accent)">Affordability Gap by AMI Tier</a> panel above, which derives household counts from ACS B19001 × HUD income limits.</span>
+        </p>
         <div class="chart-box" data-source="HUD CHAS 2018-2022" data-source-url="https://www.huduser.gov/portal/datasets/cp.html" data-vintage="CHAS 2018–2022" data-source-type="raw"><canvas id="chartChasGap" role="img" aria-label="Renter cost burden by AMI income tier chart (HUD CHAS)"></canvas></div>
         <p class="sr-only">Stacked bar chart showing renter households at each AMI income tier (≤30%, 31–50%, 51–80%, 81–100%) broken down by housing cost burden status.</p>
         <p id="chasGapStatus" style="margin-top:6px;color:var(--muted);font-size:.82rem">—</p>


### PR DESCRIPTION
## Summary

User asked whether the "Cost burden by AMI tier (HUD CHAS)" chart could also show 30/40/50/60/70/80/90/100 tiers — same granularity as the new Affordability Gap panel landed in PR #882.

**Answer: it can't, not honestly.** HUD CHAS Table 9 only publishes 4 income tiers natively (≤30, 31-50, 51-80, 81-100% AMI). Synthesizing finer 10% increments would require applying CHAS burden rates to ACS household counts uniformly within each parent band — but burden rates within CHAS's 51-80 band aren't actually uniform across the narrower 51-60 / 61-70 / 71-80 sub-tiers, so the precision would be fake.

Per user decision on this: stay with the 4 native CHAS tiers and add an inline explainer pointing readers to the 7-band view available in the Affordability Gap panel above (which uses ACS B19001 × HUD income limits — has the granularity but no burden split).

## Change

`housing-needs-assessment.html` — appended a "Why only 4 tiers?" line to the CHAS chart's description paragraph, with an anchor link (`#hnaGapCoveragePanel`) to the panel that does provide the 7-band breakdown.

No data or rendering logic touched. 1 file, +3/-1.

## Test plan

- [ ] Load housing-needs-assessment.html with any county selected
- [ ] Scroll to "Cost burden by AMI tier (HUD CHAS)" card
- [ ] Verify the "Why only 4 tiers?" line appears below the main description
- [ ] Click the "Affordability Gap by AMI Tier" link → page should scroll up to that panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)