### PR TITLE
fix(pma): wire OsmAmenities into runAnalysis result (Nearest grocery/healthcare/school/park)

### DIFF
--- a/js/market-analysis.js
+++ b/js/market-analysis.js
@@ -1552,6 +1552,32 @@
       }
     }
 
+    // Look up nearest-amenity distances for the PMA Site Summary card.
+    // OsmAmenities was previously loaded at page boot (3,301 lines down)
+    // but renderPmaSiteSummary read result.amenities — which was never
+    // attached. Fixed here: query each amenity type and store flat
+    // numeric distances so the existing renderer reads them directly.
+    var _siteAmenities = {};
+    if (window.OsmAmenities && typeof window.OsmAmenities.getAccessScore === 'function') {
+      var _access = window.OsmAmenities.getAccessScore(lat, lon);
+      if (_access) {
+        // getAccessScore returns { grocery: {distanceMiles, name, score}, ... }
+        // Flatten to numbers; the renderer's fmtMi() expects a finite number.
+        _siteAmenities = {
+          grocery:      _access.grocery     && _access.grocery.distanceMiles,
+          healthcare:   _access.healthcare  && _access.healthcare.distanceMiles,
+          schools:      _access.schools     && _access.schools.distanceMiles,
+          parks:        _access.parks       && _access.parks.distanceMiles,
+          transit:      _access.transit     && _access.transit.distanceMiles,
+          hospitals:    _access.hospitals   && _access.hospitals.distanceMiles,
+          childcare:    _access.childcare   && _access.childcare.distanceMiles,
+          // Keep the full metadata available for renderers that want
+          // the amenity name (e.g. "King Soopers @ 0.8 mi" tooltips).
+          _detail: _access
+        };
+      }
+    }
+
     lastResult = Object.assign({}, pma, {
       lat: lat, lon: lon, bufferMiles: effectiveBuffer,
       tractCount: bufTracts.length, acs: acs,
@@ -1559,6 +1585,7 @@
       prop123Count: prop123Count,
       confidence: confidence,
       dolaContext: dolaEnrichment,
+      amenities: _siteAmenities,
       _tractIds: bufTracts.map(function (t) { return t.geoid; })
     });
 


### PR DESCRIPTION
## Summary

User reported the PMA Site Summary card was showing **"—"** for Nearest grocery / healthcare / school / park on every site click. Audit:

- `data/derived/market-analysis/neighborhood_access.json` has **21,729 amenities** statewide (2,178 grocery, 2,877 healthcare, 2,551 schools, 3,263 parks, 7,879 transit stops)
- The `OsmAmenities` connector loads them at page boot ([market-analysis.js:3301](js/market-analysis.js:3301))
- But `runAnalysis()` built the `lastResult` object **without ever querying** `OsmAmenities.getAccessScore(lat, lon)`
- `renderPmaSiteSummary()` read `result.amenities`, fell through to `{}`, every card showed "—"

It was a wiring bug — five lines of glue code away from working.

## Fix

Between the PMA scoring block and the `lastResult` assignment, added an `OsmAmenities.getAccessScore()` call that produces a flat numeric `amenities` object the existing renderer already expects.

## Verification (Denver City Hall, 39.7392, -104.9903)

| Card | Was | Now |
|---|---|---|
| Nearest grocery | — | **0.25 mi** (Russell's Convenience) |
| Nearest healthcare | — | **0.19 mi** (Denver Behavioral Health Center) |
| Nearest school | — | **0.49 mi** (Compassion Road Academy) |
| Nearest park | — | **<0.1 mi** (Civic Center Park, 0.06 mi) |
| Nearest transit | — | **<0.1 mi** (Cherokee St & W 14th, 0.08 mi) |

Pure additive change. No data files touched. 27 lines added to one file.

## Test plan

- [ ] Load market-analysis.html, place a site marker, click Run Analysis
- [ ] Confirm the four "Nearest …" cards in the PMA Site Summary populate with distances
- [ ] Pick a rural site (e.g. somewhere in San Luis Valley) → confirm distances reflect sparser amenity coverage but still resolve
- [ ] Pick a site outside CO → cards may show large distances (data is CO-only); not a regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)