### PR TITLE
chore(handover): codex prep — cleanup + satellite + audits + QA script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,8 @@ _site/
 # (its own README admitted "It is not secured"); see SECURITY note in PR.
 # Keep local copies if you need them; host them somewhere authenticated instead.
 private/
+
+# IDE save-as / duplicate artifacts (macOS Finder + some editors create
+# "filename 2.ext" when re-saving). These have been polluting the tree.
+*\ 2.*
+*\ 2/

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,0 +1,185 @@
+# Codex Handover — May 2026 Session
+
+**Generated**: 2026-05-25 · **Last session merges**: PRs #881-#890
+
+This document is the entry point for a fresh reviewer (Codex or human) picking up the repository. It indexes the recent session's changes, points to audit documents for the two biggest analytical surfaces, and explains how to verify everything still works.
+
+---
+
+## TL;DR — what just landed
+
+Ten PRs merged in May 2026, organized as four threads:
+
+### Thread A — empty/broken Snapshot panels populated
+
+| PR | What |
+|---|---|
+| **#881** | Populate empty AMI Gap panel · fix BLS county lookup (was always showing "statewide median") · clarify Affordability calc (was rent-based with mortgage label) · refactor Action Plan checklist handler (one-item update vs full-state replay) · hyperlink all source labels |
+| **#888** | Wire OsmAmenities into PMA Site Summary (was always showing "—") |
+| **#889** | Roll up severe_cost_burden_rate / poverty_rate / unemployment_rate that aggregateAcs() was dropping; strengthen demand-score blend |
+
+### Thread B — AMI Gap panel rebuild (7-band view)
+
+| PR | What |
+|---|---|
+| **#882** | Expand AMI Gap from 3 → 7 bands (30/40/50/60/70/80/100) with high-contrast heatmap; show both cumulative AND per-tier views |
+| **#883** | Document HUD CHAS Cost Burden chart's 4-tier limit (can't synthesise 7 tiers); link to AMI Gap panel for finer view |
+| **#890** | LIHTC concept recommender — output AMI × bedroom matrix (replaces two flat distributions) with CHFA-preference skew |
+
+### Thread C — Methodology corrections
+
+| PR | What |
+|---|---|
+| **#884** | Owner Housing Cost Burden — ETL fix to populate SMOCAPI bins in cache · CHAS 3-bin fallback renderer (works today before next ETL run) |
+| **#885** | Housing Needs Scorecard v2 — percentile-normalised 4-component composite (replaces 45/30/25 thresholded blend) — includes owner cost burden, resort-aware, HUD-WCN-aligned |
+| **#887** | Target Vacancy fix — use ACS active-market subset (DP04_0004 + 0005) bounded 5-7% instead of inheriting observed total vacancy (which pinned 40 counties to the 12% cap) |
+
+### Thread D — Repo hygiene + tooling
+
+| PR | What |
+|---|---|
+| (this branch) | Repo cleanup — removed 4 IDE backup duplicates · added .gitignore rule · added Esri satellite tile layer · wrote audit docs · built QA/QC script |
+
+---
+
+## How to verify (TL;DR)
+
+```bash
+# Schema + unit tests (~5 seconds, no network)
+npm run test:qa-recent -- --only schema
+npm run test:qa-recent -- --only units
+
+# Full sweep including external URL liveness + headless browser smoke test
+npm run test:qa-recent
+```
+
+The script ([`test/qa-recent-changes.js`](test/qa-recent-changes.js)) covers all four QA categories the user requested:
+
+1. **Schema** — JSON file integrity (6 files: CHAS, ACS AMI gap, econ indicators, ACS tracts, LIHTC assumptions, OSM amenities)
+2. **Units** — pure-function tests for the LIHTC recommender (AMI matrix shape, row-sum invariant), Site Selection Score (6/6 vs 5/6 dimensions, opportunity-band thresholds), and HNA utils (rentBurden30Plus fallback chain)
+3. **URLs** — re-runs `scripts/audit/source-url-sweep.mjs` against the full data-source inventory (uses the allow-list updates from PR #881)
+4. **Smoke** — headless browser via Puppeteer (optional; install with `npm i --save-dev puppeteer` or skip with `--skip-puppeteer`): loads HNA page, selects Delta County, verifies rent burden + AMI gap + scorecard composite all populate
+
+The script outputs a colored pass/fail report and exits non-zero on any failure.
+
+---
+
+## Two methodology deep-dives
+
+Both audits document what's working, what's broken/stubbed, and a prioritised fix list:
+
+| Document | Covers |
+|---|---|
+| [`docs/audits/PMA-METHODOLOGY-AUDIT.md`](docs/audits/PMA-METHODOLOGY-AUDIT.md) | PMA scoring (both the 5-dimension PMA Score and the 6-dimension Site Selection Score), buffer-radius design choices, loaded-but-unused data, satellite tile layer, infrastructure feasibility stub |
+| [`docs/audits/DEAL-CALCULATOR-AUDIT.md`](docs/audits/DEAL-CALCULATOR-AUDIT.md) | LIHTC deal predictor — default assumptions vintage, geographic cost multipliers, capital stack model gaps (perm-debt sizing), confidence badge opacity, soft-funding gaps |
+
+Both audits surface fixes prioritised as 🔴 must-fix / 🟡 should-fix / 🟢 nice-to-have so a reviewer can triage quickly.
+
+---
+
+## Map of recent code touches
+
+```
+js/
+├── hna/
+│   ├── hna-renderers.js          ← Economic Indicators, BLS row, Affordability, AMI Gap, Scorecard v2,
+│   │                                Owner Cost Burden, Action Plan, Action Plan handler refactor
+│   ├── hna-controller.js         ← ACS AMI Gap load, Owner Cost Burden re-render, live-fetch trigger
+│   ├── hna-utils.js              ← rentBurden30Plus 3-tier fallback chain, AFFORD constants
+│   ├── hna-comparison.js         ← Owner burden source switch (CHAS owner_cb30 vs ACS SMOCAPI)
+│   └── housing-need-projector.js ← Recommended AMI Distribution — 7-band presets + heatmap colors
+├── lihtc-deal-predictor.js       ← AMI × bedroom matrix + CHFA-preference skew tables
+├── pma-ui-controller.js          ← Renders AMI × bedroom matrix table
+├── market-analysis.js            ← PMA scoring + aggregateAcs() new fields + satellite tile layer
+├── market-analysis/
+│   └── site-selection-score.js   ← 6-dimension Site Selection Score (no changes this session)
+└── data-source-inventory.js      ← bls-qcew → bls-laus rename
+scripts/
+└── hna/build_hna_data.py         ← SMOCAPI bin fetch (PR #884) + target-vacancy ACS active-market (PR #887)
+data/
+├── hna/chas_affordability_gap.json     ← 100% county coverage of pct_renter_cb30 + pct_owner_cb30
+├── co_ami_gap_by_county.json           ← ACS-derived 7-band gap (already existed, now wired)
+└── co-county-economic-indicators.json  ← BLS LAUS source (replaces deprecated QCEW)
+docs/audits/
+├── PMA-METHODOLOGY-AUDIT.md            ← NEW
+└── DEAL-CALCULATOR-AUDIT.md            ← NEW
+test/
+└── qa-recent-changes.js                ← NEW — QA/QC verification script
+```
+
+---
+
+## Known open issues (for Codex follow-up)
+
+Highest-priority follow-ups identified by the audits:
+
+### 🔴 Must-fix
+
+1. **Infrastructure Feasibility utility-capacity stub** ([pma-infrastructure.js:100](js/pma-infrastructure.js)). Every site currently scores 50% sewer/water headroom — `utility_capacity_co.geojson` exists as a map layer but `DataService.fetchUtilityCapacity()` was never connected. Either wire it or remove the section from the composite.
+2. **Capital stack perm-debt sizing** (deal predictor). "First Mortgage" appears as a line item but is computed as `totalCost - equity - softFunding` (the gap), not a DSCR-sized loan against projected NOI. Silently produces unfundable deals when the gap exceeds rent-supportable debt.
+3. **CHAS Table 9 ETL axis-misread** (scripts/fetch_chas.py). 25 of 64 rural CO counties currently produce "0 cost-burdened renters at ≤30% AMI" because the ETL reads CHAS Table 9 as burden-first when HUD documents it as income-first. The HNA renderer has a defensive ACS-derived fallback (PR #881), but the ETL fix is the real solution. Already spawned as a separate task.
+
+### 🟡 Should-fix
+
+4. Lower 4% deal min-units threshold from 100 → 75, or make it county-dependent
+5. Add OpEx-by-concept-type matrix (currently flat $8,500/unit statewide)
+6. Default PMA delineation to Hybrid instead of Buffer (Buffer is acknowledged as "screening only")
+7. Connect EPA Smart Location Database to Site Selection Access dimension (data loaded, not used)
+8. Surface concept-selection rationale with real signals instead of the "Family is the default" fallback string
+9. Soft funding by county — fill in remaining counties in `lihtc-assumptions.json`
+
+### 🟢 Nice-to-have
+
+10. Back-test scoring weights against CHFA awarded LIHTC projects
+11. Quarterly refresh process for `data/policy/lihtc-assumptions.json`
+12. Cap-rate-by-county model (currently no cap rate concept anywhere)
+13. Barriers-aware buffer mode (subtract `natural_barriers_co.geojson` polygons)
+
+---
+
+## Things deliberately NOT touched this session
+
+- Persona toggle in header (was removed by PR #814 before this session)
+- The Glossary, Insights, Explore, Scoping nav surfaces
+- The compliance dashboards (Prop 123, CHFA PMA Checklist)
+- The Colorado Deep Dive map (separate page from market-analysis)
+- The HNA Comparative Analysis page
+- Any data ETL beyond the build_hna_data.py SMOCAPI + target-vacancy fixes
+
+---
+
+## Honesty notes baked into the codebase
+
+The repo has unusually candid disclaimers — worth preserving:
+
+- **PMA buffer method**: explicitly labelled "screening only — NOT a professionally delineated PMA" in [market-analysis.html:154](market-analysis.html)
+- **Site Score feasibility**: doc-block at [site-selection-score.js:225](js/market-analysis/site-selection-score.js) says *"These scores are directional flags from public data. They do NOT replace Phase I ESA, geotechnical survey, or FEMA LOMA determination."*
+- **"Soil score"**: actually CDC EJI environmental burden, NOT geotechnical bearing capacity — disclosed in doc-block
+- **LIHTC predictor**: top-of-file disclaimer says *"does not constitute underwriting, legal, or investment advice"*
+- **HNA Scorecard v2**: inline `<details open>` disclosure exposes every formula + source citation
+- **Owner Cost Burden chart**: orange disclosure when fallback to CHAS 3-bin (vs ACS 5-bin), with explicit "will switch after next ETL refresh" note
+
+If you tighten any methodology, keep the proportionate disclosure intact.
+
+---
+
+## Branch + worktree state
+
+At handover:
+- `main` is at the merge commit for PR #890
+- Active worktree: `.claude/worktrees/magical-payne-a80fc5` still references `main` — safe to remove if not needed
+- All session branches squash-merged and auto-deleted
+
+Run `git branch -a` to see current state.
+
+---
+
+## Open questions for the next reviewer
+
+1. **Calibration**: are the scoring weights (PMA 30/25/15/15/15, Site Score 25/20/15/15/15/10, Scorecard v2 equal-quartered) calibrated against any historical outcomes? See audits for the back-test proposal.
+2. **Methodology versioning**: should the in-page disclosures include a methodology version number so users seeing different scores over time know what changed? Some panels already do (e.g. "v2 methodology" in Scorecard).
+3. **Refresh cadence**: `lihtc-assumptions.json` is on a quarterly target. Is that automated? Where does it get pulled from?
+
+---
+
+*Generated as part of the May 2026 session handover. For questions about specific changes, see the individual PR descriptions on GitHub — they were written verbosely so they could function as standalone references.*

--- a/docs/audits/DEAL-CALCULATOR-AUDIT.md
+++ b/docs/audits/DEAL-CALCULATOR-AUDIT.md
@@ -1,0 +1,225 @@
+# Deal Calculator + LIHTC Predictor Methodology Audit
+
+*Last updated 2026-05-25 · scope: lihtc-deal-predictor + deal-calculator.html + pro-forma.js + capital stack model*
+
+Written for the Codex handover. This audit covers how the deal calculator computes its capital stack, AMI mix, and recommendation, where the numbers come from, and what's stale/stubbed/wrong.
+
+---
+
+## 1. What the deal calculator does
+
+Three user-facing surfaces, three engines underneath:
+
+| Surface | Engine module | What it does |
+|---|---|---|
+| **deal-calculator.html** | [`js/deal-calculator.js`](../../js/deal-calculator.js) | Interactive proforma — user inputs unit count, AMI mix, costs → outputs equity, debt service, returns |
+| **PMA → Recommended Concept card** | [`js/lihtc-deal-predictor.js`](../../js/lihtc-deal-predictor.js) | Auto-recommends 9% vs 4%, concept type (family/seniors/etc), unit mix, AMI mix, indicative capital stack |
+| **HNA → Scenario Builder** | [`js/pro-forma.js`](../../js/pro-forma.js) | Multi-scenario pro-forma sensitivity (rent growth, vacancy, expense ratios) |
+
+The PMA recommender (`lihtc-deal-predictor.js`) is the most-used surface — it's the auto-recommendation users see when they click a site on the PMA map. This audit focuses there.
+
+---
+
+## 2. Default assumptions — where do they come from?
+
+The deal predictor loads assumptions from [`data/policy/lihtc-assumptions.json`](../../data/policy/lihtc-assumptions.json) (version "2026-Q1", lastUpdated 2026-03-20). Falls back to hardcoded defaults in [`lihtc-deal-predictor.js:86-103`](../../js/lihtc-deal-predictor.js) if the file fails to load.
+
+### Current default values (2026-Q1 vintage)
+
+| Assumption | Default | Hardcoded fallback | Source |
+|---|---|---|---|
+| 9% credit rate | 0.09 | same | IRC §42 |
+| 4% credit rate | 0.04 | same | IRC §42 |
+| 9% equity price | $0.87 | same | "CHFA syndication market, March 2026" |
+| 4% equity price | $0.85 | same | same |
+| Soft cost % | 22% of hard | 22% | Colorado construction cost survey Q4 2025 |
+| Dev fee % | 15% of dev cost | 15% | Industry standard |
+| Eligible basis % | 85% | 85% | Conservative LIHTC standard |
+| Hard cost / unit (family) | $275K | $350K | CO construction cost survey Q4 2025 |
+| Hard cost / unit (seniors) | $260K | $350K | same |
+| Hard cost / unit (mixed-use) | $310K | $350K | same |
+| Hard cost / unit (supportive) | $295K | $350K | same |
+| Default soft funding | $500K | same | None (round number) |
+| Operating expense / unit | $8,500/yr | not in JS | Industry standard |
+| Permanent debt rate | 6.5% | not in JS | Q1 2026 commercial debt |
+| Permanent debt amort | 35 yr | not in JS | Industry standard |
+| DSCR target | 1.2 | not in JS | Lender standard |
+
+### Geographic cost multipliers (from `_geoCostMultiplier`)
+
+Hardcoded in [`lihtc-deal-predictor.js:155-178`](../../js/lihtc-deal-predictor.js):
+- Range: ~0.65 (rural eastern plains) to ~1.55 (Pitkin / Aspen)
+- Front Range base = 1.0
+- Resort counties (Pitkin, Summit, Eagle, San Miguel, etc.) = 1.30-1.55
+- Mountain counties (Lake, Gunnison, etc.) = 1.10-1.25
+- Rural eastern plains = 0.65-0.85
+
+So effective family hard cost ranges roughly: $179K (Baca County) → $426K (Pitkin County).
+
+---
+
+## 3. What's working
+
+### 3.1 Externalized assumptions file
+
+`data/policy/lihtc-assumptions.json` is the right architecture — assumptions are configurable without code changes. CHFA syndication market shifts annually; the file lets a non-developer update equity pricing without a PR.
+
+### 3.2 Geographic cost calibration
+
+The county-level cost multipliers are reasonably calibrated. Resort/rural spread of ~2.4x matches what's seen in actual CO LIHTC awards.
+
+### 3.3 Concept-type differentiation
+
+`_selectConceptType()` picks family / seniors / mixed-use / supportive based on county demographics. Each concept has its own hard-cost basis + unit mix + AMI mix. The differentiation is meaningful (supportive housing is more expensive per unit than family).
+
+### 3.4 AMI × bedroom matrix (PR #890, just landed)
+
+The recommender now outputs a proper 2D matrix (AMI tier × bedroom count) instead of two flat marginals. CHFA-preference skew baked in (3-BR concentrated at deepest AMI, studios at higher AMI). Per-concept skew tables.
+
+### 3.5 IRC §42(d)(5)(B) basis boost handled correctly
+
+Single 40-point bonus for QCT OR DDA (not stacked 30+20=50). One election per project. Documented inline in [`scoreSubsidy`](../../js/market-analysis/site-selection-score.js).
+
+### 3.6 Honest disclaimers
+
+The doc-block in [`lihtc-deal-predictor.js:78-82`](../../js/lihtc-deal-predictor.js) explicitly says: *"…does not constitute underwriting, legal, or investment advice. Always engage a qualified LIHTC syndicator and attorney before proceeding."*
+
+---
+
+## 4. What's broken or stale
+
+### 4.1 🔴 Concept selection logic is opaque
+
+[`_selectConceptType(inputs, rationale, risks)`](../../js/lihtc-deal-predictor.js) defaults to 'family' if no clearer signal. The rationale that's exposed to users (*"Family housing is the default concept type for this market profile"*) is literally just the fallback string. For a site that genuinely could be either family or seniors, the recommendation is uninformative.
+
+**Fix:** Make the concept-selection criteria explicit (e.g., "Selected seniors because >25% of buffer population is 65+ AND median income <70% AMI"). The signals exist in the inputs; just need to be surfaced.
+
+### 4.2 🔴 4% deal min-units threshold (100 units) is hardcoded
+
+[`DEFAULT_ASSUMPTIONS.fourPctMinUnits: 100`](../../js/lihtc-deal-predictor.js#L101)
+
+The recommender pushes any deal ≥100 units toward 4% bond execution. But 4% deals are getting done at smaller scales in CO (75+ units regularly) when paired with state credits. The 100-unit threshold may unnecessarily steer smaller deals away from 4%.
+
+**Fix:** Either lower to 75 or make it a county-dependent threshold (resort markets can support smaller 4% deals because of higher rents; rural deals need more units for amortization economics).
+
+### 4.3 🟡 Soft funding lookup is incomplete
+
+`softFundingByGeography` in `lihtc-assumptions.json` covers some counties but not all 64. Missing counties fall back to `defaultSoftFunding: 500000` which is arbitrary.
+
+**Fix:** Populate the JSON with realistic annual soft-funding budgets for the remaining counties, OR pull from a live CHFA data source.
+
+### 4.4 🟡 Capital stack doesn't model perm debt sizing
+
+`_computeCapitalStack()` computes:
+- Total cost = hard + soft + dev fee
+- Equity = annualCredit × 10 × equityPrice
+- "First Mortgage" appears as a line but it's computed as `totalCost - equity - softFunding` (the gap), not as a DSCR-sized loan against actual rents.
+
+**Fix:** Properly size perm debt via DSCR using projected NOI (rent revenue × occupancy − operating expense × unit count), then check feasibility (does that loan close the gap?). Current method silently produces unfundable deals when the gap exceeds what the rents can support.
+
+### 4.5 🟡 Equity pricing is single-point
+
+Defaults to $0.87 for 9% deals across all counties + market conditions. Real syndication pricing varies by:
+- Project size (smaller deals price lower)
+- Deal complexity (mixed-finance, scattered-site = lower price)
+- Sponsor strength
+- Quarterly market conditions
+
+**Fix:** Either accept it as a screening simplification (and disclose) or build a range model (e.g., $0.80-$0.92 with sensitivity sliders).
+
+### 4.6 🟡 Operating expense per unit ($8,500) is statewide flat
+
+Real operating expenses scale by:
+- Project size (economies of scale at 80+ units)
+- Concept type (supportive housing has 2-3x the OpEx of family)
+- Resort/rural location (utilities, insurance, snow removal)
+- Age of building
+
+**Fix:** OpEx-by-concept-type matrix similar to hard-cost matrix.
+
+### 4.7 🟢 Hard cost vintage (Q4 2025) is acceptable but aging
+
+Hard costs were calibrated Q4 2025 (six months ago at audit time). CO construction costs are still inflating ~4-6% annually. The numbers will be ~2-3% stale by Q3 2026.
+
+**Fix:** Quarterly refresh of lihtc-assumptions.json from a published CO construction cost survey.
+
+### 4.8 🔴 No actual project-vs-recommendation feedback loop
+
+The recommender produces an output but there's no mechanism to track:
+- Was a recommendation accurate?
+- Did the recommended deal type actually get awarded?
+- Did the AMI mix match what got built?
+
+Without this loop, weights can't be calibrated.
+
+**Fix (longer-term):** Match recommendations against the CHFA LIHTC database (already loaded as `chfa-lihtc.json` / `hud_lihtc_co.geojson`). For each historical project, compute what the recommender WOULD have suggested and compare to what actually got built.
+
+---
+
+## 5. Specific issues from the user's recent observations
+
+### 5.1 "Why this fits" rationale was thin
+
+User screenshot showed:
+```
+Why This Fits
+- Larger scale (100 units) can support 4% bond-financed execution
+- Soft funding availability ($500K) supports 4% capital stack
+- Family housing is the default concept type for this market profile
+```
+
+The third bullet is the bare default. Improvement: surface actual demographic signals (age distribution, income, household size) that informed the family-vs-seniors call.
+
+### 5.2 AMI × unit-type cross-tab — fixed by PR #890
+
+User noted CHFA wants AMI spread across unit types. PR #890 (just landed) outputs the 2D matrix.
+
+### 5.3 "Low confidence" badge — what drives it?
+
+`_computeConfidence(inputs)` uses an arbitrary points system. A site with minimal user-input data scores "Low confidence." Users can't tell what they'd need to input to raise it.
+
+**Fix:** Surface "Missing inputs" alongside confidence — e.g., *"Low confidence — improves to Moderate if you specify proposed unit count + concept type."*
+
+---
+
+## 6. Recommendations (prioritized)
+
+### Must-fix before formal use
+
+1. **Properly size perm debt via DSCR** — current "first mortgage" is a plug number, not an underwriting figure
+2. **Surface concept-selection rationale** with real signals — eliminate the "default" string
+3. **Soft funding gaps** — fill in remaining counties OR show "N/A — not yet calibrated" instead of a fake $500K
+
+### Should-fix soon
+
+4. Lower 4% min-units to 75 or make it county-dependent
+5. OpEx-by-concept-type matrix
+6. Equity pricing range with sensitivity
+7. Confidence badge — surface what's missing
+
+### Nice-to-have
+
+8. Quarterly refresh process for `lihtc-assumptions.json`
+9. Project-vs-recommendation back-test against CHFA LIHTC database
+10. Cap-rate-by-county model (currently no cap rate concept at all)
+
+---
+
+## 7. Key file map
+
+| File | Role |
+|---|---|
+| [`js/lihtc-deal-predictor.js`](../../js/lihtc-deal-predictor.js) | Main recommender — concept type, execution, unit/AMI mix, capital stack |
+| [`js/deal-calculator.js`](../../js/deal-calculator.js) | Interactive pro-forma calculator (deal-calculator.html) |
+| [`js/pro-forma.js`](../../js/pro-forma.js) | Multi-scenario sensitivity (HNA Scenario Builder) |
+| [`data/policy/lihtc-assumptions.json`](../../data/policy/lihtc-assumptions.json) | External assumptions file (version 2026-Q1) |
+| [`test/lihtc-deal-predictor.test.js`](../../test/lihtc-deal-predictor.test.js) | Existing unit tests |
+
+---
+
+## 8. Recent session changes (referenced PRs)
+
+- **#890** — AMI × bedroom matrix replaces two flat distributions in concept recommender (fixed the user's "two flat lists" question)
+- **#885** — Housing Needs Scorecard v2 (peer-normalised, includes owner cost burden) — feeds the recommender's `inputs.affordabilityGap`
+
+Recommender outputs `suggestedMatrix` field as of PR #890. Backward-compat: `suggestedUnitMix` and `suggestedAMIMix` remain in the API.

--- a/docs/audits/PMA-METHODOLOGY-AUDIT.md
+++ b/docs/audits/PMA-METHODOLOGY-AUDIT.md
@@ -1,0 +1,171 @@
+# PMA Methodology Audit
+
+*Last updated 2026-05-25 · scope: market-analysis.html + Site Selection Score + PMA infrastructure scorecard*
+
+This audit documents what the Primary Market Area (PMA) tooling does, where it gets data, what's stubbed, what's broken, and what's recommended for follow-up work. Written for the Codex handover so a fresh reviewer can re-validate.
+
+---
+
+## 1. The two scores users see
+
+| Score | Source module | Weight model | Output |
+|---|---|---|---|
+| **PMA Score** (radar chart, 5 dimensions) | [`js/market-analysis.js` → `computePma()`](../../js/market-analysis.js) | 30/25/15/15/15 across demand/captureRisk/rentPressure/landSupply/workforce | Overall 0-100 + tier (Strong/Moderate/Marginal/Weak) |
+| **Site Selection Score** (6 dimensions) | [`js/market-analysis/site-selection-score.js`](../../js/market-analysis/site-selection-score.js) | 25/20/15/15/15/10 across demand/subsidy/feasibility/access/policy/market | Composite 0-100 + Opportunity Band (High/Moderate/Lower) |
+
+These two scores **measure different things**. The PMA Score is a market-demand/capture-risk lens (does an affordable project make sense in this market?). The Site Selection Score is a site-suitability lens (is this specific parcel a good choice?). They share some inputs (ACS demand, LIHTC saturation) but use them differently.
+
+---
+
+## 2. What's working
+
+### 2.1 PMA Score 5-dimension model (`computePma`)
+
+| Dimension | Weight | Inputs | Source |
+|---|---|---|---|
+| **Demand** | 30% | cost_burden_rate + renter_share + **(NEW 2026-05) severe_cost_burden_rate + poverty_rate** | ACS DP04 tract metrics |
+| **Capture Risk** | 25% | existing LIHTC units ÷ qualified renters | HUD LIHTC + ACS |
+| **Rent Pressure** | 15% | market median rent ÷ 60%-AMI affordable rent | ACS + HUD FMR |
+| **Land Supply / Market Tightness** | 15% | vacancy rate, Bridge MLS land cost (when available) | ACS vacancy + Bridge MLS |
+| **Workforce** | 15% | LEHD jobs density + service-employment share + workforce-tier rents | LEHD LODES + ACS |
+
+**Defensible:** Each dimension has explicit weight calibration in the doc-block and a null-propagation contract — when a data source is missing, its weight redistributes to other dimensions rather than injecting a fake 50 (see lines 619-640 of `market-analysis.js`).
+
+### 2.2 Site Selection 6-dimension model (`computeScore`)
+
+Documented in [SITE-SELECTION-SCORE.md](#) (mirror in site-selection-score.js doc-blocks). PR #889 strengthened the Demand sub-factor to include severe burden + poverty.
+
+The model honestly reports when fewer than 6 dimensions are available: output includes `dimensionsAvailable`, `dimensionsUnavailable`, `unavailableDimensions` so UI can show "scored on N of 6" rather than fake completeness.
+
+### 2.3 PMA Site Summary card (post PR #889)
+
+Now surfaces 7 facts under a buffer:
+- Boundary method
+- Census tracts
+- Housing units / Rental households
+- **Severe cost-burden, Poverty rate, Unemployment rate** (PR #889)
+- Nearest transit / grocery / healthcare / school / park (PR #888)
+
+This is the user-facing "what's in the buffer" snapshot.
+
+### 2.4 PMA delineation methods
+
+Three boundary methods available:
+1. **Buffer-based** ("legacy") — circle of N miles around site
+2. **Commuting-based** — LEHD LODES origin-destination polygon
+3. **Hybrid** ("recommended") — commuting polygon refined by school + transit district
+
+For LIHTC market studies the hybrid method is closest to NH&RA / Novogradac industry standards. Buffer is acknowledged as a screening simplification in [market-analysis.html:154](../../market-analysis.html#L154).
+
+### 2.5 Honesty disclosures already in place
+
+The codebase is unusually candid about its limits:
+- `scoreFeasibility` doc-block: *"These scores are directional flags from public data. They do NOT replace Phase I ESA, geotechnical survey, or FEMA LOMA determination."*
+- "Soil score" is actually CDC EJI environmental burden, NOT geotechnical — disclosed inline
+- Subsidy basis boost is unified (single 40-pt bonus) not stacked QCT + DDA — correct per IRC §42(d)(5)(B)
+
+---
+
+## 3. What's broken or stubbed
+
+### 3.1 🔴 Infrastructure Feasibility — utility capacity is stubbed
+
+[`pma-infrastructure.js:100-105`](../../js/pma-infrastructure.js#L100):
+```js
+return Promise.resolve({ sewerHeadroom: 0.5, waterCapacity: 0.5 });
+```
+
+Every site gets neutral 50% headroom for sewer + water because `DataService.fetchUtilityCapacity()` was never connected to the existing `utility_capacity_co.geojson` layer.
+
+**Impact:** Infrastructure feasibility composite is partially fabricated. Flood + climate parts are real; utility part is not.
+
+**Fix options:**
+1. Wire the geojson layer to a real `fetchUtilityCapacity()` method
+2. Remove the utility component from the composite if data isn't trustworthy
+3. Show "N/A — utility capacity data not available" instead of a number
+
+### 3.2 🟡 Buffer radius — design but not methodologically tight
+
+The buffer radius (5 mi default, user-adjustable) controls:
+- Which ACS tracts are aggregated (`tractsInBuffer`)
+- Which LIHTC projects count toward capture risk
+- Visual circle on the map
+
+But:
+- It does **not** modify the score itself proportionally — a 5-mile buffer and a 3-mile buffer at the same site will produce different scores via different ACS aggregates, but neither weights tracts by distance from the center
+- It does **not** account for barriers (rivers, highways) — a 5-mile buffer can cross a freeway no LIHTC tenant would walk across
+- It does **not** carve out by commute-shed automatically (that's the separate "commuting" PMA method)
+
+**Recommendation:** Either (a) document explicitly that buffer = simple radius and isn't a defensible PMA for market studies (currently this IS disclaimed at market-analysis.html:154), OR (b) move users to the Hybrid method by default and demote Buffer to "screening only" in the tab UI.
+
+### 3.3 🟡 Loaded-but-unused data
+
+Substantial data is loaded into the page but never read by the scoring engine:
+
+| File | What's in it | Could feed |
+|---|---|---|
+| `chas_tract_co.json` | Tract-level CHAS (renter+owner burden by AMI tier) | Site-level demand component, fine-grained AMI gap |
+| `cdle_job_postings_co.json` | Current job postings per county | Workforce dimension's job-trend signal |
+| `cdot_traffic_co.json` | CDOT traffic counts | Site quality / arterial access |
+| `epa_sld_co.json` | EPA Smart Location Database — walkability, transit access, density | Access dimension — replace OSM heuristics |
+| `food_access_co.json` | USDA food desert flags per tract | Access dimension food-quality signal |
+| `climate_hazards_co.json` | NOAA + EJI tract-level hazard scores | Feasibility climate component (partly used) |
+
+### 3.4 🟡 Score weights are not calibrated to outcomes
+
+The 6-dimension weights (25/20/15/15/15/10) and the 5-dimension PMA weights (30/25/15/15/15) are reasonable defaults but not back-tested against actual LIHTC project outcomes. There's no validation that weighting demand at 25% (vs 20% or 30%) produces better site recommendations.
+
+**Recommendation:** A historical back-test against awarded CHFA LIHTC projects (which got built, which struggled at lease-up) could validate or recalibrate the weights. Not a quick fix but worth flagging.
+
+### 3.5 🟢 Capture risk threshold (25%) is somewhat arbitrary
+
+`RISK.captureHigh = 0.25` — meaning "25% of qualified renters already in existing LIHTC = high capture risk." This is a reasonable rule-of-thumb but not from any specific industry standard. Some markets (resort, college towns) might appropriately have higher saturation.
+
+---
+
+## 4. Recommendations (prioritized)
+
+### Must-fix before formal use
+
+1. **Wire utility_capacity_co.geojson** to `pma-infrastructure.js → fetchUtilityCapacity()`, OR remove the utility component from the Infrastructure Feasibility scorecard. The current stub silently injects neutral data into a published score.
+
+### Should-fix soon
+
+2. **Default the PMA method tabs to Hybrid** instead of Buffer, since buffer-method analysis is explicitly disclaimed as "screening only." Keep buffer as an option but make hybrid the visible default.
+
+3. **Connect EPA SLD walkability** to the Access dimension (replaces OSM-distance heuristics with EPA's standard composite walkability/transit-access index). Data is loaded; just needs wiring.
+
+4. **Connect tract-level CHAS** (`chas_tract_co.json`) for finer site-level AMI targeting. Each tract has full CHAS renter+owner burden by AMI tier.
+
+### Nice-to-have
+
+5. Back-test the weight calibration against CHFA awarded projects.
+6. Add a "barriers-aware" buffer mode — circle minus natural-barrier polygons (rivers, freeways from `natural_barriers_co.geojson` already loaded).
+
+---
+
+## 5. Key file map
+
+| File | Role |
+|---|---|
+| [`js/market-analysis.js`](../../js/market-analysis.js) | Main PMA controller — runAnalysis, computePma, scoreDemand/CaptureRisk/RentPressure/MarketTightness/Workforce |
+| [`js/market-analysis/site-selection-score.js`](../../js/market-analysis/site-selection-score.js) | 6-dimension Site Selection Score model |
+| [`js/market-analysis/market-analysis-utils.js`](../../js/market-analysis/market-analysis-utils.js) | Helpers — `opportunityBand()` thresholds |
+| [`js/pma-infrastructure.js`](../../js/pma-infrastructure.js) | Infrastructure Feasibility composite (flood + climate + utility-STUB + food) |
+| [`js/pma-delineation.js`](../../js/pma-delineation.js) | PMA polygon rendering (buffer / commuting / hybrid) |
+| [`js/pma-commuting.js`](../../js/pma-commuting.js) | LEHD LODES commuting-shed polygon builder |
+| [`js/pma-schools.js`](../../js/pma-schools.js) | School-district-aligned PMA refinement |
+| [`js/data-connectors/osm-amenities.js`](../../js/data-connectors/osm-amenities.js) | OSM-loaded amenity lookup (used by Site Summary + Access score) |
+
+---
+
+## 6. Recent session changes (referenced PRs)
+
+- **#881** — populated empty Snapshot panels; fixed BLS county lookup; clarified Affordability math
+- **#882** — AMI Gap panel 7-band expansion + heatmap palette
+- **#885** — Housing Needs Scorecard v2 (percentile-normalised, includes owner cost burden, resort-aware)
+- **#887** — Target vacancy fix — ACS active-market subset, bounded 5-7%
+- **#888** — PMA amenity wiring (Nearest grocery/healthcare/school/park)
+- **#889** — PMA: severe burden + poverty + unemployment surfaced + strengthened demand score
+
+All merged before this audit was written.

--- a/js/market-analysis.js
+++ b/js/market-analysis.js
@@ -1863,11 +1863,30 @@
       mapEl.appendChild(loadDiv);
     }
 
-    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+    // Basemap layers — Carto Light (default, low visual noise) +
+    // Esri World Imagery (satellite, useful for screening site context
+    // visually — parcels, surrounding buildings, parking, vegetation).
+    // Esri's "World_Imagery" tile service is free for non-commercial use
+    // and doesn't require an API key. Attribution per Esri's TOS.
+    var cartoLight = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
       attribution: '© OpenStreetMap contributors © CARTO',
       subdomains: 'abcd',
       maxZoom: 19
-    }).addTo(map);
+    });
+    var esriSatellite = L.tileLayer(
+      'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+      {
+        attribution: 'Tiles © Esri — Source: Esri, Maxar, Earthstar Geographics, ' +
+          'and the GIS User Community',
+        maxZoom: 19
+      }
+    );
+    cartoLight.addTo(map);
+    L.control.layers(
+      { 'Street (Carto Light)': cartoLight, 'Satellite (Esri)': esriSatellite },
+      null,
+      { position: 'topright', collapsed: true }
+    ).addTo(map);
 
     map.on('click', function (e) {
       if (!dataLoaded) {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "test:lihtc-deal-predictor": "node test/lihtc-deal-predictor.test.js",
     "test:pma-transit": "node test/pma-transit.test.js",
     "test:soft-funding-tracker": "node test/soft-funding-tracker.test.js",
-    "test:hna-ranking-index": "node test/hna-ranking-index.test.js"
+    "test:hna-ranking-index": "node test/hna-ranking-index.test.js",
+    "test:qa-recent": "node test/qa-recent-changes.js"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",

--- a/test/qa-recent-changes.js
+++ b/test/qa-recent-changes.js
@@ -1,0 +1,496 @@
+/**
+ * test/qa-recent-changes.js
+ *
+ * QA/QC verification harness for the methodology + UI changes that
+ * landed in PRs #881 → #890 (May 2026 session). Designed for the Codex
+ * handover so a fresh reviewer can run a single command to validate
+ * that all the recent fixes still work end-to-end.
+ *
+ * Usage:
+ *   node test/qa-recent-changes.js                # full suite
+ *   node test/qa-recent-changes.js --skip-puppeteer  # data + unit only
+ *   node test/qa-recent-changes.js --only schema     # one category
+ *
+ * Categories:
+ *   schema      JSON file structural checks
+ *   units       Pure-function unit tests for scoring engines
+ *   urls        Source-URL liveness (re-uses scripts/audit/source-url-sweep.mjs)
+ *   smoke       Headless browser smoke test (requires puppeteer)
+ *
+ * Exit code: 0 = all pass · 1 = any failure
+ *
+ * Designed to be:
+ *   - Hermetic where possible (no network for schema + units)
+ *   - Single-process (no daemons / parallel workers)
+ *   - Honest about what it can't verify (e.g. live ACS API)
+ *
+ * Author: 2026-05-25 handover prep.
+ */
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+const args = process.argv.slice(2);
+const argHas = (flag) => args.indexOf(flag) >= 0;
+const argVal = (flag) => {
+  const i = args.indexOf(flag);
+  return i >= 0 ? args[i + 1] : null;
+};
+const ONLY        = argVal('--only');
+const SKIP_PUPPET = argHas('--skip-puppeteer');
+
+/* ── Test runner ──────────────────────────────────────────────────── */
+
+const results = { pass: 0, fail: 0, skip: 0, items: [] };
+
+function record(category, name, status, detail) {
+  results[status]++;
+  results.items.push({ category, name, status, detail: detail || '' });
+  const sym = status === 'pass' ? '✓' : status === 'fail' ? '✗' : '○';
+  const colorOpen  = status === 'pass' ? '\x1b[32m' : status === 'fail' ? '\x1b[31m' : '\x1b[33m';
+  const colorClose = '\x1b[0m';
+  console.log(`  ${colorOpen}${sym}${colorClose} [${category}] ${name}${detail ? '  — ' + detail : ''}`);
+}
+
+function section(title) {
+  console.log('\n\x1b[1m' + title + '\x1b[0m');
+}
+
+function shouldRun(category) {
+  return !ONLY || ONLY === category;
+}
+
+/* ── 1. Schema checks ─────────────────────────────────────────────── */
+
+function runSchemaChecks() {
+  if (!shouldRun('schema')) return;
+  section('Schema checks (JSON file integrity)');
+
+  const checks = [
+    {
+      name: 'CHAS affordability gap — 64 counties + summary fields',
+      file: 'data/hna/chas_affordability_gap.json',
+      check: (d) => {
+        if (!d.counties || Object.keys(d.counties).length !== 64) {
+          return 'expected 64 counties; got ' + (d.counties ? Object.keys(d.counties).length : 0);
+        }
+        for (const fips of Object.keys(d.counties)) {
+          const s = d.counties[fips].summary;
+          if (!s || s.pct_renter_cb30 == null || s.pct_owner_cb30 == null) {
+            return 'county ' + fips + ' missing pct_renter_cb30 / pct_owner_cb30';
+          }
+        }
+        return null;
+      }
+    },
+    {
+      name: 'ACS AMI Gap by county — 7-band data populated',
+      file: 'data/co_ami_gap_by_county.json',
+      check: (d) => {
+        if (!Array.isArray(d.counties)) return 'counties not an array';
+        const bands = d.bands || [];
+        const expected = [30, 40, 50, 60, 70, 80, 100];
+        if (JSON.stringify(bands) !== JSON.stringify(expected)) {
+          return 'bands ' + JSON.stringify(bands) + ' ≠ expected ' + JSON.stringify(expected);
+        }
+        const delta = d.counties.find(c => c.fips === '08029');
+        if (!delta || !delta.households_le_ami_pct || !delta.households_le_ami_pct['30']) {
+          return 'Delta County (08029) missing 7-band data';
+        }
+        return null;
+      }
+    },
+    {
+      name: 'Economic indicators — 64 counties + LAUS source',
+      file: 'data/co-county-economic-indicators.json',
+      check: (d) => {
+        const cnt = d.counties ? Object.keys(d.counties).length : 0;
+        if (cnt !== 64) return 'expected 64 counties; got ' + cnt;
+        if (!d.source || !/BLS LAUS/i.test(d.source)) {
+          return 'source field should mention BLS LAUS (PR #621 migration)';
+        }
+        const adams = d.counties['Adams'];
+        if (!adams || adams.unemployment_rate == null || adams.affordability_index == null) {
+          return 'Adams County missing unemployment_rate / affordability_index';
+        }
+        return null;
+      }
+    },
+    {
+      name: 'ACS tract metrics — severe_cost_burden + poverty + unemployment fields',
+      file: 'data/market/acs_tract_metrics_co.json',
+      check: (d) => {
+        const tracts = d.tracts || [];
+        if (!tracts.length) return 'no tracts in file';
+        const fields = ['severe_cost_burden_rate', 'poverty_rate', 'unemployment_rate'];
+        // At least 80% of tracts must have each field (some may be suppressed)
+        for (const f of fields) {
+          const have = tracts.filter(t => Number.isFinite(+t[f])).length;
+          if (have / tracts.length < 0.8) {
+            return f + ' populated for only ' + Math.round(have / tracts.length * 100) +
+              '% of tracts; expected ≥80%';
+          }
+        }
+        return null;
+      }
+    },
+    {
+      name: 'LIHTC assumptions — 2026-Q1 vintage + hard cost matrix',
+      file: 'data/policy/lihtc-assumptions.json',
+      check: (d) => {
+        if (!d.version || !/2026/.test(d.version)) {
+          return 'version ' + d.version + ' is stale (expected 2026-*)';
+        }
+        const hc = d.hardCostPerUnit || {};
+        if (!hc.family || !hc.seniors || !hc.mixedUse || !hc.supportive) {
+          return 'hardCostPerUnit missing one of family/seniors/mixedUse/supportive';
+        }
+        if (hc.family < 200000 || hc.family > 500000) {
+          return 'family hard cost $' + hc.family + ' outside plausible $200K-$500K range';
+        }
+        return null;
+      }
+    },
+    {
+      name: 'OSM amenities — ≥20K records covering all expected types',
+      file: 'data/derived/market-analysis/neighborhood_access.json',
+      check: (d) => {
+        const a = d.amenities || [];
+        if (a.length < 20000) return 'only ' + a.length + ' amenities; expected ≥20K';
+        const types = new Set(a.map(x => x.type));
+        for (const t of ['grocery', 'healthcare', 'school', 'park', 'transit_stop']) {
+          if (!types.has(t)) return 'missing amenity type: ' + t;
+        }
+        return null;
+      }
+    }
+  ];
+
+  for (const c of checks) {
+    const fp = path.join(ROOT, c.file);
+    if (!fs.existsSync(fp)) {
+      record('schema', c.name, 'fail', 'file missing: ' + c.file);
+      continue;
+    }
+    try {
+      const d = JSON.parse(fs.readFileSync(fp, 'utf8'));
+      const err = c.check(d);
+      if (err) record('schema', c.name, 'fail', err);
+      else record('schema', c.name, 'pass');
+    } catch (e) {
+      record('schema', c.name, 'fail', 'parse error: ' + e.message);
+    }
+  }
+}
+
+/* ── 2. Pure-function unit tests ──────────────────────────────────── */
+
+function runUnitTests() {
+  if (!shouldRun('units')) return;
+  section('Unit tests (scoring engines + AMI matrix)');
+
+  // 2a. AMI × bedroom matrix (PR #890)
+  try {
+    // lihtc-deal-predictor.js is a UMD module — `require()`'able directly.
+    delete require.cache[require.resolve(path.join(ROOT, 'js/lihtc-deal-predictor.js'))];
+    const LDP = require(path.join(ROOT, 'js/lihtc-deal-predictor.js'));
+    if (!LDP) throw new Error('LIHTCDealPredictor not exposed');
+
+    // Public entry point is predictConcept (see doc-block at top of module).
+    const out = LDP.predictConcept({
+      proposedUnits: 100,
+      countyFips: '08029',  // Delta
+      ami30UnitsNeeded: 1866,
+      ami50UnitsNeeded: 1371,
+      ami60UnitsNeeded: 627,
+      totalUndersupply: 5896,
+      isQct: false,
+      isDda: false
+    });
+
+    if (!out.suggestedMatrix) {
+      record('units', 'AMI matrix exposed on recommender output', 'fail', 'suggestedMatrix field missing');
+    } else if (!Array.isArray(out.suggestedMatrix.tiers) || out.suggestedMatrix.tiers.length !== 4) {
+      record('units', 'AMI matrix has 4 AMI-tier rows', 'fail',
+        'got ' + (out.suggestedMatrix.tiers || []).length + ' tiers');
+    } else {
+      record('units', 'AMI matrix has 4 AMI-tier rows', 'pass');
+      // Row sums match AMI marginals
+      const rowSums = out.suggestedMatrix.tiers.map(t => {
+        return ['studio', 'oneBR', 'twoBR', 'threeBR', 'fourBRPlus']
+          .reduce((s, k) => s + (t[k] || 0), 0);
+      });
+      const marginals = out.suggestedMatrix.tiers.map(t => t.total);
+      const allMatch = rowSums.every((s, i) => s === marginals[i]);
+      if (allMatch) {
+        record('units', 'AMI matrix row sums = AMI marginals', 'pass');
+      } else {
+        record('units', 'AMI matrix row sums = AMI marginals', 'fail',
+          'row sums ' + JSON.stringify(rowSums) + ' ≠ marginals ' + JSON.stringify(marginals));
+      }
+      // No bedroom counts are NaN
+      const hasNaN = out.suggestedMatrix.tiers.some(t =>
+        ['studio', 'oneBR', 'twoBR', 'threeBR'].some(k => !Number.isFinite(t[k]))
+      );
+      record('units', 'AMI matrix cells are finite integers',
+        hasNaN ? 'fail' : 'pass');
+    }
+  } catch (e) {
+    record('units', 'AMI matrix exposed on recommender output', 'fail',
+      'module-load error: ' + e.message);
+  }
+
+  // 2b. Site Selection Score weight redistribution
+  try {
+    const src = fs.readFileSync(
+      path.join(ROOT, 'js/market-analysis/site-selection-score.js'),
+      'utf8'
+    );
+    const window = {};
+    eval(src);
+    const SSS = window.SiteSelectionScore;
+    if (!SSS) throw new Error('SiteSelectionScore not exposed');
+
+    // Full inputs — should score on 6/6
+    const full = SSS.computeScore({
+      acs: { cost_burden_rate: 0.45, renter_share: 0.40, poverty_rate: 0.15, severe_burden_rate: 0.20 },
+      qctFlag: true, ddaFlag: false, fmrRatio: 1.05, nearbySubsidized: 50,
+      floodRisk: 0, soilScore: 80, cleanupFlag: false,
+      amenities: { grocery: 0.5, transit: 0.3, parks: 0.4, healthcare: 1.0, schools: 0.8 },
+      zoningCapacity: 100, publicOwnership: false, overlayCount: 2,
+      rentTrend: 0.04, jobTrend: 0.025, concentration: 0.4, serviceStrength: 0.25
+    });
+    if (full.dimensionsAvailable !== 6) {
+      record('units', 'Site Score full inputs → 6/6 dimensions', 'fail',
+        'got ' + full.dimensionsAvailable);
+    } else {
+      record('units', 'Site Score full inputs → 6/6 dimensions', 'pass');
+    }
+
+    // Missing ACS → 5/6 dimensions
+    const noAcs = SSS.computeScore({
+      acs: null,
+      qctFlag: true, ddaFlag: false, fmrRatio: 1.05, nearbySubsidized: 50,
+      floodRisk: 0, soilScore: 80, cleanupFlag: false,
+      amenities: { grocery: 0.5, transit: 0.3, parks: 0.4, healthcare: 1.0, schools: 0.8 },
+      zoningCapacity: 100, publicOwnership: false, overlayCount: 2,
+      rentTrend: 0.04, jobTrend: 0.025, concentration: 0.4, serviceStrength: 0.25
+    });
+    if (noAcs.dimensionsAvailable === 5 && noAcs.demand_score === null) {
+      record('units', 'Site Score null-ACS → demand=null + 5/6 dims', 'pass');
+    } else {
+      record('units', 'Site Score null-ACS → demand=null + 5/6 dims', 'fail',
+        'dimensionsAvailable=' + noAcs.dimensionsAvailable + ', demand=' + noAcs.demand_score);
+    }
+
+    // Opportunity band thresholds — at-boundary checks
+    const high = SSS.computeScore({
+      acs: { cost_burden_rate: 0.45, renter_share: 0.60, poverty_rate: 0.20, severe_burden_rate: 0.25 },
+      qctFlag: true, ddaFlag: true, basisBoostEligible: true,
+      fmrRatio: 1.20, nearbySubsidized: 0,
+      floodRisk: 0, soilScore: 100, cleanupFlag: false,
+      amenities: { grocery: 0.1, transit: 0.1, parks: 0.1, healthcare: 0.5, schools: 0.3 },
+      zoningCapacity: 200, publicOwnership: true, overlayCount: 4,
+      rentTrend: 0.06, jobTrend: 0.04, concentration: 0.2, serviceStrength: 0.35
+    });
+    if (high.final_score >= 70 && high.opportunity_band === 'High') {
+      record('units', 'Top-end inputs → High band (≥70)', 'pass',
+        'score=' + high.final_score);
+    } else {
+      record('units', 'Top-end inputs → High band (≥70)', 'fail',
+        'score=' + high.final_score + ' band=' + high.opportunity_band);
+    }
+  } catch (e) {
+    record('units', 'Site Selection Score module loads + scores', 'fail',
+      'module-load error: ' + e.message);
+  }
+
+  // 2c. rentBurden30Plus fallback chain (PR #881)
+  try {
+    // hna-utils.js references `location.search` at parse time — shim it
+    // before eval so we can lift the function into Node.
+    const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-utils.js'), 'utf8');
+    const window = {};
+    const location = { search: '' };
+    const document = { addEventListener: () => {} };
+    eval(src);
+    const U = window.HNAUtils;
+    if (!U || typeof U.rentBurden30Plus !== 'function') {
+      throw new Error('HNAUtils.rentBurden30Plus not exposed');
+    }
+    // Current codes — use approximate equality (IEEE-754 float arithmetic).
+    const cur = U.rentBurden30Plus({ DP04_0141PE: 25.3, DP04_0142PE: 22.1 });
+    record('units', 'rentBurden30Plus — current codes (DP04_0141 + 0142)',
+      Math.abs(cur - 47.4) < 1e-6 ? 'pass' : 'fail', 'got ' + cur);
+    // Legacy codes
+    const legacy = U.rentBurden30Plus({ DP04_0145PE: 15, DP04_0146PE: 20 });
+    record('units', 'rentBurden30Plus — legacy codes (DP04_0145 + 0146)',
+      legacy === 35 ? 'pass' : 'fail', 'got ' + legacy);
+    // Composite fallback
+    const comp = U.rentBurden30Plus({ DP04_0136PE: 33.3 });
+    record('units', 'rentBurden30Plus — composite fallback (DP04_0136)',
+      comp === 33.3 ? 'pass' : 'fail', 'got ' + comp);
+    // All missing → null
+    const none = U.rentBurden30Plus({});
+    record('units', 'rentBurden30Plus — no codes returns null',
+      none === null ? 'pass' : 'fail', 'got ' + none);
+  } catch (e) {
+    record('units', 'rentBurden30Plus fallback chain', 'fail', e.message);
+  }
+}
+
+/* ── 3. Source-URL liveness ──────────────────────────────────────── */
+
+function runUrlChecks() {
+  if (!shouldRun('urls')) return;
+  section('Source URL sweep (full inventory)');
+
+  const { spawnSync } = require('child_process');
+  const sweepScript = path.join(ROOT, 'scripts/audit/source-url-sweep.mjs');
+  if (!fs.existsSync(sweepScript)) {
+    record('urls', 'source-url-sweep.mjs available', 'fail', 'script missing');
+    return;
+  }
+
+  console.log('  (running source-url-sweep.mjs — this hits external URLs, may take 30-60s)');
+  const out = spawnSync('node', [sweepScript, '--quiet'], { encoding: 'utf8', cwd: ROOT });
+  const stdoutTail = (out.stdout || '').split('\n').slice(-3).join(' ');
+  if (out.status === 0) {
+    record('urls', 'source-url-sweep — all green or allow-listed', 'pass', stdoutTail);
+  } else {
+    record('urls', 'source-url-sweep — has hard failures', 'fail', stdoutTail);
+  }
+}
+
+/* ── 4. Headless smoke test ──────────────────────────────────────── */
+
+async function runSmokeTest() {
+  if (!shouldRun('smoke') || SKIP_PUPPET) return;
+  section('Smoke test (headless browser)');
+
+  let puppeteer;
+  try {
+    puppeteer = require('puppeteer');
+  } catch (_) {
+    record('smoke', 'puppeteer available', 'skip',
+      'puppeteer not installed (npm install --save-dev puppeteer to enable)');
+    return;
+  }
+
+  // Boot a local http-server pointing at repo root
+  const { spawn } = require('child_process');
+  const server = spawn('npx', ['http-server', ROOT, '-p', '9876', '-c-1', '-s'], {
+    stdio: ['ignore', 'pipe', 'pipe'], detached: false
+  });
+  // Wait for "Available on" line
+  await new Promise((resolve) => {
+    let buf = '';
+    server.stdout.on('data', (chunk) => {
+      buf += chunk.toString();
+      if (/Available on|Hit CTRL-C/i.test(buf)) resolve();
+    });
+    setTimeout(resolve, 5000);
+  });
+
+  const browser = await puppeteer.launch({ headless: 'new' });
+  try {
+    const page = await browser.newPage();
+    const baseUrl = 'http://localhost:9876';
+
+    // HNA page — select Delta County and verify several fixes
+    await page.goto(baseUrl + '/housing-needs-assessment.html', { waitUntil: 'networkidle2' });
+    await page.evaluate(async () => {
+      const t = document.getElementById('geoType');
+      t.value = 'county'; t.dispatchEvent(new Event('change', { bubbles: true }));
+      await new Promise(r => setTimeout(r, 2500));
+      const g = document.getElementById('geoSelect');
+      g.value = '08029'; g.dispatchEvent(new Event('change', { bubbles: true }));
+      await new Promise(r => setTimeout(r, 8000));
+    });
+
+    const hna = await page.evaluate(() => ({
+      rentBurden:    document.getElementById('statRentBurden')?.textContent,
+      gap30:         document.getElementById('statGap30')?.textContent,
+      gap100:        document.getElementById('statGap100')?.textContent,
+      scorecardComp: document.querySelector('#hnaScorecardPanel .composite-value, ' +
+                                            '#hnaScorecardPanel [style*="font-size:1.9rem"]')?.textContent,
+      blsHeader:     document.getElementById('blsLabourMarketCards')?.textContent?.split('\n')[0]
+    }));
+
+    record('smoke', 'HNA Delta — rent burden populated (not "—")',
+      hna.rentBurden && hna.rentBurden !== '—' ? 'pass' : 'fail',
+      'got: ' + hna.rentBurden);
+
+    record('smoke', 'HNA Delta — AMI Gap ≤30% populated',
+      hna.gap30 && hna.gap30 !== '—' ? 'pass' : 'fail',
+      'got: ' + hna.gap30);
+
+    record('smoke', 'HNA Delta — AMI Gap ≤100% populated (7-band view)',
+      hna.gap100 && hna.gap100 !== '—' ? 'pass' : 'fail',
+      'got: ' + hna.gap100);
+
+    record('smoke', 'HNA Delta — Scorecard v2 composite renders',
+      hna.scorecardComp && /^\d+/.test(hna.scorecardComp) ? 'pass' : 'fail',
+      'got: ' + hna.scorecardComp);
+
+    record('smoke', 'HNA Delta — BLS header reads "Delta County" (not statewide)',
+      /Delta/i.test(hna.blsHeader || '') ? 'pass' : 'fail',
+      'header: ' + hna.blsHeader);
+
+    // PMA page — load + verify amenity panel exists
+    await page.goto(baseUrl + '/market-analysis.html', { waitUntil: 'networkidle2' });
+    await new Promise(r => setTimeout(r, 3000));
+    const pma = await page.evaluate(() => ({
+      hasOsmAmenities: !!window.OsmAmenities,
+      amenityCount: window.OsmAmenities && window.OsmAmenities.getAll
+        ? window.OsmAmenities.getAll().length : 0,
+      satelliteToggle: !!document.querySelector('.leaflet-control-layers')
+    }));
+
+    record('smoke', 'PMA — OsmAmenities loaded ≥20K records',
+      pma.amenityCount >= 20000 ? 'pass' : 'fail',
+      'got ' + pma.amenityCount);
+
+    record('smoke', 'PMA — Satellite tile-layer toggle present',
+      pma.satelliteToggle ? 'pass' : 'fail');
+
+  } finally {
+    await browser.close();
+    server.kill();
+  }
+}
+
+/* ── Run ──────────────────────────────────────────────────────────── */
+
+(async function main() {
+  console.log('\x1b[1mQA/QC verification — recent changes (PRs #881-#890)\x1b[0m');
+  console.log('Repo: ' + ROOT);
+  if (ONLY) console.log('Category filter: ' + ONLY);
+  if (SKIP_PUPPET) console.log('--skip-puppeteer flag set');
+
+  runSchemaChecks();
+  runUnitTests();
+  runUrlChecks();
+  await runSmokeTest();
+
+  console.log('\n\x1b[1mSummary\x1b[0m');
+  console.log(`  passed: ${results.pass}`);
+  console.log(`  failed: ${results.fail}`);
+  console.log(`  skipped: ${results.skip}`);
+  if (results.fail > 0) {
+    console.log('\n\x1b[31mFAILED:\x1b[0m');
+    results.items.filter(i => i.status === 'fail').forEach((i) => {
+      console.log(`  [${i.category}] ${i.name}  — ${i.detail}`);
+    });
+    process.exit(1);
+  }
+  console.log('\n\x1b[32mAll checks passed.\x1b[0m');
+  process.exit(0);
+})().catch((err) => {
+  console.error('\x1b[31mRunner error:\x1b[0m', err);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

End-of-session handover prep covering four user-requested asks for the Codex review:

1. **Repo cleanup** — removed 4 IDE backup files (` 2.` duplicates accumulated from macOS Finder), added `.gitignore` rule preventing recurrence
2. **Satellite tile layer** — Esri World Imagery toggleable basemap added to PMA map
3. **Methodology audit documents** — PMA + Deal Calculator deep dives, prioritised fix lists
4. **QA/QC verification script** — `npm run test:qa-recent` covering schema, units, URLs, smoke

## Files

- `HANDOVER.md` — entry point for fresh reviewer; indexes all 10 May 2026 PRs (#881-#890), points to audits + script, lists open issues
- `docs/audits/PMA-METHODOLOGY-AUDIT.md` — 5-dimension PMA + 6-dimension Site Selection Score audit
- `docs/audits/DEAL-CALCULATOR-AUDIT.md` — LIHTC deal predictor audit (defaults vintage, geographic costs, capital stack gaps)
- `test/qa-recent-changes.js` — QA/QC harness
- `package.json` — `test:qa-recent` npm script
- `js/market-analysis.js` — Esri satellite tile layer + Leaflet layer-control widget
- `.gitignore` — IDE backup pattern (`* 2.*`)

## QA/QC script categories

| Category | What it checks |
|---|---|
| `--only schema` | 6 JSON files structural integrity (CHAS, ACS AMI gap, econ indicators, ACS tracts, LIHTC assumptions, OSM amenities) |
| `--only units` | LIHTC recommender (AMI matrix shape, row-sum invariant), Site Selection Score (6/6 vs 5/6 dims, band thresholds), HNA utils (rentBurden30Plus fallback) |
| `--only urls` | Re-runs source-url-sweep against full inventory |
| `--only smoke` | Puppeteer headless smoke test (optional; install `puppeteer` to enable) |

## Verified

```
$ npm run test:qa-recent -- --only schema
  ✓ CHAS affordability gap — 64 counties + summary fields
  ✓ ACS AMI Gap by county — 7-band data populated
  ✓ Economic indicators — 64 counties + LAUS source
  ✓ ACS tract metrics — severe_cost_burden + poverty + unemployment fields
  ✓ LIHTC assumptions — 2026-Q1 vintage + hard cost matrix
  ✓ OSM amenities — ≥20K records covering all expected types
  passed: 6  failed: 0

$ npm run test:qa-recent -- --only units
  ✓ AMI matrix has 4 AMI-tier rows
  ✓ AMI matrix row sums = AMI marginals
  ✓ AMI matrix cells are finite integers
  ✓ Site Score full inputs → 6/6 dimensions
  ✓ Site Score null-ACS → demand=null + 5/6 dims
  ✓ Top-end inputs → High band (≥70)  — score=96
  ✓ rentBurden30Plus — current codes (DP04_0141 + 0142)
  ✓ rentBurden30Plus — legacy codes (DP04_0145 + 0146)
  ✓ rentBurden30Plus — composite fallback (DP04_0136)
  ✓ rentBurden30Plus — no codes returns null
  passed: 10  failed: 0
```

## Audits surface 🔴 priorities

**Must-fix (from both audits combined):**
1. Infrastructure Feasibility utility-capacity stub (pma-infrastructure.js:100) — every site gets neutral 50% headroom; data layer exists but never wired
2. Capital stack perm-debt sizing — "First Mortgage" is a plug number, not DSCR-sized
3. CHAS Table 9 ETL axis-misread — 25 rural counties produce "0 cost-burdened at ≤30% AMI"; defensive fallback exists, real ETL fix pending

See `HANDOVER.md` for full prioritised lists.

## Test plan

- [ ] `npm run test:qa-recent -- --only schema` → 6/6 green
- [ ] `npm run test:qa-recent -- --only units` → 10/10 green
- [ ] Optional: `npm i --save-dev puppeteer && npm run test:qa-recent` → full smoke test
- [ ] Load `market-analysis.html` → confirm Layers control widget shows "Street (Carto Light)" + "Satellite (Esri)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)