### PR TITLE
feat(lihtc): Opportunity Finder — rank CO jurisdictions for 4% bond + 9% competitive LIHTC

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -77,6 +77,18 @@ The general QA script ([`test/qa-recent-changes.js`](test/qa-recent-changes.js))
 
 The Opportunity Finder verification script ([`scripts/audit/verify-opportunity-finder.mjs`](scripts/audit/verify-opportunity-finder.mjs)) is a **standalone Node re-implementation** of the JS module's rollup math — if the production code regresses, this catches it independently. 28 checks, all expected to pass. Exit code 0 = green, 1 = regression, 2 = internal error.
 
+### Opportunity Finder analysis docs
+
+For a fresh reviewer or Codex starting from scratch on the LIHTC Opportunity Finder:
+
+| Doc | Purpose |
+|---|---|
+| [`docs/methodology/LIHTC-LOCATOR-METHODOLOGY.md`](docs/methodology/LIHTC-LOCATOR-METHODOLOGY.md) | Canonical methodology (~5,000 words). Universe definition, 5 scoring dimensions with formulas, weight tables per deal type, confidence framework, decision flow, output bands, limitations, sources. v1.1. |
+| [`docs/audits/CODEX-HANDOFF-OPPORTUNITY-FINDER.md`](docs/audits/CODEX-HANDOFF-OPPORTUNITY-FINDER.md) | Codex entry-point for analyzing the Opportunity Finder. 9 structured analyses (universe, per-dimension scoring, composite, filtering, civic joins, HNA deep-links, verification harness, drift, honest-gap confirmations). |
+| [`docs/audits/REPO-AUDIT-2026-05-25.md`](docs/audits/REPO-AUDIT-2026-05-25.md) | Full repo audit with jurisdiction-level direction lock + P0–P2 roadmap + Appendix A (background work). |
+
+The methodology section is also embedded in the live `lihtc-opportunity-finder.html` page (always visible, not collapsed) so end-users see how the locator works without hunting for docs.
+
 ---
 
 ## Two methodology deep-dives

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -38,7 +38,13 @@ Ten PRs merged in May 2026, organized as four threads:
 
 | PR | What |
 |---|---|
-| (this branch) | Repo cleanup — removed 4 IDE backup duplicates · added .gitignore rule · added Esri satellite tile layer · wrote audit docs · built QA/QC script |
+| #893 | Repo cleanup — removed 4 IDE backup duplicates · added .gitignore rule · added Esri satellite tile layer · wrote audit docs · built QA/QC script |
+
+### Thread E — LIHTC Opportunity Finder (NEW page, PR #894)
+
+| PR | What |
+|---|---|
+| **#894** | New `lihtc-opportunity-finder.html` ranks every CO jurisdiction with QCT and/or DDA for 4% bond + 9% competitive LIHTC targeting · re-weights live by target round · deep-links every jurisdiction to its Housing Needs Assessment · surfaces civic capacity (Prop 123, comp plan, HNA, housing lead, HA, advocacy) · per-jurisdiction housing-news search linkouts |
 
 ---
 
@@ -51,16 +57,25 @@ npm run test:qa-recent -- --only units
 
 # Full sweep including external URL liveness + headless browser smoke test
 npm run test:qa-recent
+
+# LIHTC Opportunity Finder — dedicated verification (~3 seconds, no network)
+# Independently re-implements the rollup math in Node and asserts:
+#   data file counts · 158 opportunities · 6 with QCT+DDA · weight invariants ·
+#   score range invariants · place→county containment · civic-join coverage ·
+#   known-case spot checks (Sugar City, Cortez, Crowley, Montezuma, etc.)
+node scripts/audit/verify-opportunity-finder.mjs
+node scripts/audit/verify-opportunity-finder.mjs --verbose
+node scripts/audit/verify-opportunity-finder.mjs --json   # machine-readable
 ```
 
-The script ([`test/qa-recent-changes.js`](test/qa-recent-changes.js)) covers all four QA categories the user requested:
+The general QA script ([`test/qa-recent-changes.js`](test/qa-recent-changes.js)) covers all four categories:
 
 1. **Schema** — JSON file integrity (6 files: CHAS, ACS AMI gap, econ indicators, ACS tracts, LIHTC assumptions, OSM amenities)
 2. **Units** — pure-function tests for the LIHTC recommender (AMI matrix shape, row-sum invariant), Site Selection Score (6/6 vs 5/6 dimensions, opportunity-band thresholds), and HNA utils (rentBurden30Plus fallback chain)
 3. **URLs** — re-runs `scripts/audit/source-url-sweep.mjs` against the full data-source inventory (uses the allow-list updates from PR #881)
 4. **Smoke** — headless browser via Puppeteer (optional; install with `npm i --save-dev puppeteer` or skip with `--skip-puppeteer`): loads HNA page, selects Delta County, verifies rent burden + AMI gap + scorecard composite all populate
 
-The script outputs a colored pass/fail report and exits non-zero on any failure.
+The Opportunity Finder verification script ([`scripts/audit/verify-opportunity-finder.mjs`](scripts/audit/verify-opportunity-finder.mjs)) is a **standalone Node re-implementation** of the JS module's rollup math — if the production code regresses, this catches it independently. 28 checks, all expected to pass. Exit code 0 = green, 1 = regression, 2 = internal error.
 
 ---
 

--- a/css/navigation.css
+++ b/css/navigation.css
@@ -207,6 +207,21 @@ main {
   width: 100%;
 }
 
+/* "NEW" badge for recently-added nav items */
+.nav-link-new {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 7px;
+  font-size: .62rem;
+  font-weight: 800;
+  letter-spacing: .04em;
+  border-radius: 9999px;
+  background: var(--accent);
+  color: var(--card);
+  vertical-align: middle;
+  line-height: 1.6;
+}
+
 .nav-caret {
   font-size: .7em;
   transition: transform .2s;

--- a/css/pages/home.css
+++ b/css/pages/home.css
@@ -272,6 +272,31 @@
   text-decoration: underline;
 }
 
+/* Featured workflow step — visually elevated (e.g., the new Opportunity Finder) */
+.home-step--featured {
+  background: color-mix(in oklab, var(--accent) 6%, var(--card) 94%);
+  border-radius: 12px;
+  padding-inline: var(--sp3);
+  border-left: 4px solid var(--accent);
+  border-bottom: 1px solid var(--border);
+}
+.home-step--featured .home-step__body h3 {
+  color: var(--accent);
+}
+
+.home-step__badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 8px;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  border-radius: 9999px;
+  background: var(--accent);
+  color: var(--card);
+  vertical-align: middle;
+}
+
 
 /* ----------------------------------------------------------------
    LIHTC explainer — plain-language educational section

--- a/docs/audits/CODEX-HANDOFF-OPPORTUNITY-FINDER.md
+++ b/docs/audits/CODEX-HANDOFF-OPPORTUNITY-FINDER.md
@@ -1,0 +1,258 @@
+# Codex Handoff — LIHTC Opportunity Finder Analysis
+
+**Date**: 2026-05-25 · **For**: Codex (or fresh human reviewer) · **PR**: #894 · **Branch**: `feat/lihtc-opportunity-finder`
+
+This is the entry-point document for analyzing the LIHTC Opportunity Finder — the jurisdiction-level deal-targeting cockpit that's the strategic spine of the COHO Analytics product. Read this first. It points you at the methodology, the implementation, the verification harness, and the open work.
+
+---
+
+## TL;DR
+
+The user wants to know "where in Colorado should a developer spend scarce time looking for the next LIHTC deal?" The Opportunity Finder is the answer. **This PR ships ~70% of the target product.** It ranks 158 jurisdictions with QCT/DDA designation across 4 score dimensions and re-weights live by 9% / 4% / Any target round. The remaining 30% (5th dimension Civic Readiness in composite, 5 deal types vs 3, ScoreResult shape contract, cross-page funnel, confidence pills) is documented as Sprint 1 work in the repo audit.
+
+**Strategic direction**: jurisdiction-level (not tract-level, not site-level). Tract polygon geometry and parcel data are explicitly out of scope for this product; see Appendix A of `docs/audits/REPO-AUDIT-2026-05-25.md`.
+
+---
+
+## What to read, in order
+
+1. **[`docs/methodology/LIHTC-LOCATOR-METHODOLOGY.md`](../methodology/LIHTC-LOCATOR-METHODOLOGY.md)** — the canonical methodology. Every dimension, every weight, every confidence handling rule, every limitation. Read this first; it's the contract.
+2. **[`lihtc-opportunity-finder.html`](../../lihtc-opportunity-finder.html)** — the UI. The methodology section (always visible, near bottom of page) embeds an abridged version of the methodology doc.
+3. **[`js/lihtc-opportunity-finder.js`](../../js/lihtc-opportunity-finder.js)** — the implementation (~778 lines). Inspect against the methodology doc.
+4. **[`scripts/audit/verify-opportunity-finder.mjs`](../../scripts/audit/verify-opportunity-finder.mjs)** — independent re-implementation of the math in pure Node. 28 checks. Run with `npm run audit:opportunity-finder`.
+5. **[`docs/audits/REPO-AUDIT-2026-05-25.md`](REPO-AUDIT-2026-05-25.md)** — full repo audit with P0/P1/P2 list reflecting jurisdiction-level direction.
+
+---
+
+## Verification analysis to perform
+
+Your job is to determine whether the implementation faithfully reflects the methodology, surface any drift, and propose specific fixes. Below is a structured analysis checklist organized by methodology section.
+
+### Analysis 1 — Universe definition
+
+**Methodology says** (LIHTC-LOCATOR-METHODOLOGY §2):
+- Base universe: 482 CO places (273 incorporated + 210 CDPs) from TIGER 2024
+- 9% / 4%-with-basis-boost filter: ≥1 QCT tract OR DDA county → 158 jurisdictions
+- Preservation / workforce-resort / prop123-local filters: documented but not yet shipped
+
+**Verification questions**:
+- [ ] Does `js/lihtc-opportunity-finder.js` actually iterate over all 482 places in `place-tract-membership.json`, or does it short-circuit somewhere?
+- [ ] Is the QCT membership threshold logic (`share_of_place_area > 0.05 OR share_of_tract_area > 0.20`) correct per the methodology, and is it applied uniformly?
+- [ ] DDA county-FIPS set: does it correctly identify all 10 CO nonmetro counties as having DDA designation, and does every place in those counties inherit it?
+- [ ] What happens to jurisdictions with QCT but no DDA, or DDA but no QCT? Are they included in the universe (they should be — basis-boost is OR-logic, not AND-logic)?
+- [ ] Run `node scripts/audit/verify-opportunity-finder.mjs` — does the universe-count check pass? (158 expected total, 6 with both, 92 QCT-only, 60 DDA-only)
+
+### Analysis 2 — Per-dimension scoring
+
+For each of the 4 dimensions currently implemented (Recency, Need, Basis, Population), verify the formula matches the methodology doc:
+
+#### Dimension 1 — Need Score
+**Methodology** (§3 Dimension 1):
+```
+blended_cb30 = (renter_pct_cb30 × renter_HHs + owner_pct_cb30 × owner_HHs)
+             ÷ (renter_HHs + owner_HHs)
+severe_rent_burden = renter_pct_cb50
+need_composite = (blended_cb30 × 0.7) + (severe_rent_burden × 0.3)
+need_score = percentile_rank(need_composite, CO peer distribution) × 100
+```
+
+**Verification questions**:
+- [ ] Find `buildNeedDistribution()` and `needCompositeFor()` in the JS. Do they match this formula?
+- [ ] Specifically check: is the blended formula using the 0.7 / 0.3 mix? Where is the 0.3 weight applied (it's `pct_renter_cb50` × 0.3 + blended × 0.7)?
+- [ ] Verify the percentile rank uses CO peer distribution (not national) — check `needScoreFor()` against `needDist` sorted array
+- [ ] Edge case: tiny jurisdictions (<200 HHs) — does the formula return a `dataThin: true` flag or silently degrade?
+- [ ] Edge case: county CHAS suppression — is there a fallback to ACS DP04 direct? Where?
+
+#### Dimension 2 — Recency Score
+**Methodology** (§3 Dimension 2):
+```
+last_yr_pis = max(YR_PIS for LIHTC projects with PROJ_CTY match,
+                  filtered to valid YR_PIS != 8888)
+years_since = current_year - last_yr_pis
+recency_score = min(100, round(years_since / 25 × 100))
+              = 100 if never funded
+```
+
+**Verification questions**:
+- [ ] Find `recencyScore(lastYear)` in the JS. Does it cap at 25 years (not 20, not 30)?
+- [ ] Are YR_PIS = 8888 (HUD placeholder) explicitly excluded from the lastYear calc?
+- [ ] Is `current_year` hardcoded or derived from `new Date().getFullYear()`? (It should be derived.)
+- [ ] PROJ_CTY matching: case-insensitive uppercase trim — confirm this is the only normalization. Are there any fuzzy-match attempts? (There shouldn't be — that's a P1.)
+- [ ] Edge: does a jurisdiction with 0 PROJ_CTY matches get score 100 (never funded) or something else?
+
+#### Dimension 3 — Basis-Boost Score
+**Methodology** (§3 Dimension 3): QCT only: 60, DDA only: 60, both: 100, neither: 0.
+
+**Verification questions**:
+- [ ] Find `basisBoostScore(hasQct, hasDda)` in the JS. Does it return these exact values?
+- [ ] Is the QCT detection using the membership thresholds (5% / 20%)?
+- [ ] Is the DDA detection correctly using county-FIPS inheritance for all jurisdictions in DDA counties?
+
+#### Dimension 4 — Population Score
+**Methodology** (§3 Dimension 4): bucketed: <500: 0, 500–2k: 30, 2k–5k: 60, 5k–15k: 85, ≥15k: 100. Source: CHAS HHs ≤100% AMI × 2.5.
+
+**Verification questions**:
+- [ ] Find `populationScore(pop)` in the JS. Are the bucket boundaries exactly 500 / 2000 / 5000 / 15000?
+- [ ] Is the multiplier 2.5 (CO avg HH size)?
+- [ ] Edge: what happens if `households_le_ami_pct['100']` is null or undefined? Does the score return 0 (correct) or NaN (bug)?
+
+#### Dimension 5 — Civic Readiness Score
+**Methodology** (§3 Dimension 5): 7 binary dimensions, score = true / known × 100.
+
+**Verification questions**:
+- [ ] Civic score is **surfaced** but not **rolled into composite** in today's implementation. Confirm this matches what `_renderCivicPanel()` does (shows it as a separate badge).
+- [ ] Does the per-row "Civic" column correctly read `civic.totalScore` / `civic.maxPossible` from `policyScores[geoid]`?
+- [ ] When a place doesn't have a scorecard record, does it fall back to the containing county's record (correct) or default to 0 (would penalize unfairly)?
+
+### Analysis 3 — Composite scoring + weight invariants
+
+**Methodology** (§4): Today's implementation uses 4-dimension weights. 9% = 40·30·20·10, 4% = 25·25·15·35, Any = 35·30·20·15. Each set sums to 1.0.
+
+**Verification questions**:
+- [ ] Find `SCORE_WEIGHTS` in the JS. Do all three targets sum to exactly 1.0? Run `npm run audit:opportunity-finder` — the weight-invariant check should pass.
+- [ ] Verify `compositeScore(rec, need, basis, pop, target)` uses the active target's weights and rounds the final result.
+- [ ] Is the composite output guaranteed to be in [0, 100]? (Yes if all four component scores are bounded and weights sum to 1.) The range invariant check in the verification harness asserts this.
+
+### Analysis 4 — Filtering behavior
+
+**Methodology** + UI: default filter is `requireBoth = true`, `includeCdps = false`, target = `9pct`. Should produce 5 named jurisdictions: Montezuma, Sugar City, Crowley, Olney Springs, Ordway.
+
+**Verification questions**:
+- [ ] Run `npm run audit:opportunity-finder` — the default-filter check should output exactly these 5 names.
+- [ ] What happens when user toggles `requireBoth` off + leaves `requireQct` and `requireDda` off? The result should be all 158 jurisdictions (no designation filter).
+- [ ] What happens when user toggles `requireQct` on AND `requireDda` on (both individual)? Should it be equivalent to `requireBoth`? Trace `_applyFilters()` to confirm.
+
+### Analysis 5 — Civic-capacity joins
+
+**Methodology** (§3 Dim 5, §5): three data sources joined — `housing-policy-scorecard.json` (547 records), `local-resources.json` (68 records), `prop123_jurisdictions.json` (217 commitments).
+
+**Verification questions**:
+- [ ] For Sugar City (geoid 0875210, county 08025): does the locator surface "Prop 123 ✓ via Crowley County" since Sugar City didn't file individually but the county did? Trace the prop123 extra text construction in `_renderCivicPanel()`.
+- [ ] For Montezuma (geoid 0850105, county 08117 = Summit): does it find Montezuma's own scorecard record + Summit County's local-resources record? It should — the scorecard is keyed by place GEOID, and local-resources by `place:GEOID` → `cdp:GEOID` → `county:FIPS`.
+- [ ] Does `prop123ForName()` correctly strip the "City of " / "Town of " / "City and County of " / "County" suffix from the canonical prop123 name to match the place's bare name?
+
+### Analysis 6 — HNA deep-link integrity
+
+**Methodology**: every jurisdiction row gets a "→ HNA" link and the detail panel has two CTAs (place-level + county-level). The HNA page (`housing-needs-assessment.html`) accepts `?fips=…&geoType=place|county&auto=1`.
+
+**Verification questions**:
+- [ ] Open `lihtc-opportunity-finder.html` in a browser. Click "→ HNA" on Sugar City. Does the URL include `fips=0875210` and `geoType=place`? Does the HNA page actually auto-select Sugar City?
+- [ ] Click the county-level CTA in the detail panel. Does it correctly navigate to `?fips=08025&geoType=county`?
+- [ ] Read `housing-needs-assessment.html`'s `_resolveAutoTarget()` function. Does it handle both 5-digit (county) and 7-digit (place) FIPS? Does the URL param override prior WorkflowState?
+
+### Analysis 7 — Verification harness honesty
+
+**Verification questions**:
+- [ ] The harness `scripts/audit/verify-opportunity-finder.mjs` independently re-implements the rollup math. Spot-check 3 known cases (Sugar City, Crowley, Cortez) — does it compute the same scores as the JS implementation? It should; they're both deterministic from the same data.
+- [ ] Does the harness use the same data files as the live JS module? List them. (Should be the same 10.)
+- [ ] If the JS module is modified (e.g., a weight changes), does the harness fail until the harness is also updated? It should — the harness has a hardcoded `SCORE_WEIGHTS` table that's separately maintained.
+
+### Analysis 8 — Methodology-vs-implementation drift
+
+This is the highest-leverage analysis. Look for places where the methodology doc says X and the code does Y.
+
+**Specific drift points to check**:
+- [ ] Methodology §3 Dim 5 says Civic Readiness is surfaced but **not** in composite. Confirm by reading `_computeOpportunities()` — there should be NO civic component in the `compositeScore()` call.
+- [ ] Methodology §4 says today is 4 dimensions; target state is 5. Confirm by counting weight-table rows in the live code (should be 4).
+- [ ] Methodology §3 Dim 4 says "CO avg HH size ≈ 2.5" — is the multiplier exactly 2.5 or is it 2.4 or 2.6 in the code?
+- [ ] Methodology §3 Dim 2 says "Capped at 25+ years" — is the constant `MAX_RECENCY_YEARS = 25` in the code? (Yes — verified.)
+- [ ] Methodology §3 Dim 3 says basis-boost is QCT-only OR DDA-only = 60 (not 50, not 70). Confirm in code.
+- [ ] Methodology §6 describes the target-state ScoreResult shape with reasons / risks / missingData / nextActions. Confirm today's implementation does NOT yet return this shape — that's P0-1 in the audit.
+
+### Analysis 9 — Honest gaps in current implementation
+
+These are NOT bugs — they are intentional gaps documented in the methodology. Confirm Codex understands they're not regressions:
+
+- [ ] **No `ScoreResult` shape contract.** Today's output is an ad-hoc object. Methodology §6 describes the target shape. P0-1 in audit.
+- [ ] **Civic Readiness not in composite.** Surfaced as a column, but the composite still uses only 4 dimensions. Methodology §4 footnote acknowledges this.
+- [ ] **3 target rounds (9% / 4% / Any), not 5.** Preservation, workforce-resort, prop123-local are documented but not shipped. P0-3 in audit.
+- [ ] **No confidence pills.** Confidence is described in methodology §5 but not yet visible per-metric. P0-5 in audit.
+- [ ] **No "next action" CTA strip on HNA / PMA / Deal Calculator.** Only the Opportunity Finder has the CTAs (this PR). P0-4 in audit.
+- [ ] **Recency uses YR_PIS, not CHFA award year.** Lags awards 2–3y. P1-3 backlog.
+- [ ] **No preservation candidates panel.** NHPD data exists in repo but not consumed. P1-4 backlog.
+- [ ] **Population is a proxy.** HHs × 2.5, not ACS B01003. Methodology §3 Dim 4 acknowledges. P2 backlog.
+
+---
+
+## Quick-start verification commands
+
+```bash
+# 1. Run the verification harness — 28 independent checks against the live implementation
+npm run audit:opportunity-finder
+npm run audit:opportunity-finder:json    # machine-readable for CI
+
+# 2. Sanity-check the JS module compiles
+node --check js/lihtc-opportunity-finder.js
+
+# 3. Run the broader recent-changes QA
+npm run test:qa-recent
+
+# 4. Run the full CI test suite to ensure no regressions
+npm run test:ci
+
+# 5. Open the page locally to inspect the UI
+npx http-server -p 8080 .   # or any static server
+open http://localhost:8080/lihtc-opportunity-finder.html
+```
+
+---
+
+## Specific files to inspect
+
+| File | Lines | What to read |
+|---|---|---|
+| `lihtc-opportunity-finder.html` | full | UI structure + always-visible methodology section near the bottom |
+| `js/lihtc-opportunity-finder.js` | 1–100 | State + SCORE_WEIGHTS + helpers |
+| `js/lihtc-opportunity-finder.js` | 100–250 | Score component functions (`recencyScore`, `needCompositeFor`, `basisBoostScore`, `populationScore`, `compositeScore`) |
+| `js/lihtc-opportunity-finder.js` | 250–400 | Data loaders + opportunity rollup (`_computeOpportunities`) |
+| `js/lihtc-opportunity-finder.js` | 400–650 | Rendering (table, detail panel, civic panel, news panel) |
+| `js/lihtc-opportunity-finder.js` | 650–778 | UI wiring (filters, sorting, map) |
+| `housing-needs-assessment.html` | 2255–2370 | `_resolveAutoTarget` + `_tryAutoSelect` — extended this session for place deep-links |
+| `scripts/audit/verify-opportunity-finder.mjs` | full | Independent verification harness |
+| `docs/methodology/LIHTC-LOCATOR-METHODOLOGY.md` | full | Canonical methodology |
+| `docs/audits/REPO-AUDIT-2026-05-25.md` | full | Full repo audit; P0–P2 roadmap (jurisdiction-direction) |
+
+---
+
+## What success looks like
+
+When you're done, you should be able to answer:
+
+1. **Does the implementation faithfully reflect the methodology?** Pass/fail per dimension, with specific code references for any drift.
+2. **Are the documented limitations honest?** Are there any silent fallbacks or hidden assumptions not noted in the methodology?
+3. **Is the verification harness sufficient?** What edge cases or invariants is it missing?
+4. **What's the highest-leverage next change?** Per the audit it's P0-1 (`js/scoring/shape.js`). Confirm or challenge that recommendation.
+5. **What in the methodology doc is over-claimed?** Are there any aspirational statements that the implementation doesn't yet support? (Honestly: yes — civic readiness in composite, 5 deal types, ScoreResult shape, confidence pills. The methodology is clear these are "target state, not shipped." Verify Codex agrees the framing is honest.)
+
+---
+
+## Expected output from your analysis
+
+A short structured report (~500–1,000 words) with:
+
+1. **Verification matrix** — table of methodology claims × pass/fail/notes
+2. **Drift findings** — specific code-vs-doc inconsistencies (file:line + what each says)
+3. **Honest-gap confirmations** — list of "this is documented as a gap, not a bug" items
+4. **Test coverage gaps** — what the harness should test but doesn't
+5. **Highest-leverage next change** — your independent recommendation
+
+If you find genuine bugs (not gaps), file them as GitHub issues against the `feat/lihtc-opportunity-finder` branch / PR #894.
+
+---
+
+## Out of scope for this analysis
+
+- Tract-level concerns (`tract_boundaries_co.geojson` empty, `tract_centroids_co.json` rebuild-pending) — these affect `colorado-deep-dive.js` only, NOT this locator. See Appendix A of the repo audit.
+- Parcel-level concerns (`parcel_aggregates_co.json` stub) — site-level work, out of scope for jurisdiction targeting.
+- Rewriting the locator from scratch — this is incremental work, not a redesign.
+- Auditing the HNA page, PMA page, or Deal Calculator — separate audit docs exist for those at `docs/audits/PMA-METHODOLOGY-AUDIT.md` and `docs/audits/DEAL-CALCULATOR-AUDIT.md`.
+
+---
+
+## Contact / open questions
+
+If anything in the methodology is ambiguous, the canonical answer is in `docs/methodology/LIHTC-LOCATOR-METHODOLOGY.md`. If the methodology itself is wrong, file an issue and we'll iterate — the methodology is versioned (currently v1.1) and intentionally evolves.
+
+The repo's overall strategic direction (jurisdiction-level, not site-level; build-on the Opportunity Finder, don't build a new page) is locked per the audit's "Strategic direction lock" callout. Any proposal that contradicts that direction should explicitly call out the reversal.
+
+Good luck. The product is in pretty good shape — most of the work is consolidation, not invention.

--- a/docs/audits/REPO-AUDIT-2026-05-25.md
+++ b/docs/audits/REPO-AUDIT-2026-05-25.md
@@ -1,0 +1,644 @@
+# Colorado Housing Analytics — Repo Audit
+**Date**: 2026-05-25 · **Auditor**: Claude (senior CS + LIHTC lens) · **Branch**: `feat/lihtc-opportunity-finder`
+
+This audit was commissioned to evaluate the repo against the product question: **"Where in Colorado should a developer spend scarce time looking for the next affordable housing deal?"** It verifies findings claimed in a prior LLM audit, documents what was wrong about those claims, and produces a P0-to-P2 punch list grounded in actual file inspection.
+
+A material framing note at the top: a working version of the proposed "Deal Targeting" experience already exists at **`lihtc-opportunity-finder.html`** (PR #894, merged-pending this session). About 70% of the recommended product flow is shipped. The audit reframes recommendations as **extend the Opportunity Finder**, not "build a new page."
+
+---
+
+## 1. Executive Summary
+
+### What the repo does well
+
+- **Deep data inventory.** 547-jurisdiction HNA ranking-index, 1,447 ACS tract metrics, 1,447 CHAS tract records, 702 HUD LIHTC projects with PROJ_CTY/YR_PIS/N_UNITS, 224 QCT tracts + 10 DDA counties (HUD 2025), 217 Prop 123 commitments with filing dates, 547-jurisdiction × 7-dimension policy scorecard, 482-place AMI gap by 7 bands, TIGER 2024 place-tract spatial join.
+- **Methodology rigor where it counts.** Scorecard v2 uses percentile normalisation against CO peer distribution (PR #885), tenure-blended cost burden (PR #884), 7-band AMI gap with both cumulative and per-tier views (PR #882), CHFA-preference AMI × bedroom matrix (PR #890). Public methodology disclosure on every page.
+- **Honest data hygiene.** ACS active-market vacancy bounded 5–7% to prevent seasonal distortion (PR #887). PR descriptions explicitly note "screening tool only," "data confidence: medium," "county fallback." Source URLs hyperlinked from every metric.
+- **Recently shipped: `lihtc-opportunity-finder.html`.** Ranks 158 jurisdictions with QCT/DDA designation for 4% bond and 9% competitive rounds, deep-links to per-place HNA, surfaces civic capacity (Prop 123, comp plan, housing lead, HA, advocacy), per-jurisdiction housing-news search. **This is the seed of the "Deal Targeting" product.**
+- **CI infrastructure.** 50 GitHub Actions workflows including `deploy.yml`, `data-freshness-check`, `data-sentinels-check`, `accessibility`, `contrast-audit`, `console-error-audit`, `external-references-check`, scheduled data refreshes for FRED/HUD/ACS/CHAS/Zillow/Kalshi/HMDA.
+
+### What prevents it from being a true deal-targeting tool today
+
+1. **Critical geometry gap.** `data/market/tract_boundaries_co.geojson` is 312 bytes and contains zero features. The fallback path uses `data/market/tract_centroids_co.json` (1,605 tracts with lat/lon) but **the file's own metadata warns**: "Centroids for tracts without TIGERweb data estimated from county centroid. Rebuild via scripts/market/build_public_market_data.py for precise coordinates." So tract-level maps degrade to circle markers (no choropleth) and an unknown subset of centroids are county-pinned approximations. Yet 1,447 tract-level ACS/CHAS records exist that should have proper polygon geometry.
+2. **Parcel data is a stub.** `data/market/parcel_aggregates_co.json` reports `counties_successful: 0, coverage_pct: 0`. The site cannot answer "is there a public parcel here?" — which is the fastest LIHTC site-screening triage.
+3. **Need ≠ Dealability.** ChatGPT's framing is correct on this point. The Scorecard v2 composite is a good *need* score but the site sometimes presents it as if it implies opportunity (it doesn't — Boulder is high-need but hard to execute). The Opportunity Finder *does* separate these (recency, basis, population), but only for the QCT/DDA subset.
+4. **Scoring code is scattered.** No `js/scoring/` directory. Score logic lives in `js/market-analysis/site-selection-score.js`, `js/market-health-composite.js`, `js/housing-outcome-score.js`, `js/lihtc-deal-predictor.js`, `js/lihtc-deal-predictor-enhanced.js`, `js/chfa-award-predictor.js`, `js/lihtc-opportunity-finder.js`, etc. Drift risk is real — Boulder gets different scores depending on which page you open.
+
+### The single most important product change
+
+**Promote `lihtc-opportunity-finder.html` to the site's primary entry point**, replacing or relegating "Housing Needs Assessment" as the default landing. The HNA is a deep workup; the Opportunity Finder is the deal-sourcing cockpit. Make the HNA accessible via the existing "→ HNA" deep-links the Opportunity Finder already exposes per row. **Don't build a new "Deal Targeting" page — extend the one that already exists.**
+
+### The biggest technical/data risk
+
+The empty `tract_boundaries_co.geojson` (0 features) + the soft-rebuild status of `tract_centroids_co.json` (1,605 tracts but file metadata warns some are county-centroid approximations of unknown precision). Every consumer (`colorado-deep-dive.js`, possibly others) falls back to circle markers — *not* the choropleth UI shows in the methodology disclosure. The map renders, the status string says "X tracts rendered," but:
+- the choropleth promised in the methodology never appears, and
+- the centroids in the marker fallback include an undocumented number of county-centered fakes.
+
+This creates **false confidence**: page renders fine, status says success, but the underlying spatial truth is degraded. **P0 fix**: regenerate `tract_boundaries_co.geojson` via TIGERweb (script exists at `scripts/market/build_public_market_data.py`, cited in the file's own metadata note) and add a data sentinel that fails CI if features < 1,400. While you're there, regen the centroids file to eliminate the county-fallback approximations.
+
+---
+
+## 2. P0 / P1 / P2 Issue List
+
+### 🔴 P0 — block any further methodology work until resolved
+
+| # | Issue | Why it matters | Affected files | Recommended fix | Test |
+|---|---|---|---|---|---|
+| P0-1 | `data/market/tract_boundaries_co.geojson` has 0 features | Tract-level maps silently degrade; ratio choropleth on Colorado Deep Dive shows gray | `js/colorado-deep-dive.js:454-490`, possibly `js/market-analysis*.js` | Run `scripts/market/build_public_market_data.py` (cited in file's own metadata note) to rebuild from TIGERweb 2024 | Add sentinel: `data/market/tract_boundaries_co.geojson` must have ≥1,400 features |
+| P0-2 | `data/market/tract_centroids_co.json` is rebuild-pending (1,605 tracts with lat/lon but file metadata warns some are county-centroid approximations from an aborted rebuild) | Centroid markers visually render but include undocumented county-fallback fakes; tract-precise spatial joins (which the methodology disclosure implies) aren't actually happening for unknown subset | All tract-centroid consumers — at least `js/colorado-deep-dive.js:495`; audit with grep for other consumers | Same `build_public_market_data.py` regen — centroids derive directly from tract polygons | Sentinel: ≥1,400 centroid records all with valid `lat`/`lon` and `county_centered != true` flag (or remove the metadata warning entirely once rebuilt) |
+| P0-3 | `data/market/parcel_aggregates_co.json` has `coverage_pct: 0, counties_successful: 0` | Repo advertises parcel screening but file is a stub. Users seeing "parcel data" in UI assume it exists | `scripts/market/fetch_parcel_data*.py` failed silently | Either (a) actually run county Assessor ArcGIS fetch + add per-county fallback, (b) remove parcel-aggregate UI references and replace with "verification needed" badge | Sentinel: if `coverage_pct < 0.5`, fail build of any page that references parcel data |
+| P0-4 | Scoring drift across 7+ modules | Same jurisdiction gets different scores on HNA vs. PMA vs. Opportunity Finder. Erodes trust. | `js/market-analysis/site-selection-score.js`, `js/market-health-composite.js`, `js/housing-outcome-score.js`, `js/lihtc-deal-predictor.js`, `js/lihtc-deal-predictor-enhanced.js`, `js/chfa-award-predictor.js`, `js/lihtc-opportunity-finder.js` | Create `js/scoring/` with one source of truth per dimension (need, recency, basis, pop, civic); refactor consumers to call it | Add `test/scoring-consistency.test.js` that asserts the same input produces the same score across all consumers |
+| P0-5 | No central "score result" shape — every consumer invents its own | Hard to add confidence/sources/missing-data uniformly | Same as P0-4 | Define `ScoreResult = { score, band, confidence, reasons[], risks[], missingData[], sourceIds[], sourceVintage[], nextActions[] }` and require every scoring fn to return it | Lint rule + test that every score module's default export matches the shape |
+
+### 🟡 P1 — should-fix before next major release
+
+| # | Issue | Why it matters | Affected files | Recommended fix |
+|---|---|---|---|---|
+| P1-1 | Opportunity Finder filtered to QCT+DDA jurisdictions only | Excludes preservation deals (NHPD-tracked LIHTC expirations), workforce/resort 4% deals, non-basis-boost opportunities | `js/lihtc-opportunity-finder.js` | Add deal-type taxonomy: `9pct_competitive`, `4pct_bond`, `preservation`, `workforce_resort`, `prop123_local`. Each becomes a target-round option. |
+| P1-2 | "Find a market → Screen a site → Explain the deal" funnel is not connected | Users land on HNA, get great need data, but no link to "OK, now what?" | `housing-needs-assessment.html`, `lihtc-opportunity-finder.html`, `deal-calculator.html`, `market-analysis.html` | Add a persistent "next action" CTA strip at the bottom of each analytical page. HNA → Opportunity Finder; Opportunity Finder → PMA (with place pre-loaded); PMA → Deal Calculator (with concept pre-loaded). |
+| P1-3 | No "Confidence" surfacing on Scorecard or AMI gap | Boulder's owner cost burden is from CHAS Table 7 (county-level), not place-level SMOCAPI. User can't tell. | `js/hna/hna-controller.js`, `js/hna/hna-utils.js` | Add a small "★★★" confidence pill next to every metric: 3 = direct ACS/CHAS place, 2 = county fallback, 1 = synthetic/derived |
+| P1-4 | Compare mode does not exist | "Compare Boulder vs. Greeley vs. Pueblo" is a fundamental developer workflow | All analytical pages | Build `compare.html` that accepts `?jurisdictions=08013,0807850,0862000` and shows a side-by-side score table with all dimensions |
+| P1-5 | No export memo (.pdf or .md) | Developers need to bring opportunity findings into their pipeline meeting | All analytical pages | Build `js/export/opportunity-memo.js` that produces a downloadable .md (or .pdf via existing `hna-export.js` pattern) from the current Opportunity Finder selection |
+| P1-6 | Recent funding ≠ recent placed-in-service | Opportunity Finder's recency uses YR_PIS (placed in service) which lags awards by 2–3y. A jurisdiction that won 2024 awards but hasn't broken ground still looks "stale." | `js/lihtc-opportunity-finder.js`, `data/market/hud_lihtc_co.geojson` | Add award-year layer: fetch CHFA award announcements (which `js/chfa-award-predictor.js` already references) → join by jurisdiction → use max(YR_PIS, award_year) for recency |
+| P1-7 | Preservation pipeline not surfaced | `data/market/nhpd_co.geojson` has 20 properties with `subsidy_expiration` — these are preservation candidates ripe for 4% bond refi + Year-15 exit | Not consumed by Opportunity Finder | Add "Preservation candidates" panel: any LIHTC in jurisdiction with expiration ≤ 2030 → flag prominently |
+
+### 🟢 P2 — nice-to-have / longer-term
+
+| # | Issue | Recommendation |
+|---|---|---|
+| P2-1 | Mobile experience is desktop-first | Card-first mobile layout for Opportunity Finder; map/table become tabs not side-by-side |
+| P2-2 | No "watchlist" | Per-user (localStorage) watchlist of jurisdictions with change alerts |
+| P2-3 | QAP year switcher | `data/lihtc/qap_*.json` keyed by 2025/2026/draft-2027 → switcher in Deal Calculator |
+| P2-4 | Public-land / nonprofit-owned parcel layer | Custom data acquisition (CO State Land Board API, Colorado Trust Lands, faith-based nonprofit research) — long-term |
+| P2-5 | Water/sewer/utility readiness | Out of scope without parcel data; queue behind P0-3 |
+| P2-6 | EPA Walkability + transit access | `js/data-connectors/epa-walkability.js` exists — wire into Opportunity Finder detail panel |
+| P2-7 | Vector tiles for map performance | Migrate large geojson layers (HUD LIHTC 702 points, QCT 224 polygons) to MBTiles for first-paint <500ms |
+
+---
+
+## 3. Proposed Deal-Targeting Product Flow
+
+### Don't build `deal-targeting.html`. Extend `lihtc-opportunity-finder.html`.
+
+The user's instinct (and the ChatGPT prompt) is right that a deal-sourcing cockpit is the missing product. The mistake is treating it as net-new. PR #894 already builds the foundation. The extension is **deal-type taxonomy + cross-page funnel + export**.
+
+### Top-level funnel — "Find a market → Screen a site → Explain the deal"
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ index.html → links prominently to:                           │
+│ • Find a market  →  lihtc-opportunity-finder.html  [PRIMARY] │
+│ • Browse all needs   →  housing-needs-assessment.html        │
+│ • Screen a deal      →  deal-calculator.html                 │
+└──────────────────────────────────────────────────────────────┘
+                            ↓
+┌──────────────────────────────────────────────────────────────┐
+│ Opportunity Finder                                           │
+│ ┌─Filters─────────────────────┐ ┌─Map + Ranked table──────┐ │
+│ │ Deal type:                  │ │  Sortable jurisdiction   │ │
+│ │ ○ 9% competitive            │ │  cards, click for detail │ │
+│ │ ○ 4% bond                   │ │                          │ │
+│ │ ○ Preservation              │ │                          │ │
+│ │ ○ Workforce / resort        │ │                          │ │
+│ │ ○ Prop 123 ready            │ │                          │ │
+│ │                             │ │                          │ │
+│ │ Confidence: ≥ Med           │ │                          │ │
+│ │ County: …                   │ │                          │ │
+│ │ Population: …               │ │                          │ │
+│ └─────────────────────────────┘ └──────────────────────────┘ │
+└──────────────────────────────────────────────────────────────┘
+                            ↓ (click jurisdiction)
+┌──────────────────────────────────────────────────────────────┐
+│ Detail panel (already built — extend with):                  │
+│   • Composite + sub-scores (already shipped)                 │
+│   • Civic capacity (already shipped)                         │
+│   • Housing news links (already shipped)                     │
+│   • HNA deep-link (already shipped)                          │
+│   • [NEW] "Run PMA" CTA — opens market-analysis.html?fips=…  │
+│   • [NEW] "Build a concept" CTA — opens deal-calculator.html │
+│   • [NEW] "Add to watchlist" / "Export memo"                 │
+└──────────────────────────────────────────────────────────────┘
+                            ↓
+┌──────────────────────────────────────────────────────────────┐
+│ PMA (market-analysis.html) — pre-loaded with jurisdiction    │
+│ "So what? Demand looks supportable. Verify utilities/access."│
+└──────────────────────────────────────────────────────────────┘
+                            ↓
+┌──────────────────────────────────────────────────────────────┐
+│ Deal Calculator — pre-loaded with concept                    │
+│ "So what? 9% feasible. 4% needs additional soft funds."      │
+│ Export deal memo                                             │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Filter chips on Opportunity Finder (target state)
+
+**Deal type** (mutually exclusive, drives weight re-tuning):
+- 9% Competitive · 4% Bond · Preservation · Workforce/Resort · Prop 123 Local · Any
+
+**Designation** (combinable):
+- QCT + DDA · QCT only · DDA only · No basis-boost (Prop 123 or workforce)
+
+**Risk + readiness** (combinable):
+- ≥ Med confidence · Prop 123 committed · Comp plan on file · Local HNA on file · Housing authority present · LIHTC saturation ≤ 2 deals · Never funded
+
+**Geography** (existing):
+- County · Include CDPs · Min population
+
+### Opportunity card structure (target state, ~15s scan time)
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ Sugar City                                Target: B+         │
+│ ────────────                                                 │
+│ Crowley County · 245 pop · QCT + DDA · town                  │
+│                                                              │
+│ Best fit: 9% competitive, 30–40 units, family               │
+│ Confidence: Medium (county-fallback for owner cost burden)  │
+│                                                              │
+│ Why it rises:                                                │
+│   ✓ Never funded with LIHTC                                  │
+│   ✓ Both QCT and DDA (100/100 basis-boost score)             │
+│   ✓ Crowley Co is among CO's most cost-burdened (p82)        │
+│                                                              │
+│ Risks:                                                       │
+│   • Population <500 — bond deal absorption questionable      │
+│   • No housing lead on file; need to identify champion       │
+│   • Owner cost burden via county fallback                    │
+│                                                              │
+│ Civic capacity: 2/7  Prop 123 ✓  HNA —  Comp plan ✓          │
+│                                                              │
+│ Next action:                                                 │
+│   [Open HNA →] [Run PMA →] [Build concept →] [+ Watchlist]   │
+└──────────────────────────────────────────────────────────────┘
+```
+
+The current detail panel already has most of this. The gap is: (a) the **card-level summary** with target letter + best-fit + confidence at the top, (b) the **next-action CTA strip** linking to PMA + Deal Calculator with state pre-loaded.
+
+---
+
+## 4. Proposed Scoring Model
+
+### Dimensions (six independent, never collapsed into a single black-box)
+
+| # | Dimension | What it measures | Primary data | Confidence |
+|---|---|---|---|---|
+| 1 | **Need** | Renter + owner cost burden, severe burden, AMI gap depth | CHAS T7, ACS DP04 GRAPI/SMOCAPI | High at county, Med at place (fallback) |
+| 2 | **Deal readiness** | Civic capacity — Prop 123, comp plan, HNA, housing lead, IZ, local funding | `housing-policy-scorecard.json`, `local-resources.json`, `prop123_jurisdictions.json` | Mixed (≥70% pop, ~30% places have rich data) |
+| 3 | **Site / physical feasibility** | Population scale (bond absorption), QCT/DDA, transit, EPA walkability | LODES, EPA Walkability, OSM | Med (no parcel data — see P0-3) |
+| 4 | **Subsidy / capital-stack fit** | Prop 123 eligible, CDBG-DR/HOME availability, soft funding, CHFA award likelihood | `soft-funding-status.json`, `chfa-award-predictor.js` | Med |
+| 5 | **Competition / saturation** | LIHTC density, years since last YR_PIS, planned 9%/4% awards | HUD LIHTCDB, CHFA recent awards | High (HUD), Med (CHFA pipeline) |
+| 6 | **Data confidence** | Meta-dimension. Boolean reasons: county-fallback used, place-level missing, geometry missing, etc. | All of the above | Always available |
+
+### Weight by target deal type (re-tuning)
+
+| | Need | Readiness | Feasibility | Subsidy | Competition |
+|---|---|---|---|---|---|
+| **9% Competitive** | 30% | 15% | 15% | 10% | **30%** |
+| **4% Bond** | 25% | 15% | **30%** | 15% | 15% |
+| **Preservation** | 20% | 20% | 10% | **35%** | 15% |
+| **Workforce / Resort** | 25% | 15% | **30%** | 15% | 15% |
+| **Prop 123 Local** | 25% | **30%** | 15% | 20% | 10% |
+| **Balanced** | 25% | 20% | 20% | 15% | 20% |
+
+(The current Opportunity Finder uses 4 dimensions: recency, need, basis, pop. The above adds readiness + subsidy explicitly. Recency rolls into Competition; basis rolls into Feasibility.)
+
+### Score result shape (one source of truth)
+
+```js
+{
+  score: 72,                    // 0–100 composite
+  band: 'High',                 // High / Med / Low / Watchlist / Not-ready
+  confidence: 'Medium',         // High / Medium / Low
+  letterGrade: 'B+',            // A / A- / B+ / B / B- / C+ / C / Watchlist
+  reasons: [                    // 3–5 reasons it scored high
+    'Never funded with LIHTC (recency: 100)',
+    'Both QCT and DDA (basis: 100)',
+    'Crowley County cost burden in CO 82nd percentile'
+  ],
+  risks: [                      // 3–5 reasons to verify
+    'Population < 500 — bond absorption questionable',
+    'Owner cost burden via county fallback',
+    'No housing lead on file'
+  ],
+  missingData: [                // What we couldn't compute
+    'parcel_readiness (file empty — P0-3)',
+    'utility_capacity (no data)',
+    'planned_chfa_pipeline (manual)'
+  ],
+  sourceIds: ['chas-2018-2022', 'hud-qct-2025', 'hud-dda-2025'],
+  sourceVintage: { chas: '2018-2022', hud_qct: '2025', hud_dda: '2025' },
+  nextActions: [
+    { label: 'Open HNA', href: 'housing-needs-assessment.html?fips=…' },
+    { label: 'Run PMA', href: 'market-analysis.html?fips=…' },
+    { label: 'Build concept', href: 'deal-calculator.html?fips=…' }
+  ]
+}
+```
+
+This shape **must** be returned by every scoring function in `js/scoring/`. Add a Jest/Node test that asserts the shape matches a JSON Schema across every export.
+
+---
+
+## 5. Data Audit
+
+### Critical gaps (verified by direct file inspection)
+
+| Path | Size | Records | Status |
+|---|---|---|---|
+| `data/market/tract_boundaries_co.geojson` | 312 B | **0 features** | 🔴 P0 — empty |
+| `data/market/tract_centroids_co.json` | populated | 1,605 tracts with lat/lon but file metadata warns of pending rebuild with county-fallback approximations | 🟡 P1 — rebuild-pending |
+| `data/market/parcel_aggregates_co.json` | small | `coverage_pct: 0` | 🔴 P0 — stub |
+| `data/market/nhpd_co.geojson` | populated | 20 preservation properties | 🟡 P1 — light coverage |
+| `data/market/hud_lihtc_co.geojson` | 574 KB | 716 projects (702 valid YR_PIS) | ✅ Good |
+| `data/qct-colorado.json` | 446 KB | 224 QCT tracts | ✅ Good (HUD 2025) |
+| `data/dda-colorado.json` | 341 KB | 10 DDA counties | ✅ Good (HUD 2025) |
+| `data/market/acs_tract_metrics_co.json` | populated | 1,447 tracts | ✅ Good |
+| `data/market/chas_tract_co.json` | populated | 1,447 records | ✅ Good |
+| `data/hna/place-tract-membership.json` | 426 KB | 482 places × tracts | ✅ Good (TIGER 2024) |
+| `data/co_ami_gap_by_place.json` | 525 KB | 482 places, 7 AMI bands | ✅ Good |
+| `data/hna/chas_affordability_gap.json` | 166 KB | 64 counties | ✅ Good |
+| `data/hna/ranking-index.json` | populated | 547 rankings | ✅ Good |
+| `data/policy/housing-policy-scorecard.json` | populated | 547 × 7 dims | ✅ Good (sparse but flagged) |
+| `data/policy/prop123_jurisdictions.json` | populated | 217 commitments | ✅ Good |
+| `data/hna/local-resources.json` | populated | 68 records | 🟡 P1 — sparse |
+
+### Risky joins / proxies / fallbacks to surface in UI
+
+1. **Place cost burden uses county CHAS fallback** when SMOCAPI bins aren't cached → 25 CO counties affected. Need a confidence pill on the metric.
+2. **Population approximation** in Opportunity Finder uses `households_le_ami_pct['100'] × 2.5` (proxy for B01003). Note this in tooltip.
+3. **QCT-place membership** uses overlap thresholds (5% of place area OR 20% of tract area). Sliver-overlap risk if thresholds change.
+4. **Prop 123 county-level inheritance**: Sugar City and Olney Springs inherit commitments from Crowley County's filing. UI shows "via [County]" already; good.
+5. **`PROJ_CTY` string matching** for LIHTC projects is case-sensitive after uppercase normalization. A misspelled PROJ_CTY ("Ft Collins" vs "Fort Collins") will miss. Recommend a Levenshtein-1 fuzzy fallback.
+
+### Data files to validate (sentinel additions for CI)
+
+Add to `scripts/audit/data-sentinels-check.mjs`:
+
+```js
+{
+  kind: 'file',
+  path: 'data/market/tract_boundaries_co.geojson',
+  minRows: 1400,
+  label: 'CO tract boundary features',
+  count: (j) => (j?.features || []).length
+},
+{
+  kind: 'file',
+  path: 'data/market/tract_centroids_co.json',
+  minRows: 1400,
+  label: 'CO tract centroids',
+  count: (j) => (j?.centroids || j?.features || (Array.isArray(j) ? j : [])).length
+},
+{
+  kind: 'file',
+  path: 'data/market/parcel_aggregates_co.json',
+  minRows: 30,  // expect ≥30 counties post-fix
+  label: 'CO parcel-aggregate counties',
+  count: (j) => Object.keys(j?.counties || {}).length
+}
+```
+
+---
+
+## 6. Code Architecture Audit
+
+### Scoring duplication map
+
+Eight files run scoring logic. None share helpers:
+
+| File | Purpose | Output shape |
+|---|---|---|
+| `js/market-analysis/site-selection-score.js` | PMA 6-dim site score | Ad-hoc object |
+| `js/market-health-composite.js` | Market health (different formula) | Ad-hoc |
+| `js/housing-outcome-score.js` | Need composite (HNA) | Ad-hoc |
+| `js/lihtc-deal-predictor.js` | UMD: predictConcept() — recommends AMI×bedroom | Concept |
+| `js/lihtc-deal-predictor-enhanced.js` | Extended predictor | Concept |
+| `js/chfa-award-predictor.js` | 9% award probability | Score |
+| `js/lihtc-opportunity-finder.js` | Jurisdiction targeting | Score |
+| `js/colorado-regional-predictions.js` | Regional rollups | Forecast |
+
+**Refactor target:**
+
+```
+js/scoring/
+  index.js                       — public API
+  shape.js                       — ScoreResult JSON Schema + validator
+  need-score.js                  — wraps housing-outcome-score
+  readiness-score.js             — NEW (civic capacity)
+  feasibility-score.js           — wraps site-selection + pop/QCT/DDA
+  subsidy-score.js               — NEW (prop123, soft funding, CHFA)
+  competition-score.js           — NEW (LIHTC saturation, recency, pipeline)
+  composite.js                   — applies weights by deal type
+  confidence.js                  — meta-dimension; consumes all above
+  explainer.js                   — generates reasons/risks/missingData
+  source-vintage.js              — consumes data freshness manifest
+  weights.js                     — central weight table per deal type
+test/scoring-consistency.test.js — same input → same output everywhere
+test/scoring-shape.test.js       — every export matches ScoreResult schema
+```
+
+Migration order:
+1. Add `js/scoring/shape.js` + schema test (zero breaking change)
+2. Add `js/scoring/composite.js` that wraps current Opportunity Finder math
+3. Refactor `js/lihtc-opportunity-finder.js` to import from `js/scoring/`
+4. Migrate other consumers one at a time
+
+### Performance issues
+
+| File | Size | Issue | Fix |
+|---|---|---|---|
+| `data/market/hud_lihtc_co.geojson` | 574 KB | Loaded on every page that uses LIHTC layer | Convert to clustered or vector tiles; precompute jurisdiction rollups |
+| `data/qct-colorado.json` | 446 KB | Loaded eagerly | Simplify polygons by zoom; serve as MBTiles |
+| `data/co_ami_gap_by_place.json` | 525 KB | Loaded on Opportunity Finder + HNA | Acceptable but split into core + extended bands |
+
+### Module pattern inconsistency
+
+- UMD: `js/lihtc-deal-predictor.js` (`window.LIHTCDealPredictor` + `module.exports`)
+- IIFE: `js/lihtc-opportunity-finder.js`, `js/hna/hna-controller.js`
+- ESM: `scripts/audit/*.mjs`
+- Mixed in `js/data-connectors/`
+
+Pick one for new code. ESM via `<script type="module">` is the path of least friction; existing UMD modules can co-exist.
+
+### Testing gaps
+
+- No tests for `lihtc-opportunity-finder.js` rollup math → **covered by new `scripts/audit/verify-opportunity-finder.mjs`** (this session)
+- No tests for the empty-data fallback paths
+- No regression tests for the score consistency invariant
+- No browser smoke tests in CI (test/qa-recent-changes.js has optional puppeteer)
+
+---
+
+## 7. UI / UX Audit
+
+### What works
+
+- Source badges + hyperlinked metric labels (PR #881)
+- Methodology disclosures via `<details>` (PR #883)
+- Action Plan checklist (PR #881 fix)
+- "→ HNA" deep-links from Opportunity Finder (this session)
+- Dark mode toggle, mobile menu, skip-link, ARIA labels
+
+### What's confusing / decision-friction
+
+1. **Site landing (`index.html`) does not direct users to a workflow.** A first-time visitor doesn't know if they should start at HNA, market-analysis, or deal-calculator. **Fix**: three big tiles on `index.html`: "Find a market" → Opportunity Finder, "Browse needs" → HNA, "Run a deal" → Deal Calculator.
+2. **"Confidence" is binary at best — usually missing.** Need a star/pill on every metric showing data source quality. **Fix**: extend `js/methodology-explainer.js` to emit a `confidence` chip per metric.
+3. **No "So what?"** Every analytical page should end with a 2-sentence interpretation. **Fix**: add `<section class="so-what">` slot to every page; populate from a per-page rule (Scorecard ≥ 80 + low LIHTC density = "test 40–60 unit family concept at 30/50/60 AMI").
+4. **"Compare" doesn't exist.** Users can't compare Boulder vs. Pueblo without copy-pasting. **Fix**: see P1-4.
+5. **Map dominates mobile.** Opportunity Finder map takes 50vh on a 6" screen, table is below the fold. **Fix**: tabs on mobile (Map / Cards / Filters); cards-first.
+6. **News linkouts (this session) bury a footnote that they're Google searches.** Some users will click expecting a curated feed. Add a tiny "via Google" tag.
+
+### Accessibility quick wins
+
+- `lof-civic-cell` tooltip uses `title=` — only works on hover; add a visually-hidden expansion for keyboard users
+- News button grid has duplicate roles — wrap in `<nav aria-label="Housing news search">`
+- Table sort headers use click but no `aria-sort` initial state on inactive headers (current code only sets it post-click)
+
+---
+
+## 8. Implementation Roadmap
+
+### Sprint 1 (next 2 weeks) — "Make the data honest + stand up the funnel"
+
+1. 🔴 Regen `tract_boundaries_co.geojson` + `tract_centroids_co.json` (P0-1, P0-2) — half-day
+2. 🔴 Decide on parcel data: fix or remove (P0-3) — 1 day
+3. 🔴 Add data sentinels (P0 above) — 2 hours
+4. 🟡 Add "next action" CTA strip on HNA, Market Analysis, Deal Calculator linking to Opportunity Finder + each other (P1-2) — 1 day
+5. 🟡 Add confidence pill helper (`js/utils/source-confidence-badges.js`) — 1 day
+6. 🟡 Extend Opportunity Finder with deal-type taxonomy (P1-1) — 2 days
+
+### Sprint 2 (30–45 days) — "Scoring consolidation + Compare + Export"
+
+7. 🔴 Create `js/scoring/` with shape contract + central weights table (P0-4, P0-5) — 3 days
+8. 🟡 Build `compare.html` (P1-4) — 3 days
+9. 🟡 Build export-memo module (P1-5) — 2 days
+10. 🟡 Wire CHFA award pipeline into recency (P1-6) — 2 days
+11. 🟡 Surface preservation candidates panel (P1-7) — 1 day
+
+### Sprint 3 (longer-term) — "Site-level layer"
+
+12. 🟢 Parcel data acquisition (P0-3 deep fix or alternative) — 2 weeks
+13. 🟢 Mobile card-first rebuild — 1 week
+14. 🟢 QAP year switcher — 3 days
+15. 🟢 Vector tile migration — 1 week
+16. 🟢 Watchlist + change alerts — 1 week
+17. 🟢 Public-land + nonprofit-owned parcels — open-ended
+
+---
+
+## 9. Concrete File-Level Recommendations
+
+### Create
+
+| Path | Purpose | Sprint |
+|---|---|---|
+| `js/scoring/index.js` | Public API; exports computeScore({jurisdiction, dealType}) | 2 |
+| `js/scoring/shape.js` | ScoreResult JSON Schema | 2 |
+| `js/scoring/weights.js` | Central weight table per deal type | 2 |
+| `js/scoring/need-score.js` | Wraps housing-outcome-score | 2 |
+| `js/scoring/readiness-score.js` | NEW — civic capacity composite | 2 |
+| `js/scoring/feasibility-score.js` | Wraps site-selection-score + pop bucket | 2 |
+| `js/scoring/subsidy-score.js` | NEW — Prop 123 + soft funding + CHFA fit | 2 |
+| `js/scoring/competition-score.js` | NEW — saturation + recency + pipeline | 2 |
+| `js/scoring/composite.js` | Applies weights | 2 |
+| `js/scoring/confidence.js` | Meta-dim — counts fallbacks/missing | 2 |
+| `js/scoring/explainer.js` | Generates reasons/risks/missingData | 2 |
+| `js/utils/source-confidence-badges.js` | Per-metric ★★★ confidence pill | 1 |
+| `js/components/next-action-cta.js` | Sticky bottom CTA strip | 1 |
+| `js/components/so-what-panel.js` | Decision-oriented summary | 1 |
+| `js/components/opportunity-card.js` | Standalone card component (target state) | 2 |
+| `compare.html` | Side-by-side jurisdictional comparison | 2 |
+| `js/compare.js` | Compare controller | 2 |
+| `js/export/opportunity-memo.js` | Markdown + PDF export | 2 |
+| `test/scoring-consistency.test.js` | Same input → same output across modules | 2 |
+| `test/scoring-shape.test.js` | All scoring modules return ScoreResult shape | 2 |
+| `test/validate-geojson-not-empty.js` | Fail if any required geojson has 0 features | 1 |
+| `docs/audits/REPO-AUDIT-2026-05-25.md` | This doc (already created) | 1 |
+
+### Modify
+
+| Path | Change | Sprint |
+|---|---|---|
+| `index.html` | Replace landing copy with three CTA tiles | 1 |
+| `lihtc-opportunity-finder.html` + `.js` | Add deal-type taxonomy, preservation panel, export CTA | 1–2 |
+| `housing-needs-assessment.html` | Add "So what?" panel + next-action CTA strip + confidence pills | 1 |
+| `market-analysis.html` | Add next-action CTA + So-what; accept `?fips=` and pre-load | 1 |
+| `deal-calculator.html` | Accept `?fips=` + concept; add next-action CTA | 1 |
+| `scripts/audit/data-sentinels-check.mjs` | Add P0 file sentinels (tract, parcel) | 1 |
+| `package.json` | Add `validate:geojson` script + `audit:scoring-consistency` | 1–2 |
+| `scripts/market/build_public_market_data.py` | Run + commit output to restore tract files | 1 |
+
+### Delete / deprecate
+
+- `data/market/tract_centroids_co.json` (if rebuild succeeds, replace; otherwise document as do-not-use)
+- One of `js/lihtc-deal-predictor.js` vs `js/lihtc-deal-predictor-enhanced.js` (consolidate to a single module)
+- `js/market-analysis-cache-fix.js` if its fix is no longer needed post-rebuild
+
+---
+
+## 10. QA / QC Checklist
+
+### Commands to add
+
+```bash
+# In package.json:
+"validate:geojson":       "node test/validate-geojson-not-empty.js",
+"validate:scoring":       "node test/scoring-consistency.test.js && node test/scoring-shape.test.js",
+"validate:sources":       "node scripts/audit/data-sentinels-check.mjs",
+"validate:opportunity":   "node scripts/audit/verify-opportunity-finder.mjs",
+"audit:full":             "npm run validate:geojson && npm run validate:sources && npm run validate:scoring && npm run validate:opportunity"
+```
+
+### Tests that should FAIL with the current main branch
+
+- `validate:geojson` against `data/market/tract_boundaries_co.geojson` (0 features) → **FAIL** until P0-1 is fixed
+- `validate:sources` with the new sentinels → **FAIL** on tract_boundaries + tract_centroids + parcel_aggregates
+- `validate:scoring` → currently no scoring modules return ScoreResult → **FAIL** until P0-4/P0-5 ship
+
+### Tests already passing (this session)
+
+- `scripts/audit/verify-opportunity-finder.mjs` → 28 / 28 ✅
+- `test/qa-recent-changes.js` → all 4 categories ✅
+- `npm run test:ci` → confirmed pass on hna-ranking-index (16/16), soft-funding-tracker (40/40), and others (interrupted by test timeout but no failures observed)
+
+### Browser / accessibility checks
+
+- Lighthouse: A11y + Performance run on Opportunity Finder (sprint 1)
+- Axe-core: tabs through filter chips, table headers, news linkouts (sprint 1)
+- Mobile: simulate iPhone SE width; verify card-first layout (sprint 3)
+
+### Source/provenance checks (per-page)
+
+Every page should:
+1. Print sourceIds + vintage in the page footer (already partially shipped)
+2. Show a confidence pill next to every score/metric (P1-3)
+3. Link the metric label to its primary source URL (already shipped)
+4. Surface a `data-page-last-updated` meta tag (already shipped)
+
+---
+
+## First-Sprint Implementation Patch Plan
+
+Per the audit ask, this is the **minimum coherent first sprint** to convert the current site into a deal-targeting tool without over-rewriting. **Order matters** — do them in sequence.
+
+### Patch 1 — Regen tract geometry (P0-1, P0-2, half-day)
+
+```bash
+# Run the existing rebuild script that the file's own metadata cites
+python3 scripts/market/build_public_market_data.py
+
+# Verify outputs
+node -e "console.log(JSON.parse(require('fs').readFileSync('data/market/tract_boundaries_co.geojson')).features.length)"
+# Expected: ≥ 1,400
+```
+
+If the script doesn't exist or fails, fetch directly from TIGERweb 2024:
+```
+https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County_Sub_State_TractsBlocks/MapServer/2/query?where=STATE='08'&outFields=*&f=geojson&resultRecordCount=2000
+```
+
+### Patch 2 — Data sentinels (P0 detection, 2 hours)
+
+Add the three entries to `scripts/audit/data-sentinels-check.mjs` shown in §5 above. Wire to CI via existing `data-sentinels-check.yml` workflow.
+
+### Patch 3 — Confidence pill helper (P1-3, 1 day)
+
+```js
+// js/utils/source-confidence-badges.js
+export function confidencePill({
+  source,           // 'acs-place' | 'acs-county-fallback' | 'chas-place' | 'chas-county' | 'synthetic'
+  vintage,          // '2018-2022' | '2024' | ...
+  fallbackUsed = false
+}) {
+  const stars = fallbackUsed ? 2 : (source.includes('place') ? 3 : 2);
+  const cls = stars === 3 ? 'pill-conf-high' : stars === 2 ? 'pill-conf-med' : 'pill-conf-low';
+  return `<span class="${cls}" title="Source: ${source} · vintage ${vintage}${fallbackUsed ? ' · fallback used' : ''}">★${'★'.repeat(stars-1)}</span>`;
+}
+```
+
+Drop next to every metric on HNA, Opportunity Finder, PMA.
+
+### Patch 4 — Next-action CTA strip (P1-2, 1 day)
+
+```js
+// js/components/next-action-cta.js
+export function renderNextActionStrip({ jurisdictionFips, geoType, fromPage }) {
+  const params = `?fips=${jurisdictionFips}&geoType=${geoType}&auto=1`;
+  const links = {
+    hna:    { label: '📋 View HNA',          href: 'housing-needs-assessment.html' + params },
+    pma:    { label: '🗺️ Run market analysis', href: 'market-analysis.html' + params },
+    deal:   { label: '💵 Build a deal concept', href: 'deal-calculator.html' + params },
+    of:     { label: '🎯 Compare opportunities', href: 'lihtc-opportunity-finder.html' + params }
+  };
+  // Hide the link for the page we're currently on
+  delete links[fromPage];
+  return `<aside class="next-action-strip">` +
+    Object.values(links).map(l => `<a href="${l.href}">${l.label}</a>`).join('') +
+    `</aside>`;
+}
+```
+
+### Patch 5 — Deal-type taxonomy in Opportunity Finder (P1-1, 2 days)
+
+Extend the current `state.filters.target` enum from `9pct | 4pct | any` to:
+```
+9pct_competitive | 4pct_bond | preservation | workforce_resort | prop123_local | any
+```
+
+Add a 6th radio. Re-weight per §4 weight table. Add a preservation-candidate flag (any LIHTC in jurisdiction with `subsidy_expiration ≤ 2030` → boost score).
+
+### Patch 6 — Scoring shape contract (P0-5, 1 day, can land independently)
+
+Create `js/scoring/shape.js`:
+```js
+export const SCORE_RESULT_SCHEMA = {
+  type: 'object',
+  required: ['score', 'band', 'confidence', 'reasons', 'risks', 'missingData', 'sourceIds', 'nextActions'],
+  properties: {
+    score:        { type: 'number', minimum: 0, maximum: 100 },
+    band:         { enum: ['High', 'Medium', 'Low', 'Watchlist', 'Not-ready'] },
+    confidence:   { enum: ['High', 'Medium', 'Low'] },
+    letterGrade:  { type: 'string', pattern: '^[ABCDF][+-]?$|^Watchlist$' },
+    reasons:      { type: 'array', items: { type: 'string' }, minItems: 1 },
+    risks:        { type: 'array', items: { type: 'string' } },
+    missingData:  { type: 'array', items: { type: 'string' } },
+    sourceIds:    { type: 'array', items: { type: 'string' }, minItems: 1 },
+    sourceVintage: { type: 'object' },
+    nextActions:  { type: 'array', items: { type: 'object', required: ['label', 'href'] } }
+  }
+};
+
+export function validateScoreResult(r) {
+  // Minimal AJV-free validator; throws on shape violation
+  const required = SCORE_RESULT_SCHEMA.required;
+  for (const k of required) if (!(k in r)) throw new Error(`ScoreResult missing field: ${k}`);
+  if (r.score < 0 || r.score > 100) throw new Error(`score out of range: ${r.score}`);
+  if (!['High','Medium','Low','Watchlist','Not-ready'].includes(r.band)) throw new Error(`bad band: ${r.band}`);
+  if (!['High','Medium','Low'].includes(r.confidence)) throw new Error(`bad confidence: ${r.confidence}`);
+  return r;
+}
+```
+
+Add `test/scoring-shape.test.js` that imports every score function and asserts the result validates. This **lands without breaking anything** — the test starts failing for non-conformant modules, which is the desired forcing function.
+
+### Patch 7 — Opportunity card refactor (P1, 2 days, sprint 2)
+
+Promote the current detail-panel rendering in `lihtc-opportunity-finder.js` into a reusable `js/components/opportunity-card.js`. Add the target letter grade, best-fit deal types, confidence pill, next-action CTA strip. The card becomes the consumable artefact across Opportunity Finder, Compare, and the (future) memo export.
+
+### What NOT to do in sprint 1
+
+- **Don't rewrite the HNA page.** It's deep, working, and useful. Add a "So what?" footer and confidence pills, but leave the analytical content alone.
+- **Don't migrate to ESM modules everywhere.** Mixed module patterns are working. New code can use ESM; existing UMD/IIFE stay.
+- **Don't try to acquire parcel data in sprint 1.** Either remove the parcel-aggregate UI references or label them clearly as "data not available — verification needed."
+- **Don't migrate to vector tiles yet.** First-paint is good enough; performance is not the bottleneck. Data quality is.
+
+---
+
+## Closing — the single best next move
+
+**Run `scripts/market/build_public_market_data.py` and commit the regenerated `tract_boundaries_co.geojson` + `tract_centroids_co.json`.** Everything downstream (tract-level need maps, site-screening UI, the 1,447 ACS/CHAS records that currently have no geometry) is gated on this. Until it's fixed, every tract-level analysis the site ships is either silently degraded or rendering "data unavailable" gray polygons.
+
+After that: extend the **already-shipped** Opportunity Finder with deal-type taxonomy + next-action CTAs + confidence pills. You do not need a new page. You need to finish the one you just built.
+
+— end of audit —

--- a/docs/audits/REPO-AUDIT-2026-05-25.md
+++ b/docs/audits/REPO-AUDIT-2026-05-25.md
@@ -1,9 +1,11 @@
 # Colorado Housing Analytics — Repo Audit
-**Date**: 2026-05-25 · **Auditor**: Claude (senior CS + LIHTC lens) · **Branch**: `feat/lihtc-opportunity-finder`
+**Date**: 2026-05-25 (revised) · **Auditor**: Claude (senior CS + LIHTC lens) · **Branch**: `feat/lihtc-opportunity-finder`
 
-This audit was commissioned to evaluate the repo against the product question: **"Where in Colorado should a developer spend scarce time looking for the next affordable housing deal?"** It verifies findings claimed in a prior LLM audit, documents what was wrong about those claims, and produces a P0-to-P2 punch list grounded in actual file inspection.
+This audit evaluates the repo against the product question: **"Where in Colorado should a developer spend scarce time looking for the next affordable housing deal?"**
 
-A material framing note at the top: a working version of the proposed "Deal Targeting" experience already exists at **`lihtc-opportunity-finder.html`** (PR #894, merged-pending this session). About 70% of the recommended product flow is shipped. The audit reframes recommendations as **extend the Opportunity Finder**, not "build a new page."
+> **Strategic direction lock (2026-05-25)**: The user has chosen **jurisdiction-level** deal targeting as the product spine. The Opportunity Finder (PR #894) is the cockpit. Tract-level and parcel-level concerns are explicitly scoped OUT of the deal-targeting workflow and tracked separately as background work for other pages. This audit's P0 list reflects that direction; an appendix captures the deferred items for transparency.
+
+A working version of the proposed "Deal Targeting" experience already exists at **`lihtc-opportunity-finder.html`** (PR #894, this session). About 70% of the recommended product flow is shipped. The audit reframes recommendations as **extend the Opportunity Finder**, not "build a new page."
 
 ---
 
@@ -19,10 +21,16 @@ A material framing note at the top: a working version of the proposed "Deal Targ
 
 ### What prevents it from being a true deal-targeting tool today
 
-1. **Critical geometry gap.** `data/market/tract_boundaries_co.geojson` is 312 bytes and contains zero features. The fallback path uses `data/market/tract_centroids_co.json` (1,605 tracts with lat/lon) but **the file's own metadata warns**: "Centroids for tracts without TIGERweb data estimated from county centroid. Rebuild via scripts/market/build_public_market_data.py for precise coordinates." So tract-level maps degrade to circle markers (no choropleth) and an unknown subset of centroids are county-pinned approximations. Yet 1,447 tract-level ACS/CHAS records exist that should have proper polygon geometry.
-2. **Parcel data is a stub.** `data/market/parcel_aggregates_co.json` reports `counties_successful: 0, coverage_pct: 0`. The site cannot answer "is there a public parcel here?" — which is the fastest LIHTC site-screening triage.
-3. **Need ≠ Dealability.** ChatGPT's framing is correct on this point. The Scorecard v2 composite is a good *need* score but the site sometimes presents it as if it implies opportunity (it doesn't — Boulder is high-need but hard to execute). The Opportunity Finder *does* separate these (recency, basis, population), but only for the QCT/DDA subset.
-4. **Scoring code is scattered.** No `js/scoring/` directory. Score logic lives in `js/market-analysis/site-selection-score.js`, `js/market-health-composite.js`, `js/housing-outcome-score.js`, `js/lihtc-deal-predictor.js`, `js/lihtc-deal-predictor-enhanced.js`, `js/chfa-award-predictor.js`, `js/lihtc-opportunity-finder.js`, etc. Drift risk is real — Boulder gets different scores depending on which page you open.
+These are framed against the **jurisdiction-level** direction. Tract-level geometry and parcel-level data are not blockers for the deal-targeting workflow; they're tracked in the appendix.
+
+1. **Scoring code is scattered with no shared shape.** No `js/scoring/` directory. Score logic lives in 8 files (`js/market-analysis/site-selection-score.js`, `js/market-health-composite.js`, `js/housing-outcome-score.js`, `js/lihtc-deal-predictor.js`, `js/lihtc-deal-predictor-enhanced.js`, `js/chfa-award-predictor.js`, `js/lihtc-opportunity-finder.js`, `js/colorado-regional-predictions.js`). No common `ScoreResult` shape. Drift risk is concrete — Boulder gets different scores depending on which page you open. **This is the #1 blocker for a credible deal-targeting cockpit** because the same jurisdiction must score consistently across HNA, PMA, Opportunity Finder, and Deal Calculator.
+2. **Need ≠ Dealability is partially conflated.** The Scorecard v2 composite is a good *need* score but the site sometimes presents it as if it implies opportunity (Boulder is high-need but hard to execute). The Opportunity Finder *does* separate these (recency, basis, population), but only across 4 dimensions and only for the QCT/DDA subset. Missing: subsidy fit (Prop 123 / CDBG / CHFA pipeline) and readiness (civic capacity) as first-class scoring dimensions, not just badges.
+3. **No cross-page funnel.** Users land on HNA, get rich need data, then have no breadcrumb to "OK, where should I take this next?" The Opportunity Finder already has "→ HNA" deep-links but the reverse path doesn't exist. The Find-market → Screen-site → Explain-deal funnel only works if every page funnels forward and back.
+4. **Opportunity Finder is QCT/DDA-only.** Today's filters exclude:
+   - **Preservation candidates** (NHPD-tracked LIHTC properties with `subsidy_expiration ≤ 2030` — 4% bond refi + Year-15 exit opportunities)
+   - **Workforce / resort 4% deals** in non-basis-boost markets (mountain employers backing private-activity bond issuances)
+   - **Prop 123-funded deals** outside QCT/DDA where local readiness is the driver
+   The 158-jurisdiction default view misses ~half of CO's realistic LIHTC pipeline.
 
 ### The single most important product change
 
@@ -30,49 +38,62 @@ A material framing note at the top: a working version of the proposed "Deal Targ
 
 ### The biggest technical/data risk
 
-The empty `tract_boundaries_co.geojson` (0 features) + the soft-rebuild status of `tract_centroids_co.json` (1,605 tracts but file metadata warns some are county-centroid approximations of unknown precision). Every consumer (`colorado-deep-dive.js`, possibly others) falls back to circle markers — *not* the choropleth UI shows in the methodology disclosure. The map renders, the status string says "X tracts rendered," but:
-- the choropleth promised in the methodology never appears, and
-- the centroids in the marker fallback include an undocumented number of county-centered fakes.
+**Score drift across the 8 scoring modules.** A user comparing Boulder on the HNA page (scorecard v2, percentile-normalised 4-component) to Boulder on the Opportunity Finder (4-component recency/need/basis/pop) to Boulder on the Deal Calculator (different LIHTC predictor weighting) sees three different numbers and no explanation of why. The numbers are *all defensible individually*, but the lack of a single `ScoreResult` contract — with reasons, risks, missing data, source vintages, and confidence — means every page is its own black box.
 
-This creates **false confidence**: page renders fine, status says success, but the underlying spatial truth is degraded. **P0 fix**: regenerate `tract_boundaries_co.geojson` via TIGERweb (script exists at `scripts/market/build_public_market_data.py`, cited in the file's own metadata note) and add a data sentinel that fails CI if features < 1,400. While you're there, regen the centroids file to eliminate the county-fallback approximations.
+**Fix path**: create `js/scoring/shape.js` with a `ScoreResult` JSON Schema + a `validateScoreResult()` helper. Add a test that imports every score module and asserts conformance. This lands without breaking any existing functionality (test starts failing for non-conformant modules, which is the desired forcing function). Then migrate consumers one at a time, starting with the Opportunity Finder (already this session's focus).
 
 ---
 
 ## 2. P0 / P1 / P2 Issue List
 
-### 🔴 P0 — block any further methodology work until resolved
+### 🔴 P0 — block the jurisdiction-level deal-targeting workflow
 
-| # | Issue | Why it matters | Affected files | Recommended fix | Test |
+All five P0s are pre-conditions for a credible deal-targeting cockpit. **All five are jurisdiction-level**; none require tract polygon geometry or parcel data.
+
+| # | Issue | Why it matters for deal targeting | Affected files | Recommended fix | Test |
 |---|---|---|---|---|---|
-| P0-1 | `data/market/tract_boundaries_co.geojson` has 0 features | Tract-level maps silently degrade; ratio choropleth on Colorado Deep Dive shows gray | `js/colorado-deep-dive.js:454-490`, possibly `js/market-analysis*.js` | Run `scripts/market/build_public_market_data.py` (cited in file's own metadata note) to rebuild from TIGERweb 2024 | Add sentinel: `data/market/tract_boundaries_co.geojson` must have ≥1,400 features |
-| P0-2 | `data/market/tract_centroids_co.json` is rebuild-pending (1,605 tracts with lat/lon but file metadata warns some are county-centroid approximations from an aborted rebuild) | Centroid markers visually render but include undocumented county-fallback fakes; tract-precise spatial joins (which the methodology disclosure implies) aren't actually happening for unknown subset | All tract-centroid consumers — at least `js/colorado-deep-dive.js:495`; audit with grep for other consumers | Same `build_public_market_data.py` regen — centroids derive directly from tract polygons | Sentinel: ≥1,400 centroid records all with valid `lat`/`lon` and `county_centered != true` flag (or remove the metadata warning entirely once rebuilt) |
-| P0-3 | `data/market/parcel_aggregates_co.json` has `coverage_pct: 0, counties_successful: 0` | Repo advertises parcel screening but file is a stub. Users seeing "parcel data" in UI assume it exists | `scripts/market/fetch_parcel_data*.py` failed silently | Either (a) actually run county Assessor ArcGIS fetch + add per-county fallback, (b) remove parcel-aggregate UI references and replace with "verification needed" badge | Sentinel: if `coverage_pct < 0.5`, fail build of any page that references parcel data |
-| P0-4 | Scoring drift across 7+ modules | Same jurisdiction gets different scores on HNA vs. PMA vs. Opportunity Finder. Erodes trust. | `js/market-analysis/site-selection-score.js`, `js/market-health-composite.js`, `js/housing-outcome-score.js`, `js/lihtc-deal-predictor.js`, `js/lihtc-deal-predictor-enhanced.js`, `js/chfa-award-predictor.js`, `js/lihtc-opportunity-finder.js` | Create `js/scoring/` with one source of truth per dimension (need, recency, basis, pop, civic); refactor consumers to call it | Add `test/scoring-consistency.test.js` that asserts the same input produces the same score across all consumers |
-| P0-5 | No central "score result" shape — every consumer invents its own | Hard to add confidence/sources/missing-data uniformly | Same as P0-4 | Define `ScoreResult = { score, band, confidence, reasons[], risks[], missingData[], sourceIds[], sourceVintage[], nextActions[] }` and require every scoring fn to return it | Lint rule + test that every score module's default export matches the shape |
+| **P0-1** | **No shared `ScoreResult` shape across the 8 scoring modules** | Boulder gets different scores on HNA vs. Opportunity Finder vs. Deal Calculator. A deal-targeting cockpit requires consistency. | `js/market-analysis/site-selection-score.js`, `js/market-health-composite.js`, `js/housing-outcome-score.js`, `js/lihtc-deal-predictor.js`, `js/lihtc-deal-predictor-enhanced.js`, `js/chfa-award-predictor.js`, `js/lihtc-opportunity-finder.js`, `js/colorado-regional-predictions.js` | Create `js/scoring/shape.js` with the `ScoreResult` JSON Schema + `validateScoreResult()` helper. Lands non-breaking; tests start failing for non-conformant modules, forcing conformance. | `test/scoring-shape.test.js` — import every score module, assert default export's result validates |
+| **P0-2** | **Scoring duplication across 8 modules** | After the shape contract lands, the math itself needs consolidation. Today each module re-implements percentile rank, recency bucketing, basis-boost scoring, etc. with subtle differences. | Same 8 files as P0-1 | Create `js/scoring/` directory: `need-score.js`, `readiness-score.js`, `feasibility-score.js`, `subsidy-score.js`, `competition-score.js`, `composite.js`, `confidence.js`, `explainer.js`, `weights.js`. Migrate consumers one at a time, starting with Opportunity Finder (current focus). | `test/scoring-consistency.test.js` — same jurisdiction input → same score output via every consumer |
+| **P0-3** | **Opportunity Finder is QCT/DDA-only** | Excludes ~half of CO's LIHTC pipeline: preservation deals (NHPD `subsidy_expiration ≤ 2030`), workforce/resort 4% bond deals in non-basis-boost markets, Prop 123-funded local deals. | `js/lihtc-opportunity-finder.js`, `lihtc-opportunity-finder.html` | Add deal-type taxonomy as a 5-option radio: `9pct_competitive · 4pct_bond · preservation · workforce_resort · prop123_local · any`. Re-weight per deal type. Each option relaxes/changes the basis-boost filter. | `test/opportunity-deal-types.test.js` — assert each deal type produces a distinct ranked list with correctly weighted dimensions |
+| **P0-4** | **No cross-page funnel between HNA / Opportunity Finder / PMA / Deal Calculator** | Find-market → Screen-site → Explain-deal funnel only half-exists. Opportunity Finder has "→ HNA" deep-links (this session). HNA doesn't link forward to OF. PMA and Deal Calculator don't accept `?fips=` from anywhere. | `housing-needs-assessment.html`, `market-analysis.html`, `deal-calculator.html`, `lihtc-opportunity-finder.html`, `js/components/` (new) | Build `js/components/next-action-cta.js` — sticky bottom CTA strip. Wire `?fips=…&geoType=…&auto=1` deep-link auto-select to PMA + Deal Calculator (already shipped for HNA this session). | Manual smoke: click through HNA → OF → PMA → Deal Calculator with one jurisdiction pre-loaded throughout |
+| **P0-5** | **No confidence surfacing on jurisdiction-level scores** | Boulder's place-level owner cost burden uses county CHAS fallback. Sugar City's population is a 2.5×HHs proxy. Users can't tell which numbers to trust. | Every page that shows a score | Build `js/utils/source-confidence-badges.js` — ★/★★/★★★ pill emitting source + vintage + fallback flag. Wire to every metric (HNA, OF, PMA). | Lint check: every score render call passes a `confidence:` prop |
+
+### Demoted to background work (was P0 in v1 of this audit)
+
+| # | Was | Now | Why demoted |
+|---|---|---|---|
+| ~~P0-1 (v1)~~ tract_boundaries_co.geojson empty | 🔴 P0 | 🟢 **Background** | Affects `js/colorado-deep-dive.js` choropleth only. Doesn't touch the Opportunity Finder's place-tract-membership path (which uses tract GEOIDs, not polygons). |
+| ~~P0-2 (v1)~~ tract_centroids rebuild-pending | 🟡 P1 | 🟢 **Background** | Same — affects Colorado Deep Dive's circle-marker fallback. Opportunity Finder doesn't render tract centroids. |
+| ~~P0-3 (v1)~~ parcel_aggregates `coverage_pct: 0` | 🔴 P0 | 🟢 **Background** | Site-level concern. Sprint 3+ if we ever scope site-screening. Jurisdiction-level work has no parcel dependency. |
+
+See Appendix A for the full background-work list.
 
 ### 🟡 P1 — should-fix before next major release
 
+### 🟡 P1 — high-value follow-on after P0s land
+
 | # | Issue | Why it matters | Affected files | Recommended fix |
 |---|---|---|---|---|
-| P1-1 | Opportunity Finder filtered to QCT+DDA jurisdictions only | Excludes preservation deals (NHPD-tracked LIHTC expirations), workforce/resort 4% deals, non-basis-boost opportunities | `js/lihtc-opportunity-finder.js` | Add deal-type taxonomy: `9pct_competitive`, `4pct_bond`, `preservation`, `workforce_resort`, `prop123_local`. Each becomes a target-round option. |
-| P1-2 | "Find a market → Screen a site → Explain the deal" funnel is not connected | Users land on HNA, get great need data, but no link to "OK, now what?" | `housing-needs-assessment.html`, `lihtc-opportunity-finder.html`, `deal-calculator.html`, `market-analysis.html` | Add a persistent "next action" CTA strip at the bottom of each analytical page. HNA → Opportunity Finder; Opportunity Finder → PMA (with place pre-loaded); PMA → Deal Calculator (with concept pre-loaded). |
-| P1-3 | No "Confidence" surfacing on Scorecard or AMI gap | Boulder's owner cost burden is from CHAS Table 7 (county-level), not place-level SMOCAPI. User can't tell. | `js/hna/hna-controller.js`, `js/hna/hna-utils.js` | Add a small "★★★" confidence pill next to every metric: 3 = direct ACS/CHAS place, 2 = county fallback, 1 = synthetic/derived |
-| P1-4 | Compare mode does not exist | "Compare Boulder vs. Greeley vs. Pueblo" is a fundamental developer workflow | All analytical pages | Build `compare.html` that accepts `?jurisdictions=08013,0807850,0862000` and shows a side-by-side score table with all dimensions |
-| P1-5 | No export memo (.pdf or .md) | Developers need to bring opportunity findings into their pipeline meeting | All analytical pages | Build `js/export/opportunity-memo.js` that produces a downloadable .md (or .pdf via existing `hna-export.js` pattern) from the current Opportunity Finder selection |
-| P1-6 | Recent funding ≠ recent placed-in-service | Opportunity Finder's recency uses YR_PIS (placed in service) which lags awards by 2–3y. A jurisdiction that won 2024 awards but hasn't broken ground still looks "stale." | `js/lihtc-opportunity-finder.js`, `data/market/hud_lihtc_co.geojson` | Add award-year layer: fetch CHFA award announcements (which `js/chfa-award-predictor.js` already references) → join by jurisdiction → use max(YR_PIS, award_year) for recency |
-| P1-7 | Preservation pipeline not surfaced | `data/market/nhpd_co.geojson` has 20 properties with `subsidy_expiration` — these are preservation candidates ripe for 4% bond refi + Year-15 exit | Not consumed by Opportunity Finder | Add "Preservation candidates" panel: any LIHTC in jurisdiction with expiration ≤ 2030 → flag prominently |
+| P1-1 | Compare mode doesn't exist | "Boulder vs. Greeley vs. Pueblo" side-by-side is a fundamental deal-pipeline workflow — the natural next step after Opportunity Finder ranks options. | New `compare.html`, links from Opportunity Finder rows | Build `compare.html` accepting `?jurisdictions=08013,0807850,0862000`; render a wide table of every score dimension across the selected jurisdictions with diff highlighting |
+| P1-2 | No export memo (.md / .pdf) | Developers need a takeaway artifact from a jurisdiction screen to bring into pipeline meetings. The civic-capacity panel + scores already on the OF detail are 90% of a one-page memo. | New `js/export/opportunity-memo.js`, reuse `hna-export.js` pattern | Markdown export first (faster, no PDF dependency); PDF later via existing `hna-export.js` machinery |
+| P1-3 | Recent funding ≠ recent placed-in-service | OF's recency uses YR_PIS which lags awards by 2–3y. A jurisdiction with 2024 CHFA awards but no PIS yet looks "stale." | `js/lihtc-opportunity-finder.js`, `data/market/hud_lihtc_co.geojson`, `js/chfa-award-predictor.js` (already references award data) | Add award-year layer; recency uses `max(YR_PIS, award_year)`. Surface "awarded but not PIS" as a separate badge. |
+| P1-4 | Preservation pipeline not in the OF flow | `data/market/nhpd_co.geojson` has 20 properties with `subsidy_expiration` — 4% refi + Year-15 exit candidates. Won't surface unless preservation deal-type lands (P0-3). | `js/lihtc-opportunity-finder.js` | After P0-3 deal-type taxonomy ships, populate `preservation` ranked list from NHPD expiration ≤ 2030; auto-score with subsidy-stack dimension |
+| P1-5 | `index.html` doesn't direct users to a workflow | First-time visitor lands on a generic dashboard without knowing where to start. | `index.html` | Three big CTA tiles: "Find a market" → Opportunity Finder (PRIMARY), "Browse all needs" → HNA, "Build a deal" → Deal Calculator |
+| P1-6 | Civic-capacity score isn't weighted into the composite | OF currently shows civic score in a column but doesn't roll it into the composite. A jurisdiction with strong civic capacity (Prop 123 ✓ + comp plan + housing lead) should score higher than one without, holding need/recency constant. | `js/lihtc-opportunity-finder.js` (then `js/scoring/readiness-score.js` once P0-2 lands) | Add 5th component to composite: civic readiness, weighted heaviest in `prop123_local` deal type (30%) |
+| P1-7 | EPA Walkability + LODES (jobs access) not wired in | `js/data-connectors/epa-walkability.js` exists. LODES commuting data already loaded for HNA. Both are jurisdiction-level signals that belong in feasibility score. | `js/lihtc-opportunity-finder.js`, `js/scoring/feasibility-score.js` (P0-2) | Add walkability + jobs-access as feasibility sub-dimensions; surface in OF detail panel |
 
-### 🟢 P2 — nice-to-have / longer-term
+### 🟢 P2 — nice-to-have (within the jurisdiction product)
 
 | # | Issue | Recommendation |
 |---|---|---|
 | P2-1 | Mobile experience is desktop-first | Card-first mobile layout for Opportunity Finder; map/table become tabs not side-by-side |
-| P2-2 | No "watchlist" | Per-user (localStorage) watchlist of jurisdictions with change alerts |
-| P2-3 | QAP year switcher | `data/lihtc/qap_*.json` keyed by 2025/2026/draft-2027 → switcher in Deal Calculator |
-| P2-4 | Public-land / nonprofit-owned parcel layer | Custom data acquisition (CO State Land Board API, Colorado Trust Lands, faith-based nonprofit research) — long-term |
-| P2-5 | Water/sewer/utility readiness | Out of scope without parcel data; queue behind P0-3 |
-| P2-6 | EPA Walkability + transit access | `js/data-connectors/epa-walkability.js` exists — wire into Opportunity Finder detail panel |
-| P2-7 | Vector tiles for map performance | Migrate large geojson layers (HUD LIHTC 702 points, QCT 224 polygons) to MBTiles for first-paint <500ms |
+| P2-2 | No "watchlist" | Per-user (localStorage) watchlist of jurisdictions with change alerts on new CHFA awards, new Prop 123 commitments, new HNAs |
+| P2-3 | QAP year switcher | `data/lihtc/qap_*.json` keyed by 2025/2026/draft-2027 → switcher in Deal Calculator + OF subsidy weights |
+| P2-4 | Vector tiles for map performance | Migrate large geojson layers (HUD LIHTC 702 points, QCT 224 polygons) to MBTiles for first-paint <500ms |
+| P2-5 | "So what?" interpretation panel per page | Each analytical page ends with 2 sentences telling the user what the data implies for next action |
+| P2-6 | News-source curation beyond Google | Replace Google site-search news linkouts with a curated RSS aggregator (Colorado Sun housing tag, CPR housing tag, DenverITE, BizWest) for less-noisy results |
+
+See **Appendix A** for site-level / parcel-level / tract-geometry work that is explicitly out of scope for the jurisdiction direction but tracked for transparency.
 
 ---
 
@@ -399,31 +420,40 @@ Pick one for new code. ESM via `<script type="module">` is the path of least fri
 
 ## 8. Implementation Roadmap
 
-### Sprint 1 (next 2 weeks) — "Make the data honest + stand up the funnel"
+### Sprint 1 (next 2 weeks) — "Score consistency + funnel"
 
-1. 🔴 Regen `tract_boundaries_co.geojson` + `tract_centroids_co.json` (P0-1, P0-2) — half-day
-2. 🔴 Decide on parcel data: fix or remove (P0-3) — 1 day
-3. 🔴 Add data sentinels (P0 above) — 2 hours
-4. 🟡 Add "next action" CTA strip on HNA, Market Analysis, Deal Calculator linking to Opportunity Finder + each other (P1-2) — 1 day
-5. 🟡 Add confidence pill helper (`js/utils/source-confidence-badges.js`) — 1 day
-6. 🟡 Extend Opportunity Finder with deal-type taxonomy (P1-1) — 2 days
+1. 🔴 Create `js/scoring/shape.js` with `ScoreResult` contract (P0-1) — 1 day
+2. 🔴 Add `test/scoring-shape.test.js` (P0-1) — half-day
+3. 🔴 Migrate Opportunity Finder's score output to conform (P0-2 first consumer) — 1 day
+4. 🔴 Add deal-type taxonomy radio to OF: 9% / 4% / preservation / workforce-resort / prop123-local (P0-3) — 2 days
+5. 🔴 Add `js/components/next-action-cta.js` and wire into HNA, OF, PMA, Deal Calculator (P0-4) — 1 day
+6. 🔴 Add `js/utils/source-confidence-badges.js` and wire into OF + HNA (P0-5) — 1 day
+7. 🟡 Promote OF to a primary tile on `index.html` (P1-5) — half-day
 
-### Sprint 2 (30–45 days) — "Scoring consolidation + Compare + Export"
+### Sprint 2 (30–45 days) — "Consolidation + Compare + Export"
 
-7. 🔴 Create `js/scoring/` with shape contract + central weights table (P0-4, P0-5) — 3 days
-8. 🟡 Build `compare.html` (P1-4) — 3 days
-9. 🟡 Build export-memo module (P1-5) — 2 days
-10. 🟡 Wire CHFA award pipeline into recency (P1-6) — 2 days
-11. 🟡 Surface preservation candidates panel (P1-7) — 1 day
+8. 🔴 Migrate remaining 7 scoring modules into `js/scoring/` (P0-2) — 5 days
+9. 🟡 Build `compare.html` (P1-1) — 3 days
+10. 🟡 Build export-memo module (P1-2) — 2 days
+11. 🟡 Wire CHFA award pipeline into recency (P1-3) — 2 days
+12. 🟡 Surface preservation candidates panel (P1-4 — depends on P0-3 deal-type taxonomy) — 1 day
+13. 🟡 Roll civic readiness into composite (P1-6) — 1 day
+14. 🟡 Wire EPA Walkability + LODES jobs access (P1-7) — 2 days
 
-### Sprint 3 (longer-term) — "Site-level layer"
+### Sprint 3 (longer-term, within jurisdiction direction)
 
-12. 🟢 Parcel data acquisition (P0-3 deep fix or alternative) — 2 weeks
-13. 🟢 Mobile card-first rebuild — 1 week
-14. 🟢 QAP year switcher — 3 days
-15. 🟢 Vector tile migration — 1 week
-16. 🟢 Watchlist + change alerts — 1 week
-17. 🟢 Public-land + nonprofit-owned parcels — open-ended
+15. 🟢 Mobile card-first rebuild (P2-1) — 1 week
+16. 🟢 Watchlist + change alerts (P2-2) — 1 week
+17. 🟢 QAP year switcher (P2-3) — 3 days
+18. 🟢 Vector tile migration (P2-4) — 1 week
+19. 🟢 "So what?" panel pattern across analytical pages (P2-5) — 2 days
+20. 🟢 News-source curation (RSS aggregator replacing Google site-search) (P2-6) — 1 week
+
+### Background work (separate track, not blocking deal targeting)
+
+21. Regen `tract_boundaries_co.geojson` + `tract_centroids_co.json` (Appendix A.1, A.2) — half-day
+22. Decide on parcel data: fix-or-remove `parcel_aggregates_co.json` (Appendix A.3) — 1 day to remove, 2+ weeks to fix
+23. Site-level layer work (Appendix A.4, A.5) — only if product scope expands to site-level
 
 ---
 
@@ -520,29 +550,45 @@ Every page should:
 
 ## First-Sprint Implementation Patch Plan
 
-Per the audit ask, this is the **minimum coherent first sprint** to convert the current site into a deal-targeting tool without over-rewriting. **Order matters** — do them in sequence.
+Per the audit ask, this is the **minimum coherent first sprint** to convert the current jurisdiction-level site into a deal-targeting tool without over-rewriting. **Order matters** — do them in sequence. All patches operate at the jurisdiction level; tract geometry and parcel data work is separately tracked in Appendix A.
 
-### Patch 1 — Regen tract geometry (P0-1, P0-2, half-day)
+### Patch 1 — `ScoreResult` shape contract (P0-1, 1 day)
 
-```bash
-# Run the existing rebuild script that the file's own metadata cites
-python3 scripts/market/build_public_market_data.py
+The single most important patch. Lands without breaking anything, but starts failing CI for every non-conformant scoring module, forcing conformance.
 
-# Verify outputs
-node -e "console.log(JSON.parse(require('fs').readFileSync('data/market/tract_boundaries_co.geojson')).features.length)"
-# Expected: ≥ 1,400
+```js
+// js/scoring/shape.js
+export const SCORE_RESULT_SCHEMA = { /* see §4 for the full schema */ };
+export function validateScoreResult(r) { /* see §4 */ }
 ```
 
-If the script doesn't exist or fails, fetch directly from TIGERweb 2024:
+```js
+// test/scoring-shape.test.js
+import { validateScoreResult } from '../js/scoring/shape.js';
+import * as opportunityFinder from '../js/lihtc-opportunity-finder.js';
+// ...import every other score module
+test('OpportunityFinder returns conformant ScoreResult', () => {
+  const result = opportunityFinder.scoreJurisdiction({ ... });
+  expect(() => validateScoreResult(result)).not.toThrow();
+});
 ```
-https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County_Sub_State_TractsBlocks/MapServer/2/query?where=STATE='08'&outFields=*&f=geojson&resultRecordCount=2000
+
+After this patch lands, every existing scoring module either gets refactored to conform or its test will fail. That's the desired forcing function.
+
+### Patch 2 — Opportunity Finder is first conforming consumer (P0-2, 1 day)
+
+Migrate `js/lihtc-opportunity-finder.js`'s score output to use the shape contract. Today's ad-hoc result object becomes a proper `ScoreResult` with reasons/risks/missingData/nextActions populated. **The UI doesn't change yet** — the OF detail panel already shows most of this content; it just gets sourced from the structured result instead of inline rendering.
+
+### Patch 3 — Deal-type taxonomy (P0-3, 2 days)
+
+Extend the current `state.filters.target` enum from `9pct | 4pct | any` to:
+```
+9pct_competitive | 4pct_bond | preservation | workforce_resort | prop123_local | any
 ```
 
-### Patch 2 — Data sentinels (P0 detection, 2 hours)
+Add a 5th radio. Re-weight per §4 weight table. For `preservation`: relax the QCT+DDA basis-boost requirement; populate from NHPD `subsidy_expiration ≤ 2030`. For `workforce_resort`: relax basis-boost; weight population heavily; flag resort counties. For `prop123_local`: weight civic readiness heavily; relax basis-boost.
 
-Add the three entries to `scripts/audit/data-sentinels-check.mjs` shown in §5 above. Wire to CI via existing `data-sentinels-check.yml` workflow.
-
-### Patch 3 — Confidence pill helper (P1-3, 1 day)
+### Patch 4 — Next-action CTA strip (P0-4, 1 day)
 
 ```js
 // js/utils/source-confidence-badges.js
@@ -579,66 +625,95 @@ export function renderNextActionStrip({ jurisdictionFips, geoType, fromPage }) {
 }
 ```
 
-### Patch 5 — Deal-type taxonomy in Opportunity Finder (P1-1, 2 days)
+Drop the strip on the bottom of HNA, OF, Market Analysis, and Deal Calculator. Pass the active jurisdiction's FIPS through every link. Patch is small but unlocks the funnel completely.
 
-Extend the current `state.filters.target` enum from `9pct | 4pct | any` to:
-```
-9pct_competitive | 4pct_bond | preservation | workforce_resort | prop123_local | any
-```
+### Patch 5 — Confidence pill helper (P0-5, 1 day)
 
-Add a 6th radio. Re-weight per §4 weight table. Add a preservation-candidate flag (any LIHTC in jurisdiction with `subsidy_expiration ≤ 2030` → boost score).
-
-### Patch 6 — Scoring shape contract (P0-5, 1 day, can land independently)
-
-Create `js/scoring/shape.js`:
 ```js
-export const SCORE_RESULT_SCHEMA = {
-  type: 'object',
-  required: ['score', 'band', 'confidence', 'reasons', 'risks', 'missingData', 'sourceIds', 'nextActions'],
-  properties: {
-    score:        { type: 'number', minimum: 0, maximum: 100 },
-    band:         { enum: ['High', 'Medium', 'Low', 'Watchlist', 'Not-ready'] },
-    confidence:   { enum: ['High', 'Medium', 'Low'] },
-    letterGrade:  { type: 'string', pattern: '^[ABCDF][+-]?$|^Watchlist$' },
-    reasons:      { type: 'array', items: { type: 'string' }, minItems: 1 },
-    risks:        { type: 'array', items: { type: 'string' } },
-    missingData:  { type: 'array', items: { type: 'string' } },
-    sourceIds:    { type: 'array', items: { type: 'string' }, minItems: 1 },
-    sourceVintage: { type: 'object' },
-    nextActions:  { type: 'array', items: { type: 'object', required: ['label', 'href'] } }
-  }
-};
-
-export function validateScoreResult(r) {
-  // Minimal AJV-free validator; throws on shape violation
-  const required = SCORE_RESULT_SCHEMA.required;
-  for (const k of required) if (!(k in r)) throw new Error(`ScoreResult missing field: ${k}`);
-  if (r.score < 0 || r.score > 100) throw new Error(`score out of range: ${r.score}`);
-  if (!['High','Medium','Low','Watchlist','Not-ready'].includes(r.band)) throw new Error(`bad band: ${r.band}`);
-  if (!['High','Medium','Low'].includes(r.confidence)) throw new Error(`bad confidence: ${r.confidence}`);
-  return r;
+// js/utils/source-confidence-badges.js
+export function confidencePill({
+  source,           // 'acs-place' | 'acs-county-fallback' | 'chas-place' | 'chas-county' | 'synthetic'
+  vintage,          // '2018-2022' | '2024' | ...
+  fallbackUsed = false
+}) {
+  const stars = fallbackUsed ? 2 : (source.includes('place') ? 3 : 2);
+  const cls = stars === 3 ? 'pill-conf-high' : stars === 2 ? 'pill-conf-med' : 'pill-conf-low';
+  return `<span class="${cls}" title="Source: ${source} · vintage ${vintage}${fallbackUsed ? ' · fallback used' : ''}">★${'★'.repeat(stars-1)}</span>`;
 }
 ```
 
-Add `test/scoring-shape.test.js` that imports every score function and asserts the result validates. This **lands without breaking anything** — the test starts failing for non-conformant modules, which is the desired forcing function.
+Wire next to every score / metric on OF detail panel + HNA Executive Snapshot. Adding it on PMA and Deal Calculator can wait for sprint 2.
 
-### Patch 7 — Opportunity card refactor (P1, 2 days, sprint 2)
+### Patch 6 — Promote OF on the landing page (P1-5, half-day)
 
-Promote the current detail-panel rendering in `lihtc-opportunity-finder.js` into a reusable `js/components/opportunity-card.js`. Add the target letter grade, best-fit deal types, confidence pill, next-action CTA strip. The card becomes the consumable artefact across Opportunity Finder, Compare, and the (future) memo export.
+`index.html` gets three big tiles at the top. "Find a market" (primary, prominent) → Opportunity Finder. "Browse needs by jurisdiction" → HNA. "Build a deal concept" → Deal Calculator. Don't rewrite the rest of `index.html`; just the top hero section.
+
+### Patch 7 (sprint 2) — Opportunity card refactor
+
+Promote the current detail-panel rendering in `lihtc-opportunity-finder.js` into a reusable `js/components/opportunity-card.js`. Add the target letter grade, best-fit deal types, confidence pill, next-action CTA strip. The card becomes the consumable artefact across Opportunity Finder, Compare (P1-1), and the future memo export (P1-2).
 
 ### What NOT to do in sprint 1
 
-- **Don't rewrite the HNA page.** It's deep, working, and useful. Add a "So what?" footer and confidence pills, but leave the analytical content alone.
+- **Don't regen tract geometry.** It's a known issue but it doesn't affect the deal-targeting workflow. Queue separately. (Appendix A.1, A.2)
+- **Don't touch parcel data.** Same reason. (Appendix A.3)
+- **Don't rewrite the HNA page.** It's deep, working, and useful. Add the next-action CTA strip + confidence pills, but leave the analytical content alone.
+- **Don't migrate the other 7 scoring modules in sprint 1.** Just the OF. The shape contract starts failing CI for them, which establishes the forcing function — but actually refactoring them is sprint 2 work.
 - **Don't migrate to ESM modules everywhere.** Mixed module patterns are working. New code can use ESM; existing UMD/IIFE stay.
-- **Don't try to acquire parcel data in sprint 1.** Either remove the parcel-aggregate UI references or label them clearly as "data not available — verification needed."
-- **Don't migrate to vector tiles yet.** First-paint is good enough; performance is not the bottleneck. Data quality is.
+- **Don't migrate to vector tiles yet.** First-paint is good enough; consistency is the bottleneck, not performance.
 
 ---
 
 ## Closing — the single best next move
 
-**Run `scripts/market/build_public_market_data.py` and commit the regenerated `tract_boundaries_co.geojson` + `tract_centroids_co.json`.** Everything downstream (tract-level need maps, site-screening UI, the 1,447 ACS/CHAS records that currently have no geometry) is gated on this. Until it's fixed, every tract-level analysis the site ships is either silently degraded or rendering "data unavailable" gray polygons.
+**Create `js/scoring/shape.js` with the `ScoreResult` contract + `validateScoreResult()` helper, and a `test/scoring-shape.test.js` that asserts every score module's output conforms.**
 
-After that: extend the **already-shipped** Opportunity Finder with deal-type taxonomy + next-action CTAs + confidence pills. You do not need a new page. You need to finish the one you just built.
+This is a one-day patch that:
+1. Lands without breaking anything (existing modules continue working unchanged)
+2. Starts failing CI for every non-conformant scoring module, forcing conformance over time
+3. Unblocks every other P0 (consolidation, deal-type taxonomy, confidence surfacing all depend on a stable result shape)
+4. Establishes the contract that lets HNA, Opportunity Finder, PMA, and Deal Calculator give the *same* score for the *same* jurisdiction — which is the credibility prerequisite for a deal-targeting cockpit
+
+After that lands, the Opportunity Finder gets:
+- 5-option deal-type taxonomy (9% / 4% / preservation / workforce-resort / prop123-local)
+- Civic readiness weighted into the composite
+- Next-action CTAs to PMA + Deal Calculator with `?fips=` pre-load
+- Confidence pills on every metric
+
+**You do not need a new page. You need to finish the one you just built — and make every score on the site agree with itself.**
+
+---
+
+## Appendix A — Background work (out of scope for jurisdiction-level deal targeting)
+
+The audit's v1 P0 list (now revised) had three items that turned out to be specific to other surfaces. They're real issues, but they don't block the deal-targeting workflow and shouldn't compete with it for sprint capacity. Listed here for transparency and so Codex (or a future maintainer) doesn't chase them under the wrong banner.
+
+### A.1 — `data/market/tract_boundaries_co.geojson` is empty
+- **File**: 312 bytes, 0 features
+- **Sole consumer**: `js/colorado-deep-dive.js:454-490` (rent/income choropleth)
+- **Impact**: Colorado Deep Dive page silently falls through to circle-marker fallback
+- **Not affecting**: HNA, Opportunity Finder, PMA, Deal Calculator (none consume tract polygons)
+- **Fix path**: Run `scripts/market/build_public_market_data.py` (cited in the file's own metadata note). Half-day work. Queue separately from deal-targeting sprint.
+
+### A.2 — `data/market/tract_centroids_co.json` is rebuild-pending
+- **File**: 1,605 tracts with lat/lon, but metadata warns of county-fallback approximations from an aborted rebuild
+- **Sole consumer**: `js/colorado-deep-dive.js:495` (marker fallback when boundaries empty)
+- **Impact**: Tract markers render but include undocumented county-pinned fakes
+- **Not affecting**: Opportunity Finder uses `place-tract-membership.json` (GEOID joins only, no geometry needed)
+- **Fix path**: Same `build_public_market_data.py` regen as A.1
+
+### A.3 — `data/market/parcel_aggregates_co.json` is a stub
+- **File**: `counties_successful: 0, coverage_pct: 0`
+- **Impact**: Any future site-level parcel screening cannot operate
+- **Not affecting**: Jurisdiction-level deal targeting (no parcel dependency)
+- **Fix path**: Either run the county Assessor ArcGIS fetch properly (multi-week project given the patchwork of CO assessor APIs), or remove the parcel-aggregate UI references entirely and replace with "Site-level screening: requires verification by user." If the product never goes site-level, this can stay deferred indefinitely.
+
+### A.4 — Site-level layers (water, sewer, slope, wildfire, wetlands, transit access, etc.)
+- **Status**: Not in repo today
+- **Impact**: Out of scope for jurisdiction-level deal targeting
+- **Recommendation**: Only revisit if the product explicitly scopes site-level screening. Today, the OF detail panel's "Next action: contact local jurisdiction to verify utilities" is the right answer.
+
+### A.5 — Public-land + nonprofit-owned parcel layer
+- **Status**: Not in repo today; would need custom data acquisition
+- **Recommendation**: Long-term; not in any first sprint
 
 — end of audit —

--- a/docs/methodology/LIHTC-LOCATOR-METHODOLOGY.md
+++ b/docs/methodology/LIHTC-LOCATOR-METHODOLOGY.md
@@ -1,0 +1,482 @@
+# LIHTC Locator Methodology
+
+**Version**: 1.1 (2026-05-25) · **Status**: Live in `lihtc-opportunity-finder.html` · **Maintainer**: Open
+
+This document is the canonical methodology behind the COHO Analytics LIHTC Opportunity Finder. It describes — at the level of detail a developer, a CHFA reviewer, or a county housing director would expect — exactly how the locator ranks Colorado jurisdictions for affordable-housing deal targeting, what data backs each score, and what it explicitly does NOT do.
+
+A condensed version of this methodology is embedded in the Opportunity Finder UI under "How is this calculated?" Users who want the full math come here.
+
+---
+
+## 1. The product question
+
+**"Which Colorado jurisdictions deserve scarce developer attention as candidates for the next LIHTC deal?"**
+
+This question has three sub-questions that the locator answers separately so the user can distinguish them:
+
+1. **Where is the housing need acute?** — high cost burden, deep AMI gap, severe rent burden
+2. **Where is a deal *executable*?** — basis-boost eligibility, civic readiness, population scale, subsidy stack feasibility
+3. **Where is competition light?** — funding-recency headroom, LIHTC saturation gap
+
+The locator never collapses these into a single black-box score. Each dimension is reported separately so a user can see *why* a jurisdiction rises (or doesn't) and can re-weight them for their own deal strategy.
+
+A locator is **not** a site-screen. It can tell you Sugar City scores well for a 9% deal. It cannot tell you whether the south side of Sugar City has a usable parcel, water capacity, or a zoning path. Those questions require parcel-level work that is out of scope; see §9 for the boundary.
+
+---
+
+## 2. The universe — which jurisdictions get scored
+
+### 2a. Base universe
+
+The locator starts with **Colorado's full place inventory** from TIGER 2024:
+- 273 incorporated places (cities + towns)
+- 210 census-designated places (CDPs)
+- 64 counties (used as fallback geography for some signals)
+
+Total: 547 jurisdictions in `data/policy/housing-policy-scorecard.json`. The Opportunity Finder works against the 482 places with tract-membership data (`data/hna/place-tract-membership.json`).
+
+### 2b. Per-deal-type universe filtering
+
+Different deal types have different eligibility universes. The locator filters the base universe per the user's selected target round:
+
+| Target deal type | Universe filter | CO count (today) |
+|---|---|---|
+| **9% Competitive** | ≥1 QCT tract OR DDA county | 158 jurisdictions |
+| **4% Bond + basis boost** | ≥1 QCT tract OR DDA county | 158 |
+| **4% Bond (no basis boost)** | Population ≥5,000 HHs (~12,500 people) | TBD when shipped |
+| **Preservation** | ≥1 LIHTC or HUD-assisted property with `subsidy_expiration ≤ horizon` (today: 2030) | ~20 from NHPD, expanded as data improves |
+| **Workforce / Resort** | Resort county subset (Pitkin, San Miguel, Summit, Eagle, Routt, Garfield, La Plata, Grand) AND population ≥1,000 | ~15 |
+| **Prop 123 Local** | Prop 123 commitment filed AND (comp plan ✓ OR HNA ✓ OR housing lead ✓) | ~80 |
+| **Any (balanced)** | Union of all above | ~200 |
+
+The 9% / 4%-with-basis filter is the most restrictive because IRC §42(d)(5)(B) basis boost is a real underwriting differentiator. The locator does not pretend that a market without QCT/DDA designation is automatically out — Prop 123 + local-funding stacks work — but those need different filters.
+
+### 2c. Why incorporated-places-first
+
+LIHTC awards typically require a jurisdiction with permitting authority for entitlement, consent letters, and impact-fee waivers. CDPs are unincorporated communities; deals sited in CDPs use county permitting. The locator's default `includeCdps = false` reflects this; users can toggle CDPs on to see all candidates.
+
+---
+
+## 3. The five scoring dimensions
+
+Every jurisdiction in the universe receives five independent 0–100 scores. These are then composited with weights that depend on the target deal type (§4).
+
+### Dimension 1 — Housing Need Score
+
+**What it measures**: How acute is the housing affordability problem? Blends renter cost burden, owner cost burden, and severe rent burden. Normalized to a Colorado-wide percentile.
+
+**Formula**:
+
+```
+blended_cb30 = (renter_pct_cb30 × renter_HHs + owner_pct_cb30 × owner_HHs)
+             ÷ (renter_HHs + owner_HHs)
+
+severe_rent_burden = renter_pct_cb50    [% of renters paying ≥50% of income on rent]
+
+need_composite = (blended_cb30 × 0.7) + (severe_rent_burden × 0.3)
+
+need_score = percentile_rank(need_composite, CO peer distribution) × 100
+```
+
+**Why this shape**: Tenure-blended cost burden is the HUD Worst Case Housing Needs (WCN) framework's anchor metric. Severe rent burden (pct_cb50) gets a 30% weight because households at 50%+ are in immediate stress, while 30%+ is the broader-burden frame. Percentile-normalization against CO peers prevents resort-area distortion (Aspen has 70%+ rent burden but the percentile clips its influence).
+
+**Data sources**:
+- HUD CHAS 2018–2022 Table 7 (cost burden by tenure and AMI band) — `data/hna/chas_affordability_gap.json` (county-level) or `data/market/chas_tract_co.json` (tract-level, 1,447 records)
+- ACS DP04 GRAPI (renter cost burden) and DP04 SMOCAPI (owner cost burden, 2018–2022 5-year)
+
+**Confidence handling**:
+- **High**: Place-level CHAS Table 7 directly available (rare — only large places)
+- **Medium**: County CHAS used for place (most common case — note that `data/co_ami_gap_by_place.json` aggregates this)
+- **Low**: Owner cost burden via 3-bin CHAS fallback (used when SMOCAPI cache miss — see PR #884)
+
+**Edge cases**:
+- Tiny jurisdictions (<200 HHs total) return a "data-thin" flag — percentile rank is unreliable
+- Jurisdictions in counties with CHAS suppression: composite uses ACS GRAPI/SMOCAPI direct (lower precision)
+
+---
+
+### Dimension 2 — Recency / Competition Score
+
+**What it measures**: How long since this jurisdiction last got LIHTC funding? Longer = more "saturation headroom" → more competitive for CHFA's geographic-gap scoring on 9% rounds.
+
+**Formula**:
+
+```
+last_yr_pis = max(YR_PIS for all LIHTC projects with PROJ_CTY matching jurisdiction
+                  AND YR_PIS valid AND YR_PIS != 8888)
+
+years_since = current_year - last_yr_pis
+            = ∞ if never funded
+
+recency_score = min(100, round(years_since / 25 × 100))
+              = 100 if never funded
+              =  60 if 15 years ago
+              =  20 if 5 years ago
+              =   0 if last year
+```
+
+**Why this shape**: CHFA's 9% Qualified Allocation Plan rewards geographic distribution; jurisdictions with no recent activity are explicitly preferred. The 25-year cap matches the LIHTC compliance period — beyond that, a deal can no longer be considered "saturated." Future enhancement (P1): add CHFA award year (typically 2–3y ahead of PIS) for fresher signal.
+
+**Data sources**:
+- HUD LIHTC Database (LIHTCDB), filtered to CO `state == 'CO'` — `data/market/hud_lihtc_co.geojson` (716 projects, 702 with valid YR_PIS)
+- Match rule: `PROJ_CTY.toUpperCase().trim() === jurisdiction_name.toUpperCase().trim()`
+
+**Confidence handling**:
+- **High**: Jurisdiction has ≥3 LIHTC projects on record (high-confidence saturation signal)
+- **Medium**: 1–2 projects on record
+- **Low**: Zero projects — could indicate undeveloped market OR could indicate PROJ_CTY mismatch (e.g., "Ft. Collins" vs "Fort Collins")
+
+**Edge cases**:
+- YR_PIS = 8888 (HUD placeholder for in-pipeline projects) excluded
+- Misspelled PROJ_CTY misses match (P1 fuzzy-match enhancement on backlog)
+- Two-jurisdiction projects (e.g., subdivision crosses city/CDP line): counted toward the listed PROJ_CTY
+
+---
+
+### Dimension 3 — Basis-Boost / Subsidy Fit Score
+
+**What it measures**: How much of the IRC §42(d)(5)(B) basis-boost stack does this jurisdiction qualify for? Stronger basis = better economics on both 9% and 4% deals.
+
+**Formula**:
+
+```
+basis_score = 100 if (in QCT and in DDA)
+              60 if (in QCT XOR in DDA)
+               0 otherwise
+```
+
+**Why this shape**: IRC §42(d)(5)(B) basis boost is a single 30% election. A jurisdiction has the option whether it's in a QCT, a DDA, or both. The locator scores BOTH higher than EITHER because a deal in a jurisdiction with both designations has a stronger underwriting narrative (basis-boost election + matching geographic-distribution scoring), even though the federal boost itself is the same 30%. Future enhancement: layer in soft-funding stack (Prop 123, CDBG-HOME, state HDF) for non-basis-boost markets.
+
+**Data sources**:
+- HUD QCT 2025 designations — `data/qct-colorado.json` (224 CO tracts)
+- HUD DDA 2025 designations — `data/dda-colorado.json` (10 CO nonmetro counties, county-based for nonmetro CO)
+
+**Place-to-QCT membership**: A place "contains" a QCT tract if the tract appears in `place-tract-membership.json` with overlap thresholds:
+- Tract's share of place area > 5%, OR
+- Place's share of tract area > 20%
+
+This filters out sliver overlaps where a tiny corner of a tract touches a place boundary.
+
+**Place-to-DDA membership**: DDA designation in Colorado is county-based (all 10 CO DDAs are nonmetro counties). Every jurisdiction in a DDA county inherits the designation.
+
+**Confidence**: Always **High** for this dimension. QCT/DDA designations are HUD-published, annual, and unambiguous.
+
+---
+
+### Dimension 4 — Population / Market Feasibility Score
+
+**What it measures**: Does this jurisdiction have enough renter households to lease up a typical LIHTC project? Critical for 4% bond deals (need 100–200 units of absorption), less critical for 9% deals (often 30–60 units).
+
+**Formula**:
+
+```
+population_proxy = households_le_ami_pct['100']    [# HHs ≤100% AMI from CHAS]
+                 × 2.5                              [avg CO HH size]
+
+population_score = 0   if proxy < 500              (cannot absorb 50-unit project)
+                  30   if proxy < 2,000            (small rural, 9% candidate, 30–40 units)
+                  60   if proxy < 5,000            (mid-size, 4% bond viability questionable)
+                  85   if proxy < 15,000           (sweet spot for 4% bond)
+                 100   if proxy ≥ 15,000           (large 4% bond market)
+```
+
+**Why this shape**: Bond deals (4%) need scale because their fixed transaction costs (issuance fees, trustees, legal) only pencil at 100+ units. A 60-unit 9% deal in a 1,500-person town is doable; the same project on bonds rarely is. The thresholds match Colorado LIHTC pipeline empirically — most CHFA-awarded 9% rural deals are in towns of 2,000–15,000 people; most bond deals are in places ≥15,000.
+
+**Data sources**:
+- CHAS households ≤100% AMI by place — `data/co_ami_gap_by_place.json`, field `households_le_ami_pct['100']`
+- Multiplied by 2.5 (CO avg HH size, ACS DP02)
+
+**Confidence handling**:
+- **Medium**: This is a proxy; the locator uses HHs × 2.5 instead of B01003 because ACS B01003 isn't yet wired in. Replacement is P2 backlog.
+- **Low** for jurisdictions with <100 HHs at any AMI tier (CHAS suppression risk).
+
+**Edge cases**:
+- Resort areas with high second-home stock: B01003 would over-count seasonal population; HH-based proxy is actually closer to "renter base" truth in resort markets
+- Border-of-bracket jurisdictions (2,000 vs 2,001 HHs): the bucketing creates a step function — sort ties get broken by other dimensions
+
+---
+
+### Dimension 5 — Civic Readiness Score
+
+**What it measures**: Is the local government ready to actually deliver a deal? Has it filed Prop 123, written a comp plan, hired a housing lead, passed inclusionary zoning, established local funding?
+
+**Formula**:
+
+```
+civic_score = (count of dimensions where flag === true)
+            / (count of dimensions with non-null values)
+            × 100
+
+dimensions = [
+  prop123_committed,           // filed under HB22-1304 / Prop 123 by Nov 2022+annual
+  has_hna,                     // published a Housing Needs Assessment (own, not COHO's)
+  has_comp_plan,               // comp plan with housing element
+  has_iz_ordinance,            // inclusionary zoning
+  has_local_funding,           // local housing fund / fee waiver / dedicated revenue
+  has_housing_authority,       // PHA presence (county or local)
+  has_housing_nonprofits       // 501(c)(3) housing developers / advocates
+]
+```
+
+**Why this shape**: A deal is harder in a jurisdiction that hasn't articulated affordable-housing intent. The 7 dimensions are the standard civic-capacity indicators used by Prop 123 administrators (DOLA) when reviewing eligibility. The score is bounded by **knownDimensions** because not every flag is publicly available for every jurisdiction — and the locator should not penalize a place for missing data the same way it penalizes a place for an actual "no."
+
+**Data sources**:
+- `data/policy/housing-policy-scorecard.json` — central scorecard with 547 jurisdictions × 7 dimensions
+- `data/policy/prop123_jurisdictions.json` — 217 commitments with filing dates + fast-track flags (joins by name to surface filing detail in UI)
+- `data/hna/local-resources.json` — actual URLs for housing lead, housing authorities, advocacy orgs, plans on file (sparse but rich where present)
+
+**Confidence handling**:
+- **High**: All 7 dimensions have explicit true/false in scorecard
+- **Medium**: 5–6 dimensions filled
+- **Low**: <5 dimensions filled (~half of CDPs land here)
+
+**Current status in the implementation**: The civic score is shown in the table column and the detail panel, BUT it is not yet rolled into the composite (P1-6 in the audit). Today's composite weights only Need + Recency + Basis + Population. Adding civic readiness to the composite is sprint-2 work; today's locator surfaces civic-capacity for the user to weight manually.
+
+---
+
+## 4. Composite scoring — per-deal-type weight table
+
+Once the five dimension scores are computed, they get composited into one 0–100 number using weights that depend on the user's target deal type.
+
+| Dimension | 9% Competitive | 4% Bond | Preservation | Workforce-Resort | Prop 123 Local | Balanced |
+|---|---|---|---|---|---|---|
+| **Need** | 30% | 25% | 20% | 25% | 25% | 25% |
+| **Recency / Competition** | **30%** | 15% | 15% | 15% | 10% | 20% |
+| **Basis-Boost / Subsidy** | 15% | 15% | **35%** | 15% | 20% | 15% |
+| **Population / Feasibility** | 15% | **30%** | 10% | **30%** | 15% | 20% |
+| **Civic Readiness** | 10% | 15% | 20% | 15% | **30%** | 20% |
+
+**Why these weights:**
+
+- **9% Competitive**: Recency dominates because CHFA's 9% QAP explicitly scores geographic distribution. Need is heavily weighted because 9% deals run on stronger income-targeting (30%/50% AMI deep). Civic readiness is less critical because CHFA's 9% review is the most rigorous gate — they evaluate readiness during application.
+- **4% Bond**: Population is heaviest because bond deals need 100–200 units of absorption. Civic readiness matters more than for 9% because the local jurisdiction has to *issue* private-activity bonds.
+- **Preservation**: Basis/subsidy is the defining variable — preservation deals run on 4% refi + expiring LIHTC + Year-15 exit. Need still matters (you want to preserve where the need is acute) but population matters less (existing units have existing residents).
+- **Workforce-Resort**: Population (for absorption) + civic readiness (resort communities typically have housing strategies). Need is bounded because resort areas always have severe need; the differentiator is execution.
+- **Prop 123 Local**: Civic readiness IS the gate. Without comp plan + commitment + lead, the Prop 123 stack doesn't unlock. Basis matters less because state money doesn't require federal basis boost.
+- **Balanced**: Roughly equal distribution for exploratory mode when the user hasn't picked a deal type.
+
+**Today's implementation** (per `js/lihtc-opportunity-finder.js`):
+- Only 4 dimensions implemented: Recency · Need · Basis · Population (no civic readiness in composite yet, no preservation/workforce/prop123-local deal types)
+- 3 target rounds: 9% (40/30/20/10) · 4% (25/25/15/35) · Any (35/30/20/15)
+- Weight invariant: each set sums to exactly 1.0 (asserted in `scripts/audit/verify-opportunity-finder.mjs`)
+
+Migrating to the 5-dimension + 5-deal-type model is P0-3 + P1-6 in the audit's first sprint.
+
+---
+
+## 5. Confidence framework — surface uncertainty, don't hide it
+
+Every score result carries a confidence rating that reflects the quality of its inputs. This is a meta-dimension; it doesn't change the composite score, but it changes how the result is presented.
+
+### Confidence inputs
+
+For each jurisdiction, the locator counts:
+
+| Signal | High contribution | Medium | Low |
+|---|---|---|---|
+| Cost-burden source | Place SMOCAPI direct | County CHAS fallback | 3-bin CHAS approximation |
+| Population source | ACS B01003 direct (when wired) | CHAS HH proxy ×2.5 (today) | Unknown |
+| Civic data coverage | 7 of 7 scorecard dimensions populated | 5–6 of 7 | <5 of 7 |
+| LIHTC project record | ≥3 PROJ_CTY matches | 1–2 matches | 0 matches (genuine gap or mismatch) |
+| QCT/DDA membership | Direct overlap > 20% | Threshold 5–20% | Sliver (excluded but worth noting) |
+
+### Confidence levels
+
+- **High**: All five score dimensions sourced from direct data; civic ≥ 5 dimensions filled; no major fallback used
+- **Medium**: At least one dimension uses a fallback OR civic 3–4 of 7 OR population is a proxy
+- **Low**: Multiple fallbacks OR civic <3 of 7 OR major dimension missing entirely
+
+### How confidence shows up
+
+Today (current implementation): not surfaced as a separate pill. Wiring it is P0-5 in the audit's first sprint.
+
+Target state: every score number gets a ★/★★/★★★ pill next to it on the table and detail panel, with hover tooltip showing the actual source + vintage + fallback flags. Example:
+
+> Need score: **82** ★★ (Crowley County CHAS 2018–2022, place-level CHAS suppressed)
+
+---
+
+## 6. Decision-support metadata — what each score result includes
+
+The locator does not just output a number. Each jurisdiction's score result is a structured object:
+
+```js
+{
+  score: 72,                    // composite 0–100
+  band: 'High',                 // High / Medium / Low / Watchlist / Not-ready
+  letterGrade: 'B+',            // A / A- / B+ / B / B- / C+ / C / Watchlist
+  confidence: 'Medium',         // High / Medium / Low (§5)
+  bestFit: ['9pct_competitive', 'prop123_local'],
+
+  reasons: [                    // why this jurisdiction rose (top 3)
+    'Never funded with LIHTC (recency: 100)',
+    'Both QCT and DDA designation (basis: 100)',
+    'Crowley County cost burden in CO 82nd percentile'
+  ],
+
+  risks: [                      // execution risks to verify
+    'Population < 500 — bond deal absorption questionable',
+    'Owner cost burden via county fallback',
+    'No housing lead on file — identify champion'
+  ],
+
+  missingData: [                // what we couldn't compute
+    'parcel_readiness (not in scope — site work required)',
+    'utility_capacity (not in scope)',
+    'planned_chfa_pipeline (manual — see CHFA award announcements)'
+  ],
+
+  sourceIds: [                  // dataset IDs cited
+    'chas-2018-2022', 'hud-qct-2025', 'hud-dda-2025',
+    'hud-lihtcdb', 'dola-prop123'
+  ],
+
+  sourceVintage: {
+    chas: '2018-2022',
+    hud_qct: '2025',
+    hud_dda: '2025',
+    lihtcdb: '1987-2020',
+    prop123: '2024-12-09'
+  },
+
+  nextActions: [                // funnel forward
+    { label: '📋 Open HNA',          href: 'housing-needs-assessment.html?fips=…' },
+    { label: '🗺️ Run market analysis', href: 'market-analysis.html?fips=…' },
+    { label: '💵 Build deal concept',  href: 'deal-calculator.html?fips=…' }
+  ]
+}
+```
+
+This shape is the same across every scoring module (target state per §4 of the audit). It enables:
+- **Compare mode** — side-by-side jurisdiction tables
+- **Export memos** — markdown / PDF developer takeaways
+- **Watchlist alerts** — diff against historical scores
+- **Audit replay** — a single result fully reproduces the methodology
+
+Today's implementation returns a partial version of this shape (no `reasons`, `risks`, `missingData`, `nextActions`). Completing it is P0-1 in the audit.
+
+---
+
+## 7. Decision framework — how to use the score
+
+The locator output is the *start* of a deal-screening conversation, not the end. The recommended decision flow:
+
+### Step 1 — Filter
+Pick a target deal type (9% / 4% / preservation / workforce-resort / prop123-local). The locator re-weights and re-filters to the relevant universe.
+
+### Step 2 — Read top 10
+Sort by composite score. Look at the top 10. For each: skim the `reasons` (does the rise make sense?) and the `risks` (does any flag disqualify?).
+
+### Step 3 — Cross-check civic capacity
+For top candidates, open the detail panel and scan civic readiness. A jurisdiction with **strong scores but Prop 123 not committed + no housing lead + no comp plan** is harder to execute. Bring it forward to the next step but flag the readiness gap as an early conversation with local officials.
+
+### Step 4 — Funnel forward to HNA
+For each shortlist candidate, click "📋 Open HNA" to see the full Housing Needs Assessment — owner cost burden, AMI gap by tier, action-plan checklist. This validates whether the locator's signal lines up with the deeper needs picture.
+
+### Step 5 — Funnel forward to PMA
+Click "🗺️ Run market analysis" (Patch 4 of sprint 1 once shipped) to open the Primary Market Area workup. Verify:
+- Rental demand is real (vacancy, absorption)
+- Comparable rents support the AMI mix you'd target
+- Site amenities are within reach
+- No major infrastructure or environmental risk surfaces
+
+### Step 6 — Build a concept
+Click "💵 Build deal concept" to open the Deal Calculator with the jurisdiction pre-loaded. Test a 9% concept (30–60 units, 30/50/60 AMI mix) vs. a 4% concept (100–200 units, 50/60/80 AMI mix). See which pencils.
+
+### Step 7 — Export memo
+Ship the result to your pipeline meeting. (Patch 9 in audit sprint 2.)
+
+### Step 8 — Watchlist
+Add the jurisdiction to your watchlist. The site notifies you when CHFA announces new awards, NHPD records new subsidy expirations, or Prop 123 filings change. (P2 backlog.)
+
+---
+
+## 8. Output bands and letter grades
+
+### Score bands
+
+| Composite score | Band | Letter | Interpretation |
+|---|---|---|---|
+| 85–100 | **High** | A / A- | Strong candidate; move to PMA |
+| 70–84 | **High** | B+ / B | Solid; verify civic readiness |
+| 55–69 | **Medium** | B- / C+ | Worth a deeper look; deal type matters |
+| 40–54 | **Medium** | C / C- | Watchlist; need a clear theme to pursue |
+| 25–39 | **Low** | D | Hard sell; usually a saturation or population problem |
+| 0–24 | **Not-ready** | F | Skip unless very specific local angle |
+
+### Letter grade modifiers (target state, not yet implemented)
+
+- **+ modifier**: high confidence (★★★) and ≥3 reasons → bumps grade up half-step
+- **– modifier**: low confidence (★) or critical missing data → bumps grade down half-step
+- **Watchlist override**: if all dimensions are medium but one is exceptional (e.g., Prop 123 ✓ + comp plan ✓ + housing lead ✓ in a low-need / low-recency market) → flag as Watchlist regardless of composite
+
+---
+
+## 9. Known limitations — what the locator does NOT do
+
+Be honest about scope. The locator is a **jurisdiction-level screen**, not a site-screening or underwriting tool. It explicitly does not provide:
+
+| Out of scope | Why | Where to go instead |
+|---|---|---|
+| Parcel readiness | No parcel data layer (see Appendix A of repo audit) | Local county Assessor + zoning lookup |
+| Utility / water / sewer capacity | No data layer | District-by-district inquiry |
+| Floodplain / wildfire / wetlands / slope | No env layer | FEMA, USFS, USACE, CGS slope analysis |
+| Public land / nonprofit-owned parcels | No layer (custom acquisition required) | CO State Land Board API, county Assessor |
+| Zoning compatibility | No layer | Local planning department |
+| Walkability / transit / grocery access | Layer exists but not wired in (P1-7) | Use HNA Site Selection Score page meanwhile |
+| Detailed AMI / unit-mix recommendation | Out of scope | Use LIHTC Concept Recommender (already on PMA page) |
+| Capital stack sizing | Out of scope | Use Deal Calculator |
+| CHFA award probability | Approximate (no real 9% scoring engine) | Use `js/chfa-award-predictor.js` page |
+| Live CHFA pipeline / NOFA timing | Manual | CHFA QAP + CHFA award announcements page |
+| Site comparison | Out of scope | (Compare mode P1-1 forthcoming) |
+
+The locator's job is to **narrow 482 jurisdictions to a credible shortlist of 5–15**. Everything below the jurisdiction level requires either: (a) wired-in data layers the repo doesn't have, (b) site-specific work a tool can't substitute for.
+
+---
+
+## 10. Methodology change log
+
+| Version | Date | Changes |
+|---|---|---|
+| 1.0 | 2026-05-25 (PR #894) | Initial jurisdiction-level rebuild (was tract-level). 4 dimensions: recency / need / basis / pop. 3 target rounds: 9% / 4% / any. Civic capacity surfaced but not in composite. |
+| 1.1 | 2026-05-25 (revised) | Methodology doc published. 5-dimension target state documented (added Civic Readiness). 5 deal types target state documented (added preservation, workforce-resort, prop123-local). Today's implementation gap from target state called out explicitly. |
+
+Next planned: v2.0 after Sprint 1 patches ship (ScoreResult contract, deal-type taxonomy, confidence pills, next-action CTAs, civic readiness rolled into composite).
+
+---
+
+## 11. References
+
+### Federal programs / regulations
+- IRC §42 (Low-Income Housing Tax Credit) and §42(d)(5)(B) (basis boost)
+- HUD CHAS (Comprehensive Housing Affordability Strategy) — Tables 7, 8, 9
+- HUD LIHTC Database (LIHTCDB)
+- HUD QCT designations (annual, IRC §42(d)(5)(B)(ii))
+- HUD DDA designations (annual, IRC §42(d)(5)(B)(iii))
+- HUD Worst Case Housing Needs (WCN) framework
+
+### Colorado-specific
+- HB22-1304 / Proposition 123 (Affordable Housing Financing Fund, Affordable Housing Support Fund)
+- DOLA Prop 123 commitment filings — <https://cdola.colorado.gov/commitment-filings>
+- CHFA Qualified Allocation Plan (annual) — <https://www.chfainfo.com/multifamily/QAP>
+- Colorado Demography Office (CDO) population projections
+
+### Data sources cited
+- `data/qct-colorado.json` — HUD QCT 2025 (224 CO tracts)
+- `data/dda-colorado.json` — HUD DDA 2025 (10 CO nonmetro counties)
+- `data/market/hud_lihtc_co.geojson` — HUD LIHTCDB 1987–2020, 716 projects
+- `data/hna/chas_affordability_gap.json` — HUD CHAS 2018–2022 (64 counties)
+- `data/market/chas_tract_co.json` — HUD CHAS 2018–2022 (1,447 tracts)
+- `data/hna/place-tract-membership.json` — TIGER 2024 (482 places × tracts)
+- `data/co_ami_gap_by_place.json` — ACS + CHAS derived (482 places × 7 AMI bands)
+- `data/policy/housing-policy-scorecard.json` — composite (547 jurisdictions × 7 dimensions)
+- `data/policy/prop123_jurisdictions.json` — DOLA Prop 123 filings (217 commitments)
+- `data/hna/local-resources.json` — housing lead / authority / advocacy URLs (68 records)
+- `data/market/nhpd_co.geojson` — National Housing Preservation Database (20 properties)
+
+### Related repo documentation
+- [`docs/audits/REPO-AUDIT-2026-05-25.md`](../audits/REPO-AUDIT-2026-05-25.md) — full repo audit with P0/P1 roadmap
+- [`docs/audits/PMA-METHODOLOGY-AUDIT.md`](../audits/PMA-METHODOLOGY-AUDIT.md) — PMA methodology audit
+- [`docs/audits/DEAL-CALCULATOR-AUDIT.md`](../audits/DEAL-CALCULATOR-AUDIT.md) — Deal Calculator audit
+- [`HANDOVER.md`](../../HANDOVER.md) — codex session handover summary
+- [`scripts/audit/verify-opportunity-finder.mjs`](../../scripts/audit/verify-opportunity-finder.mjs) — verification harness (28 checks)

--- a/docs/methodology/LIHTC-LOCATOR-METHODOLOGY.md
+++ b/docs/methodology/LIHTC-LOCATOR-METHODOLOGY.md
@@ -118,7 +118,7 @@ recency_score = min(100, round(years_since / 25 × 100))
 **Why this shape**: CHFA's 9% Qualified Allocation Plan rewards geographic distribution; jurisdictions with no recent activity are explicitly preferred. The 25-year cap matches the LIHTC compliance period — beyond that, a deal can no longer be considered "saturated." Future enhancement (P1): add CHFA award year (typically 2–3y ahead of PIS) for fresher signal.
 
 **Data sources**:
-- HUD LIHTC Database (LIHTCDB), filtered to CO `state == 'CO'` — `data/market/hud_lihtc_co.geojson` (716 projects, 702 with valid YR_PIS)
+- CHFA public LIHTC cache, with HUD LIHTCDB fallback — `data/chfa-lihtc.json`, fallback `data/market/hud_lihtc_co.geojson` (716 projects, 702 with valid YR_PIS)
 - Match rule: `PROJ_CTY.toUpperCase().trim() === jurisdiction_name.toUpperCase().trim()`
 
 **Confidence handling**:
@@ -450,7 +450,7 @@ Next planned: v2.0 after Sprint 1 patches ship (ScoreResult contract, deal-type 
 ### Federal programs / regulations
 - IRC §42 (Low-Income Housing Tax Credit) and §42(d)(5)(B) (basis boost)
 - HUD CHAS (Comprehensive Housing Affordability Strategy) — Tables 7, 8, 9
-- HUD LIHTC Database (LIHTCDB)
+- CHFA public LIHTC cache / HUD LIHTC Database (LIHTCDB)
 - HUD QCT designations (annual, IRC §42(d)(5)(B)(ii))
 - HUD DDA designations (annual, IRC §42(d)(5)(B)(iii))
 - HUD Worst Case Housing Needs (WCN) framework
@@ -464,7 +464,8 @@ Next planned: v2.0 after Sprint 1 patches ship (ScoreResult contract, deal-type 
 ### Data sources cited
 - `data/qct-colorado.json` — HUD QCT 2025 (224 CO tracts)
 - `data/dda-colorado.json` — HUD DDA 2025 (10 CO nonmetro counties)
-- `data/market/hud_lihtc_co.geojson` — HUD LIHTCDB 1987–2020, 716 projects
+- `data/chfa-lihtc.json` — CHFA public LIHTC cache, 716 projects
+- `data/market/hud_lihtc_co.geojson` — HUD LIHTCDB fallback, 716 projects
 - `data/hna/chas_affordability_gap.json` — HUD CHAS 2018–2022 (64 counties)
 - `data/market/chas_tract_co.json` — HUD CHAS 2018–2022 (1,447 tracts)
 - `data/hna/place-tract-membership.json` — TIGER 2024 (482 places × tracts)

--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -2256,52 +2256,75 @@
   // After jurisdiction is set (e.g., from comparative analysis redirect with
   // ?fips=08001&auto=1), pre-populate #geoType and #geoSelect so the user
   // doesn't have to re-enter their jurisdiction on this page.
-  function _resolveAutoFips() {
-    // 1. Prefer explicit URL param (e.g. ?fips=08001&auto=1)
+  //
+  // Supports BOTH 5-digit county FIPS (e.g. 08001 = Adams County) and
+  // 7-digit place FIPS (e.g. 0823020 = Cortez city). Geo type is determined
+  // by the explicit ?geoType= param or auto-detected by FIPS length.
+  // Place deep-link is used by the LIHTC Opportunity Finder to jump from
+  // a jurisdiction row into the full HNA workup.
+  function _resolveAutoTarget() {
+    // 1. Prefer explicit URL params (?fips=0823020&geoType=place&auto=1)
     try {
       var sp = new URLSearchParams(window.location.search);
-      var f  = sp.get('fips');
-      if (f && /^\d{5}$/.test(f)) return f;
+      var f  = sp.get('fips') || sp.get('geoid');
+      var t  = sp.get('geoType');
+      if (f && /^\d{5}$/.test(f))      return { fips: f, geoType: t || 'county' };
+      if (f && /^\d{7}$/.test(f))      return { fips: f, geoType: t || 'place'  };
     } catch (_) {}
     // 2. WorkflowState jurisdiction
     try {
       var proj = window.WorkflowState && window.WorkflowState.getActiveProject();
       var jx   = proj && (proj.jurisdiction || (proj.steps && proj.steps.jurisdiction));
-      if (jx && (jx.fips || jx.countyFips)) return jx.fips || jx.countyFips;
+      if (jx) {
+        if (jx.placeGeoid && /^\d{7}$/.test(jx.placeGeoid)) {
+          return { fips: jx.placeGeoid, geoType: 'place' };
+        }
+        if (jx.fips || jx.countyFips) {
+          return { fips: jx.fips || jx.countyFips, geoType: 'county' };
+        }
+      }
     } catch (_) {}
     // 3. SiteState legacy county
     try {
       var sc = window.SiteState && window.SiteState.getCounty();
-      if (sc && sc.fips) return sc.fips;
+      if (sc && sc.fips) return { fips: sc.fips, geoType: 'county' };
     } catch (_) {}
     return null;
   }
 
-  function _tryAutoSelect(targetFips, attempts) {
-    if (!targetFips) return;
+  // Back-compat shim — some callers may still reference the old name
+  function _resolveAutoFips() {
+    var t = _resolveAutoTarget();
+    return t && t.geoType === 'county' ? t.fips : null;
+  }
+
+  function _tryAutoSelect(target, attempts) {
+    if (!target) return;
+    // Back-compat: accept a bare FIPS string and assume county
+    if (typeof target === 'string') target = { fips: target, geoType: 'county' };
     attempts = attempts || 0;
     if (attempts > 12) return;   // give up after ~6 s
 
     var geoTypeEl   = document.getElementById('geoType');
     var geoSelectEl = document.getElementById('geoSelect');
     if (!geoTypeEl || !geoSelectEl) {
-      setTimeout(function () { _tryAutoSelect(targetFips, attempts + 1); }, 400);
+      setTimeout(function () { _tryAutoSelect(target, attempts + 1); }, 400);
       return;
     }
 
-    // Ensure we're showing the county view
-    if (geoTypeEl.value !== 'county') {
-      geoTypeEl.value = 'county';
+    // Ensure we're showing the right geoType view
+    if (geoTypeEl.value !== target.geoType) {
+      geoTypeEl.value = target.geoType;
       geoTypeEl.dispatchEvent(new Event('change', { bubbles: true }));
-      setTimeout(function () { _tryAutoSelect(targetFips, attempts + 1); }, 500);
+      setTimeout(function () { _tryAutoSelect(target, attempts + 1); }, 500);
       return;
     }
 
-    // Find an option whose value matches the county FIPS
+    // Find an option whose value matches the FIPS
     var opts  = geoSelectEl.options;
     var found = false;
     for (var i = 0; i < opts.length; i++) {
-      if (opts[i].value === targetFips) {
+      if (opts[i].value === target.fips) {
         geoSelectEl.value = opts[i].value;
         geoSelectEl.dispatchEvent(new Event('change', { bubbles: true }));
         found = true;
@@ -2310,7 +2333,7 @@
     }
 
     if (!found) {
-      setTimeout(function () { _tryAutoSelect(targetFips, attempts + 1); }, 500);
+      setTimeout(function () { _tryAutoSelect(target, attempts + 1); }, 500);
     }
   }
 
@@ -2333,13 +2356,20 @@
     // SiteState fallback
     document.addEventListener('sitestate:county-changed', _debouncedOnGeoChange);
 
-    // Fix #1: auto-select county if arriving from jurisdiction flow
+    // Fix #1: auto-select county OR place if arriving from jurisdiction flow
     // Skip if hna-controller already restored a sub-county (place/cdp) selection
+    // unless we have an explicit URL param (which wins — e.g. coming from
+    // the LIHTC Opportunity Finder which wants to override prior state).
+    var hasUrlParam = false;
+    try {
+      var _sp = new URLSearchParams(window.location.search);
+      hasUrlParam = !!(_sp.get('fips') || _sp.get('geoid'));
+    } catch (_) {}
     var jxCheck = window.WorkflowState && window.WorkflowState.getJurisdiction();
-    if (!(jxCheck && jxCheck.type === 'city' && (jxCheck.placeGeoid || jxCheck.displayName))) {
-      var autoFips = _resolveAutoFips();
-      if (autoFips) {
-        setTimeout(function () { _tryAutoSelect(autoFips); }, 300);
+    if (hasUrlParam || !(jxCheck && jxCheck.type === 'city' && (jxCheck.placeGeoid || jxCheck.displayName))) {
+      var autoTarget = _resolveAutoTarget();
+      if (autoTarget) {
+        setTimeout(function () { _tryAutoSelect(autoTarget); }, 300);
       }
     }
 

--- a/index.html
+++ b/index.html
@@ -113,59 +113,72 @@
         </div>
         <ol class="home-steps" aria-label="Workflow steps">
 
-          <li class="home-step">
+          <li class="home-step home-step--featured">
             <span class="home-step__num" aria-hidden="true">01</span>
             <div class="home-step__body">
-              <h3>Select Your Jurisdiction</h3>
-              <p>Set the location for your analysis. This determines AMI income limits,
-                 HUD Fair Market Rents, QCT and DDA designations, ACS demographic data,
-                 and CHFA development history for your area.</p>
-              <a href="select-jurisdiction.html" aria-label="Step 1: Select jurisdiction">Go to jurisdiction selection →</a>
+              <h3>LIHTC Opportunity Finder <span class="home-step__badge">NEW</span></h3>
+              <p>Where in Colorado should you spend scarce time looking for the next deal?
+                 Rank 158 jurisdictions with QCT or DDA designation by funding-recency,
+                 housing need, basis-boost, population, and civic capacity. Re-weights live
+                 for 4% bond vs 9% competitive rounds. The deal-targeting cockpit before
+                 you commit to a jurisdiction.</p>
+              <a href="lihtc-opportunity-finder.html" aria-label="Step 1: LIHTC Opportunity Finder">Go to opportunity finder →</a>
             </div>
           </li>
 
           <li class="home-step">
             <span class="home-step__num" aria-hidden="true">02</span>
             <div class="home-step__body">
-              <h3>Housing Needs Assessment</h3>
-              <p>Understand who needs housing — income distribution, cost burden, tenure
-                 patterns, and the gap between what exists and what's needed. Includes
-                 neighborhood character context, 10-year demand projections, and a
-                 recommended AMI distribution for your jurisdiction.</p>
-              <a href="housing-needs-assessment.html" aria-label="Step 2: Housing needs assessment">Go to housing needs assessment →</a>
+              <h3>Select Your Jurisdiction</h3>
+              <p>Set the location for your analysis. This determines AMI income limits,
+                 HUD Fair Market Rents, QCT and DDA designations, ACS demographic data,
+                 and CHFA development history for your area.</p>
+              <a href="select-jurisdiction.html" aria-label="Step 2: Select jurisdiction">Go to jurisdiction selection →</a>
             </div>
           </li>
 
           <li class="home-step">
             <span class="home-step__num" aria-hidden="true">03</span>
             <div class="home-step__body">
-              <h3>Market Analysis &amp; Site Feasibility</h3>
-              <p>Define a Primary Market Area. Score your site on demand, competition,
-                 rent pressure, land supply, and workforce access. Identify QCT and DDA
-                 designations that affect your eligible basis. Required for all CHFA applications.</p>
-              <a href="market-analysis.html" aria-label="Step 3: Market analysis and site feasibility">Go to market analysis →</a>
+              <h3>Housing Needs Assessment</h3>
+              <p>Understand who needs housing — income distribution, cost burden, tenure
+                 patterns, and the gap between what exists and what's needed. Includes
+                 neighborhood character context, 10-year demand projections, and a
+                 recommended AMI distribution for your jurisdiction.</p>
+              <a href="housing-needs-assessment.html" aria-label="Step 3: Housing needs assessment">Go to housing needs assessment →</a>
             </div>
           </li>
 
           <li class="home-step">
             <span class="home-step__num" aria-hidden="true">04</span>
             <div class="home-step__body">
-              <h3>Scenario Builder</h3>
-              <p>Design your unit mix and income targeting. Set rents by AMI tier against
-                 HUD Fair Market Rent limits. Choose between 9% competitive and 4%
-                 bond-financed credits. See how your mix addresses 20-year projected demand.</p>
-              <a href="hna-scenario-builder.html" aria-label="Step 4: Scenario builder">Go to scenario builder →</a>
+              <h3>Market Analysis &amp; Site Feasibility</h3>
+              <p>Define a Primary Market Area. Score your site on demand, competition,
+                 rent pressure, land supply, and workforce access. Identify QCT and DDA
+                 designations that affect your eligible basis. Required for all CHFA applications.</p>
+              <a href="market-analysis.html" aria-label="Step 4: Market analysis and site feasibility">Go to market analysis →</a>
             </div>
           </li>
 
           <li class="home-step">
             <span class="home-step__num" aria-hidden="true">05</span>
             <div class="home-step__body">
+              <h3>Scenario Builder</h3>
+              <p>Design your unit mix and income targeting. Set rents by AMI tier against
+                 HUD Fair Market Rent limits. Choose between 9% competitive and 4%
+                 bond-financed credits. See how your mix addresses 20-year projected demand.</p>
+              <a href="hna-scenario-builder.html" aria-label="Step 5: Scenario builder">Go to scenario builder →</a>
+            </div>
+          </li>
+
+          <li class="home-step">
+            <span class="home-step__num" aria-hidden="true">06</span>
+            <div class="home-step__body">
               <h3>Deal Calculator</h3>
               <p>Size your LIHTC capital stack. Calculate equity proceeds, permanent loan
                  capacity from NOI, and the gap that soft sources need to fill. Compare
                  9% and 4% scenarios side by side. Identify CRA lenders and CHFA programs.</p>
-              <a href="deal-calculator.html" aria-label="Step 5: Deal calculator">Go to deal calculator →</a>
+              <a href="deal-calculator.html" aria-label="Step 6: Deal calculator">Go to deal calculator →</a>
             </div>
           </li>
 

--- a/js/lihtc-opportunity-finder.js
+++ b/js/lihtc-opportunity-finder.js
@@ -1,25 +1,38 @@
 /**
  * js/lihtc-opportunity-finder.js
  *
- * Client-side analysis that joins HUD LIHTC projects to QCT + DDA polygons,
- * computes a per-area opportunity score, and drives a filterable ranked
- * table + Leaflet map. No build pipeline — all data is loaded directly
- * from /data/ and the join happens in-browser at page load.
+ * JURISDICTION-LEVEL LIHTC opportunity analyzer.
  *
- * Scoring (matches the methodology disclosure in the page):
- *   opportunity = 0.35 * recency
- *               + 0.30 * housing_need
- *               + 0.20 * basis_boost
- *               + 0.15 * population_feasibility
+ * Per user feedback (2026-05-25): the original tract-level rollup
+ * answered "which polygon" when the actual workflow needs "which
+ * jurisdiction to target." This rebuild rolls every signal up to the
+ * place (city / town / CDP) level so a developer can scan a sortable
+ * table of CO jurisdictions and target candidates for 4% bond rounds
+ * or 9% competitive rounds.
  *
- * Data sources:
- *   data/qct-colorado.json                 — 224 QCT polygons
- *   data/dda-colorado.json                 — 10 DDA polygons
- *   data/market/hud_lihtc_co.geojson       — 716 LIHTC project points (YR_PIS)
- *   data/hna/chas_affordability_gap.json   — Housing-need composite per county
- *   data/market/acs_tract_metrics_co.json  — Population per tract (for QCT pop join)
+ * Per jurisdiction we compute:
+ *   - # of QCTs intersecting the place (via place-tract-membership)
+ *   - DDA designation (containing county is one of CO's 10 nonmetro DDAs)
+ *   - All LIHTC projects in the jurisdiction (matched by PROJ_CTY)
+ *   - Last YR_PIS + years-since
+ *   - HNA Scorecard composite for the containing county
+ *   - Population (from co_ami_gap_by_place's implied HH counts)
+ *   - Opportunity score, weighted differently for 4% vs 9% targets
  *
- * Author: 2026-05-25 LIHTC Opportunity Finder MVP.
+ * Score weights by target:
+ *   9% Competitive:  40% recency · 30% need · 20% basis-boost · 10% pop
+ *   4% Bond:         25% recency · 25% need · 15% basis-boost · 35% pop
+ *   Any (balanced):  35% recency · 30% need · 20% basis-boost · 15% pop
+ *
+ * Rationale: 9% awards reward geographic-gap + housing-need scoring;
+ * QCT/DDA basis boost is competitive. 4% bond deals are scale-driven —
+ * need a population base for 100-200 unit absorption. Both benefit from
+ * basis boost but it's less of the differentiator in 4%.
+ *
+ * Sources: HUD QCT + DDA designations, HUD LIHTC project data,
+ * data/hna/place-tract-membership.json (TIGER 2024 spatial join),
+ * data/co_ami_gap_by_place.json (per-place HHs from ACS), CHAS county
+ * cost-burden composite, geo-config place labels.
  */
 
 (function () {
@@ -28,27 +41,44 @@
   /* ── State ────────────────────────────────────────────────────────── */
 
   var state = {
-    qctFeatures: [],     // raw QCT polygons
-    ddaFeatures: [],     // raw DDA polygons
-    projects:    [],     // HUD LIHTC project points (filtered to valid YR_PIS)
-    chasByFips:  {},     // CHAS data keyed by 5-digit county FIPS
-    tractPop:    {},     // population by 11-digit tract GEOID
-    countyName:  {},     // county FIPS → display name
-    opportunities: [],   // computed per-area records (after _computeOpportunities)
-    map:         null,
-    layers:      { qct: null, dda: null, projects: null, highlight: null },
-    selectedId:  null,
-    sortKey:     'score',
-    sortDir:     'desc',
+    qctTractIds: new Set(),         // Set of tract GEOIDs that are QCTs
+    ddaCountyFips: new Set(),       // Set of 5-digit county FIPS designated as DDA
+    ddaFeatures: [],                // raw DDA polygons (for map rendering)
+    placeMembership: {},            // place geoid → { name, tracts:[{tract_geoid, share_of_place_area}] }
+    placeFromAmi: {},               // place geoid → AMI/HHs row (for population)
+    projects: [],                   // HUD LIHTC project points (filtered to valid YR_PIS)
+    chasByFips: {},                 // 5-digit county FIPS → CHAS county record
+    countyName: {},                 // 5-digit county FIPS → display name
+    placeMeta: {},                  // place geoid → { label, containingCounty, type }
+    opportunities: [],
+    map: null,
+    layers: { jurisdiction: null, dda: null, qct: null, highlight: null },
+    selectedId: null,
+    sortKey: 'score',
+    sortDir: 'desc',
     filters: {
-      showQct: true, showDda: true, showBoth: true,
-      county: '', city: '',
-      minYearsSince: 0, minScore: 0, minPop: 0
+      target: '9pct',     // '9pct' | '4pct' | 'any'
+      requireQct: false,
+      requireDda: false,
+      requireBoth: true,  // user's primary ask — default ON
+      county: '',
+      minYearsSince: 0,
+      minScore: 0,
+      minPop: 0,
+      includeCdps: false  // CDPs aren't incorporated; LIHTC typically goes in incorporated places
     }
   };
 
   var CURRENT_YEAR = new Date().getFullYear();
-  var MAX_RECENCY_YEARS = 25;  // years-since-last capped at 25 for score
+  var MAX_RECENCY_YEARS = 25;
+
+  /* ── Score weights by target ──────────────────────────────────────── */
+
+  var SCORE_WEIGHTS = {
+    '9pct': { recency: 0.40, need: 0.30, basis: 0.20, pop: 0.10 },
+    '4pct': { recency: 0.25, need: 0.25, basis: 0.15, pop: 0.35 },
+    'any':  { recency: 0.35, need: 0.30, basis: 0.20, pop: 0.15 }
+  };
 
   /* ── Helpers ──────────────────────────────────────────────────────── */
 
@@ -62,112 +92,55 @@
     if (!Number.isFinite(+n)) return '—';
     return Math.round(+n).toLocaleString('en-US');
   }
-  function fmtMaybe(s) {
-    return (s != null && s !== '') ? s : '—';
-  }
   function setStatus(text) {
     var el = $('lofStatusBanner');
     if (el) el.textContent = text;
   }
 
-  // Ray-casting point-in-polygon. polygon = array of [lng, lat] rings.
-  // For MultiPolygon callers iterate the outer container themselves.
-  function pointInPolygon(lng, lat, ring) {
-    var inside = false;
-    for (var i = 0, j = ring.length - 1; i < ring.length; j = i++) {
-      var xi = ring[i][0], yi = ring[i][1];
-      var xj = ring[j][0], yj = ring[j][1];
-      var intersect = ((yi > lat) !== (yj > lat)) &&
-        (lng < (xj - xi) * (lat - yi) / (yj - yi) + xi);
-      if (intersect) inside = !inside;
-    }
-    return inside;
-  }
-
-  // Test whether a Point falls inside a GeoJSON Polygon or MultiPolygon.
-  function pointInGeoFeature(lng, lat, feature) {
-    var g = feature.geometry;
-    if (!g) return false;
-    if (g.type === 'Polygon') {
-      // First ring = outer, subsequent = holes. For LIHTC opportunity
-      // analysis the hole case is rare enough we treat outer ring only.
-      return pointInPolygon(lng, lat, g.coordinates[0]);
-    }
-    if (g.type === 'MultiPolygon') {
-      for (var i = 0; i < g.coordinates.length; i++) {
-        if (pointInPolygon(lng, lat, g.coordinates[i][0])) return true;
-      }
-    }
-    return false;
-  }
-
-  // Centroid of polygon ring (rough average — good enough for naming /
-  // map labels, not for area calculations).
-  function ringCentroid(ring) {
-    var x = 0, y = 0;
-    for (var i = 0; i < ring.length; i++) {
-      x += ring[i][0]; y += ring[i][1];
-    }
-    return [x / ring.length, y / ring.length];
-  }
-  function featureCentroid(feature) {
-    var g = feature.geometry;
-    if (!g) return [-105.5, 39];
-    if (g.type === 'Polygon') return ringCentroid(g.coordinates[0]);
-    if (g.type === 'MultiPolygon') return ringCentroid(g.coordinates[0][0]);
-    return [-105.5, 39];
-  }
-
-  // Look up the county for a tract GEOID (first 5 chars).
-  function tractToCounty(tractGeoid) {
-    return String(tractGeoid).substring(0, 5);
+  // Strip "(city)" / "(town)" / "(CDP)" suffix to match PROJ_CTY values.
+  function placeNameToCity(label) {
+    if (!label) return '';
+    return label.replace(/\s*\([^)]+\)\s*$/, '').trim();
   }
 
   /* ── Score components ─────────────────────────────────────────────── */
 
-  /**
-   * Years-since-last → 0–100. ≥MAX_RECENCY_YEARS years = full score.
-   * "Never funded" (no projects in area) also gets full score.
-   */
   function recencyScore(lastYear) {
     if (lastYear == null) return 100;
     var years = Math.max(0, CURRENT_YEAR - lastYear);
     return Math.min(100, Math.round((years / MAX_RECENCY_YEARS) * 100));
   }
 
-  /**
-   * Housing-need from county CHAS summary (mirrors Scorecard v2 inputs).
-   * Composite of renter cost burden + owner cost burden weighted by HHs
-   * + severe burden share. Normalised against CO statewide distribution.
-   */
   function buildNeedDistribution() {
     var dist = [];
-    Object.values(state.chasByFips).forEach(function (rec) {
-      var s = rec.summary || {};
+    Object.keys(state.chasByFips).forEach(function (fips) {
+      var s = state.chasByFips[fips].summary || {};
       var renterHH = +s.total_renter_hh || 0;
       var ownerHH  = +s.total_owner_hh  || 0;
       var total = renterHH + ownerHH;
       if (!total || s.pct_renter_cb30 == null || s.pct_owner_cb30 == null) return;
       var blended = (s.pct_renter_cb30 * renterHH + s.pct_owner_cb30 * ownerHH) / total;
       var severe = +s.pct_renter_cb50 || 0;
-      var composite = blended * 0.7 + severe * 0.3;
-      dist.push(composite);
+      dist.push(blended * 0.7 + severe * 0.3);
     });
     dist.sort(function (a, b) { return a - b; });
     return dist;
   }
-  function needScoreFor(countyFips, needDist) {
+  function needCompositeFor(countyFips) {
     var rec = state.chasByFips[countyFips];
-    if (!rec || !rec.summary) return 30;  // default low if unknown
+    if (!rec || !rec.summary) return null;
     var s = rec.summary;
     var renterHH = +s.total_renter_hh || 0;
     var ownerHH  = +s.total_owner_hh  || 0;
     var total = renterHH + ownerHH;
-    if (!total) return 30;
+    if (!total) return null;
     var blended = (s.pct_renter_cb30 * renterHH + s.pct_owner_cb30 * ownerHH) / total;
     var severe = +s.pct_renter_cb50 || 0;
-    var composite = blended * 0.7 + severe * 0.3;
-    // Percentile rank within CO
+    return blended * 0.7 + severe * 0.3;
+  }
+  function needScoreFor(countyFips, needDist) {
+    var composite = needCompositeFor(countyFips);
+    if (composite == null) return 30;
     var below = 0;
     for (var i = 0; i < needDist.length; i++) {
       if (needDist[i] < composite) below++;
@@ -176,80 +149,92 @@
     return Math.round((below / needDist.length) * 100);
   }
 
-  /**
-   * Basis-boost score:
-   *   QCT only:  60  (40 of 100)
-   *   DDA only:  60  (40 of 100)
-   *   Both:      100 (60 of 100 in the composite — the strongest case)
-   *   Neither:   0
-   * The "Neither" branch is unreachable here because everything in our
-   * opportunity list is by definition a QCT or DDA, but kept for clarity.
-   */
   function basisBoostScore(isQct, isDda) {
     if (isQct && isDda) return 100;
     if (isQct || isDda) return 60;
     return 0;
   }
 
-  /**
-   * Population feasibility — under 500 = 0, 500-2000 = 50, 2000+ = 100.
-   * Floor that filters out small rural tracts where a 50-unit project
-   * couldn't lease up.
-   */
   function populationScore(pop) {
-    if (pop == null || !Number.isFinite(+pop)) return 50;  // unknown = mid
+    if (pop == null || !Number.isFinite(+pop)) return 0;
     var n = +pop;
     if (n < 500) return 0;
-    if (n < 2000) return 50;
+    if (n < 2000) return 30;
+    if (n < 5000) return 60;
+    if (n < 15000) return 85;
     return 100;
+  }
+
+  function compositeScore(rec, need, basis, pop, target) {
+    var w = SCORE_WEIGHTS[target] || SCORE_WEIGHTS.any;
+    return Math.round(rec * w.recency + need * w.need + basis * w.basis + pop * w.pop);
   }
 
   /* ── Data loading ─────────────────────────────────────────────────── */
 
   function loadAll() {
-    setStatus('Loading data (HUD QCT, DDA, LIHTC projects, CHAS, ACS)…');
+    setStatus('Loading jurisdiction data (HUD QCT, DDA, LIHTC, CHAS, place memberships)…');
     return Promise.all([
       fetch('data/qct-colorado.json').then(function (r) { return r.json(); }),
       fetch('data/dda-colorado.json').then(function (r) { return r.json(); }),
       fetch('data/market/hud_lihtc_co.geojson').then(function (r) { return r.json(); }),
       fetch('data/hna/chas_affordability_gap.json').then(function (r) { return r.json(); }),
-      fetch('data/market/acs_tract_metrics_co.json').then(function (r) { return r.json(); }),
+      fetch('data/hna/place-tract-membership.json').then(function (r) { return r.json(); }),
+      fetch('data/co_ami_gap_by_place.json').then(function (r) { return r.json(); }),
       fetch('data/hna/geo-config.json').then(function (r) { return r.json(); })
-        .catch(function () { return null; })
     ]).then(function (parts) {
-      state.qctFeatures = parts[0].features || [];
-      state.ddaFeatures = parts[1].features || [];
+      // Build QCT tract-ID set
+      (parts[0].features || []).forEach(function (f) {
+        var g = f.properties && f.properties.GEOID;
+        if (g) state.qctTractIds.add(g);
+      });
 
-      // Filter projects to those with usable YR_PIS (excludes the 8888 placeholder)
+      // Build DDA county-FIPS set + keep raw features for map
+      state.ddaFeatures = parts[1].features || [];
+      state.ddaFeatures.forEach(function (f) {
+        var g = f.properties && f.properties.GEOID;
+        if (g && g.length === 5) state.ddaCountyFips.add(g);
+      });
+
+      // HUD LIHTC projects, filtered to valid YR_PIS
       state.projects = (parts[2].features || []).filter(function (f) {
         var y = parseInt(f.properties && f.properties.YR_PIS, 10);
         return Number.isFinite(y) && y >= 1980 && y <= 2030;
       });
 
-      state.chasByFips = (parts[3].counties || {});
+      state.chasByFips = parts[3].counties || {};
+      state.placeMembership = (parts[4].places) || {};
+      state.placeFromAmi = (parts[5].places) || {};
 
-      // Tract population index — for QCT population join
-      (parts[4].tracts || []).forEach(function (t) {
-        state.tractPop[t.geoid] = +t.pop || 0;
+      // Place + county labels from geo-config
+      var gc = parts[6] || {};
+      (gc.counties || []).forEach(function (c) {
+        state.countyName[c.geoid] = c.label;
+      });
+      // Build comprehensive place-meta from featured + places + cdps
+      var allPlaces = []
+        .concat(gc.featured || [])
+        .concat(gc.places || [])
+        .concat(gc.cdps || []);
+      allPlaces.forEach(function (p) {
+        if (!p.geoid) return;
+        // Determine type from label (city / town / CDP suffix)
+        var labelLower = (p.label || '').toLowerCase();
+        var type = 'place';
+        if (labelLower.indexOf('cdp') !== -1) type = 'cdp';
+        else if (labelLower.indexOf('city') !== -1) type = 'city';
+        else if (labelLower.indexOf('town') !== -1) type = 'town';
+        else if (p.type) type = p.type;
+        state.placeMeta[p.geoid] = {
+          label: p.label,
+          containingCounty: p.containingCounty,
+          type: type
+        };
       });
 
-      // County name index
-      if (parts[5] && Array.isArray(parts[5].counties)) {
-        parts[5].counties.forEach(function (c) {
-          state.countyName[c.geoid] = c.label;
-        });
-      } else {
-        // Build from CHAS records as fallback
-        Object.keys(state.chasByFips).forEach(function (fips) {
-          var nm = state.chasByFips[fips].name;
-          if (nm) state.countyName[fips] = nm + ' County';
-        });
-      }
-
-      setStatus('Computing opportunity scores for ' +
-        state.qctFeatures.length + ' QCTs + ' +
-        state.ddaFeatures.length + ' DDAs against ' +
-        state.projects.length + ' LIHTC projects…');
+      setStatus('Rolling up ' + Object.keys(state.placeMembership).length +
+        ' jurisdictions against ' + state.qctTractIds.size + ' QCTs · ' +
+        state.ddaCountyFips.size + ' DDAs · ' + state.projects.length + ' LIHTC projects…');
     });
   }
 
@@ -259,19 +244,49 @@
     var needDist = buildNeedDistribution();
     var ops = [];
 
-    // ── Per-QCT analysis ──
-    state.qctFeatures.forEach(function (feat) {
-      var props = feat.properties || {};
-      var tractGeoid = props.GEOID;
-      var countyFips = tractToCounty(tractGeoid);
-      var pop = state.tractPop[tractGeoid] || null;
-      var centroid = featureCentroid(feat);
+    // Index projects by upper-case PROJ_CTY for fast lookup
+    var projectsByCity = {};
+    state.projects.forEach(function (p) {
+      var c = ((p.properties && p.properties.PROJ_CTY) || '').toUpperCase().trim();
+      if (!c) return;
+      (projectsByCity[c] = projectsByCity[c] || []).push(p);
+    });
 
-      // Projects inside this QCT polygon
-      var inside = state.projects.filter(function (p) {
-        var c = p.geometry && p.geometry.coordinates;
-        return c && pointInGeoFeature(c[0], c[1], feat);
+    Object.keys(state.placeMembership).forEach(function (placeGeoid) {
+      var membership = state.placeMembership[placeGeoid];
+      if (!membership) return;
+      var meta = state.placeMeta[placeGeoid] || {};
+      var label = membership.name || meta.label || placeGeoid;
+      var containingCounty = meta.containingCounty;
+      if (!containingCounty) {
+        // Fall back to tract's county prefix
+        var firstTract = (membership.tracts || [])[0];
+        if (firstTract && firstTract.tract_geoid) {
+          containingCounty = firstTract.tract_geoid.substring(0, 5);
+        }
+      }
+      var type = meta.type || (label.toLowerCase().indexOf('cdp') !== -1 ? 'cdp' : 'place');
+
+      // QCT membership — any tract intersecting the place that's also a QCT counts
+      // We require a meaningful overlap (share_of_place_area > 0.05 OR share_of_tract_area > 0.20)
+      // so a sliver-overlap doesn't claim the QCT.
+      var qctTracts = (membership.tracts || []).filter(function (t) {
+        if (!state.qctTractIds.has(t.tract_geoid)) return false;
+        var sp = +t.share_of_place_area || 0;
+        var st = +t.share_of_tract_area || 0;
+        return sp > 0.05 || st > 0.20;
       });
+      var hasQct = qctTracts.length > 0;
+
+      // DDA membership — place's containing county is in the DDA set
+      var hasDda = containingCounty && state.ddaCountyFips.has(containingCounty);
+
+      // Skip jurisdictions with NEITHER (not basis-boost eligible)
+      if (!hasQct && !hasDda) return;
+
+      // LIHTC projects in the jurisdiction (matched by PROJ_CTY)
+      var cityNameForLookup = placeNameToCity(label).toUpperCase();
+      var inside = (projectsByCity[cityNameForLookup] || []);
       var lastYear = inside.reduce(function (max, p) {
         var y = parseInt(p.properties.YR_PIS, 10);
         return (Number.isFinite(y) && y > max) ? y : max;
@@ -281,142 +296,60 @@
         return sum + (+p.properties.N_UNITS || 0);
       }, 0);
 
-      // Score components
+      // Population — from co_ami_gap_by_place's households at ≤100% AMI × 2.5
+      // (approximate; the file doesn't directly publish total population)
+      var amiRec = state.placeFromAmi[placeGeoid];
+      var pop = null;
+      if (amiRec && amiRec.households_le_ami_pct && amiRec.households_le_ami_pct['100']) {
+        // households_le_ami_pct['100'] is HH count at ≤100% AMI which is
+        // most of population by HH count. Avg CO HH size ≈ 2.5
+        pop = Math.round((+amiRec.households_le_ami_pct['100'] || 0) * 2.5);
+      }
+
+      // HNA need composite
+      var needComposite = needCompositeFor(containingCounty);
+      var needPct = needScoreFor(containingCounty, needDist);
+
+      // Component scores
       var recScore = recencyScore(lastYear);
-      var needS  = needScoreFor(countyFips, needDist);
-      var bbS    = basisBoostScore(true, false);  // QCT only (will upgrade if also DDA later)
-      var popS   = populationScore(pop);
-      var composite = Math.round(
-        0.35 * recScore + 0.30 * needS + 0.20 * bbS + 0.15 * popS
-      );
+      var bbScore = basisBoostScore(hasQct, hasDda);
+      var popScore = populationScore(pop);
+
+      // Compute score for each target — we'll use the active one in the table
+      var score9 = compositeScore(recScore, needPct, bbScore, popScore, '9pct');
+      var score4 = compositeScore(recScore, needPct, bbScore, popScore, '4pct');
+      var scoreAny = compositeScore(recScore, needPct, bbScore, popScore, 'any');
 
       ops.push({
-        id:           'qct-' + tractGeoid,
-        kind:         'QCT',
-        geoid:        tractGeoid,
-        name:         props.NAME || ('Census Tract ' + (props.TRACT || '')),
-        countyFips:   countyFips,
-        countyName:   state.countyName[countyFips] || ('County ' + countyFips),
-        city:         null,  // QCT is a tract — city derived from projects inside
-        type:         'QCT',
-        isQct:        true,
-        isDda:        false,
+        id:           placeGeoid,
+        placeGeoid:   placeGeoid,
+        name:         placeNameToCity(label),
+        labelFull:    label,
+        type:         type,
+        containingCounty: containingCounty,
+        countyName:   state.countyName[containingCounty] || (containingCounty ? 'County ' + containingCounty : '—'),
+        hasQct:       hasQct,
+        hasDda:       hasDda,
+        hasBoth:      hasQct && hasDda,
+        qctTracts:    qctTracts,
+        qctCount:     qctTracts.length,
         projects:     inside,
         projectCount: inside.length,
         totalUnits:   totalUnits,
         lastYear:     lastYear,
         yearsSince:   lastYear != null ? CURRENT_YEAR - lastYear : null,
         population:   pop,
+        // Component scores
         recencyScore: recScore,
-        needScore:    needS,
-        basisBoostScore: bbS,
-        populationScore: popS,
-        score:        composite,
-        centroid:     centroid,
-        feature:      feat
+        needScore:    needPct,
+        needCompositePct: needComposite != null ? Math.round(needComposite * 100) : null,
+        basisBoostScore: bbScore,
+        populationScore: popScore,
+        // Target-specific composites
+        score9:       score9,
+        score4:       score4,
+        scoreAny:     scoreAny
       });
-    });
-
-    // ── Per-DDA analysis ──
-    state.ddaFeatures.forEach(function (feat) {
-      var props = feat.properties || {};
-      var ddaName = props.DDA_NAME || props.NAME || ('DDA ' + props.DDA_CODE);
-      var ddaType = props.DDATYPE || props.DDA_TYPE; // M = metro, NM = nonmetro
-      var countyFips;
-      if (props.GEOID && props.GEOID.length === 5) {
-        countyFips = props.GEOID;  // nonmetro DDAs are county-based
-      } else {
-        // Metro DDAs are ZIP-based — pick the county whose centroid is closest
-        // to the DDA centroid (approximate but good enough for display)
-        var centroid0 = featureCentroid(feat);
-        countyFips = null; // best-effort, may stay null
-      }
-      var centroid = featureCentroid(feat);
-
-      var inside = state.projects.filter(function (p) {
-        var c = p.geometry && p.geometry.coordinates;
-        return c && pointInGeoFeature(c[0], c[1], feat);
-      });
-      var lastYear = inside.reduce(function (max, p) {
-        var y = parseInt(p.properties.YR_PIS, 10);
-        return (Number.isFinite(y) && y > max) ? y : max;
-      }, -Infinity);
-      if (lastYear === -Infinity) lastYear = null;
-      var totalUnits = inside.reduce(function (sum, p) {
-        return sum + (+p.properties.N_UNITS || 0);
-      }, 0);
-
-      // Population: sum population of all CO tracts whose centroid falls inside
-      // the DDA polygon. For county-based nonmetro DDAs we can shortcut by
-      // summing tract pops for that county, but the polygon-based count is
-      // more accurate so we use it uniformly.
-      var pop = 0;
-      // Cheap heuristic: use county-level pop estimate when available
-      // (full tract iteration would be slower). For nonmetro DDAs the
-      // polygon IS the county boundary so this is correct.
-      if (countyFips && state.chasByFips[countyFips]) {
-        var s = state.chasByFips[countyFips].summary || {};
-        pop = ((+s.total_renter_hh) || 0) + ((+s.total_owner_hh) || 0);
-        // HHs to pop heuristic: × 2.5 (avg CO household size)
-        pop = Math.round(pop * 2.5);
-      }
-
-      var recScore = recencyScore(lastYear);
-      var needS  = countyFips ? needScoreFor(countyFips, needDist) : 50;
-      var bbS    = basisBoostScore(false, true);
-      var popS   = populationScore(pop);
-      var composite = Math.round(
-        0.35 * recScore + 0.30 * needS + 0.20 * bbS + 0.15 * popS
-      );
-
-      ops.push({
-        id:           'dda-' + (props.DDA_CODE || props.OBJECTID || ddaName),
-        kind:         'DDA',
-        geoid:        props.GEOID || props.DDA_CODE,
-        name:         ddaName,
-        countyFips:   countyFips,
-        countyName:   countyFips ? (state.countyName[countyFips] || ('County ' + countyFips)) : '—',
-        type:         ddaType === 'M' ? 'DDA · metro' : 'DDA · nonmetro',
-        isQct:        false,
-        isDda:        true,
-        projects:     inside,
-        projectCount: inside.length,
-        totalUnits:   totalUnits,
-        lastYear:     lastYear,
-        yearsSince:   lastYear != null ? CURRENT_YEAR - lastYear : null,
-        population:   pop || null,
-        recencyScore: recScore,
-        needScore:    needS,
-        basisBoostScore: bbS,
-        populationScore: popS,
-        score:        composite,
-        centroid:     centroid,
-        feature:      feat
-      });
-    });
-
-    // ── Detect QCT × DDA overlap → flip "both" + recompute basis-boost ──
-    // O(qct × dda) = 224 × 10 = 2240 tests, negligible.
-    var ddaOps = ops.filter(function (o) { return o.kind === 'DDA'; });
-    ops.forEach(function (op) {
-      if (op.kind !== 'QCT') return;
-      for (var i = 0; i < ddaOps.length; i++) {
-        var ddaCentroid = ddaOps[i].centroid;
-        // Quick test: does the QCT contain the DDA centroid OR does the
-        // DDA contain the QCT centroid? Either signals overlap.
-        if (pointInGeoFeature(ddaCentroid[0], ddaCentroid[1], op.feature) ||
-            pointInGeoFeature(op.centroid[0], op.centroid[1], ddaOps[i].feature)) {
-          op.isDda = true;
-          op.type = 'QCT + DDA';
-          var newBbS = basisBoostScore(true, true);
-          op.basisBoostScore = newBbS;
-          op.score = Math.round(
-            0.35 * op.recencyScore + 0.30 * op.needScore +
-            0.20 * newBbS + 0.15 * op.populationScore
-          );
-          break;
-        }
-      }
     });
 
     state.opportunities = ops;
@@ -424,39 +357,29 @@
 
   /* ── Filtering ────────────────────────────────────────────────────── */
 
+  function _activeScore(op) {
+    var t = state.filters.target;
+    if (t === '9pct') return op.score9;
+    if (t === '4pct') return op.score4;
+    return op.scoreAny;
+  }
+
   function _applyFilters() {
     var f = state.filters;
     return state.opportunities.filter(function (op) {
-      // Area-type toggles
-      if (op.isQct && op.isDda) {
-        if (!f.showBoth) return false;
-      } else if (op.isQct) {
-        if (!f.showQct) return false;
-      } else if (op.isDda) {
-        if (!f.showDda) return false;
-      }
-      // County
-      if (f.county && op.countyFips !== f.county) return false;
-      // City — match against any project's PROJ_CTY
-      if (f.city) {
-        var matchCity = op.projects.some(function (p) {
-          return ((p.properties && p.properties.PROJ_CTY) || '').toUpperCase() === f.city.toUpperCase();
-        });
-        if (!matchCity) return false;
-      }
-      // Years-since-last-funded
-      if (f.minYearsSince > 0) {
-        if (op.yearsSince == null || op.yearsSince < f.minYearsSince) return false;
-      }
-      // Score
-      if (op.score < f.minScore) return false;
-      // Population
+      if (f.requireBoth && !op.hasBoth) return false;
+      if (f.requireQct && !op.hasQct) return false;
+      if (f.requireDda && !op.hasDda) return false;
+      if (!f.includeCdps && op.type === 'cdp') return false;
+      if (f.county && op.containingCounty !== f.county) return false;
+      if (f.minYearsSince > 0 && (op.yearsSince == null || op.yearsSince < f.minYearsSince)) return false;
+      if (f.minScore > 0 && _activeScore(op) < f.minScore) return false;
       if (f.minPop > 0 && (op.population || 0) < f.minPop) return false;
       return true;
     });
   }
 
-  /* ── Render: summary cards + table + map ──────────────────────────── */
+  /* ── Render ───────────────────────────────────────────────────────── */
 
   function _scoreBand(score) {
     if (score >= 70) return 'high';
@@ -467,24 +390,32 @@
   function _renderSummary(filtered) {
     var n = filtered.length;
     var neverFunded = filtered.filter(function (op) { return op.lastYear == null; }).length;
-    var qctOnly = filtered.filter(function (op) { return op.isQct && !op.isDda; }).length;
-    var ddaOnly = filtered.filter(function (op) { return op.isDda && !op.isQct; }).length;
-    var both = filtered.filter(function (op) { return op.isQct && op.isDda; }).length;
-    var avgScore = n ? Math.round(filtered.reduce(function (s, op) { return s + op.score; }, 0) / n) : 0;
+    var withQctAndDda = filtered.filter(function (op) { return op.hasBoth; }).length;
+    var avgScore = n ? Math.round(filtered.reduce(function (s, op) { return s + _activeScore(op); }, 0) / n) : 0;
+    var top = filtered[0];
+    var targetLabel = state.filters.target === '9pct' ? '9% Competitive'
+                    : state.filters.target === '4pct' ? '4% Bond'
+                    : 'Balanced (any)';
     var html =
-      '<div class="lof-summary-card"><div class="k">Areas matching filters</div>' +
+      '<div class="lof-summary-card"><div class="k">Target round</div>' +
+        '<div class="v" style="font-size:.95rem;line-height:1.25">' + targetLabel + '</div>' +
+        '<div class="s">' + (
+          state.filters.target === '9pct' ? '40·30·20·10 weighting' :
+          state.filters.target === '4pct' ? '25·25·15·35 weighting' :
+                                             '35·30·20·15 weighting'
+        ) + '</div></div>' +
+      '<div class="lof-summary-card"><div class="k">Jurisdictions matching</div>' +
         '<div class="v">' + n + '</div>' +
-        '<div class="s">QCT only ' + qctOnly + ' · DDA only ' + ddaOnly + ' · Both ' + both + '</div></div>' +
+        '<div class="s">' + withQctAndDda + ' with QCT + DDA</div></div>' +
       '<div class="lof-summary-card"><div class="k">Avg opportunity score</div>' +
         '<div class="v">' + avgScore + '<span style="font-size:.7rem;color:var(--muted)">/100</span></div></div>' +
-      '<div class="lof-summary-card"><div class="k">Never-funded areas</div>' +
+      '<div class="lof-summary-card"><div class="k">Never-funded jurisdictions</div>' +
         '<div class="v">' + neverFunded + '</div>' +
         '<div class="s">no LIHTC project on record</div></div>';
-    var top = filtered.length ? filtered[0] : null;
     if (top) {
-      html += '<div class="lof-summary-card"><div class="k">Top-ranked area</div>' +
+      html += '<div class="lof-summary-card"><div class="k">Top target</div>' +
         '<div class="v" style="font-size:.95rem;line-height:1.25">' + escHtml(top.name) + '</div>' +
-        '<div class="s">' + escHtml(top.countyName) + ' · ' + top.score + '/100</div></div>';
+        '<div class="s">' + escHtml(top.countyName) + ' · ' + _activeScore(top) + '/100</div></div>';
     }
     $('lofSummaryCards').innerHTML = html;
   }
@@ -492,36 +423,34 @@
   function _renderTable(filtered) {
     var tbody = $('lofTableBody');
     if (!filtered.length) {
-      tbody.innerHTML = '<tr><td colspan="8" class="lof-loading">No areas match the current filters.</td></tr>';
+      tbody.innerHTML = '<tr><td colspan="9" class="lof-loading">No jurisdictions match the current filters.</td></tr>';
       return;
     }
     var rows = filtered.map(function (op) {
       var typeHtml = '';
-      if (op.isQct && op.isDda) {
-        typeHtml = '<span class="lof-badge lof-badge--both">QCT + DDA</span>';
-      } else if (op.isQct) {
-        typeHtml = '<span class="lof-badge lof-badge--qct">QCT</span>';
-      } else {
-        typeHtml = '<span class="lof-badge lof-badge--dda">DDA</span>';
-      }
+      if (op.hasBoth) typeHtml = '<span class="lof-badge lof-badge--both">QCT + DDA</span>';
+      else if (op.hasQct) typeHtml = '<span class="lof-badge lof-badge--qct">QCT</span>';
+      else if (op.hasDda) typeHtml = '<span class="lof-badge lof-badge--dda">DDA</span>';
       var lastFundedText = op.lastYear != null
-        ? op.lastYear + ' (' + op.yearsSince + ' yrs ago)'
+        ? op.lastYear + ' <span style="color:var(--muted)">(' + op.yearsSince + 'y)</span>'
         : '<em>Never</em>';
-      var scoreCls = 'lof-score-' + _scoreBand(op.score);
+      var activeScore = _activeScore(op);
+      var scoreCls = 'lof-score-' + _scoreBand(activeScore);
       var selectedCls = (state.selectedId === op.id) ? ' is-selected' : '';
       return '<tr data-op-id="' + escHtml(op.id) + '" class="' + selectedCls.trim() + '">' +
-        '<td><span class="lof-score-cell ' + scoreCls + '">' + op.score + '</span></td>' +
-        '<td>' + escHtml(op.name) + '</td>' +
-        '<td>' + typeHtml + '</td>' +
+        '<td><span class="lof-score-cell ' + scoreCls + '">' + activeScore + '</span></td>' +
+        '<td><strong>' + escHtml(op.name) + '</strong>' +
+          '<div style="font-size:.72rem;color:var(--muted);text-transform:capitalize">' + escHtml(op.type) + '</div></td>' +
+        '<td>' + typeHtml + (op.qctCount > 1 ? '<span style="font-size:.7rem;color:var(--muted);margin-left:4px">×' + op.qctCount + '</span>' : '') + '</td>' +
         '<td>' + escHtml(op.countyName) + '</td>' +
         '<td>' + lastFundedText + '</td>' +
-        '<td>' + op.projectCount + '</td>' +
-        '<td>' + fmtInt(op.totalUnits) + '</td>' +
+        '<td>' + op.projectCount + (op.totalUnits ? ' <span style="color:var(--muted);font-size:.72rem">(' + fmtInt(op.totalUnits) + ' u)</span>' : '') + '</td>' +
+        '<td>' + (op.needScore != null ? op.needScore : '—') + '<span style="font-size:.7rem;color:var(--muted)">p</span></td>' +
         '<td>' + (op.population != null ? fmtInt(op.population) : '—') + '</td>' +
+        '<td style="font-size:.72rem;color:var(--muted)">9%·' + op.score9 + ' · 4%·' + op.score4 + '</td>' +
       '</tr>';
     }).join('');
     tbody.innerHTML = rows;
-    // Bind row clicks
     Array.from(tbody.querySelectorAll('tr[data-op-id]')).forEach(function (tr) {
       tr.addEventListener('click', function () {
         _showDetail(tr.getAttribute('data-op-id'));
@@ -531,50 +460,77 @@
 
   function _renderMap(filtered) {
     if (!state.map) return;
-    ['qct', 'dda', 'highlight'].forEach(function (k) {
+    ['jurisdiction', 'dda', 'qct', 'highlight'].forEach(function (k) {
       if (state.layers[k]) {
         state.map.removeLayer(state.layers[k]);
         state.layers[k] = null;
       }
     });
 
-    var qctLayer = window.L.layerGroup();
-    var ddaLayer = window.L.layerGroup();
-
+    // Draw DDA county polygons (light blue) for jurisdictions in DDA counties
+    var ddaCountyInFilter = new Set();
     filtered.forEach(function (op) {
-      var color = op.score >= 70 ? '#16a34a' : op.score >= 50 ? '#f59e0b' : '#94a3b8';
-      var coords = op.feature.geometry.coordinates;
-      var ringsForLeaflet;
-      if (op.feature.geometry.type === 'Polygon') {
-        ringsForLeaflet = coords.map(function (ring) {
+      if (op.hasDda && op.containingCounty) ddaCountyInFilter.add(op.containingCounty);
+    });
+    var ddaLayer = window.L.layerGroup();
+    state.ddaFeatures.forEach(function (f) {
+      var fips = f.properties && f.properties.GEOID;
+      if (!fips || !ddaCountyInFilter.has(fips)) return;
+      var coords = f.geometry.coordinates;
+      var rings;
+      if (f.geometry.type === 'Polygon') {
+        rings = coords.map(function (ring) {
           return ring.map(function (c) { return [c[1], c[0]]; });
         });
-      } else if (op.feature.geometry.type === 'MultiPolygon') {
-        ringsForLeaflet = coords.map(function (poly) {
+      } else if (f.geometry.type === 'MultiPolygon') {
+        rings = coords.map(function (poly) {
           return poly.map(function (ring) {
             return ring.map(function (c) { return [c[1], c[0]]; });
           });
         });
-      } else {
-        return;
-      }
-      var poly = window.L.polygon(ringsForLeaflet, {
-        color: color, weight: 1.4, fillColor: color, fillOpacity: 0.18, opacity: 0.85
+      } else return;
+      var poly = window.L.polygon(rings, {
+        color: '#3b82f6', weight: 1, fillColor: '#3b82f6', fillOpacity: 0.08, opacity: 0.5,
+        interactive: false
       });
-      poly.bindTooltip(
+      ddaLayer.addLayer(poly);
+    });
+    ddaLayer.addTo(state.map);
+    state.layers.dda = ddaLayer;
+
+    // Markers for each jurisdiction using its centroid (computed from
+    // average of containing tracts — approximate but fast)
+    var jurisLayer = window.L.layerGroup();
+    filtered.forEach(function (op) {
+      var lat = null, lng = null;
+      // Use any LIHTC project in the jurisdiction as the marker anchor;
+      // failing that, fall back to county centroid.
+      if (op.projects.length) {
+        var c = op.projects[0].geometry.coordinates;
+        lng = c[0]; lat = c[1];
+      } else if (op.containingCounty) {
+        // Approximate county centroid from CHAS / fallback to state center
+        lat = 39.0; lng = -105.5;
+      }
+      if (lat == null) return;
+      var activeScore = _activeScore(op);
+      var color = activeScore >= 70 ? '#16a34a' : activeScore >= 50 ? '#f59e0b' : '#94a3b8';
+      var marker = window.L.circleMarker([lat, lng], {
+        radius: 6 + Math.round(activeScore / 25),
+        color: '#fff', weight: 1.5,
+        fillColor: color, fillOpacity: 0.9
+      });
+      marker.bindTooltip(
         '<strong>' + escHtml(op.name) + '</strong><br>' +
-        op.type + ' · ' + escHtml(op.countyName) + '<br>' +
-        'Score: ' + op.score + '/100',
+        op.countyName + ' · score ' + activeScore + '/100<br>' +
+        (op.lastYear != null ? 'Last LIHTC: ' + op.lastYear : 'Never funded'),
         { sticky: true }
       );
-      poly.on('click', function () { _showDetail(op.id); });
-      if (op.kind === 'QCT') qctLayer.addLayer(poly);
-      else ddaLayer.addLayer(poly);
+      marker.on('click', function () { _showDetail(op.id); });
+      jurisLayer.addLayer(marker);
     });
-    qctLayer.addTo(state.map);
-    ddaLayer.addTo(state.map);
-    state.layers.qct = qctLayer;
-    state.layers.dda = ddaLayer;
+    jurisLayer.addTo(state.map);
+    state.layers.jurisdiction = jurisLayer;
   }
 
   function _showDetail(opId) {
@@ -582,79 +538,58 @@
     if (!op) return;
     state.selectedId = opId;
     var detail = $('lofDetail');
-    $('lofDetailTitle').textContent = op.name + '  ·  ' + op.type;
+    $('lofDetailTitle').textContent = op.name + '  ·  ' + op.countyName;
+
+    // Designation summary
+    var designations = [];
+    if (op.hasQct) designations.push(op.qctCount + ' QCT' + (op.qctCount > 1 ? 's' : ''));
+    if (op.hasDda) designations.push('DDA (county-wide)');
+
     var facts = $('lofDetailFacts');
     facts.innerHTML =
-      '<dt>County</dt><dd>' + escHtml(op.countyName) + '</dd>' +
-      '<dt>Opportunity score</dt><dd>' + op.score + '/100  (rec ' + op.recencyScore +
-        ' · need ' + op.needScore + ' · basis ' + op.basisBoostScore + ' · pop ' + op.populationScore + ')</dd>' +
+      '<dt>Designation</dt><dd>' + designations.join(' + ') + '</dd>' +
+      '<dt>9% Competitive score</dt><dd>' + op.score9 + '/100  ' +
+        '<span style="color:var(--muted);font-size:.78rem">(rec ' + op.recencyScore +
+        ' · need p' + op.needScore + ' · basis ' + op.basisBoostScore +
+        ' · pop ' + op.populationScore + ')</span></dd>' +
+      '<dt>4% Bond score</dt><dd>' + op.score4 + '/100</dd>' +
       '<dt>Last LIHTC project</dt><dd>' + (op.lastYear != null
         ? op.lastYear + ' (' + op.yearsSince + ' years ago)'
-        : 'Never funded on record') + '</dd>' +
-      '<dt>Existing LIHTC saturation</dt><dd>' + op.projectCount + ' project(s) · ' +
+        : '<em>Never funded on record</em>') + '</dd>' +
+      '<dt>Existing LIHTC stock</dt><dd>' + op.projectCount + ' project(s) · ' +
         fmtInt(op.totalUnits) + ' total units</dd>' +
-      '<dt>Population</dt><dd>' + (op.population != null ? fmtInt(op.population) : 'unknown') + '</dd>';
+      '<dt>HNA need composite</dt><dd>' + (op.needCompositePct != null ? op.needCompositePct + '% ' : '') +
+        '<span style="color:var(--muted);font-size:.78rem">(CO percentile rank: p' + op.needScore + ')</span></dd>' +
+      '<dt>Population (approx)</dt><dd>' + (op.population != null ? fmtInt(op.population) : 'unknown') + '</dd>' +
+      (op.qctCount > 0 ?
+        '<dt>QCT tracts in jurisdiction</dt><dd style="font-family:ui-monospace,monospace;font-size:.78rem">' +
+          op.qctTracts.map(function (t) { return t.tract_geoid; }).join(', ') +
+        '</dd>' : '');
 
-    // Projects in same city + county
-    var sameCityNames = new Set();
-    op.projects.forEach(function (p) {
-      var c = (p.properties && p.properties.PROJ_CTY) || '';
-      if (c) sameCityNames.add(c.toUpperCase());
-    });
-    var sameCityProjects = state.projects.filter(function (p) {
-      var c = ((p.properties && p.properties.PROJ_CTY) || '').toUpperCase();
-      return c && sameCityNames.has(c);
-    });
-    var sameCountyProjects = op.countyFips
-      ? state.projects.filter(function (p) {
-          return (p.properties && p.properties.CNTY_FIPS) === op.countyFips;
-        })
-      : [];
-    var combined = new Map();
-    sameCityProjects.concat(sameCountyProjects).forEach(function (p) {
-      var key = (p.properties.PROJECT || '') + '|' + (p.properties.YR_PIS || '');
-      if (!combined.has(key)) combined.set(key, p);
-    });
-    var projectList = Array.from(combined.values()).sort(function (a, b) {
+    // Projects in jurisdiction, sorted by YR_PIS descending
+    var projects = op.projects.slice().sort(function (a, b) {
       return (+b.properties.YR_PIS || 0) - (+a.properties.YR_PIS || 0);
     });
-
     var projHtml = '';
-    if (!projectList.length) {
-      projHtml = '<div class="lof-detail-project" style="color:var(--muted);font-style:italic;">No LIHTC projects on record in this city or county.</div>';
+    if (!projects.length) {
+      projHtml = '<div class="lof-detail-project" style="color:var(--muted);font-style:italic;">No LIHTC projects on record for this jurisdiction.</div>';
     } else {
-      projHtml = projectList.slice(0, 30).map(function (p) {
+      projHtml = projects.map(function (p) {
         var pr = p.properties;
         return '<div class="lof-detail-project">' +
           '<div class="lof-detail-project-name">' + escHtml(pr.PROJECT || '(unnamed)') + '</div>' +
           '<div class="lof-detail-project-meta">' +
-            escHtml(pr.PROJ_CTY || '—') + ' · ' +
-            escHtml(pr.CNTY_NAME || '—') + ' · ' +
             'YR_PIS ' + (pr.YR_PIS || '—') + ' · ' +
-            (pr.N_UNITS || 0) + ' units · ' +
-            (pr.CREDIT || '—') + ' credit' +
+            (pr.N_UNITS || 0) + ' units (' + (pr.LI_UNITS || 0) + ' LI) · ' +
+            (pr.CREDIT || '—') + ' credit · ' +
+            'QCT ' + (pr.QCT === '1' || pr.QCT === 1 ? 'yes' : (pr.QCT || 'no')) +
           '</div>' +
         '</div>';
       }).join('');
-      if (projectList.length > 30) {
-        projHtml += '<div class="lof-detail-project" style="color:var(--muted);">' +
-          '+ ' + (projectList.length - 30) + ' more not shown' +
-        '</div>';
-      }
     }
     $('lofDetailProjects').innerHTML = projHtml;
     detail.hidden = false;
 
-    // Highlight on map
-    if (state.map && op.centroid) {
-      if (state.layers.highlight) state.map.removeLayer(state.layers.highlight);
-      state.layers.highlight = window.L.circleMarker(
-        [op.centroid[1], op.centroid[0]],
-        { radius: 12, color: '#ef4444', weight: 3, fillOpacity: 0.0 }
-      ).addTo(state.map);
-      state.map.setView([op.centroid[1], op.centroid[0]], 10);
-    }
-    // Highlight table row
     Array.from(document.querySelectorAll('#lofTableBody tr')).forEach(function (tr) {
       tr.classList.toggle('is-selected', tr.getAttribute('data-op-id') === opId);
     });
@@ -668,15 +603,16 @@
     var dir = state.sortDir === 'asc' ? 1 : -1;
     function val(op) {
       switch (k) {
-        case 'score':         return op.score;
+        case 'score':         return _activeScore(op);
         case 'name':          return (op.name || '').toLowerCase();
-        case 'type':          return op.type;
+        case 'type':          return (op.hasBoth ? 2 : op.hasQct ? 1 : 0);
         case 'county':        return (op.countyName || '').toLowerCase();
         case 'lastYear':      return op.lastYear == null ? -Infinity : op.lastYear;
         case 'projectCount':  return op.projectCount;
-        case 'totalUnits':    return op.totalUnits;
+        case 'needScore':     return op.needScore == null ? -1 : op.needScore;
         case 'population':    return op.population || 0;
-        default:              return op.score;
+        case 'altScores':     return op.score9;  // sortable proxy
+        default:              return _activeScore(op);
       }
     }
     return arr.slice().sort(function (a, b) {
@@ -687,7 +623,7 @@
     });
   }
 
-  /* ── Refresh pipeline ─────────────────────────────────────────────── */
+  /* ── Refresh ──────────────────────────────────────────────────────── */
 
   function _refresh() {
     var filtered = _sortOps(_applyFilters());
@@ -700,15 +636,8 @@
 
   function _populateFilterDropdowns() {
     var counties = {};
-    var cities = {};
     state.opportunities.forEach(function (op) {
-      if (op.countyFips) counties[op.countyFips] = op.countyName;
-      op.projects.forEach(function (p) {
-        var c = (p.properties && p.properties.PROJ_CTY) || '';
-        if (c) cities[c.toUpperCase()] = c.split(' ').map(function (w) {
-          return w.charAt(0) + w.slice(1).toLowerCase();
-        }).join(' ');
-      });
+      if (op.containingCounty) counties[op.containingCounty] = op.countyName;
     });
     var countySel = $('lofCounty');
     Object.keys(counties).sort(function (a, b) {
@@ -719,76 +648,86 @@
       opt.textContent = counties[fips];
       countySel.appendChild(opt);
     });
-    var citySel = $('lofCity');
-    Object.keys(cities).sort().forEach(function (key) {
-      var opt = document.createElement('option');
-      opt.value = key;  // upper-case key for matching
-      opt.textContent = cities[key];
-      citySel.appendChild(opt);
-    });
   }
 
   function _wireFilters() {
-    var qctEl = $('lofShowQct'), ddaEl = $('lofShowDda'), bothEl = $('lofShowBoth');
-    var countyEl = $('lofCounty'), cityEl = $('lofCity');
-    var minYearsEl = $('lofMinYearsSince'), minScoreEl = $('lofMinScore'), minPopEl = $('lofMinPop');
-    var minYearsValEl = $('lofMinYearsSinceVal'), minScoreValEl = $('lofMinScoreVal');
+    var targetRadios = document.querySelectorAll('input[name="lofTarget"]');
+    targetRadios.forEach(function (r) {
+      r.addEventListener('change', function () {
+        if (r.checked) {
+          state.filters.target = r.value;
+          _refresh();
+        }
+      });
+    });
 
-    [qctEl, ddaEl, bothEl].forEach(function (el) {
+    var reqQct = $('lofRequireQct'), reqDda = $('lofRequireDda'), reqBoth = $('lofRequireBoth');
+    [reqQct, reqDda, reqBoth].forEach(function (el) {
+      if (!el) return;
       el.addEventListener('change', function () {
-        state.filters.showQct = qctEl.checked;
-        state.filters.showDda = ddaEl.checked;
-        state.filters.showBoth = bothEl.checked;
+        state.filters.requireQct = reqQct.checked;
+        state.filters.requireDda = reqDda.checked;
+        state.filters.requireBoth = reqBoth.checked;
         _refresh();
       });
     });
-    countyEl.addEventListener('change', function () {
-      state.filters.county = countyEl.value;
-      _refresh();
+
+    var includeCdps = $('lofIncludeCdps');
+    if (includeCdps) {
+      includeCdps.addEventListener('change', function () {
+        state.filters.includeCdps = includeCdps.checked;
+        _refresh();
+      });
+    }
+
+    $('lofCounty').addEventListener('change', function (e) {
+      state.filters.county = e.target.value; _refresh();
     });
-    cityEl.addEventListener('change', function () {
-      state.filters.city = cityEl.value;
-      _refresh();
-    });
-    minYearsEl.addEventListener('input', function () {
-      state.filters.minYearsSince = +minYearsEl.value;
-      minYearsValEl.textContent = minYearsEl.value;
-      _refresh();
-    });
-    minScoreEl.addEventListener('input', function () {
-      state.filters.minScore = +minScoreEl.value;
-      minScoreValEl.textContent = minScoreEl.value;
-      _refresh();
-    });
-    minPopEl.addEventListener('change', function () {
-      state.filters.minPop = +minPopEl.value || 0;
-      _refresh();
-    });
-    $('lofResetFilters').addEventListener('click', function () {
-      state.filters = {
-        showQct: true, showDda: true, showBoth: true,
-        county: '', city: '',
-        minYearsSince: 0, minScore: 0, minPop: 0
-      };
-      qctEl.checked = true; ddaEl.checked = true; bothEl.checked = true;
-      countyEl.value = ''; cityEl.value = '';
-      minYearsEl.value = 0; minYearsValEl.textContent = '0';
-      minScoreEl.value = 0; minScoreValEl.textContent = '0';
-      minPopEl.value = 0;
+
+    var minYears = $('lofMinYearsSince'), minYearsVal = $('lofMinYearsSinceVal');
+    minYears.addEventListener('input', function () {
+      state.filters.minYearsSince = +minYears.value;
+      minYearsVal.textContent = minYears.value;
       _refresh();
     });
 
-    // Column-header sort clicks
+    var minScore = $('lofMinScore'), minScoreVal = $('lofMinScoreVal');
+    minScore.addEventListener('input', function () {
+      state.filters.minScore = +minScore.value;
+      minScoreVal.textContent = minScore.value;
+      _refresh();
+    });
+
+    var minPop = $('lofMinPop');
+    minPop.addEventListener('change', function () {
+      state.filters.minPop = +minPop.value || 0; _refresh();
+    });
+
+    $('lofResetFilters').addEventListener('click', function () {
+      state.filters = {
+        target: '9pct',
+        requireQct: false, requireDda: false, requireBoth: true,
+        county: '', minYearsSince: 0, minScore: 0, minPop: 0,
+        includeCdps: false
+      };
+      document.querySelector('input[name="lofTarget"][value="9pct"]').checked = true;
+      reqQct.checked = false; reqDda.checked = false; reqBoth.checked = true;
+      if (includeCdps) includeCdps.checked = false;
+      $('lofCounty').value = '';
+      minYears.value = 0; minYearsVal.textContent = '0';
+      minScore.value = 0; minScoreVal.textContent = '0';
+      minPop.value = 0;
+      _refresh();
+    });
+
     Array.from(document.querySelectorAll('#lofTable thead th[data-sort]')).forEach(function (th) {
       th.addEventListener('click', function () {
         var key = th.getAttribute('data-sort');
         if (state.sortKey === key) {
           state.sortDir = state.sortDir === 'asc' ? 'desc' : 'asc';
         } else {
-          state.sortKey = key;
-          state.sortDir = 'desc';
+          state.sortKey = key; state.sortDir = 'desc';
         }
-        // Update aria-sort attrs
         Array.from(document.querySelectorAll('#lofTable thead th[data-sort]')).forEach(function (h) {
           h.removeAttribute('aria-sort');
         });
@@ -800,8 +739,7 @@
 
   function _initMap() {
     if (!window.L || !$('lofMap')) return;
-    state.map = window.L.map('lofMap', { preferCanvas: true })
-      .setView([39.0, -105.5], 7);
+    state.map = window.L.map('lofMap', { preferCanvas: true }).setView([39.0, -105.5], 7);
     var cartoLight = window.L.tileLayer(
       'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png',
       { attribution: '© OpenStreetMap contributors © CARTO', subdomains: 'abcd', maxZoom: 19 }
@@ -828,7 +766,7 @@
         _populateFilterDropdowns();
         _wireFilters();
         setStatus('Ranked ' + state.opportunities.length +
-          ' opportunity zones across Colorado · click a row or polygon for details.');
+          ' Colorado jurisdictions with QCT and/or DDA designations · click a row for project history.');
         _refresh();
       })
       .catch(function (err) {

--- a/js/lihtc-opportunity-finder.js
+++ b/js/lihtc-opportunity-finder.js
@@ -103,6 +103,19 @@
     return label.replace(/\s*\([^)]+\)\s*$/, '').trim();
   }
 
+  // Build a deep-link to the Housing Needs Assessment for a specific
+  // place (7-digit GEOID) or county (5-digit). The HNA page's
+  // _resolveAutoTarget reads ?fips= + ?geoType= to pre-select the
+  // jurisdiction so the user lands directly on the full HNA workup.
+  function hnaUrlForPlace(placeGeoid) {
+    return 'housing-needs-assessment.html?fips=' + encodeURIComponent(placeGeoid) +
+      '&geoType=place&auto=1';
+  }
+  function hnaUrlForCounty(countyFips) {
+    return 'housing-needs-assessment.html?fips=' + encodeURIComponent(countyFips) +
+      '&geoType=county&auto=1';
+  }
+
   /* ── Score components ─────────────────────────────────────────────── */
 
   function recencyScore(lastYear) {
@@ -440,6 +453,11 @@
       return '<tr data-op-id="' + escHtml(op.id) + '" class="' + selectedCls.trim() + '">' +
         '<td><span class="lof-score-cell ' + scoreCls + '">' + activeScore + '</span></td>' +
         '<td><strong>' + escHtml(op.name) + '</strong>' +
+          ' <a href="' + escHtml(hnaUrlForPlace(op.placeGeoid)) + '" ' +
+            'target="_blank" rel="noopener" class="lof-hna-link" ' +
+            'title="Open Housing Needs Assessment for ' + escHtml(op.name) + '" ' +
+            'aria-label="Open Housing Needs Assessment for ' + escHtml(op.name) + ' in new tab" ' +
+            'onclick="event.stopPropagation()">→ HNA</a>' +
           '<div style="font-size:.72rem;color:var(--muted);text-transform:capitalize">' + escHtml(op.type) + '</div></td>' +
         '<td>' + typeHtml + (op.qctCount > 1 ? '<span style="font-size:.7rem;color:var(--muted);margin-left:4px">×' + op.qctCount + '</span>' : '') + '</td>' +
         '<td>' + escHtml(op.countyName) + '</td>' +
@@ -545,6 +563,24 @@
     if (op.hasQct) designations.push(op.qctCount + ' QCT' + (op.qctCount > 1 ? 's' : ''));
     if (op.hasDda) designations.push('DDA (county-wide)');
 
+    // HNA deep-link CTAs — open the full Housing Needs Assessment workup
+    // for the place AND its containing county (different geographic
+    // scopes — both useful: place is the bond-deal market; county is the
+    // 9% award geography in many CHFA scoring categories).
+    var hnaCta = $('lofDetailHnaCta');
+    if (hnaCta) {
+      hnaCta.innerHTML =
+        '<a class="lof-hna-cta lof-hna-cta--primary" href="' + escHtml(hnaUrlForPlace(op.placeGeoid)) +
+          '" target="_blank" rel="noopener">' +
+          '📋 Housing Needs Assessment — ' + escHtml(op.name) +
+        '</a>' +
+        (op.containingCounty ?
+          '<a class="lof-hna-cta lof-hna-cta--secondary" href="' + escHtml(hnaUrlForCounty(op.containingCounty)) +
+            '" target="_blank" rel="noopener">' +
+            'County HNA — ' + escHtml(op.countyName) +
+          '</a>' : '');
+    }
+
     var facts = $('lofDetailFacts');
     facts.innerHTML =
       '<dt>Designation</dt><dd>' + designations.join(' + ') + '</dd>' +
@@ -552,14 +588,20 @@
         '<span style="color:var(--muted);font-size:.78rem">(rec ' + op.recencyScore +
         ' · need p' + op.needScore + ' · basis ' + op.basisBoostScore +
         ' · pop ' + op.populationScore + ')</span></dd>' +
-      '<dt>4% Bond score</dt><dd>' + op.score4 + '/100</dd>' +
+      '<dt>4% Bond score</dt><dd>' + op.score4 + '/100  ' +
+        '<span style="color:var(--muted);font-size:.78rem">(rec ' + op.recencyScore +
+        ' · need p' + op.needScore + ' · basis ' + op.basisBoostScore +
+        ' · pop ' + op.populationScore + ', re-weighted 25/25/15/35)</span></dd>' +
       '<dt>Last LIHTC project</dt><dd>' + (op.lastYear != null
         ? op.lastYear + ' (' + op.yearsSince + ' years ago)'
         : '<em>Never funded on record</em>') + '</dd>' +
       '<dt>Existing LIHTC stock</dt><dd>' + op.projectCount + ' project(s) · ' +
         fmtInt(op.totalUnits) + ' total units</dd>' +
       '<dt>HNA need composite</dt><dd>' + (op.needCompositePct != null ? op.needCompositePct + '% ' : '') +
-        '<span style="color:var(--muted);font-size:.78rem">(CO percentile rank: p' + op.needScore + ')</span></dd>' +
+        '<span style="color:var(--muted);font-size:.78rem">(CO percentile rank: p' + op.needScore + ')</span>' +
+        ' &nbsp;<a href="' + escHtml(hnaUrlForPlace(op.placeGeoid)) + '" target="_blank" rel="noopener" ' +
+          'style="font-size:.78rem;font-weight:600">View full HNA →</a>' +
+      '</dd>' +
       '<dt>Population (approx)</dt><dd>' + (op.population != null ? fmtInt(op.population) : 'unknown') + '</dd>' +
       (op.qctCount > 0 ?
         '<dt>QCT tracts in jurisdiction</dt><dd style="font-family:ui-monospace,monospace;font-size:.78rem">' +

--- a/js/lihtc-opportunity-finder.js
+++ b/js/lihtc-opportunity-finder.js
@@ -416,6 +416,12 @@
       var localRes = localResForPlace(placeGeoid, type, containingCounty);
       var prop123 = prop123ForName(placeNameToCity(label));
 
+      var civicRawScore = civic && Number.isFinite(civic.totalScore) ? civic.totalScore : null;
+      var civicMax = civic && Number.isFinite(civic.maxPossible) && civic.maxPossible > 0
+        ? civic.maxPossible
+        : 7;
+      var civicPct = civicRawScore != null ? Math.round((civicRawScore / civicMax) * 100) : null;
+
       ops.push({
         id:           placeGeoid,
         placeGeoid:   placeGeoid,
@@ -449,8 +455,9 @@
         civic:        civic,
         localRes:     localRes,
         prop123Detail: prop123,
-        civicScore:   civic && Number.isFinite(civic.totalScore) ? civic.totalScore : null,
-        civicMax:     civic && Number.isFinite(civic.maxPossible) ? civic.maxPossible : 7
+        civicScore:   civicPct,
+        civicRawScore: civicRawScore,
+        civicMax:     civicMax
       });
     });
 
@@ -532,7 +539,7 @@
     var prop123 = dims.prop123_committed ? '✓' : '·';
     var hna = dims.has_hna ? '✓' : '·';
     var plan = dims.has_comp_plan ? '✓' : '·';
-    var band = op.civicScore >= 5 ? 'high' : op.civicScore >= 3 ? 'med' : 'low';
+    var band = op.civicScore >= 70 ? 'high' : op.civicScore >= 40 ? 'med' : 'low';
     var tipBits = [
       'Prop 123: ' + (dims.prop123_committed ? 'committed' : (dims.prop123_committed === false ? 'no' : '—')),
       'HNA: '      + (dims.has_hna           ? 'yes' : (dims.has_hna === false ? 'no' : '—')),
@@ -543,7 +550,7 @@
     ];
     return '<span class="lof-civic-cell lof-civic-' + band + '" ' +
       'title="' + escHtml(tipBits.join(' · ')) + '">' +
-      op.civicScore + '<span style="font-size:.7rem;color:var(--muted)">/' + op.civicMax + '</span> ' +
+      op.civicScore + '<span style="font-size:.7rem;color:var(--muted)">/100</span> ' +
       '<span style="font-family:ui-monospace,monospace;font-size:.7rem;letter-spacing:.05em">' +
       prop123 + hna + plan +
       '</span></span>';
@@ -784,9 +791,9 @@
 
     var scoreBadge = '';
     if (op.civicScore != null) {
-      var band = op.civicScore >= 5 ? 'high' : op.civicScore >= 3 ? 'med' : 'low';
+      var band = op.civicScore >= 70 ? 'high' : op.civicScore >= 40 ? 'med' : 'low';
       scoreBadge = '<span class="lof-civic-score-badge lof-civic-' + band + '">' +
-        'Policy score ' + op.civicScore + '/' + op.civicMax +
+        'Policy score ' + op.civicScore + '/100 (' + op.civicRawScore + '/' + op.civicMax + ' signals)' +
       '</span>';
     } else {
       scoreBadge = '<span class="lof-civic-score-badge lof-civic-unk">No policy-scorecard record</span>';

--- a/js/lihtc-opportunity-finder.js
+++ b/js/lihtc-opportunity-finder.js
@@ -50,6 +50,9 @@
     chasByFips: {},                 // 5-digit county FIPS → CHAS county record
     countyName: {},                 // 5-digit county FIPS → display name
     placeMeta: {},                  // place geoid → { label, containingCounty, type }
+    policyScores: {},               // geoid (5- or 7-digit) → { totalScore, dimensions } from policy scorecard
+    localResources: {},             // "county:FIPS" / "place:FIPS" / "cdp:FIPS" → { prop123, housingAuthority, housingLead, housingPlans, advocacy }
+    prop123ByName: {},              // upper-cased jurisdiction name → prop123 record (filing date, fast-track)
     opportunities: [],
     map: null,
     layers: { jurisdiction: null, dda: null, qct: null, highlight: null },
@@ -186,7 +189,14 @@
   /* ── Data loading ─────────────────────────────────────────────────── */
 
   function loadAll() {
-    setStatus('Loading jurisdiction data (HUD QCT, DDA, LIHTC, CHAS, place memberships)…');
+    setStatus('Loading jurisdiction data (HUD QCT, DDA, LIHTC, CHAS, place memberships, civic capacity)…');
+    // Some of these are non-critical (civic-capacity layers) — wrap each in
+    // a catch so a missing/malformed file doesn't break the whole page.
+    function loadSoft(url) {
+      return fetch(url)
+        .then(function (r) { return r.ok ? r.json() : null; })
+        .catch(function () { return null; });
+    }
     return Promise.all([
       fetch('data/qct-colorado.json').then(function (r) { return r.json(); }),
       fetch('data/dda-colorado.json').then(function (r) { return r.json(); }),
@@ -194,7 +204,10 @@
       fetch('data/hna/chas_affordability_gap.json').then(function (r) { return r.json(); }),
       fetch('data/hna/place-tract-membership.json').then(function (r) { return r.json(); }),
       fetch('data/co_ami_gap_by_place.json').then(function (r) { return r.json(); }),
-      fetch('data/hna/geo-config.json').then(function (r) { return r.json(); })
+      fetch('data/hna/geo-config.json').then(function (r) { return r.json(); }),
+      loadSoft('data/policy/housing-policy-scorecard.json'),
+      loadSoft('data/hna/local-resources.json'),
+      loadSoft('data/policy/prop123_jurisdictions.json')
     ]).then(function (parts) {
       // Build QCT tract-ID set
       (parts[0].features || []).forEach(function (f) {
@@ -245,10 +258,68 @@
         };
       });
 
+      // Soft civic-capacity layers — each defaults to empty on miss
+      var scorecard = parts[7];
+      if (scorecard && scorecard.scores) {
+        state.policyScores = scorecard.scores;
+      }
+      var localRes = parts[8];
+      if (localRes && typeof localRes === 'object') {
+        state.localResources = localRes;
+      }
+      var prop123 = parts[9];
+      if (prop123 && Array.isArray(prop123.jurisdictions)) {
+        prop123.jurisdictions.forEach(function (j) {
+          // Strip "City and County of " / "Town of " prefixes to maximise name-match
+          var key = (j.name || '').toUpperCase()
+            .replace(/^CITY AND COUNTY OF\s+/, '')
+            .replace(/^TOWN OF\s+/, '')
+            .replace(/^CITY OF\s+/, '')
+            .replace(/\s+COUNTY$/, '')
+            .trim();
+          if (key) state.prop123ByName[key] = j;
+        });
+      }
+
       setStatus('Rolling up ' + Object.keys(state.placeMembership).length +
         ' jurisdictions against ' + state.qctTractIds.size + ' QCTs · ' +
-        state.ddaCountyFips.size + ' DDAs · ' + state.projects.length + ' LIHTC projects…');
+        state.ddaCountyFips.size + ' DDAs · ' + state.projects.length + ' LIHTC projects · ' +
+        Object.keys(state.policyScores).length + ' policy-score records…');
     });
+  }
+
+  /* ── Civic-capacity helpers ───────────────────────────────────────── */
+
+  // Pull the policy-scorecard record for a place (7-digit geoid).
+  // Falls back to the containing county record if no place-level entry.
+  function civicForPlace(placeGeoid, countyFips) {
+    return state.policyScores[placeGeoid] ||
+           (countyFips ? state.policyScores[countyFips] : null) ||
+           null;
+  }
+
+  // Pull the local-resources record, trying place / cdp / county keys in turn.
+  function localResForPlace(placeGeoid, type, countyFips) {
+    var lr = state.localResources;
+    var k;
+    if (type === 'cdp') {
+      k = 'cdp:' + placeGeoid;
+      if (lr[k]) return lr[k];
+    }
+    k = 'place:' + placeGeoid;
+    if (lr[k]) return lr[k];
+    if (countyFips) {
+      k = 'county:' + countyFips;
+      if (lr[k]) return lr[k];
+    }
+    return null;
+  }
+
+  // Pull the detailed prop123 commitment record by jurisdiction name.
+  function prop123ForName(placeName) {
+    if (!placeName) return null;
+    var key = placeName.toUpperCase().trim();
+    return state.prop123ByName[key] || null;
   }
 
   /* ── Opportunity assembly ─────────────────────────────────────────── */
@@ -333,6 +404,18 @@
       var score4 = compositeScore(recScore, needPct, bbScore, popScore, '4pct');
       var scoreAny = compositeScore(recScore, needPct, bbScore, popScore, 'any');
 
+      // Civic capacity — policy scorecard + local-resources details + prop123 detail.
+      // We join three sources:
+      //   1. policyScores[geoid].dimensions: boolean flags has_hna, prop123_committed,
+      //      has_comp_plan, has_housing_authority, has_housing_nonprofits, has_iz_ordinance,
+      //      has_local_funding — gives a 0–7 score per place.
+      //   2. localResources["place:GEOID"|"cdp:GEOID"|"county:FIPS"]: actual URLs for
+      //      housingAuthority, housingLead, housingPlans, advocacy, prop123 link.
+      //   3. prop123ByName[NAME]: filing date + fast-track flag (from prop123_jurisdictions).
+      var civic = civicForPlace(placeGeoid, containingCounty);
+      var localRes = localResForPlace(placeGeoid, type, containingCounty);
+      var prop123 = prop123ForName(placeNameToCity(label));
+
       ops.push({
         id:           placeGeoid,
         placeGeoid:   placeGeoid,
@@ -361,7 +444,13 @@
         // Target-specific composites
         score9:       score9,
         score4:       score4,
-        scoreAny:     scoreAny
+        scoreAny:     scoreAny,
+        // Civic capacity layer (all nullable — sparse coverage)
+        civic:        civic,
+        localRes:     localRes,
+        prop123Detail: prop123,
+        civicScore:   civic && Number.isFinite(civic.totalScore) ? civic.totalScore : null,
+        civicMax:     civic && Number.isFinite(civic.maxPossible) ? civic.maxPossible : 7
       });
     });
 
@@ -433,10 +522,55 @@
     $('lofSummaryCards').innerHTML = html;
   }
 
+  /* ── Civic-capacity cell renderer (table) ─────────────────────────── */
+
+  function _civicCell(op) {
+    if (op.civicScore == null) {
+      return '<span style="color:var(--muted);font-size:.78rem">—</span>';
+    }
+    var dims = (op.civic && op.civic.dimensions) || {};
+    var prop123 = dims.prop123_committed ? '✓' : '·';
+    var hna = dims.has_hna ? '✓' : '·';
+    var plan = dims.has_comp_plan ? '✓' : '·';
+    var band = op.civicScore >= 5 ? 'high' : op.civicScore >= 3 ? 'med' : 'low';
+    var tipBits = [
+      'Prop 123: ' + (dims.prop123_committed ? 'committed' : (dims.prop123_committed === false ? 'no' : '—')),
+      'HNA: '      + (dims.has_hna           ? 'yes' : (dims.has_hna === false ? 'no' : '—')),
+      'Comp plan: '+ (dims.has_comp_plan     ? 'yes' : (dims.has_comp_plan === false ? 'no' : '—')),
+      'HA: '       + (dims.has_housing_authority ? 'yes' : 'no'),
+      'IZ: '       + (dims.has_iz_ordinance      ? 'yes' : 'no'),
+      'Local $: '  + (dims.has_local_funding     ? 'yes' : 'no')
+    ];
+    return '<span class="lof-civic-cell lof-civic-' + band + '" ' +
+      'title="' + escHtml(tipBits.join(' · ')) + '">' +
+      op.civicScore + '<span style="font-size:.7rem;color:var(--muted)">/' + op.civicMax + '</span> ' +
+      '<span style="font-family:ui-monospace,monospace;font-size:.7rem;letter-spacing:.05em">' +
+      prop123 + hna + plan +
+      '</span></span>';
+  }
+
+  /* ── News linkouts ────────────────────────────────────────────────── */
+
+  // Build a Google News query that includes the jurisdiction name and
+  // an affordable-housing context. CO Sun and CPR don't have public
+  // tag-search APIs we can deep-link to reliably, so we use Google
+  // site-search URLs for those.
+  function newsUrls(placeName, countyName) {
+    var n = encodeURIComponent('"' + placeName + '" Colorado affordable housing');
+    var c = encodeURIComponent('"' + countyName + '" affordable housing');
+    return {
+      googleNews:  'https://news.google.com/search?q=' + n + '&hl=en-US&gl=US&ceid=US%3Aen',
+      coloradoSun:'https://www.google.com/search?q=site%3Acoloradosun.com+' + n,
+      cpr:        'https://www.google.com/search?q=site%3Acpr.org+' + n,
+      bizwest:    'https://www.google.com/search?q=site%3Abizwest.com+' + n,
+      countyNews: 'https://news.google.com/search?q=' + c + '&hl=en-US&gl=US&ceid=US%3Aen'
+    };
+  }
+
   function _renderTable(filtered) {
     var tbody = $('lofTableBody');
     if (!filtered.length) {
-      tbody.innerHTML = '<tr><td colspan="9" class="lof-loading">No jurisdictions match the current filters.</td></tr>';
+      tbody.innerHTML = '<tr><td colspan="10" class="lof-loading">No jurisdictions match the current filters.</td></tr>';
       return;
     }
     var rows = filtered.map(function (op) {
@@ -465,6 +599,7 @@
         '<td>' + op.projectCount + (op.totalUnits ? ' <span style="color:var(--muted);font-size:.72rem">(' + fmtInt(op.totalUnits) + ' u)</span>' : '') + '</td>' +
         '<td>' + (op.needScore != null ? op.needScore : '—') + '<span style="font-size:.7rem;color:var(--muted)">p</span></td>' +
         '<td>' + (op.population != null ? fmtInt(op.population) : '—') + '</td>' +
+        '<td>' + _civicCell(op) + '</td>' +
         '<td style="font-size:.72rem;color:var(--muted)">9%·' + op.score9 + ' · 4%·' + op.score4 + '</td>' +
       '</tr>';
     }).join('');
@@ -551,6 +686,147 @@
     state.layers.jurisdiction = jurisLayer;
   }
 
+  /* ── Detail-panel sub-renderers ───────────────────────────────────── */
+
+  function _renderCivicPanel(op) {
+    var dims = (op.civic && op.civic.dimensions) || {};
+    var lr = op.localRes || {};
+    var p123Detail = op.prop123Detail;
+
+    function checkRow(label, val, extra) {
+      var icon = val === true  ? '<span class="lof-civic-check lof-civic-yes">✓</span>'
+               : val === false ? '<span class="lof-civic-check lof-civic-no">✗</span>'
+               :                  '<span class="lof-civic-check lof-civic-unk">?</span>';
+      return '<div class="lof-civic-row">' +
+        '<span class="lof-civic-label">' + label + '</span>' + icon +
+        (extra ? '<span class="lof-civic-extra">' + extra + '</span>' : '') +
+      '</div>';
+    }
+
+    // Prop 123 row — pull from local-resources (link) + prop123_jurisdictions (filing date).
+    // Three coverage tiers:
+    //   1. Direct prop123 jurisdiction record (filed under own name) — show filing date + fast-track.
+    //   2. local-resources has a prop123 entry (often county-level) — show status.
+    //   3. policy-scorecard says prop123_committed=true via county fallback — show "via [County]".
+    var p123Extra = '';
+    if (p123Detail) {
+      var bits = [];
+      if (p123Detail.filing_date) bits.push('filed ' + p123Detail.filing_date);
+      if (p123Detail.fast_track)  bits.push('<span class="lof-pill lof-pill--accent">fast-track</span>');
+      if (p123Detail.required_commitment) bits.push(escHtml(p123Detail.required_commitment));
+      var p123Link = (lr.prop123 && lr.prop123.link) ||
+                     p123Detail.source_url ||
+                     'https://cdola.colorado.gov/commitment-filings';
+      p123Extra = bits.join(' · ') +
+        ' <a href="' + escHtml(p123Link) + '" target="_blank" rel="noopener">DOLA filing →</a>';
+    } else if (lr.prop123) {
+      p123Extra = escHtml(lr.prop123.status || 'See DOLA filings') +
+        ' <a href="' + escHtml(lr.prop123.link || 'https://cdola.colorado.gov/commitment-filings') +
+        '" target="_blank" rel="noopener">DOLA filing →</a>';
+    } else if (dims.prop123_committed === true && op.countyName) {
+      p123Extra = '<span class="lof-civic-sub">via ' + escHtml(op.countyName) +
+        ' commitment</span> <a href="https://cdola.colorado.gov/commitment-filings" ' +
+        'target="_blank" rel="noopener">DOLA filings →</a>';
+    }
+
+    // Housing lead row — local-resources.housingLead
+    var leadExtra = '';
+    if (lr.housingLead && lr.housingLead.name) {
+      leadExtra = escHtml(lr.housingLead.name);
+      if (lr.housingLead.url) {
+        leadExtra += ' <a href="' + escHtml(lr.housingLead.url) + '" target="_blank" rel="noopener">contact →</a>';
+      }
+    }
+
+    // Housing plans row — local-resources.housingPlans (comp plan / HNA / housing element)
+    var planRows = '';
+    if (Array.isArray(lr.housingPlans) && lr.housingPlans.length) {
+      planRows = '<div class="lof-civic-row lof-civic-row--block">' +
+        '<span class="lof-civic-label">Plans on file</span>' +
+        '<ul class="lof-civic-list">' +
+        lr.housingPlans.map(function (p) {
+          var url = p.url ? ' <a href="' + escHtml(p.url) + '" target="_blank" rel="noopener">→</a>' : '';
+          var yr = p.year ? ' (' + p.year + ')' : '';
+          return '<li><strong>' + escHtml(p.type || 'Plan') + '</strong>' + yr + url +
+            (p.title ? '<br><span class="lof-civic-sub">' + escHtml(p.title) + '</span>' : '') +
+          '</li>';
+        }).join('') +
+        '</ul></div>';
+    }
+
+    // Housing authorities row
+    var haRows = '';
+    if (Array.isArray(lr.housingAuthority) && lr.housingAuthority.length) {
+      haRows = '<div class="lof-civic-row lof-civic-row--block">' +
+        '<span class="lof-civic-label">Housing authorities</span>' +
+        '<ul class="lof-civic-list">' +
+        lr.housingAuthority.map(function (h) {
+          var url = h.url ? ' <a href="' + escHtml(h.url) + '" target="_blank" rel="noopener">→</a>' : '';
+          var contact = h.contact ? ' <span class="lof-civic-sub">(' + escHtml(h.contact) + ')</span>' : '';
+          var units = h.totalUnits ? ' <span class="lof-civic-sub">· ' + fmtInt(h.totalUnits) + ' units</span>' : '';
+          return '<li>' + escHtml(h.name) + url + contact + units + '</li>';
+        }).join('') +
+        '</ul></div>';
+    }
+
+    // Advocacy / nonprofits row
+    var advRows = '';
+    if (Array.isArray(lr.advocacy) && lr.advocacy.length) {
+      advRows = '<div class="lof-civic-row lof-civic-row--block">' +
+        '<span class="lof-civic-label">Advocacy &amp; nonprofits</span>' +
+        '<ul class="lof-civic-list">' +
+        lr.advocacy.map(function (a) {
+          var url = a.url ? ' <a href="' + escHtml(a.url) + '" target="_blank" rel="noopener">→</a>' : '';
+          return '<li>' + escHtml(a.name) + url + '</li>';
+        }).join('') +
+        '</ul></div>';
+    }
+
+    var scoreBadge = '';
+    if (op.civicScore != null) {
+      var band = op.civicScore >= 5 ? 'high' : op.civicScore >= 3 ? 'med' : 'low';
+      scoreBadge = '<span class="lof-civic-score-badge lof-civic-' + band + '">' +
+        'Policy score ' + op.civicScore + '/' + op.civicMax +
+      '</span>';
+    } else {
+      scoreBadge = '<span class="lof-civic-score-badge lof-civic-unk">No policy-scorecard record</span>';
+    }
+
+    return '<h4 class="lof-section-h">Civic capacity ' + scoreBadge + '</h4>' +
+      checkRow('Prop 123 committed',  dims.prop123_committed,    p123Extra) +
+      checkRow('Local HNA published', dims.has_hna,              '') +
+      checkRow('Comp plan / housing element', dims.has_comp_plan, '') +
+      checkRow('Inclusionary zoning ordinance', dims.has_iz_ordinance, '') +
+      checkRow('Local housing funding', dims.has_local_funding,   '') +
+      (leadExtra ?
+        '<div class="lof-civic-row"><span class="lof-civic-label">Housing lead</span>' +
+        '<span class="lof-civic-check lof-civic-yes">✓</span>' +
+        '<span class="lof-civic-extra">' + leadExtra + '</span></div>'
+        : '') +
+      planRows + haRows + advRows;
+  }
+
+  function _renderNewsPanel(op) {
+    var urls = newsUrls(op.name, op.countyName.replace(/\s+County$/, ''));
+    var cityName = encodeURIComponent(op.name + ' Colorado');
+    return '<h4 class="lof-section-h">Housing news &amp; research</h4>' +
+      '<div class="lof-news-grid">' +
+        '<a class="lof-news-btn" href="' + urls.googleNews + '" target="_blank" rel="noopener">' +
+          '🗞️ Google News<br><span>"' + escHtml(op.name) + '" affordable housing</span></a>' +
+        '<a class="lof-news-btn" href="' + urls.coloradoSun + '" target="_blank" rel="noopener">' +
+          '☀️ Colorado Sun<br><span>site search</span></a>' +
+        '<a class="lof-news-btn" href="' + urls.cpr + '" target="_blank" rel="noopener">' +
+          '📻 Colorado Public Radio<br><span>site search</span></a>' +
+        '<a class="lof-news-btn" href="' + urls.bizwest + '" target="_blank" rel="noopener">' +
+          '📰 BizWest<br><span>site search</span></a>' +
+        '<a class="lof-news-btn" href="' + urls.countyNews + '" target="_blank" rel="noopener">' +
+          '🏛️ County news<br><span>"' + escHtml(op.countyName) + '"</span></a>' +
+        '<a class="lof-news-btn" href="https://www.google.com/search?q=' + cityName +
+          '+housing+coordinator+OR+director+OR+manager" target="_blank" rel="noopener">' +
+          '🔎 Find housing staff<br><span>web search</span></a>' +
+      '</div>';
+  }
+
   function _showDetail(opId) {
     var op = state.opportunities.find(function (x) { return x.id === opId; });
     if (!op) return;
@@ -608,6 +884,14 @@
           op.qctTracts.map(function (t) { return t.tract_geoid; }).join(', ') +
         '</dd>' : '');
 
+    // Civic capacity panel — Prop 123, HNA, comp plan, housing lead, HA, advocacy
+    var civicEl = $('lofDetailCivic');
+    if (civicEl) civicEl.innerHTML = _renderCivicPanel(op);
+
+    // News + research linkouts
+    var newsEl = $('lofDetailNews');
+    if (newsEl) newsEl.innerHTML = _renderNewsPanel(op);
+
     // Projects in jurisdiction, sorted by YR_PIS descending
     var projects = op.projects.slice().sort(function (a, b) {
       return (+b.properties.YR_PIS || 0) - (+a.properties.YR_PIS || 0);
@@ -653,6 +937,7 @@
         case 'projectCount':  return op.projectCount;
         case 'needScore':     return op.needScore == null ? -1 : op.needScore;
         case 'population':    return op.population || 0;
+        case 'civicScore':    return op.civicScore == null ? -1 : op.civicScore;
         case 'altScores':     return op.score9;  // sortable proxy
         default:              return _activeScore(op);
       }

--- a/js/lihtc-opportunity-finder.js
+++ b/js/lihtc-opportunity-finder.js
@@ -1,0 +1,839 @@
+/**
+ * js/lihtc-opportunity-finder.js
+ *
+ * Client-side analysis that joins HUD LIHTC projects to QCT + DDA polygons,
+ * computes a per-area opportunity score, and drives a filterable ranked
+ * table + Leaflet map. No build pipeline — all data is loaded directly
+ * from /data/ and the join happens in-browser at page load.
+ *
+ * Scoring (matches the methodology disclosure in the page):
+ *   opportunity = 0.35 * recency
+ *               + 0.30 * housing_need
+ *               + 0.20 * basis_boost
+ *               + 0.15 * population_feasibility
+ *
+ * Data sources:
+ *   data/qct-colorado.json                 — 224 QCT polygons
+ *   data/dda-colorado.json                 — 10 DDA polygons
+ *   data/market/hud_lihtc_co.geojson       — 716 LIHTC project points (YR_PIS)
+ *   data/hna/chas_affordability_gap.json   — Housing-need composite per county
+ *   data/market/acs_tract_metrics_co.json  — Population per tract (for QCT pop join)
+ *
+ * Author: 2026-05-25 LIHTC Opportunity Finder MVP.
+ */
+
+(function () {
+  'use strict';
+
+  /* ── State ────────────────────────────────────────────────────────── */
+
+  var state = {
+    qctFeatures: [],     // raw QCT polygons
+    ddaFeatures: [],     // raw DDA polygons
+    projects:    [],     // HUD LIHTC project points (filtered to valid YR_PIS)
+    chasByFips:  {},     // CHAS data keyed by 5-digit county FIPS
+    tractPop:    {},     // population by 11-digit tract GEOID
+    countyName:  {},     // county FIPS → display name
+    opportunities: [],   // computed per-area records (after _computeOpportunities)
+    map:         null,
+    layers:      { qct: null, dda: null, projects: null, highlight: null },
+    selectedId:  null,
+    sortKey:     'score',
+    sortDir:     'desc',
+    filters: {
+      showQct: true, showDda: true, showBoth: true,
+      county: '', city: '',
+      minYearsSince: 0, minScore: 0, minPop: 0
+    }
+  };
+
+  var CURRENT_YEAR = new Date().getFullYear();
+  var MAX_RECENCY_YEARS = 25;  // years-since-last capped at 25 for score
+
+  /* ── Helpers ──────────────────────────────────────────────────────── */
+
+  function $(id) { return document.getElementById(id); }
+  function escHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+  function fmtInt(n) {
+    if (!Number.isFinite(+n)) return '—';
+    return Math.round(+n).toLocaleString('en-US');
+  }
+  function fmtMaybe(s) {
+    return (s != null && s !== '') ? s : '—';
+  }
+  function setStatus(text) {
+    var el = $('lofStatusBanner');
+    if (el) el.textContent = text;
+  }
+
+  // Ray-casting point-in-polygon. polygon = array of [lng, lat] rings.
+  // For MultiPolygon callers iterate the outer container themselves.
+  function pointInPolygon(lng, lat, ring) {
+    var inside = false;
+    for (var i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+      var xi = ring[i][0], yi = ring[i][1];
+      var xj = ring[j][0], yj = ring[j][1];
+      var intersect = ((yi > lat) !== (yj > lat)) &&
+        (lng < (xj - xi) * (lat - yi) / (yj - yi) + xi);
+      if (intersect) inside = !inside;
+    }
+    return inside;
+  }
+
+  // Test whether a Point falls inside a GeoJSON Polygon or MultiPolygon.
+  function pointInGeoFeature(lng, lat, feature) {
+    var g = feature.geometry;
+    if (!g) return false;
+    if (g.type === 'Polygon') {
+      // First ring = outer, subsequent = holes. For LIHTC opportunity
+      // analysis the hole case is rare enough we treat outer ring only.
+      return pointInPolygon(lng, lat, g.coordinates[0]);
+    }
+    if (g.type === 'MultiPolygon') {
+      for (var i = 0; i < g.coordinates.length; i++) {
+        if (pointInPolygon(lng, lat, g.coordinates[i][0])) return true;
+      }
+    }
+    return false;
+  }
+
+  // Centroid of polygon ring (rough average — good enough for naming /
+  // map labels, not for area calculations).
+  function ringCentroid(ring) {
+    var x = 0, y = 0;
+    for (var i = 0; i < ring.length; i++) {
+      x += ring[i][0]; y += ring[i][1];
+    }
+    return [x / ring.length, y / ring.length];
+  }
+  function featureCentroid(feature) {
+    var g = feature.geometry;
+    if (!g) return [-105.5, 39];
+    if (g.type === 'Polygon') return ringCentroid(g.coordinates[0]);
+    if (g.type === 'MultiPolygon') return ringCentroid(g.coordinates[0][0]);
+    return [-105.5, 39];
+  }
+
+  // Look up the county for a tract GEOID (first 5 chars).
+  function tractToCounty(tractGeoid) {
+    return String(tractGeoid).substring(0, 5);
+  }
+
+  /* ── Score components ─────────────────────────────────────────────── */
+
+  /**
+   * Years-since-last → 0–100. ≥MAX_RECENCY_YEARS years = full score.
+   * "Never funded" (no projects in area) also gets full score.
+   */
+  function recencyScore(lastYear) {
+    if (lastYear == null) return 100;
+    var years = Math.max(0, CURRENT_YEAR - lastYear);
+    return Math.min(100, Math.round((years / MAX_RECENCY_YEARS) * 100));
+  }
+
+  /**
+   * Housing-need from county CHAS summary (mirrors Scorecard v2 inputs).
+   * Composite of renter cost burden + owner cost burden weighted by HHs
+   * + severe burden share. Normalised against CO statewide distribution.
+   */
+  function buildNeedDistribution() {
+    var dist = [];
+    Object.values(state.chasByFips).forEach(function (rec) {
+      var s = rec.summary || {};
+      var renterHH = +s.total_renter_hh || 0;
+      var ownerHH  = +s.total_owner_hh  || 0;
+      var total = renterHH + ownerHH;
+      if (!total || s.pct_renter_cb30 == null || s.pct_owner_cb30 == null) return;
+      var blended = (s.pct_renter_cb30 * renterHH + s.pct_owner_cb30 * ownerHH) / total;
+      var severe = +s.pct_renter_cb50 || 0;
+      var composite = blended * 0.7 + severe * 0.3;
+      dist.push(composite);
+    });
+    dist.sort(function (a, b) { return a - b; });
+    return dist;
+  }
+  function needScoreFor(countyFips, needDist) {
+    var rec = state.chasByFips[countyFips];
+    if (!rec || !rec.summary) return 30;  // default low if unknown
+    var s = rec.summary;
+    var renterHH = +s.total_renter_hh || 0;
+    var ownerHH  = +s.total_owner_hh  || 0;
+    var total = renterHH + ownerHH;
+    if (!total) return 30;
+    var blended = (s.pct_renter_cb30 * renterHH + s.pct_owner_cb30 * ownerHH) / total;
+    var severe = +s.pct_renter_cb50 || 0;
+    var composite = blended * 0.7 + severe * 0.3;
+    // Percentile rank within CO
+    var below = 0;
+    for (var i = 0; i < needDist.length; i++) {
+      if (needDist[i] < composite) below++;
+      else if (needDist[i] === composite) below += 0.5;
+    }
+    return Math.round((below / needDist.length) * 100);
+  }
+
+  /**
+   * Basis-boost score:
+   *   QCT only:  60  (40 of 100)
+   *   DDA only:  60  (40 of 100)
+   *   Both:      100 (60 of 100 in the composite — the strongest case)
+   *   Neither:   0
+   * The "Neither" branch is unreachable here because everything in our
+   * opportunity list is by definition a QCT or DDA, but kept for clarity.
+   */
+  function basisBoostScore(isQct, isDda) {
+    if (isQct && isDda) return 100;
+    if (isQct || isDda) return 60;
+    return 0;
+  }
+
+  /**
+   * Population feasibility — under 500 = 0, 500-2000 = 50, 2000+ = 100.
+   * Floor that filters out small rural tracts where a 50-unit project
+   * couldn't lease up.
+   */
+  function populationScore(pop) {
+    if (pop == null || !Number.isFinite(+pop)) return 50;  // unknown = mid
+    var n = +pop;
+    if (n < 500) return 0;
+    if (n < 2000) return 50;
+    return 100;
+  }
+
+  /* ── Data loading ─────────────────────────────────────────────────── */
+
+  function loadAll() {
+    setStatus('Loading data (HUD QCT, DDA, LIHTC projects, CHAS, ACS)…');
+    return Promise.all([
+      fetch('data/qct-colorado.json').then(function (r) { return r.json(); }),
+      fetch('data/dda-colorado.json').then(function (r) { return r.json(); }),
+      fetch('data/market/hud_lihtc_co.geojson').then(function (r) { return r.json(); }),
+      fetch('data/hna/chas_affordability_gap.json').then(function (r) { return r.json(); }),
+      fetch('data/market/acs_tract_metrics_co.json').then(function (r) { return r.json(); }),
+      fetch('data/hna/geo-config.json').then(function (r) { return r.json(); })
+        .catch(function () { return null; })
+    ]).then(function (parts) {
+      state.qctFeatures = parts[0].features || [];
+      state.ddaFeatures = parts[1].features || [];
+
+      // Filter projects to those with usable YR_PIS (excludes the 8888 placeholder)
+      state.projects = (parts[2].features || []).filter(function (f) {
+        var y = parseInt(f.properties && f.properties.YR_PIS, 10);
+        return Number.isFinite(y) && y >= 1980 && y <= 2030;
+      });
+
+      state.chasByFips = (parts[3].counties || {});
+
+      // Tract population index — for QCT population join
+      (parts[4].tracts || []).forEach(function (t) {
+        state.tractPop[t.geoid] = +t.pop || 0;
+      });
+
+      // County name index
+      if (parts[5] && Array.isArray(parts[5].counties)) {
+        parts[5].counties.forEach(function (c) {
+          state.countyName[c.geoid] = c.label;
+        });
+      } else {
+        // Build from CHAS records as fallback
+        Object.keys(state.chasByFips).forEach(function (fips) {
+          var nm = state.chasByFips[fips].name;
+          if (nm) state.countyName[fips] = nm + ' County';
+        });
+      }
+
+      setStatus('Computing opportunity scores for ' +
+        state.qctFeatures.length + ' QCTs + ' +
+        state.ddaFeatures.length + ' DDAs against ' +
+        state.projects.length + ' LIHTC projects…');
+    });
+  }
+
+  /* ── Opportunity assembly ─────────────────────────────────────────── */
+
+  function _computeOpportunities() {
+    var needDist = buildNeedDistribution();
+    var ops = [];
+
+    // ── Per-QCT analysis ──
+    state.qctFeatures.forEach(function (feat) {
+      var props = feat.properties || {};
+      var tractGeoid = props.GEOID;
+      var countyFips = tractToCounty(tractGeoid);
+      var pop = state.tractPop[tractGeoid] || null;
+      var centroid = featureCentroid(feat);
+
+      // Projects inside this QCT polygon
+      var inside = state.projects.filter(function (p) {
+        var c = p.geometry && p.geometry.coordinates;
+        return c && pointInGeoFeature(c[0], c[1], feat);
+      });
+      var lastYear = inside.reduce(function (max, p) {
+        var y = parseInt(p.properties.YR_PIS, 10);
+        return (Number.isFinite(y) && y > max) ? y : max;
+      }, -Infinity);
+      if (lastYear === -Infinity) lastYear = null;
+      var totalUnits = inside.reduce(function (sum, p) {
+        return sum + (+p.properties.N_UNITS || 0);
+      }, 0);
+
+      // Score components
+      var recScore = recencyScore(lastYear);
+      var needS  = needScoreFor(countyFips, needDist);
+      var bbS    = basisBoostScore(true, false);  // QCT only (will upgrade if also DDA later)
+      var popS   = populationScore(pop);
+      var composite = Math.round(
+        0.35 * recScore + 0.30 * needS + 0.20 * bbS + 0.15 * popS
+      );
+
+      ops.push({
+        id:           'qct-' + tractGeoid,
+        kind:         'QCT',
+        geoid:        tractGeoid,
+        name:         props.NAME || ('Census Tract ' + (props.TRACT || '')),
+        countyFips:   countyFips,
+        countyName:   state.countyName[countyFips] || ('County ' + countyFips),
+        city:         null,  // QCT is a tract — city derived from projects inside
+        type:         'QCT',
+        isQct:        true,
+        isDda:        false,
+        projects:     inside,
+        projectCount: inside.length,
+        totalUnits:   totalUnits,
+        lastYear:     lastYear,
+        yearsSince:   lastYear != null ? CURRENT_YEAR - lastYear : null,
+        population:   pop,
+        recencyScore: recScore,
+        needScore:    needS,
+        basisBoostScore: bbS,
+        populationScore: popS,
+        score:        composite,
+        centroid:     centroid,
+        feature:      feat
+      });
+    });
+
+    // ── Per-DDA analysis ──
+    state.ddaFeatures.forEach(function (feat) {
+      var props = feat.properties || {};
+      var ddaName = props.DDA_NAME || props.NAME || ('DDA ' + props.DDA_CODE);
+      var ddaType = props.DDATYPE || props.DDA_TYPE; // M = metro, NM = nonmetro
+      var countyFips;
+      if (props.GEOID && props.GEOID.length === 5) {
+        countyFips = props.GEOID;  // nonmetro DDAs are county-based
+      } else {
+        // Metro DDAs are ZIP-based — pick the county whose centroid is closest
+        // to the DDA centroid (approximate but good enough for display)
+        var centroid0 = featureCentroid(feat);
+        countyFips = null; // best-effort, may stay null
+      }
+      var centroid = featureCentroid(feat);
+
+      var inside = state.projects.filter(function (p) {
+        var c = p.geometry && p.geometry.coordinates;
+        return c && pointInGeoFeature(c[0], c[1], feat);
+      });
+      var lastYear = inside.reduce(function (max, p) {
+        var y = parseInt(p.properties.YR_PIS, 10);
+        return (Number.isFinite(y) && y > max) ? y : max;
+      }, -Infinity);
+      if (lastYear === -Infinity) lastYear = null;
+      var totalUnits = inside.reduce(function (sum, p) {
+        return sum + (+p.properties.N_UNITS || 0);
+      }, 0);
+
+      // Population: sum population of all CO tracts whose centroid falls inside
+      // the DDA polygon. For county-based nonmetro DDAs we can shortcut by
+      // summing tract pops for that county, but the polygon-based count is
+      // more accurate so we use it uniformly.
+      var pop = 0;
+      // Cheap heuristic: use county-level pop estimate when available
+      // (full tract iteration would be slower). For nonmetro DDAs the
+      // polygon IS the county boundary so this is correct.
+      if (countyFips && state.chasByFips[countyFips]) {
+        var s = state.chasByFips[countyFips].summary || {};
+        pop = ((+s.total_renter_hh) || 0) + ((+s.total_owner_hh) || 0);
+        // HHs to pop heuristic: × 2.5 (avg CO household size)
+        pop = Math.round(pop * 2.5);
+      }
+
+      var recScore = recencyScore(lastYear);
+      var needS  = countyFips ? needScoreFor(countyFips, needDist) : 50;
+      var bbS    = basisBoostScore(false, true);
+      var popS   = populationScore(pop);
+      var composite = Math.round(
+        0.35 * recScore + 0.30 * needS + 0.20 * bbS + 0.15 * popS
+      );
+
+      ops.push({
+        id:           'dda-' + (props.DDA_CODE || props.OBJECTID || ddaName),
+        kind:         'DDA',
+        geoid:        props.GEOID || props.DDA_CODE,
+        name:         ddaName,
+        countyFips:   countyFips,
+        countyName:   countyFips ? (state.countyName[countyFips] || ('County ' + countyFips)) : '—',
+        type:         ddaType === 'M' ? 'DDA · metro' : 'DDA · nonmetro',
+        isQct:        false,
+        isDda:        true,
+        projects:     inside,
+        projectCount: inside.length,
+        totalUnits:   totalUnits,
+        lastYear:     lastYear,
+        yearsSince:   lastYear != null ? CURRENT_YEAR - lastYear : null,
+        population:   pop || null,
+        recencyScore: recScore,
+        needScore:    needS,
+        basisBoostScore: bbS,
+        populationScore: popS,
+        score:        composite,
+        centroid:     centroid,
+        feature:      feat
+      });
+    });
+
+    // ── Detect QCT × DDA overlap → flip "both" + recompute basis-boost ──
+    // O(qct × dda) = 224 × 10 = 2240 tests, negligible.
+    var ddaOps = ops.filter(function (o) { return o.kind === 'DDA'; });
+    ops.forEach(function (op) {
+      if (op.kind !== 'QCT') return;
+      for (var i = 0; i < ddaOps.length; i++) {
+        var ddaCentroid = ddaOps[i].centroid;
+        // Quick test: does the QCT contain the DDA centroid OR does the
+        // DDA contain the QCT centroid? Either signals overlap.
+        if (pointInGeoFeature(ddaCentroid[0], ddaCentroid[1], op.feature) ||
+            pointInGeoFeature(op.centroid[0], op.centroid[1], ddaOps[i].feature)) {
+          op.isDda = true;
+          op.type = 'QCT + DDA';
+          var newBbS = basisBoostScore(true, true);
+          op.basisBoostScore = newBbS;
+          op.score = Math.round(
+            0.35 * op.recencyScore + 0.30 * op.needScore +
+            0.20 * newBbS + 0.15 * op.populationScore
+          );
+          break;
+        }
+      }
+    });
+
+    state.opportunities = ops;
+  }
+
+  /* ── Filtering ────────────────────────────────────────────────────── */
+
+  function _applyFilters() {
+    var f = state.filters;
+    return state.opportunities.filter(function (op) {
+      // Area-type toggles
+      if (op.isQct && op.isDda) {
+        if (!f.showBoth) return false;
+      } else if (op.isQct) {
+        if (!f.showQct) return false;
+      } else if (op.isDda) {
+        if (!f.showDda) return false;
+      }
+      // County
+      if (f.county && op.countyFips !== f.county) return false;
+      // City — match against any project's PROJ_CTY
+      if (f.city) {
+        var matchCity = op.projects.some(function (p) {
+          return ((p.properties && p.properties.PROJ_CTY) || '').toUpperCase() === f.city.toUpperCase();
+        });
+        if (!matchCity) return false;
+      }
+      // Years-since-last-funded
+      if (f.minYearsSince > 0) {
+        if (op.yearsSince == null || op.yearsSince < f.minYearsSince) return false;
+      }
+      // Score
+      if (op.score < f.minScore) return false;
+      // Population
+      if (f.minPop > 0 && (op.population || 0) < f.minPop) return false;
+      return true;
+    });
+  }
+
+  /* ── Render: summary cards + table + map ──────────────────────────── */
+
+  function _scoreBand(score) {
+    if (score >= 70) return 'high';
+    if (score >= 50) return 'med';
+    return 'low';
+  }
+
+  function _renderSummary(filtered) {
+    var n = filtered.length;
+    var neverFunded = filtered.filter(function (op) { return op.lastYear == null; }).length;
+    var qctOnly = filtered.filter(function (op) { return op.isQct && !op.isDda; }).length;
+    var ddaOnly = filtered.filter(function (op) { return op.isDda && !op.isQct; }).length;
+    var both = filtered.filter(function (op) { return op.isQct && op.isDda; }).length;
+    var avgScore = n ? Math.round(filtered.reduce(function (s, op) { return s + op.score; }, 0) / n) : 0;
+    var html =
+      '<div class="lof-summary-card"><div class="k">Areas matching filters</div>' +
+        '<div class="v">' + n + '</div>' +
+        '<div class="s">QCT only ' + qctOnly + ' · DDA only ' + ddaOnly + ' · Both ' + both + '</div></div>' +
+      '<div class="lof-summary-card"><div class="k">Avg opportunity score</div>' +
+        '<div class="v">' + avgScore + '<span style="font-size:.7rem;color:var(--muted)">/100</span></div></div>' +
+      '<div class="lof-summary-card"><div class="k">Never-funded areas</div>' +
+        '<div class="v">' + neverFunded + '</div>' +
+        '<div class="s">no LIHTC project on record</div></div>';
+    var top = filtered.length ? filtered[0] : null;
+    if (top) {
+      html += '<div class="lof-summary-card"><div class="k">Top-ranked area</div>' +
+        '<div class="v" style="font-size:.95rem;line-height:1.25">' + escHtml(top.name) + '</div>' +
+        '<div class="s">' + escHtml(top.countyName) + ' · ' + top.score + '/100</div></div>';
+    }
+    $('lofSummaryCards').innerHTML = html;
+  }
+
+  function _renderTable(filtered) {
+    var tbody = $('lofTableBody');
+    if (!filtered.length) {
+      tbody.innerHTML = '<tr><td colspan="8" class="lof-loading">No areas match the current filters.</td></tr>';
+      return;
+    }
+    var rows = filtered.map(function (op) {
+      var typeHtml = '';
+      if (op.isQct && op.isDda) {
+        typeHtml = '<span class="lof-badge lof-badge--both">QCT + DDA</span>';
+      } else if (op.isQct) {
+        typeHtml = '<span class="lof-badge lof-badge--qct">QCT</span>';
+      } else {
+        typeHtml = '<span class="lof-badge lof-badge--dda">DDA</span>';
+      }
+      var lastFundedText = op.lastYear != null
+        ? op.lastYear + ' (' + op.yearsSince + ' yrs ago)'
+        : '<em>Never</em>';
+      var scoreCls = 'lof-score-' + _scoreBand(op.score);
+      var selectedCls = (state.selectedId === op.id) ? ' is-selected' : '';
+      return '<tr data-op-id="' + escHtml(op.id) + '" class="' + selectedCls.trim() + '">' +
+        '<td><span class="lof-score-cell ' + scoreCls + '">' + op.score + '</span></td>' +
+        '<td>' + escHtml(op.name) + '</td>' +
+        '<td>' + typeHtml + '</td>' +
+        '<td>' + escHtml(op.countyName) + '</td>' +
+        '<td>' + lastFundedText + '</td>' +
+        '<td>' + op.projectCount + '</td>' +
+        '<td>' + fmtInt(op.totalUnits) + '</td>' +
+        '<td>' + (op.population != null ? fmtInt(op.population) : '—') + '</td>' +
+      '</tr>';
+    }).join('');
+    tbody.innerHTML = rows;
+    // Bind row clicks
+    Array.from(tbody.querySelectorAll('tr[data-op-id]')).forEach(function (tr) {
+      tr.addEventListener('click', function () {
+        _showDetail(tr.getAttribute('data-op-id'));
+      });
+    });
+  }
+
+  function _renderMap(filtered) {
+    if (!state.map) return;
+    ['qct', 'dda', 'highlight'].forEach(function (k) {
+      if (state.layers[k]) {
+        state.map.removeLayer(state.layers[k]);
+        state.layers[k] = null;
+      }
+    });
+
+    var qctLayer = window.L.layerGroup();
+    var ddaLayer = window.L.layerGroup();
+
+    filtered.forEach(function (op) {
+      var color = op.score >= 70 ? '#16a34a' : op.score >= 50 ? '#f59e0b' : '#94a3b8';
+      var coords = op.feature.geometry.coordinates;
+      var ringsForLeaflet;
+      if (op.feature.geometry.type === 'Polygon') {
+        ringsForLeaflet = coords.map(function (ring) {
+          return ring.map(function (c) { return [c[1], c[0]]; });
+        });
+      } else if (op.feature.geometry.type === 'MultiPolygon') {
+        ringsForLeaflet = coords.map(function (poly) {
+          return poly.map(function (ring) {
+            return ring.map(function (c) { return [c[1], c[0]]; });
+          });
+        });
+      } else {
+        return;
+      }
+      var poly = window.L.polygon(ringsForLeaflet, {
+        color: color, weight: 1.4, fillColor: color, fillOpacity: 0.18, opacity: 0.85
+      });
+      poly.bindTooltip(
+        '<strong>' + escHtml(op.name) + '</strong><br>' +
+        op.type + ' · ' + escHtml(op.countyName) + '<br>' +
+        'Score: ' + op.score + '/100',
+        { sticky: true }
+      );
+      poly.on('click', function () { _showDetail(op.id); });
+      if (op.kind === 'QCT') qctLayer.addLayer(poly);
+      else ddaLayer.addLayer(poly);
+    });
+    qctLayer.addTo(state.map);
+    ddaLayer.addTo(state.map);
+    state.layers.qct = qctLayer;
+    state.layers.dda = ddaLayer;
+  }
+
+  function _showDetail(opId) {
+    var op = state.opportunities.find(function (x) { return x.id === opId; });
+    if (!op) return;
+    state.selectedId = opId;
+    var detail = $('lofDetail');
+    $('lofDetailTitle').textContent = op.name + '  ·  ' + op.type;
+    var facts = $('lofDetailFacts');
+    facts.innerHTML =
+      '<dt>County</dt><dd>' + escHtml(op.countyName) + '</dd>' +
+      '<dt>Opportunity score</dt><dd>' + op.score + '/100  (rec ' + op.recencyScore +
+        ' · need ' + op.needScore + ' · basis ' + op.basisBoostScore + ' · pop ' + op.populationScore + ')</dd>' +
+      '<dt>Last LIHTC project</dt><dd>' + (op.lastYear != null
+        ? op.lastYear + ' (' + op.yearsSince + ' years ago)'
+        : 'Never funded on record') + '</dd>' +
+      '<dt>Existing LIHTC saturation</dt><dd>' + op.projectCount + ' project(s) · ' +
+        fmtInt(op.totalUnits) + ' total units</dd>' +
+      '<dt>Population</dt><dd>' + (op.population != null ? fmtInt(op.population) : 'unknown') + '</dd>';
+
+    // Projects in same city + county
+    var sameCityNames = new Set();
+    op.projects.forEach(function (p) {
+      var c = (p.properties && p.properties.PROJ_CTY) || '';
+      if (c) sameCityNames.add(c.toUpperCase());
+    });
+    var sameCityProjects = state.projects.filter(function (p) {
+      var c = ((p.properties && p.properties.PROJ_CTY) || '').toUpperCase();
+      return c && sameCityNames.has(c);
+    });
+    var sameCountyProjects = op.countyFips
+      ? state.projects.filter(function (p) {
+          return (p.properties && p.properties.CNTY_FIPS) === op.countyFips;
+        })
+      : [];
+    var combined = new Map();
+    sameCityProjects.concat(sameCountyProjects).forEach(function (p) {
+      var key = (p.properties.PROJECT || '') + '|' + (p.properties.YR_PIS || '');
+      if (!combined.has(key)) combined.set(key, p);
+    });
+    var projectList = Array.from(combined.values()).sort(function (a, b) {
+      return (+b.properties.YR_PIS || 0) - (+a.properties.YR_PIS || 0);
+    });
+
+    var projHtml = '';
+    if (!projectList.length) {
+      projHtml = '<div class="lof-detail-project" style="color:var(--muted);font-style:italic;">No LIHTC projects on record in this city or county.</div>';
+    } else {
+      projHtml = projectList.slice(0, 30).map(function (p) {
+        var pr = p.properties;
+        return '<div class="lof-detail-project">' +
+          '<div class="lof-detail-project-name">' + escHtml(pr.PROJECT || '(unnamed)') + '</div>' +
+          '<div class="lof-detail-project-meta">' +
+            escHtml(pr.PROJ_CTY || '—') + ' · ' +
+            escHtml(pr.CNTY_NAME || '—') + ' · ' +
+            'YR_PIS ' + (pr.YR_PIS || '—') + ' · ' +
+            (pr.N_UNITS || 0) + ' units · ' +
+            (pr.CREDIT || '—') + ' credit' +
+          '</div>' +
+        '</div>';
+      }).join('');
+      if (projectList.length > 30) {
+        projHtml += '<div class="lof-detail-project" style="color:var(--muted);">' +
+          '+ ' + (projectList.length - 30) + ' more not shown' +
+        '</div>';
+      }
+    }
+    $('lofDetailProjects').innerHTML = projHtml;
+    detail.hidden = false;
+
+    // Highlight on map
+    if (state.map && op.centroid) {
+      if (state.layers.highlight) state.map.removeLayer(state.layers.highlight);
+      state.layers.highlight = window.L.circleMarker(
+        [op.centroid[1], op.centroid[0]],
+        { radius: 12, color: '#ef4444', weight: 3, fillOpacity: 0.0 }
+      ).addTo(state.map);
+      state.map.setView([op.centroid[1], op.centroid[0]], 10);
+    }
+    // Highlight table row
+    Array.from(document.querySelectorAll('#lofTableBody tr')).forEach(function (tr) {
+      tr.classList.toggle('is-selected', tr.getAttribute('data-op-id') === opId);
+    });
+    detail.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  /* ── Sorting ──────────────────────────────────────────────────────── */
+
+  function _sortOps(arr) {
+    var k = state.sortKey;
+    var dir = state.sortDir === 'asc' ? 1 : -1;
+    function val(op) {
+      switch (k) {
+        case 'score':         return op.score;
+        case 'name':          return (op.name || '').toLowerCase();
+        case 'type':          return op.type;
+        case 'county':        return (op.countyName || '').toLowerCase();
+        case 'lastYear':      return op.lastYear == null ? -Infinity : op.lastYear;
+        case 'projectCount':  return op.projectCount;
+        case 'totalUnits':    return op.totalUnits;
+        case 'population':    return op.population || 0;
+        default:              return op.score;
+      }
+    }
+    return arr.slice().sort(function (a, b) {
+      var va = val(a), vb = val(b);
+      if (va < vb) return -1 * dir;
+      if (va > vb) return  1 * dir;
+      return 0;
+    });
+  }
+
+  /* ── Refresh pipeline ─────────────────────────────────────────────── */
+
+  function _refresh() {
+    var filtered = _sortOps(_applyFilters());
+    _renderSummary(filtered);
+    _renderTable(filtered);
+    _renderMap(filtered);
+  }
+
+  /* ── Wire UI ──────────────────────────────────────────────────────── */
+
+  function _populateFilterDropdowns() {
+    var counties = {};
+    var cities = {};
+    state.opportunities.forEach(function (op) {
+      if (op.countyFips) counties[op.countyFips] = op.countyName;
+      op.projects.forEach(function (p) {
+        var c = (p.properties && p.properties.PROJ_CTY) || '';
+        if (c) cities[c.toUpperCase()] = c.split(' ').map(function (w) {
+          return w.charAt(0) + w.slice(1).toLowerCase();
+        }).join(' ');
+      });
+    });
+    var countySel = $('lofCounty');
+    Object.keys(counties).sort(function (a, b) {
+      return counties[a].localeCompare(counties[b]);
+    }).forEach(function (fips) {
+      var opt = document.createElement('option');
+      opt.value = fips;
+      opt.textContent = counties[fips];
+      countySel.appendChild(opt);
+    });
+    var citySel = $('lofCity');
+    Object.keys(cities).sort().forEach(function (key) {
+      var opt = document.createElement('option');
+      opt.value = key;  // upper-case key for matching
+      opt.textContent = cities[key];
+      citySel.appendChild(opt);
+    });
+  }
+
+  function _wireFilters() {
+    var qctEl = $('lofShowQct'), ddaEl = $('lofShowDda'), bothEl = $('lofShowBoth');
+    var countyEl = $('lofCounty'), cityEl = $('lofCity');
+    var minYearsEl = $('lofMinYearsSince'), minScoreEl = $('lofMinScore'), minPopEl = $('lofMinPop');
+    var minYearsValEl = $('lofMinYearsSinceVal'), minScoreValEl = $('lofMinScoreVal');
+
+    [qctEl, ddaEl, bothEl].forEach(function (el) {
+      el.addEventListener('change', function () {
+        state.filters.showQct = qctEl.checked;
+        state.filters.showDda = ddaEl.checked;
+        state.filters.showBoth = bothEl.checked;
+        _refresh();
+      });
+    });
+    countyEl.addEventListener('change', function () {
+      state.filters.county = countyEl.value;
+      _refresh();
+    });
+    cityEl.addEventListener('change', function () {
+      state.filters.city = cityEl.value;
+      _refresh();
+    });
+    minYearsEl.addEventListener('input', function () {
+      state.filters.minYearsSince = +minYearsEl.value;
+      minYearsValEl.textContent = minYearsEl.value;
+      _refresh();
+    });
+    minScoreEl.addEventListener('input', function () {
+      state.filters.minScore = +minScoreEl.value;
+      minScoreValEl.textContent = minScoreEl.value;
+      _refresh();
+    });
+    minPopEl.addEventListener('change', function () {
+      state.filters.minPop = +minPopEl.value || 0;
+      _refresh();
+    });
+    $('lofResetFilters').addEventListener('click', function () {
+      state.filters = {
+        showQct: true, showDda: true, showBoth: true,
+        county: '', city: '',
+        minYearsSince: 0, minScore: 0, minPop: 0
+      };
+      qctEl.checked = true; ddaEl.checked = true; bothEl.checked = true;
+      countyEl.value = ''; cityEl.value = '';
+      minYearsEl.value = 0; minYearsValEl.textContent = '0';
+      minScoreEl.value = 0; minScoreValEl.textContent = '0';
+      minPopEl.value = 0;
+      _refresh();
+    });
+
+    // Column-header sort clicks
+    Array.from(document.querySelectorAll('#lofTable thead th[data-sort]')).forEach(function (th) {
+      th.addEventListener('click', function () {
+        var key = th.getAttribute('data-sort');
+        if (state.sortKey === key) {
+          state.sortDir = state.sortDir === 'asc' ? 'desc' : 'asc';
+        } else {
+          state.sortKey = key;
+          state.sortDir = 'desc';
+        }
+        // Update aria-sort attrs
+        Array.from(document.querySelectorAll('#lofTable thead th[data-sort]')).forEach(function (h) {
+          h.removeAttribute('aria-sort');
+        });
+        th.setAttribute('aria-sort', state.sortDir === 'asc' ? 'ascending' : 'descending');
+        _refresh();
+      });
+    });
+  }
+
+  function _initMap() {
+    if (!window.L || !$('lofMap')) return;
+    state.map = window.L.map('lofMap', { preferCanvas: true })
+      .setView([39.0, -105.5], 7);
+    var cartoLight = window.L.tileLayer(
+      'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png',
+      { attribution: '© OpenStreetMap contributors © CARTO', subdomains: 'abcd', maxZoom: 19 }
+    );
+    var esriSat = window.L.tileLayer(
+      'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+      { attribution: 'Tiles © Esri', maxZoom: 19 }
+    );
+    cartoLight.addTo(state.map);
+    window.L.control.layers(
+      { 'Street': cartoLight, 'Satellite': esriSat },
+      null,
+      { position: 'topright', collapsed: true }
+    ).addTo(state.map);
+  }
+
+  /* ── Boot ─────────────────────────────────────────────────────────── */
+
+  document.addEventListener('DOMContentLoaded', function () {
+    _initMap();
+    loadAll()
+      .then(function () {
+        _computeOpportunities();
+        _populateFilterDropdowns();
+        _wireFilters();
+        setStatus('Ranked ' + state.opportunities.length +
+          ' opportunity zones across Colorado · click a row or polygon for details.');
+        _refresh();
+      })
+      .catch(function (err) {
+        console.error('[LIHTC Opportunity Finder] load failed:', err);
+        setStatus('Failed to load data: ' + (err && err.message || err));
+      });
+  });
+}());

--- a/js/lihtc-opportunity-finder.js
+++ b/js/lihtc-opportunity-finder.js
@@ -29,7 +29,7 @@
  * need a population base for 100-200 unit absorption. Both benefit from
  * basis boost but it's less of the differentiator in 4%.
  *
- * Sources: HUD QCT + DDA designations, HUD LIHTC project data,
+ * Sources: HUD QCT + DDA designations, CHFA/HUD LIHTC project data,
  * data/hna/place-tract-membership.json (TIGER 2024 spatial join),
  * data/co_ami_gap_by_place.json (per-place HHs from ACS), CHAS county
  * cost-burden composite, geo-config place labels.
@@ -46,7 +46,7 @@
     ddaFeatures: [],                // raw DDA polygons (for map rendering)
     placeMembership: {},            // place geoid → { name, tracts:[{tract_geoid, share_of_place_area}] }
     placeFromAmi: {},               // place geoid → AMI/HHs row (for population)
-    projects: [],                   // HUD LIHTC project points (filtered to valid YR_PIS)
+    projects: [],                   // CHFA/HUD LIHTC project points (filtered to valid YR_PIS)
     chasByFips: {},                 // 5-digit county FIPS → CHAS county record
     countyName: {},                 // 5-digit county FIPS → display name
     placeMeta: {},                  // place geoid → { label, containingCounty, type }
@@ -197,10 +197,26 @@
         .then(function (r) { return r.ok ? r.json() : null; })
         .catch(function () { return null; });
     }
+    function loadFirstJson(urls) {
+      var i = 0;
+      function next() {
+        if (i >= urls.length) {
+          throw new Error('Unable to load any of: ' + urls.join(', '));
+        }
+        var url = urls[i++];
+        return fetch(url)
+          .then(function (r) {
+            if (!r.ok) throw new Error(url + ' returned ' + r.status);
+            return r.json();
+          })
+          .catch(next);
+      }
+      return next();
+    }
     return Promise.all([
       fetch('data/qct-colorado.json').then(function (r) { return r.json(); }),
       fetch('data/dda-colorado.json').then(function (r) { return r.json(); }),
-      fetch('data/market/hud_lihtc_co.geojson').then(function (r) { return r.json(); }),
+      loadFirstJson(['data/chfa-lihtc.json', 'data/market/hud_lihtc_co.geojson']),
       fetch('data/hna/chas_affordability_gap.json').then(function (r) { return r.json(); }),
       fetch('data/hna/place-tract-membership.json').then(function (r) { return r.json(); }),
       fetch('data/co_ami_gap_by_place.json').then(function (r) { return r.json(); }),
@@ -222,7 +238,7 @@
         if (g && g.length === 5) state.ddaCountyFips.add(g);
       });
 
-      // HUD LIHTC projects, filtered to valid YR_PIS
+      // CHFA/HUD LIHTC projects, filtered to valid YR_PIS
       state.projects = (parts[2].features || []).filter(function (f) {
         var y = parseInt(f.properties && f.properties.YR_PIS, 10);
         return Number.isFinite(y) && y >= 1980 && y <= 2030;

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -6,8 +6,9 @@
  * Information Architecture:
  * ─────────────────────────────────────────────────────────────────────────
  * SCOPING A PROJECT (primary workflow):
- *   LIHTC Guide (start here) → Select Jurisdiction → HNA → Market Analysis
- *   → Scenario Builder → Deal Calculator
+ *   LIHTC Guide (start here) → Opportunity Finder (find a market) →
+ *   Select Jurisdiction → HNA → Market Analysis → Scenario Builder →
+ *   Deal Calculator
  *
  * EXPLORE (comparative & context):
  *   Compare Jurisdictions, Colorado Deep Dive, CHFA Portfolio,
@@ -26,12 +27,13 @@
     {
       label: "Scoping a Project",
       items: [
-        { label: "LIHTC Guide",            href: "lihtc-guide-for-stakeholders.html", desc: "Start here — LIHTC basics for all audiences" },
-        { label: "Select Jurisdiction",     href: "select-jurisdiction.html",     desc: "Step 1: Choose your county or city" },
-        { label: "Housing Needs Assessment",href: "housing-needs-assessment.html", desc: "Step 2: Community need evidence" },
-        { label: "Market Analysis",         href: "market-analysis.html",          desc: "Step 3: Site screening & PMA scoring" },
-        { label: "Scenario Builder",        href: "hna-scenario-builder.html",     desc: "Step 4: 20-year demographic projections" },
-        { label: "Deal Calculator",         href: "deal-calculator.html",          desc: "Step 5: LIHTC pro forma & capital stack" },
+        { label: "LIHTC Guide",             href: "lihtc-guide-for-stakeholders.html", desc: "Start here — LIHTC basics for all audiences" },
+        { label: "Opportunity Finder",      href: "lihtc-opportunity-finder.html",  desc: "Step 1: Rank CO jurisdictions for 4% bond + 9% competitive LIHTC", isNew: true },
+        { label: "Select Jurisdiction",     href: "select-jurisdiction.html",       desc: "Step 2: Pick your target county / city" },
+        { label: "Housing Needs Assessment",href: "housing-needs-assessment.html",  desc: "Step 3: Community need evidence" },
+        { label: "Market Analysis",         href: "market-analysis.html",           desc: "Step 4: Site screening & PMA scoring" },
+        { label: "Scenario Builder",        href: "hna-scenario-builder.html",      desc: "Step 5: 20-year demographic projections" },
+        { label: "Deal Calculator",         href: "deal-calculator.html",           desc: "Step 6: LIHTC pro forma & capital stack" },
       ]
     },
     {
@@ -185,7 +187,7 @@
               </button>
               <div class="nav-dropdown" hidden>
                 ${g.items.map(l => `<a class="${activeClass(l.href)}" href="${normalizeHref(l.href)}">
-                  <span class="nav-link-label">${l.label}</span>
+                  <span class="nav-link-label">${l.label}${l.isNew ? ' <span class="nav-link-new">NEW</span>' : ''}</span>
                   <span class="nav-link-desc">${l.desc}</span>
                 </a>`).join('')}
               </div>
@@ -221,7 +223,7 @@
               ${g.label} <span class="nav-caret" aria-hidden="true">▾</span>
             </button>
             <div class="mobile-nav-section-items" hidden>
-              ${g.items.map(l => `<a class="${activeClass(l.href)}" href="${normalizeHref(l.href)}">${l.label}</a>`).join('')}
+              ${g.items.map(l => `<a class="${activeClass(l.href)}" href="${normalizeHref(l.href)}">${l.label}${l.isNew ? ' <span class="nav-link-new">NEW</span>' : ''}</a>`).join('')}
             </div>
           </div>
         `).join('')}

--- a/lihtc-opportunity-finder.html
+++ b/lihtc-opportunity-finder.html
@@ -155,6 +155,72 @@
     .lof-summary-card .k { font-size: .74rem; color: var(--muted); font-weight: 700; }
     .lof-summary-card .s { font-size: .7rem; color: var(--muted); margin-top: 2px; }
 
+    /* HNA deep-link in table jurisdiction cell — discreet but discoverable */
+    .lof-hna-link {
+      display: inline-block;
+      margin-left: 6px;
+      padding: 1px 8px;
+      font-size: .68rem;
+      font-weight: 700;
+      letter-spacing: .02em;
+      border-radius: 9999px;
+      background: color-mix(in oklab, var(--accent) 12%, var(--card) 88%);
+      color: var(--accent);
+      text-decoration: none;
+      border: 1px solid color-mix(in oklab, var(--accent) 35%, var(--border) 65%);
+      vertical-align: middle;
+      transition: background .15s, color .15s, transform .1s;
+    }
+    .lof-hna-link:hover {
+      background: var(--accent);
+      color: var(--card);
+      transform: translateY(-1px);
+      text-decoration: none;
+    }
+
+    /* Detail-panel CTA row — prominent linkout to full HNA workup */
+    .lof-hna-cta-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin: 4px 0 12px;
+    }
+    .lof-hna-cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 14px;
+      border-radius: 8px;
+      font-weight: 700;
+      font-size: .85rem;
+      text-decoration: none;
+      border: 1px solid var(--border);
+      transition: transform .1s, box-shadow .15s, background .15s;
+    }
+    .lof-hna-cta:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+      text-decoration: none;
+    }
+    .lof-hna-cta--primary {
+      background: var(--accent);
+      color: var(--card);
+      border-color: var(--accent);
+    }
+    .lof-hna-cta--primary:hover {
+      background: color-mix(in oklab, var(--accent) 88%, #000 12%);
+      color: var(--card);
+    }
+    .lof-hna-cta--secondary {
+      background: color-mix(in oklab, var(--accent) 8%, var(--card) 92%);
+      color: var(--accent);
+      border-color: color-mix(in oklab, var(--accent) 40%, var(--border) 60%);
+    }
+    .lof-hna-cta--secondary:hover {
+      background: color-mix(in oklab, var(--accent) 20%, var(--card) 80%);
+      color: var(--accent);
+    }
+
     .lof-loading { color: var(--muted); font-size: .9rem; padding: 16px 0; text-align: center; }
   </style>
 </head>
@@ -298,6 +364,7 @@
 
         <div id="lofDetail" class="lof-detail" hidden>
           <h3 id="lofDetailTitle">—</h3>
+          <div id="lofDetailHnaCta" class="lof-hna-cta-row"></div>
           <dl id="lofDetailFacts"></dl>
           <h4 style="margin:14px 0 4px;font-size:.9rem;">LIHTC projects in this jurisdiction</h4>
           <div id="lofDetailProjects" class="lof-detail-projects"></div>

--- a/lihtc-opportunity-finder.html
+++ b/lihtc-opportunity-finder.html
@@ -1,0 +1,321 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="theme-color" content="#096e65" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#0fd4cf" media="(prefers-color-scheme: dark)">
+  <title>LIHTC Opportunity Finder | COHO Analytics</title>
+  <meta name="description" content="Find Colorado QCT and DDA areas with the best LIHTC development opportunity — ranked by funding-recency headroom, housing need, basis-boost eligibility, and population feasibility.">
+  <meta property="og:title" content="LIHTC Opportunity Finder | COHO Analytics">
+  <meta property="og:description" content="Rank every Colorado QCT and DDA by LIHTC opportunity score. Find areas with the most funding-recency headroom + highest acute housing need.">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="assets/og-image.png">
+  <script src="js/config.js"></script>
+  <script src="js/path-resolver.js"></script>
+  <script src="js/fetch-helper.js"></script>
+  <script src="js/data-service-portable.js"></script>
+  <link rel="stylesheet" href="js/vendor/leaflet.css">
+  <script src="js/vendor/leaflet.js"></script>
+  <link rel="stylesheet" href="css/site-theme.css">
+  <link rel="stylesheet" href="css/layout.css">
+  <link rel="stylesheet" href="css/pages.css">
+  <link rel="stylesheet" href="css/responsive.css">
+  <script defer src="js/components/toast.js"></script>
+  <script defer src="js/navigation.js"></script>
+  <script defer src="js/dark-mode-toggle.js"></script>
+  <script defer src="js/mobile-menu.js"></script>
+  <style>
+    /* Page-specific layout — 2-col with filter sidebar + main content */
+    .lof-layout {
+      display: grid;
+      grid-template-columns: 280px 1fr;
+      gap: var(--sp4);
+      margin-top: var(--sp3);
+    }
+    @media (max-width: 900px) {
+      .lof-layout { grid-template-columns: 1fr; }
+    }
+    .lof-sidebar {
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 16px;
+      background: color-mix(in oklab, var(--card) 90%, var(--bg2) 10%);
+      align-self: start;
+      position: sticky;
+      top: 80px;
+    }
+    .lof-sidebar h3 { margin: 0 0 12px; font-size: 1rem; }
+    .lof-filter { margin-bottom: 14px; }
+    .lof-filter label { display: block; font-size: .82rem; font-weight: 600; margin-bottom: 4px; color: var(--muted); }
+    .lof-filter select, .lof-filter input[type="text"], .lof-filter input[type="number"] {
+      width: 100%; padding: 6px 8px; border: 1px solid var(--border); border-radius: 6px;
+      background: var(--card); color: var(--text); font: inherit;
+    }
+    .lof-filter input[type="range"] { width: 100%; }
+    .lof-range-val { font-size: .78rem; color: var(--muted); margin-left: 4px; }
+    .lof-toggle-row { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 4px; }
+    .lof-toggle-row label {
+      display: inline-flex; align-items: center; gap: 4px;
+      padding: 4px 10px; border: 1px solid var(--border); border-radius: 9999px;
+      cursor: pointer; font-size: .78rem; font-weight: 600;
+      background: var(--card);
+    }
+    .lof-toggle-row input[type="checkbox"] { margin: 0; }
+    .lof-toggle-row label:has(input:checked) {
+      background: color-mix(in oklab, var(--accent) 18%, var(--card) 82%);
+      border-color: var(--accent);
+    }
+    .lof-reset {
+      width: 100%; padding: 8px; border: 1px solid var(--border); border-radius: 6px;
+      background: var(--bg2); cursor: pointer; font-weight: 600;
+    }
+    .lof-main { min-width: 0; }
+    #lofMap {
+      height: 50vh; min-height: 360px;
+      border-radius: 12px; border: 1px solid var(--border);
+      margin-bottom: 16px;
+    }
+    .lof-table-wrap { overflow-x: auto; border: 1px solid var(--border); border-radius: 12px; }
+    .lof-table {
+      width: 100%; border-collapse: collapse; font-size: .88rem;
+    }
+    .lof-table th, .lof-table td {
+      padding: 8px 12px; text-align: left;
+      border-bottom: 1px solid var(--border);
+    }
+    .lof-table thead th {
+      background: color-mix(in oklab, var(--card) 88%, var(--bg2) 12%);
+      font-weight: 700;
+      font-size: .78rem;
+      letter-spacing: .02em;
+      text-transform: uppercase;
+      color: var(--muted);
+      cursor: pointer;
+      user-select: none;
+    }
+    .lof-table thead th:hover { color: var(--accent); }
+    .lof-table thead th[aria-sort="ascending"]::after { content: ' ▲'; color: var(--accent); }
+    .lof-table thead th[aria-sort="descending"]::after { content: ' ▼'; color: var(--accent); }
+    .lof-table tbody tr { cursor: pointer; }
+    .lof-table tbody tr:hover {
+      background: color-mix(in oklab, var(--accent) 8%, var(--card) 92%);
+    }
+    .lof-table tbody tr.is-selected {
+      background: color-mix(in oklab, var(--accent) 18%, var(--card) 82%);
+    }
+    .lof-score-cell {
+      display: inline-block; min-width: 36px; padding: 2px 8px; border-radius: 9999px;
+      font-weight: 800; font-variant-numeric: tabular-nums;
+    }
+    .lof-score-high { background: color-mix(in oklab, var(--good) 30%, var(--card) 70%); color: var(--good); }
+    .lof-score-med { background: color-mix(in oklab, var(--warn) 28%, var(--card) 72%); color: var(--warn); }
+    .lof-score-low { background: color-mix(in oklab, var(--muted) 18%, var(--card) 82%); color: var(--muted); }
+    .lof-badge {
+      display: inline-block; padding: 1px 7px; border-radius: 9999px; font-size: .68rem;
+      font-weight: 700; margin-right: 4px;
+      background: var(--bg2); color: var(--text); border: 1px solid var(--border);
+    }
+    .lof-badge--qct { background: color-mix(in oklab, #f97316 20%, var(--card) 80%); color: #f97316; border-color: #f97316; }
+    .lof-badge--dda { background: color-mix(in oklab, #3b82f6 20%, var(--card) 80%); color: #3b82f6; border-color: #3b82f6; }
+    .lof-badge--both { background: color-mix(in oklab, var(--good) 22%, var(--card) 78%); color: var(--good); border-color: var(--good); }
+
+    .lof-detail {
+      margin-top: 16px;
+      padding: 16px;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: color-mix(in oklab, var(--card) 92%, var(--bg2) 8%);
+    }
+    .lof-detail h3 { margin: 0 0 8px; font-size: 1rem; }
+    .lof-detail dt { font-weight: 600; color: var(--muted); font-size: .78rem; margin-top: 8px; }
+    .lof-detail dd { margin: 2px 0 0; font-size: .9rem; }
+    .lof-detail-projects {
+      max-height: 240px; overflow-y: auto; margin-top: 8px;
+      border: 1px solid var(--border); border-radius: 8px;
+      background: var(--card);
+    }
+    .lof-detail-project {
+      padding: 8px 12px; border-bottom: 1px solid var(--border);
+      font-size: .85rem;
+    }
+    .lof-detail-project:last-child { border-bottom: none; }
+    .lof-detail-project-name { font-weight: 700; }
+    .lof-detail-project-meta { color: var(--muted); font-size: .78rem; margin-top: 2px; }
+
+    .lof-summary-cards {
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 10px; margin: 12px 0 16px;
+    }
+    .lof-summary-card {
+      border: 1px solid var(--border); border-radius: 10px;
+      padding: 10px; background: color-mix(in oklab, var(--card) 88%, var(--bg2) 12%);
+    }
+    .lof-summary-card .v { font-size: 1.25rem; font-weight: 900; }
+    .lof-summary-card .k { font-size: .74rem; color: var(--muted); font-weight: 700; }
+    .lof-summary-card .s { font-size: .7rem; color: var(--muted); margin-top: 2px; }
+
+    .lof-loading { color: var(--muted); font-size: .9rem; padding: 16px 0; text-align: center; }
+  </style>
+</head>
+<body data-page-last-updated="2026-05-25" data-page-source="HUD LIHTC · HUD QCT/DDA · ACS · CHAS">
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+
+  <header class="site-header">
+    <!-- Injected by navigation.js -->
+  </header>
+
+  <main id="main-content">
+    <div style="padding:1rem 0 0.5rem">
+      <span class="kicker">Analysis · LIHTC</span>
+      <h1 style="margin-bottom:0.25rem">LIHTC Opportunity Finder</h1>
+      <p class="pma-intro-text">
+        Every Colorado <strong>QCT</strong> (Qualified Census Tract) and <strong>DDA</strong> (Difficult Development Area)
+        ranked by LIHTC development opportunity. Combines funding-recency headroom (how long since the last
+        LIHTC project was placed in service), housing need (Housing Needs Scorecard v2 composite),
+        basis-boost eligibility (IRC §42(d)(5)(B)), and population feasibility.
+      </p>
+      <p class="pma-intro-note" role="note">
+        <strong>Screening tool only.</strong> Opportunity scores are a starting point for site
+        identification. Final LIHTC site selection requires a formal CHFA-required PMA, market
+        study, and developer underwriting. All data is public (HUD LIHTC, HUD QCT/DDA designations,
+        ACS, CHAS) — no proprietary signals.
+      </p>
+    </div>
+
+    <div id="lofStatusBanner" style="font-size:.86rem; color:var(--muted); padding:.4rem 0;">
+      Loading data…
+    </div>
+
+    <div class="lof-layout">
+      <!-- ── Filter sidebar ── -->
+      <aside class="lof-sidebar" aria-labelledby="lofFilterHeading">
+        <h3 id="lofFilterHeading">Filters</h3>
+
+        <div class="lof-filter">
+          <label>Area type</label>
+          <div class="lof-toggle-row" role="group" aria-label="QCT or DDA filter">
+            <label><input type="checkbox" id="lofShowQct" checked> QCT</label>
+            <label><input type="checkbox" id="lofShowDda" checked> DDA</label>
+            <label><input type="checkbox" id="lofShowBoth" checked> Both</label>
+          </div>
+        </div>
+
+        <div class="lof-filter">
+          <label for="lofCounty">County</label>
+          <select id="lofCounty" aria-label="Filter by county">
+            <option value="">All counties</option>
+          </select>
+        </div>
+
+        <div class="lof-filter">
+          <label for="lofCity">City</label>
+          <select id="lofCity" aria-label="Filter by city">
+            <option value="">All cities</option>
+          </select>
+        </div>
+
+        <div class="lof-filter">
+          <label for="lofMinYearsSince">
+            Min years since last LIHTC
+            <span class="lof-range-val" id="lofMinYearsSinceVal">0</span>
+          </label>
+          <input type="range" id="lofMinYearsSince" min="0" max="40" step="1" value="0">
+        </div>
+
+        <div class="lof-filter">
+          <label for="lofMinScore">
+            Min opportunity score
+            <span class="lof-range-val" id="lofMinScoreVal">0</span>
+          </label>
+          <input type="range" id="lofMinScore" min="0" max="100" step="5" value="0">
+        </div>
+
+        <div class="lof-filter">
+          <label for="lofMinPop">Min population</label>
+          <input type="number" id="lofMinPop" min="0" step="500" placeholder="0" value="0">
+        </div>
+
+        <button type="button" class="lof-reset" id="lofResetFilters">Reset filters</button>
+
+        <p style="margin-top:14px;font-size:.72rem;color:var(--muted);line-height:1.45;">
+          <strong>Methodology:</strong> opportunity = 35% recency + 30% housing need + 20%
+          basis-boost + 15% population feasibility. See methodology disclosure below the table.
+        </p>
+      </aside>
+
+      <!-- ── Main pane ── -->
+      <section class="lof-main">
+        <div class="lof-summary-cards" id="lofSummaryCards">
+          <!-- populated by JS -->
+        </div>
+
+        <div id="lofMap" role="region" aria-label="Map of QCT and DDA opportunity zones"></div>
+
+        <div class="lof-table-wrap">
+          <table class="lof-table" id="lofTable" aria-label="Ranked LIHTC opportunity zones">
+            <thead>
+              <tr>
+                <th data-sort="score">Score</th>
+                <th data-sort="name">Area</th>
+                <th data-sort="type">Type</th>
+                <th data-sort="county">County</th>
+                <th data-sort="lastYear">Last funded</th>
+                <th data-sort="projectCount">Projects</th>
+                <th data-sort="totalUnits">Units</th>
+                <th data-sort="population">Pop.</th>
+              </tr>
+            </thead>
+            <tbody id="lofTableBody">
+              <tr><td colspan="8" class="lof-loading">Loading…</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div id="lofDetail" class="lof-detail" hidden>
+          <h3 id="lofDetailTitle">—</h3>
+          <dl id="lofDetailFacts"></dl>
+          <h4 style="margin:14px 0 4px;font-size:.9rem;">Projects in same city / county</h4>
+          <div id="lofDetailProjects" class="lof-detail-projects"></div>
+        </div>
+
+        <details style="margin-top:18px; padding:.6rem .8rem; border:1px solid var(--border); border-radius:10px;">
+          <summary style="cursor:pointer; font-weight:700; font-size:.92rem;">How is the opportunity score calculated?</summary>
+          <div style="margin-top:8px; font-size:.86rem; line-height:1.55;">
+            <p>Each QCT or DDA gets a 0–100 score from four components:</p>
+            <ul style="margin:6px 0 8px; padding-left:22px;">
+              <li><strong>Recency (35%)</strong> — years since the most recent LIHTC project was placed
+                in service in the area. Capped at 25+ years. Areas with no funded LIHTC ever get the
+                top score. Signals saturation headroom — CHFA's geographic-distribution scoring rewards
+                gap areas.</li>
+              <li><strong>Housing need (30%)</strong> — Scorecard v2 composite (PR #885) for the
+                containing county: a percentile-normalised blend of tenure-blended cost burden,
+                deep-need share, affordability pressure (home price ÷ HHI), and HUD worst-case-needs
+                signal. Higher = more acute need.</li>
+              <li><strong>Basis-boost (20%)</strong> — QCT: 40 of 100, DDA: 40, both: 60, neither: 0.
+                IRC §42(d)(5)(B) basis boost is a single election, but areas in BOTH a QCT and a DDA
+                often have a stronger competitive case in QAP scoring.</li>
+              <li><strong>Population feasibility (15%)</strong> — &lt;500: 0 pts, 500–2,000: 50,
+                ≥2,000: 100. LIHTC projects need a leasing pool. Acts as a floor that filters out
+                small rural tracts where a 50-unit project couldn't absorb.</li>
+            </ul>
+            <p>
+              <strong>Sources:</strong> HUD LIHTC database (716 CO projects, YR_PIS 1987–2020),
+              HUD QCT designations (224 CO tracts), HUD DDA designations (10 CO areas — county-based
+              non-metro + ZIP-based metro), HUD CHAS for housing-need composite, ACS for population.
+            </p>
+            <p>
+              <strong>Caveats:</strong> Projects with <code>YR_PIS = 8888</code> in HUD's source data
+              (placeholder for pipeline projects) are excluded from the last-funded computation.
+              Point-in-polygon assignment uses project lat/lng vs. QCT/DDA polygon — projects
+              right on a boundary edge may be ambiguous.
+            </p>
+          </div>
+        </details>
+      </section>
+    </div>
+  </main>
+
+  <script src="js/lihtc-opportunity-finder.js" defer></script>
+</body>
+</html>

--- a/lihtc-opportunity-finder.html
+++ b/lihtc-opportunity-finder.html
@@ -27,6 +27,7 @@
   <script defer src="js/mobile-menu.js"></script>
   <style>
     /* Page-specific layout — 2-col with filter sidebar + main content */
+    body { overflow-x: clip; }
     .lof-layout {
       display: grid;
       grid-template-columns: 280px 1fr;
@@ -75,8 +76,15 @@
       height: 50vh; min-height: 360px;
       border-radius: 12px; border: 1px solid var(--border);
       margin-bottom: 16px;
+      max-width: 100%;
+      overflow: hidden;
     }
-    .lof-table-wrap { overflow-x: auto; border: 1px solid var(--border); border-radius: 12px; }
+    .lof-table-wrap {
+      max-width: 100%;
+      overflow-x: auto;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+    }
     .lof-table {
       width: 100%; border-collapse: collapse; font-size: .88rem;
     }
@@ -319,6 +327,7 @@
       border: 1px solid var(--border);
       border-radius: 14px;
       background: color-mix(in oklab, var(--card) 95%, var(--accent) 5%);
+      overflow-x: auto;
     }
     .lof-meth-header h2 {
       margin: 0 0 6px;
@@ -549,7 +558,7 @@
                 <th data-sort="projectCount" title="LIHTC projects in jurisdiction">Projects</th>
                 <th data-sort="needScore" title="HNA need percentile (0–100p)">Need p</th>
                 <th data-sort="population" title="Approx population (HHs ≤100% AMI × 2.5)">Pop.</th>
-                <th data-sort="civicScore" title="Civic-capacity score: Prop 123 + HNA + comp plan + housing authority + nonprofits + IZ + local funding (0–7); icons: Prop 123 / HNA / Comp plan">Civic</th>
+                <th data-sort="civicScore" title="Civic-capacity score: Prop 123 + HNA + comp plan + housing authority + nonprofits + IZ + local funding (0–100); icons: Prop 123 / HNA / Comp plan">Civic</th>
                 <th data-sort="altScores" title="9% and 4% composite scores">Alt scores</th>
               </tr>
             </thead>
@@ -778,7 +787,7 @@
               <li><a href="https://www.huduser.gov/portal/datasets/qct.html" target="_blank" rel="noopener">HUD DDA 2025</a> — 10 CO nonmetro counties (<code>data/dda-colorado.json</code>)</li>
               <li><a href="https://lihtc.huduser.gov/" target="_blank" rel="noopener">HUD LIHTC Database</a> — 716 CO projects 1987–2020 (<code>data/market/hud_lihtc_co.geojson</code>)</li>
               <li><a href="https://www.huduser.gov/portal/datasets/cp.html" target="_blank" rel="noopener">HUD CHAS 2018–2022</a> — county-level (64) + tract-level (1,447 records)</li>
-              <li><a href="https://www.census.gov/programs-surveys/geography/data/tiger-data.html" target="_blank" rel="noopener">TIGER 2024</a> — place-tract spatial join (<code>data/hna/place-tract-membership.json</code>)</li>
+              <li><a href="https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-line-file.2024.html" target="_blank" rel="noopener">TIGER 2024</a> — place-tract spatial join (<code>data/hna/place-tract-membership.json</code>)</li>
               <li><a href="https://cdola.colorado.gov/commitment-filings" target="_blank" rel="noopener">DOLA Prop 123 commitments</a> — 217 filings (<code>data/policy/prop123_jurisdictions.json</code>)</li>
               <li>Housing policy scorecard — 547 jurisdictions × 7 civic dimensions (<code>data/policy/housing-policy-scorecard.json</code>)</li>
               <li>Local resources — housing leads, authorities, advocacy URLs (<code>data/hna/local-resources.json</code>)</li>

--- a/lihtc-opportunity-finder.html
+++ b/lihtc-opportunity-finder.html
@@ -429,7 +429,7 @@
     }
   </style>
 </head>
-<body data-page-last-updated="2026-05-25" data-page-source="HUD LIHTC · HUD QCT/DDA · ACS · CHAS">
+<body data-page-last-updated="2026-05-25" data-page-source="CHFA/HUD LIHTC · HUD QCT/DDA · ACS · CHAS">
   <a class="skip-link" href="#main-content">Skip to main content</a>
 
   <header class="site-header">
@@ -451,7 +451,7 @@
       <p class="pma-intro-note" role="note">
         <strong>Screening tool only.</strong> Opportunity scores are a starting point for site
         identification. Final LIHTC site selection requires a formal CHFA-required PMA, market
-        study, and developer underwriting. All data is public (HUD LIHTC, HUD QCT/DDA designations,
+        study, and developer underwriting. All data is public (CHFA/HUD LIHTC, HUD QCT/DDA designations,
         ACS, CHAS, TIGER place-tract spatial joins) — no proprietary signals.
       </p>
     </div>
@@ -645,7 +645,7 @@
               </li>
               <li>
                 <strong>Recency / Competition Score</strong> — years since last LIHTC YR_PIS in jurisdiction. Capped at 25y → 100 if never funded. Higher = more saturation headroom = stronger 9% candidate.
-                <br><em>Source:</em> HUD LIHTC Database (716 CO projects), PROJ_CTY match.
+                <br><em>Source:</em> CHFA public LIHTC cache with HUD fallback (716 CO projects), PROJ_CTY match.
               </li>
               <li>
                 <strong>Basis-Boost / Subsidy Fit Score</strong> — QCT only: 60 · DDA only: 60 · both: 100 · neither: 0. IRC §42(d)(5)(B).
@@ -785,7 +785,7 @@
             <ul class="lof-meth-sources">
               <li><a href="https://www.huduser.gov/portal/datasets/qct.html" target="_blank" rel="noopener">HUD QCT 2025</a> — 224 CO tracts (<code>data/qct-colorado.json</code>)</li>
               <li><a href="https://www.huduser.gov/portal/datasets/qct.html" target="_blank" rel="noopener">HUD DDA 2025</a> — 10 CO nonmetro counties (<code>data/dda-colorado.json</code>)</li>
-              <li><a href="https://lihtc.huduser.gov/" target="_blank" rel="noopener">HUD LIHTC Database</a> — 716 CO projects 1987–2020 (<code>data/market/hud_lihtc_co.geojson</code>)</li>
+              <li><a href="https://lihtc.huduser.gov/" target="_blank" rel="noopener">CHFA/HUD LIHTC project cache</a> — 716 CO projects 1987–2020 (<code>data/chfa-lihtc.json</code>, fallback <code>data/market/hud_lihtc_co.geojson</code>)</li>
               <li><a href="https://www.huduser.gov/portal/datasets/cp.html" target="_blank" rel="noopener">HUD CHAS 2018–2022</a> — county-level (64) + tract-level (1,447 records)</li>
               <li><a href="https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-line-file.2024.html" target="_blank" rel="noopener">TIGER 2024</a> — place-tract spatial join (<code>data/hna/place-tract-membership.json</code>)</li>
               <li><a href="https://cdola.colorado.gov/commitment-filings" target="_blank" rel="noopener">DOLA Prop 123 commitments</a> — 217 filings (<code>data/policy/prop123_jurisdictions.json</code>)</li>

--- a/lihtc-opportunity-finder.html
+++ b/lihtc-opportunity-finder.html
@@ -222,6 +222,95 @@
     }
 
     .lof-loading { color: var(--muted); font-size: .9rem; padding: 16px 0; text-align: center; }
+
+    /* Civic-capacity inline cell (table) */
+    .lof-civic-cell {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 2px 8px; border-radius: 9999px;
+      font-weight: 800; font-variant-numeric: tabular-nums;
+    }
+    .lof-civic-high { background: color-mix(in oklab, var(--good) 28%, var(--card) 72%); color: var(--good); }
+    .lof-civic-med  { background: color-mix(in oklab, var(--warn) 26%, var(--card) 74%); color: var(--warn); }
+    .lof-civic-low  { background: color-mix(in oklab, var(--muted) 18%, var(--card) 82%); color: var(--muted); }
+    .lof-civic-unk  { background: var(--bg2); color: var(--muted); border: 1px dashed var(--border); }
+
+    /* Civic-capacity panel (detail) */
+    .lof-section-h {
+      display: flex; align-items: center; justify-content: space-between;
+      margin: 18px 0 8px; font-size: .95rem;
+      padding-bottom: 4px; border-bottom: 1px solid var(--border);
+    }
+    .lof-detail-civic {
+      margin-top: 6px;
+      font-size: .88rem;
+    }
+    .lof-civic-row {
+      display: grid;
+      grid-template-columns: 200px 24px 1fr;
+      gap: 8px; align-items: baseline;
+      padding: 6px 0; border-bottom: 1px dashed color-mix(in oklab, var(--border) 50%, transparent 50%);
+    }
+    .lof-civic-row--block {
+      grid-template-columns: 1fr;
+      gap: 4px;
+    }
+    .lof-civic-label { color: var(--muted); font-weight: 600; font-size: .82rem; }
+    .lof-civic-check { text-align: center; font-weight: 800; }
+    .lof-civic-yes   { color: var(--good); }
+    .lof-civic-no    { color: var(--muted); }
+    .lof-civic-extra { color: var(--text); font-size: .85rem; }
+    .lof-civic-sub   { color: var(--muted); font-size: .76rem; }
+    .lof-civic-list {
+      margin: 4px 0 0; padding-left: 18px;
+      font-size: .85rem;
+    }
+    .lof-civic-list li { margin: 4px 0; }
+    .lof-civic-score-badge {
+      display: inline-block; padding: 2px 10px; border-radius: 9999px;
+      font-size: .76rem; font-weight: 800;
+    }
+    .lof-pill {
+      display: inline-block; padding: 0 6px; border-radius: 9999px;
+      font-size: .68rem; font-weight: 700;
+      background: var(--bg2); color: var(--text); border: 1px solid var(--border);
+    }
+    .lof-pill--accent {
+      background: color-mix(in oklab, var(--accent) 18%, var(--card) 82%);
+      color: var(--accent); border-color: var(--accent);
+    }
+
+    /* News linkout grid */
+    .lof-detail-news { margin-top: 10px; }
+    .lof-news-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 8px;
+    }
+    .lof-news-btn {
+      display: block;
+      padding: 10px 12px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: color-mix(in oklab, var(--card) 92%, var(--bg2) 8%);
+      color: var(--text);
+      text-decoration: none;
+      font-size: .82rem;
+      font-weight: 700;
+      transition: transform .1s, box-shadow .15s, background .15s;
+    }
+    .lof-news-btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+      background: color-mix(in oklab, var(--accent) 6%, var(--card) 94%);
+      text-decoration: none;
+    }
+    .lof-news-btn span {
+      display: block;
+      font-size: .72rem;
+      font-weight: 500;
+      color: var(--muted);
+      margin-top: 2px;
+    }
   </style>
 </head>
 <body data-page-last-updated="2026-05-25" data-page-source="HUD LIHTC · HUD QCT/DDA · ACS · CHAS">
@@ -353,11 +442,12 @@
                 <th data-sort="projectCount" title="LIHTC projects in jurisdiction">Projects</th>
                 <th data-sort="needScore" title="HNA need percentile (0–100p)">Need p</th>
                 <th data-sort="population" title="Approx population (HHs ≤100% AMI × 2.5)">Pop.</th>
+                <th data-sort="civicScore" title="Civic-capacity score: Prop 123 + HNA + comp plan + housing authority + nonprofits + IZ + local funding (0–7); icons: Prop 123 / HNA / Comp plan">Civic</th>
                 <th data-sort="altScores" title="9% and 4% composite scores">Alt scores</th>
               </tr>
             </thead>
             <tbody id="lofTableBody">
-              <tr><td colspan="9" class="lof-loading">Loading…</td></tr>
+              <tr><td colspan="10" class="lof-loading">Loading…</td></tr>
             </tbody>
           </table>
         </div>
@@ -366,6 +456,8 @@
           <h3 id="lofDetailTitle">—</h3>
           <div id="lofDetailHnaCta" class="lof-hna-cta-row"></div>
           <dl id="lofDetailFacts"></dl>
+          <div id="lofDetailCivic" class="lof-detail-civic"></div>
+          <div id="lofDetailNews" class="lof-detail-news"></div>
           <h4 style="margin:14px 0 4px;font-size:.9rem;">LIHTC projects in this jurisdiction</h4>
           <div id="lofDetailProjects" class="lof-detail-projects"></div>
         </div>

--- a/lihtc-opportunity-finder.html
+++ b/lihtc-opportunity-finder.html
@@ -311,6 +311,113 @@
       color: var(--muted);
       margin-top: 2px;
     }
+
+    /* ── Methodology section (always visible, scannable) ── */
+    .lof-methodology {
+      margin: 32px 0 24px;
+      padding: 20px 24px;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: color-mix(in oklab, var(--card) 95%, var(--accent) 5%);
+    }
+    .lof-meth-header h2 {
+      margin: 0 0 6px;
+      font-size: 1.4rem;
+      letter-spacing: -0.01em;
+    }
+    .lof-meth-lede {
+      margin: 0 0 6px;
+      font-size: .95rem;
+      color: var(--muted);
+      line-height: 1.5;
+    }
+    .lof-meth-lede a { font-weight: 700; }
+    .lof-meth-block {
+      margin-top: 22px;
+      padding-top: 18px;
+      border-top: 1px solid color-mix(in oklab, var(--border) 60%, transparent 40%);
+    }
+    .lof-meth-block h3 {
+      margin: 0 0 8px;
+      font-size: 1.04rem;
+      font-weight: 700;
+    }
+    .lof-meth-block p {
+      margin: 6px 0;
+      font-size: .9rem;
+      line-height: 1.55;
+    }
+    .lof-meth-list, .lof-meth-decision, .lof-meth-caveats, .lof-meth-sources {
+      margin: 8px 0;
+      padding-left: 22px;
+      font-size: .9rem;
+      line-height: 1.55;
+    }
+    .lof-meth-list li, .lof-meth-decision li, .lof-meth-caveats li, .lof-meth-sources li {
+      margin: 6px 0;
+    }
+    .lof-meth-dimensions {
+      margin: 10px 0;
+      padding-left: 22px;
+      font-size: .9rem;
+      line-height: 1.6;
+    }
+    .lof-meth-dimensions li { margin: 10px 0; }
+    .lof-meth-dimensions li em { color: var(--muted); font-style: normal; font-size: .82rem; }
+
+    .lof-meth-table {
+      width: 100%;
+      margin: 10px 0;
+      border-collapse: collapse;
+      font-size: .85rem;
+    }
+    .lof-meth-table thead {
+      background: color-mix(in oklab, var(--card) 86%, var(--bg2) 14%);
+    }
+    .lof-meth-table th, .lof-meth-table td {
+      padding: 7px 10px;
+      border: 1px solid var(--border);
+      text-align: left;
+    }
+    .lof-meth-table th { font-weight: 700; font-size: .8rem; color: var(--muted); }
+    .lof-meth-table tr:nth-child(even) td {
+      background: color-mix(in oklab, var(--card) 97%, var(--bg2) 3%);
+    }
+    .lof-meth-weight-table td:not(:first-child) { text-align: center; }
+    .lof-meth-weight-table mark {
+      background: color-mix(in oklab, var(--accent) 25%, var(--card) 75%);
+      color: var(--accent);
+      padding: 1px 6px; border-radius: 4px;
+      font-weight: 700;
+    }
+    .lof-meth-future {
+      opacity: .65;
+    }
+    .lof-meth-future em { font-style: italic; color: var(--muted); }
+
+    .lof-meth-note {
+      margin-top: 10px;
+      padding: 8px 12px;
+      border-left: 3px solid color-mix(in oklab, var(--accent) 60%, var(--border) 40%);
+      background: color-mix(in oklab, var(--accent) 5%, var(--card) 95%);
+      font-size: .84rem;
+      line-height: 1.5;
+      border-radius: 0 6px 6px 0;
+    }
+    .lof-meth-footer {
+      margin: 22px 0 0;
+      padding-top: 16px;
+      border-top: 1px solid color-mix(in oklab, var(--border) 60%, transparent 40%);
+      font-size: .82rem;
+      color: var(--muted);
+    }
+    .lof-meth-footer a { font-weight: 700; }
+    .lof-meth-footer code {
+      background: var(--bg2);
+      padding: 1px 6px;
+      border-radius: 4px;
+      font-size: .9em;
+    }
   </style>
 </head>
 <body data-page-last-updated="2026-05-25" data-page-source="HUD LIHTC · HUD QCT/DDA · ACS · CHAS">
@@ -418,7 +525,7 @@
         <p style="margin-top:14px;font-size:.72rem;color:var(--muted);line-height:1.45;">
           <strong>Methodology:</strong> opportunity score = weighted blend of recency, need
           (Scorecard v2 percentile), basis-boost, and population. Weights re-tune by target round.
-          See full methodology below the table.
+          <a href="#lofMethHeading" style="font-weight:700">Read full methodology ↓</a>
         </p>
       </aside>
 
@@ -462,70 +569,227 @@
           <div id="lofDetailProjects" class="lof-detail-projects"></div>
         </div>
 
-        <details style="margin-top:18px; padding:.6rem .8rem; border:1px solid var(--border); border-radius:10px;">
-          <summary style="cursor:pointer; font-weight:700; font-size:.92rem;">How is the opportunity score calculated?</summary>
-          <div style="margin-top:8px; font-size:.86rem; line-height:1.55;">
-            <p>
-              Each jurisdiction (city / town / CDP) with QCT and/or DDA designation gets a 0–100
-              composite score from four components. <strong>Weights re-tune by target round</strong>
-              because 4% bond deals and 9% competitive deals optimise on different signals:
+        <!-- ── METHODOLOGY (always visible — users should see how the locator works) ── -->
+        <section class="lof-methodology" aria-labelledby="lofMethHeading">
+          <header class="lof-meth-header">
+            <h2 id="lofMethHeading">How this locator works</h2>
+            <p class="lof-meth-lede">
+              A LIHTC locator answers <em>"where should a developer spend scarce time looking for
+              the next deal?"</em> It is <strong>not</strong> a site-screen — it narrows 482 Colorado
+              jurisdictions to a credible shortlist of 5–15. Everything below the jurisdiction level
+              (parcel, utilities, zoning, environmental) requires site work.
+              <a href="docs/methodology/LIHTC-LOCATOR-METHODOLOGY.md" target="_blank" rel="noopener">Full methodology →</a>
             </p>
-            <table style="width:100%; margin:8px 0; font-size:.82rem; border-collapse:collapse;">
+          </header>
+
+          <!-- The product question -->
+          <div class="lof-meth-block">
+            <h3>The three questions the locator separates</h3>
+            <ol class="lof-meth-list">
+              <li><strong>Where is housing need acute?</strong> — high cost burden, deep AMI gap, severe rent burden</li>
+              <li><strong>Where is a deal executable?</strong> — basis-boost eligibility, civic readiness, population scale</li>
+              <li><strong>Where is competition light?</strong> — funding-recency headroom, LIHTC saturation gap</li>
+            </ol>
+            <p class="lof-meth-note">
+              The locator never collapses these into a single black-box score. You see <em>why</em> a
+              jurisdiction rises and can re-weight the dimensions for your own deal strategy.
+            </p>
+          </div>
+
+          <!-- Universe definition -->
+          <div class="lof-meth-block">
+            <h3>The universe — which jurisdictions get scored</h3>
+            <p>
+              Starts with Colorado's 482 incorporated places, towns, and CDPs (TIGER 2024). Each
+              target deal type then filters this universe differently. Today's implementation ranks
+              the <strong>158 jurisdictions with QCT and/or DDA designation</strong> (basis-boost
+              eligible). Target state adds preservation, workforce-resort, and Prop 123 deal types
+              with relaxed designation requirements.
+            </p>
+            <table class="lof-meth-table">
               <thead>
-                <tr style="background:color-mix(in oklab, var(--card) 88%, var(--bg2) 12%);">
-                  <th style="padding:6px 8px; text-align:left; border:1px solid var(--border);">Component</th>
-                  <th style="padding:6px 8px; text-align:center; border:1px solid var(--border);">9% Competitive</th>
-                  <th style="padding:6px 8px; text-align:center; border:1px solid var(--border);">4% Bond</th>
-                  <th style="padding:6px 8px; text-align:center; border:1px solid var(--border);">Balanced</th>
+                <tr><th>Target deal type</th><th>Universe filter</th><th>CO count</th></tr>
+              </thead>
+              <tbody>
+                <tr><td><strong>9% Competitive</strong></td><td>≥1 QCT tract OR DDA county</td><td>158</td></tr>
+                <tr><td><strong>4% Bond (basis-boost)</strong></td><td>≥1 QCT tract OR DDA county</td><td>158</td></tr>
+                <tr class="lof-meth-future"><td><strong>Preservation</strong></td><td>LIHTC w/ expiration ≤ 2030</td><td>~20 <em>(planned)</em></td></tr>
+                <tr class="lof-meth-future"><td><strong>Workforce / Resort</strong></td><td>Resort county subset, pop ≥1,000</td><td>~15 <em>(planned)</em></td></tr>
+                <tr class="lof-meth-future"><td><strong>Prop 123 Local</strong></td><td>Prop 123 ✓ AND (comp plan OR HNA OR housing lead)</td><td>~80 <em>(planned)</em></td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Five scoring dimensions -->
+          <div class="lof-meth-block">
+            <h3>The five scoring dimensions</h3>
+            <p>
+              Every jurisdiction in the universe gets five independent 0–100 scores. <strong>Today's
+              implementation uses four</strong> (Recency · Need · Basis · Population). Civic
+              Readiness ships as a separate column but is not yet rolled into the composite — that's
+              sprint-1 work per the repo audit.
+            </p>
+            <ol class="lof-meth-dimensions">
+              <li>
+                <strong>Housing Need Score</strong> — tenure-blended cost burden (renter+owner pct_cb30 weighted by HH counts), severe rent burden (pct_cb50), and AMI gap depth. Percentile-normalized against CO peers.
+                <br><em>Source:</em> HUD CHAS 2018–2022 Table 7, ACS DP04 GRAPI/SMOCAPI.
+              </li>
+              <li>
+                <strong>Recency / Competition Score</strong> — years since last LIHTC YR_PIS in jurisdiction. Capped at 25y → 100 if never funded. Higher = more saturation headroom = stronger 9% candidate.
+                <br><em>Source:</em> HUD LIHTC Database (716 CO projects), PROJ_CTY match.
+              </li>
+              <li>
+                <strong>Basis-Boost / Subsidy Fit Score</strong> — QCT only: 60 · DDA only: 60 · both: 100 · neither: 0. IRC §42(d)(5)(B).
+                <br><em>Source:</em> HUD QCT 2025 (224 CO tracts), HUD DDA 2025 (10 CO nonmetro counties).
+              </li>
+              <li>
+                <strong>Population / Market Feasibility Score</strong> — bucketed: &lt;500: 0 · 500–2k: 30 · 2k–5k: 60 · 5k–15k: 85 · ≥15k: 100. Heaviest in 4% bond deals (need 100–200 unit absorption).
+                <br><em>Source:</em> CHAS HHs ≤100% AMI × 2.5 HH-size proxy.
+              </li>
+              <li class="lof-meth-future">
+                <strong>Civic Readiness Score</strong> <em>(surfaced but not yet in composite)</em> — 7 binary dimensions: Prop 123 ✓, HNA ✓, comp plan ✓, IZ ordinance ✓, local funding ✓, housing authority ✓, housing nonprofits ✓. Score = (true dims) / (known dims) × 100.
+                <br><em>Source:</em> housing-policy-scorecard.json (547 jurisdictions × 7 dims), prop123_jurisdictions.json (217 commitments), local-resources.json (URLs).
+              </li>
+            </ol>
+          </div>
+
+          <!-- Weight table -->
+          <div class="lof-meth-block">
+            <h3>Per-deal-type weighting (re-tuned live by your target selection)</h3>
+            <p>
+              Different deal types optimize on different signals. 9% competitive rewards
+              geographic-gap (recency-heavy). 4% bond rewards scale (population-heavy). Preservation
+              rewards subsidy fit. Prop 123 deals require civic readiness.
+            </p>
+            <table class="lof-meth-table lof-meth-weight-table">
+              <thead>
+                <tr>
+                  <th>Dimension</th>
+                  <th>9% Competitive</th>
+                  <th>4% Bond</th>
+                  <th>Preservation</th>
+                  <th>Workforce-Resort</th>
+                  <th>Prop 123 Local</th>
+                  <th>Balanced</th>
                 </tr>
               </thead>
               <tbody>
-                <tr><td style="padding:5px 8px; border:1px solid var(--border);"><strong>Recency</strong></td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">40%</td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">25%</td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">35%</td></tr>
-                <tr><td style="padding:5px 8px; border:1px solid var(--border);"><strong>Housing need</strong></td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">30%</td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">25%</td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">30%</td></tr>
-                <tr><td style="padding:5px 8px; border:1px solid var(--border);"><strong>Basis-boost</strong></td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">20%</td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">15%</td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">20%</td></tr>
-                <tr><td style="padding:5px 8px; border:1px solid var(--border);"><strong>Population</strong></td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">10%</td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">35%</td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">15%</td></tr>
+                <tr><td><strong>Need</strong></td><td>30%</td><td>25%</td><td>20%</td><td>25%</td><td>25%</td><td>25%</td></tr>
+                <tr><td><strong>Recency / Competition</strong></td><td><mark>30%</mark></td><td>15%</td><td>15%</td><td>15%</td><td>10%</td><td>20%</td></tr>
+                <tr><td><strong>Basis / Subsidy</strong></td><td>15%</td><td>15%</td><td><mark>35%</mark></td><td>15%</td><td>20%</td><td>15%</td></tr>
+                <tr><td><strong>Population / Feasibility</strong></td><td>15%</td><td><mark>30%</mark></td><td>10%</td><td><mark>30%</mark></td><td>15%</td><td>20%</td></tr>
+                <tr><td><strong>Civic Readiness</strong></td><td>10%</td><td>15%</td><td>20%</td><td>15%</td><td><mark>30%</mark></td><td>20%</td></tr>
               </tbody>
             </table>
-            <ul style="margin:6px 0 8px; padding-left:22px;">
-              <li><strong>Recency</strong> — years since the jurisdiction's most recent LIHTC project
-                was placed in service (PROJ_CTY match against HUD LIHTC). Capped at 25+ years.
-                Jurisdictions that have <em>never</em> been funded get 100. Signals saturation
-                headroom — CHFA's geographic-distribution scoring rewards gap areas. <strong>Heaviest
-                in 9%</strong> because gap-area scoring is a 9% QAP differentiator.</li>
-              <li><strong>Housing need</strong> — Scorecard v2 composite for the containing county,
-                expressed as a Colorado-wide percentile. Blends tenure-blended cost burden
-                (renter pct_cb30 × renter HHs + owner pct_cb30 × owner HHs) and severe rent burden
-                (≥50% income). Source: HUD CHAS Table 7.</li>
-              <li><strong>Basis-boost</strong> — QCT only: 60 of 100, DDA only: 60, both: 100,
-                neither: 0. IRC §42(d)(5)(B) basis boost is a single election, but jurisdictions
-                with <em>both</em> designations have the strongest underwriting case
-                (the default filter).</li>
-              <li><strong>Population</strong> — bucketed: &lt;500: 0, 500–2k: 30, 2k–5k: 60, 5k–15k:
-                85, ≥15k: 100. <strong>Heaviest in 4% bond</strong> because bond deals typically
-                need 100–200 units to absorb, which requires a population base.</li>
-            </ul>
-            <p>
-              <strong>Sources:</strong> HUD LIHTC database (~716 CO projects, YR_PIS 1987–2020),
-              HUD QCT designations (224 CO tracts), HUD DDA designations (10 CO nonmetro counties),
-              <code>data/hna/place-tract-membership.json</code> (TIGER 2024 spatial join of CO
-              places against tracts), HUD CHAS Table 7 for cost-burden composite, ACS DP04 for
-              population proxy.
-            </p>
-            <p>
-              <strong>Caveats:</strong>
-              (1) Projects with <code>YR_PIS = 8888</code> (HUD placeholder for in-pipeline projects)
-              are excluded.
-              (2) Project-to-jurisdiction matching uses <code>PROJ_CTY</code> string equality — a
-              project with a misspelled or unincorporated PROJ_CTY may not be counted.
-              (3) Population is approximate: derived from CHAS households ≤100% AMI × 2.5 average
-              household size, not direct ACS B01003.
-              (4) QCT-place membership requires the tract's area share of the place to exceed 5% or
-              the place's area share of the tract to exceed 20% — sliver-overlaps don't claim a QCT.
-              (5) DDA designation in Colorado is county-based for the 10 nonmetro CO counties; all
-              jurisdictions in those counties inherit the designation.
+            <p class="lof-meth-note">
+              <strong>Today's implementation uses a simplified 4-dimension table</strong> (no Civic
+              Readiness in composite, no preservation/workforce/prop123-local deal types). 9% =
+              40·30·20·10 · 4% = 25·25·15·35 · Any = 35·30·20·15. Migration to the full table is
+              sprint-2 work per the repo audit.
             </p>
           </div>
-        </details>
+
+          <!-- Confidence framework -->
+          <div class="lof-meth-block">
+            <h3>Confidence — surface uncertainty, don't hide it</h3>
+            <p>
+              Every score carries a confidence rating reflecting input quality. Confidence does
+              <em>not</em> change the composite — it changes how the result is presented.
+            </p>
+            <ul class="lof-meth-list">
+              <li><strong>★★★ High</strong> — all five dimensions from direct data; civic ≥ 5 of 7 dims filled; no major fallback used</li>
+              <li><strong>★★ Medium</strong> — at least one dimension uses a fallback OR civic 3–4 of 7 OR population is a proxy</li>
+              <li><strong>★ Low</strong> — multiple fallbacks OR civic &lt;3 of 7 OR major dimension missing entirely</li>
+            </ul>
+            <p class="lof-meth-note">
+              Confidence pills next to every metric are sprint-1 work; today the locator surfaces
+              this as table column hover-tooltips and detail-panel inline notes.
+            </p>
+          </div>
+
+          <!-- Decision flow -->
+          <div class="lof-meth-block">
+            <h3>How to use the result — a developer's decision flow</h3>
+            <ol class="lof-meth-decision">
+              <li><strong>Filter.</strong> Pick a target deal type. Locator re-weights + re-filters.</li>
+              <li><strong>Read top 10.</strong> Sort by composite. Skim reasons (does the rise make sense?) and risks (does any flag disqualify?).</li>
+              <li><strong>Cross-check civic.</strong> Strong scores but no Prop 123 + no housing lead + no comp plan = harder to execute. Flag for early conversation.</li>
+              <li><strong>Funnel forward to HNA.</strong> Click "📋 Open HNA" — verify locator signal matches deeper needs picture.</li>
+              <li><strong>Funnel forward to PMA.</strong> Click "🗺️ Run market analysis" — verify rental demand, comparable rents, amenities, no infrastructure or environmental risk.</li>
+              <li><strong>Build a concept.</strong> Click "💵 Build deal concept" — test 9% (30–60 units, 30/50/60 AMI) vs 4% (100–200 units, 50/60/80 AMI). See which pencils.</li>
+              <li><strong>Export memo.</strong> Take it to your pipeline meeting. <em>(planned)</em></li>
+            </ol>
+          </div>
+
+          <!-- Score bands -->
+          <div class="lof-meth-block">
+            <h3>Output bands</h3>
+            <table class="lof-meth-table">
+              <thead><tr><th>Score</th><th>Band</th><th>Letter</th><th>Interpretation</th></tr></thead>
+              <tbody>
+                <tr><td>85–100</td><td><strong>High</strong></td><td>A / A-</td><td>Strong candidate — move to PMA</td></tr>
+                <tr><td>70–84</td><td><strong>High</strong></td><td>B+ / B</td><td>Solid — verify civic readiness</td></tr>
+                <tr><td>55–69</td><td><strong>Medium</strong></td><td>B- / C+</td><td>Worth a deeper look; deal type matters</td></tr>
+                <tr><td>40–54</td><td><strong>Medium</strong></td><td>C / C-</td><td>Watchlist; need a clear theme</td></tr>
+                <tr><td>25–39</td><td><strong>Low</strong></td><td>D</td><td>Hard sell; usually saturation or population</td></tr>
+                <tr><td>0–24</td><td><strong>Not-ready</strong></td><td>F</td><td>Skip unless specific local angle</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Limitations -->
+          <div class="lof-meth-block">
+            <h3>What this locator does NOT do</h3>
+            <p>Be honest about scope. The locator is a jurisdiction-level screen, not site-screening or underwriting.</p>
+            <table class="lof-meth-table">
+              <thead><tr><th>Out of scope</th><th>Why</th><th>Where to go instead</th></tr></thead>
+              <tbody>
+                <tr><td>Parcel readiness</td><td>No parcel data layer</td><td>County Assessor + zoning lookup</td></tr>
+                <tr><td>Utility / water / sewer capacity</td><td>No data layer</td><td>District-by-district inquiry</td></tr>
+                <tr><td>Floodplain / wildfire / wetlands / slope</td><td>No env layer</td><td>FEMA, USFS, USACE</td></tr>
+                <tr><td>Zoning compatibility</td><td>No layer</td><td>Local planning department</td></tr>
+                <tr><td>Walkability / transit / grocery access</td><td>Layer exists, not yet wired in</td><td>HNA Site Selection Score page</td></tr>
+                <tr><td>Detailed AMI / unit-mix recommendation</td><td>Out of scope</td><td>LIHTC Concept Recommender (PMA page)</td></tr>
+                <tr><td>Capital stack sizing</td><td>Out of scope</td><td>Deal Calculator</td></tr>
+                <tr><td>CHFA pipeline / NOFA timing</td><td>Manual</td><td>CHFA QAP + award announcements</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Caveats -->
+          <div class="lof-meth-block">
+            <h3>Caveats &amp; known data quirks</h3>
+            <ol class="lof-meth-caveats">
+              <li>HUD <code>YR_PIS = 8888</code> placeholders (in-pipeline projects) are excluded from recency.</li>
+              <li>Project-to-jurisdiction matching uses <code>PROJ_CTY</code> string equality — a misspelled PROJ_CTY ("Ft Collins" vs "Fort Collins") misses match. Fuzzy-match is a backlog item.</li>
+              <li>Population is approximate — derived from CHAS HHs ≤100% AMI × 2.5 avg HH size, not direct ACS B01003. Resort areas with high second-home stock are actually closer to the renter-base truth via HH proxy than via B01003.</li>
+              <li>QCT-place membership requires tract's share of place &gt; 5% OR place's share of tract &gt; 20%. Sliver overlaps don't claim a QCT.</li>
+              <li>DDA designation in CO is county-based (all 10 CO DDAs are nonmetro counties); all jurisdictions in DDA counties inherit the designation.</li>
+              <li>Civic-capacity coverage is sparse. ~70% of jurisdictions have populated scorecard records; ~30% rely on county-level inheritance.</li>
+              <li>Recency uses YR_PIS (placed in service) which lags awards by 2–3y. A jurisdiction with 2024 awards but no PIS yet looks "stale." CHFA-pipeline integration is a backlog item.</li>
+            </ol>
+          </div>
+
+          <!-- Sources -->
+          <div class="lof-meth-block">
+            <h3>Data sources</h3>
+            <ul class="lof-meth-sources">
+              <li><a href="https://www.huduser.gov/portal/datasets/qct.html" target="_blank" rel="noopener">HUD QCT 2025</a> — 224 CO tracts (<code>data/qct-colorado.json</code>)</li>
+              <li><a href="https://www.huduser.gov/portal/datasets/qct.html" target="_blank" rel="noopener">HUD DDA 2025</a> — 10 CO nonmetro counties (<code>data/dda-colorado.json</code>)</li>
+              <li><a href="https://lihtc.huduser.gov/" target="_blank" rel="noopener">HUD LIHTC Database</a> — 716 CO projects 1987–2020 (<code>data/market/hud_lihtc_co.geojson</code>)</li>
+              <li><a href="https://www.huduser.gov/portal/datasets/cp.html" target="_blank" rel="noopener">HUD CHAS 2018–2022</a> — county-level (64) + tract-level (1,447 records)</li>
+              <li><a href="https://www.census.gov/programs-surveys/geography/data/tiger-data.html" target="_blank" rel="noopener">TIGER 2024</a> — place-tract spatial join (<code>data/hna/place-tract-membership.json</code>)</li>
+              <li><a href="https://cdola.colorado.gov/commitment-filings" target="_blank" rel="noopener">DOLA Prop 123 commitments</a> — 217 filings (<code>data/policy/prop123_jurisdictions.json</code>)</li>
+              <li>Housing policy scorecard — 547 jurisdictions × 7 civic dimensions (<code>data/policy/housing-policy-scorecard.json</code>)</li>
+              <li>Local resources — housing leads, authorities, advocacy URLs (<code>data/hna/local-resources.json</code>)</li>
+            </ul>
+          </div>
+
+          <p class="lof-meth-footer">
+            Methodology version 1.1 (2026-05-25). Verification: <code>npm run audit:opportunity-finder</code> runs 28 independent checks against this implementation.
+            <br><a href="docs/methodology/LIHTC-LOCATOR-METHODOLOGY.md" target="_blank" rel="noopener">Read the full methodology doc →</a>
+          </p>
+        </section>
       </section>
     </div>
   </main>

--- a/lihtc-opportunity-finder.html
+++ b/lihtc-opportunity-finder.html
@@ -6,9 +6,9 @@
   <meta name="theme-color" content="#096e65" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="#0fd4cf" media="(prefers-color-scheme: dark)">
   <title>LIHTC Opportunity Finder | COHO Analytics</title>
-  <meta name="description" content="Find Colorado QCT and DDA areas with the best LIHTC development opportunity — ranked by funding-recency headroom, housing need, basis-boost eligibility, and population feasibility.">
+  <meta name="description" content="Rank Colorado jurisdictions with QCT and/or DDA designations for 4% bond and 9% competitive LIHTC rounds — by funding-recency, housing need, basis-boost eligibility, and population.">
   <meta property="og:title" content="LIHTC Opportunity Finder | COHO Analytics">
-  <meta property="og:description" content="Rank every Colorado QCT and DDA by LIHTC opportunity score. Find areas with the most funding-recency headroom + highest acute housing need.">
+  <meta property="og:description" content="Target Colorado jurisdictions for 4% bond and 9% competitive LIHTC rounds. Sortable by last placed-in-service year, HNA need score, and population.">
   <meta property="og:type" content="website">
   <meta property="og:image" content="assets/og-image.png">
   <script src="js/config.js"></script>
@@ -170,16 +170,18 @@
       <span class="kicker">Analysis · LIHTC</span>
       <h1 style="margin-bottom:0.25rem">LIHTC Opportunity Finder</h1>
       <p class="pma-intro-text">
-        Every Colorado <strong>QCT</strong> (Qualified Census Tract) and <strong>DDA</strong> (Difficult Development Area)
-        ranked by LIHTC development opportunity. Combines funding-recency headroom (how long since the last
-        LIHTC project was placed in service), housing need (Housing Needs Scorecard v2 composite),
-        basis-boost eligibility (IRC §42(d)(5)(B)), and population feasibility.
+        Colorado jurisdictions (cities, towns, CDPs) with <strong>QCT</strong> (Qualified Census Tract)
+        and/or <strong>DDA</strong> (Difficult Development Area) designations, ranked for
+        <strong>4% bond</strong> and <strong>9% competitive</strong> LIHTC targeting. Sortable by
+        last placed-in-service year, HNA need score, and population. Combines funding-recency,
+        housing need (Scorecard v2 composite), basis-boost eligibility (IRC §42(d)(5)(B)), and
+        population — re-weighted per round (4% bonds emphasise scale, 9% emphasises geographic gap).
       </p>
       <p class="pma-intro-note" role="note">
         <strong>Screening tool only.</strong> Opportunity scores are a starting point for site
         identification. Final LIHTC site selection requires a formal CHFA-required PMA, market
         study, and developer underwriting. All data is public (HUD LIHTC, HUD QCT/DDA designations,
-        ACS, CHAS) — no proprietary signals.
+        ACS, CHAS, TIGER place-tract spatial joins) — no proprietary signals.
       </p>
     </div>
 
@@ -193,25 +195,45 @@
         <h3 id="lofFilterHeading">Filters</h3>
 
         <div class="lof-filter">
-          <label>Area type</label>
-          <div class="lof-toggle-row" role="group" aria-label="QCT or DDA filter">
-            <label><input type="checkbox" id="lofShowQct" checked> QCT</label>
-            <label><input type="checkbox" id="lofShowDda" checked> DDA</label>
-            <label><input type="checkbox" id="lofShowBoth" checked> Both</label>
+          <label>Target round</label>
+          <div class="lof-toggle-row" role="radiogroup" aria-label="Target LIHTC round">
+            <label><input type="radio" name="lofTarget" value="9pct" checked> 9% Competitive</label>
+            <label><input type="radio" name="lofTarget" value="4pct"> 4% Bond</label>
+            <label><input type="radio" name="lofTarget" value="any"> Any (balanced)</label>
           </div>
+          <p style="margin:6px 0 0; font-size:.7rem; color:var(--muted); line-height:1.4;">
+            Re-weights the score: 9% rewards recency &amp; need (geographic-gap scoring); 4% rewards
+            scale (need ≥150 units to absorb a bond deal).
+          </p>
+        </div>
+
+        <div class="lof-filter">
+          <label>Basis-boost requirement</label>
+          <div class="lof-toggle-row" role="group" aria-label="Designation requirements">
+            <label><input type="checkbox" id="lofRequireBoth" checked> QCT + DDA</label>
+            <label><input type="checkbox" id="lofRequireQct"> QCT only</label>
+            <label><input type="checkbox" id="lofRequireDda"> DDA only</label>
+          </div>
+          <p style="margin:6px 0 0; font-size:.7rem; color:var(--muted); line-height:1.4;">
+            Defaults to jurisdictions with <em>both</em> designations — strongest IRC §42(d)(5)(B)
+            basis-boost case. Uncheck to widen.
+          </p>
+        </div>
+
+        <div class="lof-filter">
+          <div class="lof-toggle-row" role="group" aria-label="Place-type filter">
+            <label><input type="checkbox" id="lofIncludeCdps"> Include CDPs (unincorporated)</label>
+          </div>
+          <p style="margin:6px 0 0; font-size:.7rem; color:var(--muted); line-height:1.4;">
+            CDPs are unincorporated communities. LIHTC awards typically require an incorporated
+            jurisdiction for permitting / consent letters.
+          </p>
         </div>
 
         <div class="lof-filter">
           <label for="lofCounty">County</label>
           <select id="lofCounty" aria-label="Filter by county">
             <option value="">All counties</option>
-          </select>
-        </div>
-
-        <div class="lof-filter">
-          <label for="lofCity">City</label>
-          <select id="lofCity" aria-label="Filter by city">
-            <option value="">All cities</option>
           </select>
         </div>
 
@@ -239,8 +261,9 @@
         <button type="button" class="lof-reset" id="lofResetFilters">Reset filters</button>
 
         <p style="margin-top:14px;font-size:.72rem;color:var(--muted);line-height:1.45;">
-          <strong>Methodology:</strong> opportunity = 35% recency + 30% housing need + 20%
-          basis-boost + 15% population feasibility. See methodology disclosure below the table.
+          <strong>Methodology:</strong> opportunity score = weighted blend of recency, need
+          (Scorecard v2 percentile), basis-boost, and population. Weights re-tune by target round.
+          See full methodology below the table.
         </p>
       </aside>
 
@@ -250,24 +273,25 @@
           <!-- populated by JS -->
         </div>
 
-        <div id="lofMap" role="region" aria-label="Map of QCT and DDA opportunity zones"></div>
+        <div id="lofMap" role="region" aria-label="Map of QCT and DDA jurisdictions"></div>
 
         <div class="lof-table-wrap">
-          <table class="lof-table" id="lofTable" aria-label="Ranked LIHTC opportunity zones">
+          <table class="lof-table" id="lofTable" aria-label="Ranked LIHTC opportunity jurisdictions">
             <thead>
               <tr>
-                <th data-sort="score">Score</th>
-                <th data-sort="name">Area</th>
-                <th data-sort="type">Type</th>
+                <th data-sort="score" aria-sort="descending" title="Active target's composite score">Score</th>
+                <th data-sort="name">Jurisdiction</th>
+                <th data-sort="type" title="QCT / DDA / both">Type</th>
                 <th data-sort="county">County</th>
-                <th data-sort="lastYear">Last funded</th>
-                <th data-sort="projectCount">Projects</th>
-                <th data-sort="totalUnits">Units</th>
-                <th data-sort="population">Pop.</th>
+                <th data-sort="lastYear" title="Most recent LIHTC YR_PIS">Last funded</th>
+                <th data-sort="projectCount" title="LIHTC projects in jurisdiction">Projects</th>
+                <th data-sort="needScore" title="HNA need percentile (0–100p)">Need p</th>
+                <th data-sort="population" title="Approx population (HHs ≤100% AMI × 2.5)">Pop.</th>
+                <th data-sort="altScores" title="9% and 4% composite scores">Alt scores</th>
               </tr>
             </thead>
             <tbody id="lofTableBody">
-              <tr><td colspan="8" class="lof-loading">Loading…</td></tr>
+              <tr><td colspan="9" class="lof-loading">Loading…</td></tr>
             </tbody>
           </table>
         </div>
@@ -275,40 +299,71 @@
         <div id="lofDetail" class="lof-detail" hidden>
           <h3 id="lofDetailTitle">—</h3>
           <dl id="lofDetailFacts"></dl>
-          <h4 style="margin:14px 0 4px;font-size:.9rem;">Projects in same city / county</h4>
+          <h4 style="margin:14px 0 4px;font-size:.9rem;">LIHTC projects in this jurisdiction</h4>
           <div id="lofDetailProjects" class="lof-detail-projects"></div>
         </div>
 
         <details style="margin-top:18px; padding:.6rem .8rem; border:1px solid var(--border); border-radius:10px;">
           <summary style="cursor:pointer; font-weight:700; font-size:.92rem;">How is the opportunity score calculated?</summary>
           <div style="margin-top:8px; font-size:.86rem; line-height:1.55;">
-            <p>Each QCT or DDA gets a 0–100 score from four components:</p>
+            <p>
+              Each jurisdiction (city / town / CDP) with QCT and/or DDA designation gets a 0–100
+              composite score from four components. <strong>Weights re-tune by target round</strong>
+              because 4% bond deals and 9% competitive deals optimise on different signals:
+            </p>
+            <table style="width:100%; margin:8px 0; font-size:.82rem; border-collapse:collapse;">
+              <thead>
+                <tr style="background:color-mix(in oklab, var(--card) 88%, var(--bg2) 12%);">
+                  <th style="padding:6px 8px; text-align:left; border:1px solid var(--border);">Component</th>
+                  <th style="padding:6px 8px; text-align:center; border:1px solid var(--border);">9% Competitive</th>
+                  <th style="padding:6px 8px; text-align:center; border:1px solid var(--border);">4% Bond</th>
+                  <th style="padding:6px 8px; text-align:center; border:1px solid var(--border);">Balanced</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td style="padding:5px 8px; border:1px solid var(--border);"><strong>Recency</strong></td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">40%</td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">25%</td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">35%</td></tr>
+                <tr><td style="padding:5px 8px; border:1px solid var(--border);"><strong>Housing need</strong></td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">30%</td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">25%</td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">30%</td></tr>
+                <tr><td style="padding:5px 8px; border:1px solid var(--border);"><strong>Basis-boost</strong></td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">20%</td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">15%</td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">20%</td></tr>
+                <tr><td style="padding:5px 8px; border:1px solid var(--border);"><strong>Population</strong></td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">10%</td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">35%</td><td style="padding:5px 8px; text-align:center; border:1px solid var(--border);">15%</td></tr>
+              </tbody>
+            </table>
             <ul style="margin:6px 0 8px; padding-left:22px;">
-              <li><strong>Recency (35%)</strong> — years since the most recent LIHTC project was placed
-                in service in the area. Capped at 25+ years. Areas with no funded LIHTC ever get the
-                top score. Signals saturation headroom — CHFA's geographic-distribution scoring rewards
-                gap areas.</li>
-              <li><strong>Housing need (30%)</strong> — Scorecard v2 composite (PR #885) for the
-                containing county: a percentile-normalised blend of tenure-blended cost burden,
-                deep-need share, affordability pressure (home price ÷ HHI), and HUD worst-case-needs
-                signal. Higher = more acute need.</li>
-              <li><strong>Basis-boost (20%)</strong> — QCT: 40 of 100, DDA: 40, both: 60, neither: 0.
-                IRC §42(d)(5)(B) basis boost is a single election, but areas in BOTH a QCT and a DDA
-                often have a stronger competitive case in QAP scoring.</li>
-              <li><strong>Population feasibility (15%)</strong> — &lt;500: 0 pts, 500–2,000: 50,
-                ≥2,000: 100. LIHTC projects need a leasing pool. Acts as a floor that filters out
-                small rural tracts where a 50-unit project couldn't absorb.</li>
+              <li><strong>Recency</strong> — years since the jurisdiction's most recent LIHTC project
+                was placed in service (PROJ_CTY match against HUD LIHTC). Capped at 25+ years.
+                Jurisdictions that have <em>never</em> been funded get 100. Signals saturation
+                headroom — CHFA's geographic-distribution scoring rewards gap areas. <strong>Heaviest
+                in 9%</strong> because gap-area scoring is a 9% QAP differentiator.</li>
+              <li><strong>Housing need</strong> — Scorecard v2 composite for the containing county,
+                expressed as a Colorado-wide percentile. Blends tenure-blended cost burden
+                (renter pct_cb30 × renter HHs + owner pct_cb30 × owner HHs) and severe rent burden
+                (≥50% income). Source: HUD CHAS Table 7.</li>
+              <li><strong>Basis-boost</strong> — QCT only: 60 of 100, DDA only: 60, both: 100,
+                neither: 0. IRC §42(d)(5)(B) basis boost is a single election, but jurisdictions
+                with <em>both</em> designations have the strongest underwriting case
+                (the default filter).</li>
+              <li><strong>Population</strong> — bucketed: &lt;500: 0, 500–2k: 30, 2k–5k: 60, 5k–15k:
+                85, ≥15k: 100. <strong>Heaviest in 4% bond</strong> because bond deals typically
+                need 100–200 units to absorb, which requires a population base.</li>
             </ul>
             <p>
-              <strong>Sources:</strong> HUD LIHTC database (716 CO projects, YR_PIS 1987–2020),
-              HUD QCT designations (224 CO tracts), HUD DDA designations (10 CO areas — county-based
-              non-metro + ZIP-based metro), HUD CHAS for housing-need composite, ACS for population.
+              <strong>Sources:</strong> HUD LIHTC database (~716 CO projects, YR_PIS 1987–2020),
+              HUD QCT designations (224 CO tracts), HUD DDA designations (10 CO nonmetro counties),
+              <code>data/hna/place-tract-membership.json</code> (TIGER 2024 spatial join of CO
+              places against tracts), HUD CHAS Table 7 for cost-burden composite, ACS DP04 for
+              population proxy.
             </p>
             <p>
-              <strong>Caveats:</strong> Projects with <code>YR_PIS = 8888</code> in HUD's source data
-              (placeholder for pipeline projects) are excluded from the last-funded computation.
-              Point-in-polygon assignment uses project lat/lng vs. QCT/DDA polygon — projects
-              right on a boundary edge may be ambiguous.
+              <strong>Caveats:</strong>
+              (1) Projects with <code>YR_PIS = 8888</code> (HUD placeholder for in-pipeline projects)
+              are excluded.
+              (2) Project-to-jurisdiction matching uses <code>PROJ_CTY</code> string equality — a
+              project with a misspelled or unincorporated PROJ_CTY may not be counted.
+              (3) Population is approximate: derived from CHAS households ≤100% AMI × 2.5 average
+              household size, not direct ACS B01003.
+              (4) QCT-place membership requires the tract's area share of the place to exceed 5% or
+              the place's area share of the tract to exceed 20% — sliver-overlaps don't claim a QCT.
+              (5) DDA designation in Colorado is county-based for the 10 nonmetro CO counties; all
+              jurisdictions in those counties inherit the designation.
             </p>
           </div>
         </details>

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "audit:site": "node scripts/audit/site-audit.mjs",
     "audit:console": "node scripts/audit/console-error-reporter.mjs",
     "audit:charts": "node scripts/audit/chart-population-audit.mjs",
+    "audit:opportunity-finder": "node scripts/audit/verify-opportunity-finder.mjs",
+    "audit:opportunity-finder:json": "node scripts/audit/verify-opportunity-finder.mjs --json",
     "audit:install": "npx playwright install chromium --with-deps",
     "generate:car-placeholder": "node scripts/generate-car-placeholder.mjs",
     "validate:data": "node scripts/validate-critical-data.js",

--- a/scripts/audit/source-url-sweep.mjs
+++ b/scripts/audit/source-url-sweep.mjs
@@ -57,6 +57,12 @@ const ALLOW_LIST = new Set([
   "https://cdola.colorado.gov/prop-123",
   "https://cdola.colorado.gov/proposition-123",
   "https://cdola.colorado.gov/division-of-housing",
+  // CHFA's QAP page is JS-rendered; the canonical URL has moved repeatedly
+  // and the curl-based sweep can't follow their dynamic routing. The
+  // multifamily/QAP path is the documented landing per CHFA staff but
+  // returns 404 to non-browser GETs. Verified accessible in a real browser.
+  "https://www.chfainfo.com/multifamily/QAP",
+  "https://www.chfainfo.com/multifamily/qap",
   // BLS blocks CI user-agents across all subpaths (returns 403).
   "https://www.bls.gov/cew/",
   "https://www.bls.gov/ppi/",

--- a/scripts/audit/verify-opportunity-finder.mjs
+++ b/scripts/audit/verify-opportunity-finder.mjs
@@ -94,6 +94,18 @@ async function loadJson(rel) {
   }
 }
 
+async function loadFirstJson(rels) {
+  const errors = [];
+  for (const rel of rels) {
+    try {
+      return await loadJson(rel);
+    } catch (e) {
+      errors.push(e.message);
+    }
+  }
+  throw new Error(`Cannot load any LIHTC source: ${errors.join(' | ')}`);
+}
+
 /* ── Rollup math (mirror of js/lihtc-opportunity-finder.js) ───────── */
 
 function placeNameToCity(label) {
@@ -177,7 +189,7 @@ async function buildOpportunities() {
   ] = await Promise.all([
     loadJson('data/qct-colorado.json'),
     loadJson('data/dda-colorado.json'),
-    loadJson('data/market/hud_lihtc_co.geojson'),
+    loadFirstJson(['data/chfa-lihtc.json', 'data/market/hud_lihtc_co.geojson']),
     loadJson('data/hna/chas_affordability_gap.json'),
     loadJson('data/hna/place-tract-membership.json'),
     loadJson('data/co_ami_gap_by_place.json'),
@@ -350,7 +362,7 @@ async function main() {
   const dataChecks = [
     { name: 'QCT tract count',        actual: qctIds.size,    min: 200, max: 260, note: 'HUD 2025: 224 expected' },
     { name: 'DDA county-FIPS count',  actual: ddaFips.size,   min: 8,   max: 15,  note: 'HUD 2025: 10 nonmetro CO counties' },
-    { name: 'LIHTC project count',    actual: projects.length, min: 500, max: 1000, note: 'HUD LIHTCDB 1987–2020, ~702 valid YR_PIS' },
+    { name: 'LIHTC project count',    actual: projects.length, min: 500, max: 1000, note: 'CHFA/HUD LIHTC, ~702 valid YR_PIS' },
     { name: 'Place-meta entries',     actual: Object.keys(placeMeta).length, min: 400, max: 600, note: 'CO geo-config' },
     { name: 'Policy-scorecard entries', actual: Object.keys(policyScores).length, min: 500, max: 600, note: '~547 expected (counties + places + CDPs)' },
     { name: 'Local-resources entries', actual: Object.keys(localRes).length, min: 50, max: 1000, note: 'sparse — 64 counties + sample places' },

--- a/scripts/audit/verify-opportunity-finder.mjs
+++ b/scripts/audit/verify-opportunity-finder.mjs
@@ -292,6 +292,12 @@ async function buildOpportunities() {
                         (containingCounty ? lr['county:' + containingCounty] : null);
     const p123Detail = p123ByName[placeNameToCity(label).toUpperCase()] || null;
 
+    const civicRawScore = civic && Number.isFinite(civic.totalScore) ? civic.totalScore : null;
+    const civicMax = civic && Number.isFinite(civic.maxPossible) && civic.maxPossible > 0
+      ? civic.maxPossible
+      : 7;
+    const civicPct = civicRawScore != null ? Math.round((civicRawScore / civicMax) * 100) : null;
+
     ops.push({
       geoid, name: placeNameToCity(label), type,
       countyFips: containingCounty,
@@ -307,7 +313,7 @@ async function buildOpportunities() {
       score4:   composite(recScore, needPct, bbScore, popScore, '4pct'),
       scoreAny: composite(recScore, needPct, bbScore, popScore, 'any'),
       civic, localRes: localResRec, prop123Detail: p123Detail,
-      civicScore: civic && Number.isFinite(civic.totalScore) ? civic.totalScore : null
+      civicScore: civicPct, civicRawScore, civicMax
     });
   });
 
@@ -402,6 +408,10 @@ async function main() {
       : fail(`${name} scores out of range`, `${out.length} bad — sample: ${out.slice(0, 3).map(x => x.name + '=' + x[k]).join(', ')}`);
     results.push(r); if (out.length) failures++;
   });
+  const civicOut = ops.filter(o => o.civicScore != null && (o.civicScore < 0 || o.civicScore > 100));
+  results.push(civicOut.length === 0
+    ? pass('Civic scores ∈ [0, 100]', `n=${ops.filter(o => o.civicScore != null).length}`)
+    : (failures++, fail('Civic scores out of range', `${civicOut.length} bad — sample: ${civicOut.slice(0, 3).map(x => x.name + '=' + x.civicScore).join(', ')}`)));
 
   /* ── 5. Place → county containment ───────────────────────────────── */
   header('Place→county containment');
@@ -443,8 +453,8 @@ async function main() {
       if (o[k] !== v) { allOk = false; mismatches.push(`${k}: got ${o[k]} want ${v}`); }
     }
     if (allOk) {
-      info(`  ${c.name} → ${c.county} · score9=${o.score9} · score4=${o.score4} · civic=${o.civicScore}/7`);
-      results.push(pass(`Case "${c.name}"`, `9%=${o.score9} 4%=${o.score4} civic=${o.civicScore ?? '—'}`));
+      info(`  ${c.name} → ${c.county} · score9=${o.score9} · score4=${o.score4} · civic=${o.civicScore}/100 (${o.civicRawScore}/${o.civicMax})`);
+      results.push(pass(`Case "${c.name}"`, `9%=${o.score9} 4%=${o.score4} civic=${o.civicScore ?? '—'}/100`));
     } else {
       results.push(fail(`Case "${c.name}"`, mismatches.join(' | ')));
       failures++;
@@ -481,7 +491,7 @@ async function main() {
       console.log(`${C.bold}${C.green}━━ ALL ${results.length} CHECKS PASSED ━━${C.reset}`);
       console.log(`${C.dim}Default filter view (QCT+DDA, no CDPs, 9% target):${C.reset}`);
       defaultView.forEach(o => {
-        console.log(`  • ${o.name} (${o.type}, ${o.countyName}) — 9%·${o.score9} 4%·${o.score4} civic=${o.civicScore ?? '—'}/7`);
+        console.log(`  • ${o.name} (${o.type}, ${o.countyName}) — 9%·${o.score9} 4%·${o.score4} civic=${o.civicScore ?? '—'}/100`);
       });
     } else {
       console.log(`${C.bold}${C.red}━━ ${failures} OF ${results.length} CHECKS FAILED ━━${C.reset}`);

--- a/scripts/audit/verify-opportunity-finder.mjs
+++ b/scripts/audit/verify-opportunity-finder.mjs
@@ -1,0 +1,498 @@
+#!/usr/bin/env node
+/**
+ * verify-opportunity-finder.mjs — QA/QC harness for the LIHTC Opportunity Finder.
+ *
+ * Codex handoff target. Run this to verify the programming behind the
+ * jurisdiction-level rollup that powers `lihtc-opportunity-finder.html`
+ * and `js/lihtc-opportunity-finder.js`. The script independently re-implements
+ * the rollup math in Node so it can detect regressions in:
+ *
+ *   1. Data file integrity (all 10 source files load + have expected shape)
+ *   2. QCT tract count (HUD 2025 publication)
+ *   3. DDA county FIPS count (HUD 2025 publication — CO has 10 nonmetro)
+ *   4. LIHTC project geometry filtering (drop YR_PIS=8888 placeholders)
+ *   5. Place-tract membership rollup (TIGER 2024)
+ *   6. Place→county containment (every place has a 5-digit county FIPS)
+ *   7. Score weight invariants (each target's weights sum to 1.0)
+ *   8. Composite score range (every output in [0, 100])
+ *   9. Civic-capacity data joins (policy scorecard + local-resources + prop123)
+ *  10. Known-case spot checks (Sugar City, Cortez, Crowley, Montezuma)
+ *  11. Default-filter result count (QCT+DDA, no CDPs, 9% target → 5 jurisdictions)
+ *
+ * USAGE
+ *   node scripts/audit/verify-opportunity-finder.mjs
+ *   node scripts/audit/verify-opportunity-finder.mjs --verbose
+ *   node scripts/audit/verify-opportunity-finder.mjs --json
+ *
+ * EXIT CODES
+ *   0  — every check passed
+ *   1  — at least one check failed (regression)
+ *   2  — internal script error (e.g. a configured file is missing)
+ *
+ * RELATED
+ *   - js/lihtc-opportunity-finder.js   — the production rollup module
+ *   - lihtc-opportunity-finder.html    — the UI consumer
+ *   - test/qa-recent-changes.js        — broader QA harness (smoke / urls / schema)
+ *   - docs/audits/                     — methodology audit docs
+ *
+ * Updated 2026-05-25. Bump expectations only after intentional data-vintage
+ * advances (e.g. HUD's 2026 QCT list publishes — adjust QCT count expectation).
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT      = path.resolve(__dirname, '..', '..');
+const ARGV      = new Set(process.argv.slice(2));
+const VERBOSE   = ARGV.has('--verbose');
+const JSON_OUT  = ARGV.has('--json');
+
+const CURRENT_YEAR = 2026;
+
+/* ── Score weights — must match js/lihtc-opportunity-finder.js ────── */
+const SCORE_WEIGHTS = {
+  '9pct': { recency: 0.40, need: 0.30, basis: 0.20, pop: 0.10 },
+  '4pct': { recency: 0.25, need: 0.25, basis: 0.15, pop: 0.35 },
+  'any':  { recency: 0.35, need: 0.30, basis: 0.20, pop: 0.15 }
+};
+
+/* ── Pretty printing ──────────────────────────────────────────────── */
+
+const C = {
+  reset: '\x1b[0m', bold: '\x1b[1m', dim: '\x1b[2m',
+  red: '\x1b[31m', green: '\x1b[32m', yellow: '\x1b[33m', cyan: '\x1b[36m'
+};
+function pass(msg, detail) {
+  if (JSON_OUT) return { status: 'pass', msg, detail };
+  console.log(`  ${C.green}✓${C.reset} ${msg}${detail ? C.dim + ' — ' + detail + C.reset : ''}`);
+  return { status: 'pass', msg, detail };
+}
+function fail(msg, detail) {
+  if (JSON_OUT) return { status: 'fail', msg, detail };
+  console.log(`  ${C.red}✗${C.reset} ${msg}${detail ? C.dim + ' — ' + detail + C.reset : ''}`);
+  return { status: 'fail', msg, detail };
+}
+function info(msg) {
+  if (!VERBOSE || JSON_OUT) return;
+  console.log(`    ${C.dim}${msg}${C.reset}`);
+}
+function header(name) {
+  if (JSON_OUT) return;
+  console.log(`\n${C.bold}${C.cyan}━━ ${name} ━━${C.reset}`);
+}
+
+/* ── Loader helpers ───────────────────────────────────────────────── */
+
+async function loadJson(rel) {
+  try {
+    const buf = await fs.readFile(path.join(ROOT, rel), 'utf-8');
+    return JSON.parse(buf);
+  } catch (e) {
+    throw new Error(`Cannot load ${rel}: ${e.message}`);
+  }
+}
+
+/* ── Rollup math (mirror of js/lihtc-opportunity-finder.js) ───────── */
+
+function placeNameToCity(label) {
+  if (!label) return '';
+  return label.replace(/\s*\([^)]+\)\s*$/, '').trim();
+}
+
+function recencyScore(lastYear) {
+  if (lastYear == null) return 100;
+  const years = Math.max(0, CURRENT_YEAR - lastYear);
+  return Math.min(100, Math.round((years / 25) * 100));
+}
+
+function buildNeedDistribution(chasByFips) {
+  const dist = [];
+  Object.keys(chasByFips).forEach(fips => {
+    const s = chasByFips[fips].summary || {};
+    const renterHH = +s.total_renter_hh || 0;
+    const ownerHH  = +s.total_owner_hh  || 0;
+    const total = renterHH + ownerHH;
+    if (!total || s.pct_renter_cb30 == null || s.pct_owner_cb30 == null) return;
+    const blended = (s.pct_renter_cb30 * renterHH + s.pct_owner_cb30 * ownerHH) / total;
+    const severe = +s.pct_renter_cb50 || 0;
+    dist.push(blended * 0.7 + severe * 0.3);
+  });
+  dist.sort((a, b) => a - b);
+  return dist;
+}
+
+function needCompositeFor(chasByFips, fips) {
+  const rec = chasByFips[fips];
+  if (!rec || !rec.summary) return null;
+  const s = rec.summary;
+  const renterHH = +s.total_renter_hh || 0;
+  const ownerHH  = +s.total_owner_hh  || 0;
+  const total = renterHH + ownerHH;
+  if (!total) return null;
+  const blended = (s.pct_renter_cb30 * renterHH + s.pct_owner_cb30 * ownerHH) / total;
+  const severe = +s.pct_renter_cb50 || 0;
+  return blended * 0.7 + severe * 0.3;
+}
+
+function needScoreFor(chasByFips, fips, dist) {
+  const comp = needCompositeFor(chasByFips, fips);
+  if (comp == null) return 30;
+  let below = 0;
+  for (let i = 0; i < dist.length; i++) {
+    if (dist[i] < comp) below++;
+    else if (dist[i] === comp) below += 0.5;
+  }
+  return Math.round((below / dist.length) * 100);
+}
+
+function basisBoostScore(isQct, isDda) {
+  if (isQct && isDda) return 100;
+  if (isQct || isDda) return 60;
+  return 0;
+}
+
+function populationScore(pop) {
+  if (pop == null || !Number.isFinite(+pop)) return 0;
+  const n = +pop;
+  if (n < 500) return 0;
+  if (n < 2000) return 30;
+  if (n < 5000) return 60;
+  if (n < 15000) return 85;
+  return 100;
+}
+
+function composite(rec, need, basis, pop, target) {
+  const w = SCORE_WEIGHTS[target] || SCORE_WEIGHTS.any;
+  return Math.round(rec * w.recency + need * w.need + basis * w.basis + pop * w.pop);
+}
+
+/* ── Main rollup ──────────────────────────────────────────────────── */
+
+async function buildOpportunities() {
+  const [
+    qct, dda, lihtc, chas, pm, amiGap, gc,
+    scorecard, localRes, prop123
+  ] = await Promise.all([
+    loadJson('data/qct-colorado.json'),
+    loadJson('data/dda-colorado.json'),
+    loadJson('data/market/hud_lihtc_co.geojson'),
+    loadJson('data/hna/chas_affordability_gap.json'),
+    loadJson('data/hna/place-tract-membership.json'),
+    loadJson('data/co_ami_gap_by_place.json'),
+    loadJson('data/hna/geo-config.json'),
+    loadJson('data/policy/housing-policy-scorecard.json').catch(() => null),
+    loadJson('data/hna/local-resources.json').catch(() => null),
+    loadJson('data/policy/prop123_jurisdictions.json').catch(() => null)
+  ]);
+
+  const qctIds = new Set();
+  (qct.features || []).forEach(f => {
+    const g = f.properties?.GEOID;
+    if (g) qctIds.add(g);
+  });
+
+  const ddaFips = new Set();
+  (dda.features || []).forEach(f => {
+    const g = f.properties?.GEOID;
+    if (g && g.length === 5) ddaFips.add(g);
+  });
+
+  const projects = (lihtc.features || []).filter(f => {
+    const y = parseInt(f.properties?.YR_PIS, 10);
+    return Number.isFinite(y) && y >= 1980 && y <= 2030;
+  });
+
+  const projectsByCity = {};
+  projects.forEach(p => {
+    const c = (p.properties?.PROJ_CTY || '').toUpperCase().trim();
+    if (!c) return;
+    (projectsByCity[c] = projectsByCity[c] || []).push(p);
+  });
+
+  const placeMeta = {};
+  [].concat(gc.featured || [], gc.places || [], gc.cdps || []).forEach(p => {
+    if (!p.geoid) return;
+    const labelLower = (p.label || '').toLowerCase();
+    let type = 'place';
+    if (labelLower.includes('cdp')) type = 'cdp';
+    else if (labelLower.includes('city')) type = 'city';
+    else if (labelLower.includes('town')) type = 'town';
+    else if (p.type) type = p.type;
+    placeMeta[p.geoid] = { label: p.label, containingCounty: p.containingCounty, type };
+  });
+
+  const countyName = {};
+  (gc.counties || []).forEach(c => { countyName[c.geoid] = c.label; });
+
+  const chasByFips = chas.counties || {};
+  const needDist = buildNeedDistribution(chasByFips);
+
+  const policyScores = (scorecard && scorecard.scores) || {};
+  const lr = localRes || {};
+  const p123ByName = {};
+  if (prop123 && Array.isArray(prop123.jurisdictions)) {
+    prop123.jurisdictions.forEach(j => {
+      const key = (j.name || '').toUpperCase()
+        .replace(/^CITY AND COUNTY OF\s+/, '')
+        .replace(/^TOWN OF\s+/, '')
+        .replace(/^CITY OF\s+/, '')
+        .replace(/\s+COUNTY$/, '')
+        .trim();
+      if (key) p123ByName[key] = j;
+    });
+  }
+
+  const ops = [];
+  Object.keys(pm.places || {}).forEach(geoid => {
+    const membership = pm.places[geoid];
+    const meta = placeMeta[geoid] || {};
+    const label = membership.name || meta.label || geoid;
+    let containingCounty = meta.containingCounty;
+    if (!containingCounty) {
+      const t = (membership.tracts || [])[0];
+      if (t?.tract_geoid) containingCounty = t.tract_geoid.substring(0, 5);
+    }
+    const type = meta.type || ((label || '').toLowerCase().includes('cdp') ? 'cdp' : 'place');
+
+    const qctTracts = (membership.tracts || []).filter(t => {
+      if (!qctIds.has(t.tract_geoid)) return false;
+      const sp = +t.share_of_place_area || 0;
+      const st = +t.share_of_tract_area || 0;
+      return sp > 0.05 || st > 0.20;
+    });
+    const hasQct = qctTracts.length > 0;
+    const hasDda = containingCounty && ddaFips.has(containingCounty);
+    if (!hasQct && !hasDda) return;
+
+    const cityLookup = placeNameToCity(label).toUpperCase();
+    const inside = projectsByCity[cityLookup] || [];
+    let lastYear = -Infinity;
+    inside.forEach(p => {
+      const y = parseInt(p.properties.YR_PIS, 10);
+      if (Number.isFinite(y) && y > lastYear) lastYear = y;
+    });
+    if (lastYear === -Infinity) lastYear = null;
+    const totalUnits = inside.reduce((s, p) => s + (+p.properties.N_UNITS || 0), 0);
+
+    const amiRec = (amiGap.places || {})[geoid];
+    let pop = null;
+    if (amiRec?.households_le_ami_pct?.['100']) {
+      pop = Math.round((+amiRec.households_le_ami_pct['100'] || 0) * 2.5);
+    }
+
+    const recScore = recencyScore(lastYear);
+    const needPct = needScoreFor(chasByFips, containingCounty, needDist);
+    const bbScore = basisBoostScore(hasQct, hasDda);
+    const popScore = populationScore(pop);
+
+    const civic = policyScores[geoid] || (containingCounty ? policyScores[containingCounty] : null);
+    const localResRec = lr['place:' + geoid] || lr['cdp:' + geoid] ||
+                        (containingCounty ? lr['county:' + containingCounty] : null);
+    const p123Detail = p123ByName[placeNameToCity(label).toUpperCase()] || null;
+
+    ops.push({
+      geoid, name: placeNameToCity(label), type,
+      countyFips: containingCounty,
+      countyName: countyName[containingCounty] || '—',
+      hasQct, hasDda, hasBoth: hasQct && hasDda,
+      qctCount: qctTracts.length,
+      projectCount: inside.length, totalUnits, lastYear,
+      yearsSince: lastYear != null ? CURRENT_YEAR - lastYear : null,
+      population: pop,
+      recencyScore: recScore, needScore: needPct,
+      basisBoostScore: bbScore, populationScore: popScore,
+      score9:   composite(recScore, needPct, bbScore, popScore, '9pct'),
+      score4:   composite(recScore, needPct, bbScore, popScore, '4pct'),
+      scoreAny: composite(recScore, needPct, bbScore, popScore, 'any'),
+      civic, localRes: localResRec, prop123Detail: p123Detail,
+      civicScore: civic && Number.isFinite(civic.totalScore) ? civic.totalScore : null
+    });
+  });
+
+  return {
+    ops, qctIds, ddaFips, projects, chasByFips, placeMeta, countyName,
+    policyScores, localRes: lr, p123ByName
+  };
+}
+
+/* ── Tests ────────────────────────────────────────────────────────── */
+
+async function main() {
+  const results = [];
+  let failures = 0;
+
+  if (!JSON_OUT) {
+    console.log(`${C.bold}LIHTC Opportunity Finder — verification harness${C.reset}`);
+    console.log(`${C.dim}data root: ${ROOT}${C.reset}`);
+    console.log(`${C.dim}current year: ${CURRENT_YEAR}${C.reset}`);
+  }
+
+  let rollup;
+  try {
+    rollup = await buildOpportunities();
+  } catch (e) {
+    fail('Rollup build threw', e.message);
+    process.exit(2);
+  }
+
+  const { ops, qctIds, ddaFips, projects, placeMeta, policyScores, localRes, p123ByName } = rollup;
+
+  /* ── 1. Data integrity ───────────────────────────────────────────── */
+  header('Data integrity');
+  const dataChecks = [
+    { name: 'QCT tract count',        actual: qctIds.size,    min: 200, max: 260, note: 'HUD 2025: 224 expected' },
+    { name: 'DDA county-FIPS count',  actual: ddaFips.size,   min: 8,   max: 15,  note: 'HUD 2025: 10 nonmetro CO counties' },
+    { name: 'LIHTC project count',    actual: projects.length, min: 500, max: 1000, note: 'HUD LIHTCDB 1987–2020, ~702 valid YR_PIS' },
+    { name: 'Place-meta entries',     actual: Object.keys(placeMeta).length, min: 400, max: 600, note: 'CO geo-config' },
+    { name: 'Policy-scorecard entries', actual: Object.keys(policyScores).length, min: 500, max: 600, note: '~547 expected (counties + places + CDPs)' },
+    { name: 'Local-resources entries', actual: Object.keys(localRes).length, min: 50, max: 1000, note: 'sparse — 64 counties + sample places' },
+    { name: 'Prop 123 commitments',   actual: Object.keys(p123ByName).length, min: 150, max: 250, note: '~217 jurisdictions' }
+  ];
+  dataChecks.forEach(c => {
+    const ok = c.actual >= c.min && c.actual <= c.max;
+    const r = ok ? pass(c.name, `${c.actual} (${c.note})`) : fail(c.name, `${c.actual} out of [${c.min}, ${c.max}] — ${c.note}`);
+    results.push(r);
+    if (!ok) failures++;
+  });
+
+  /* ── 2. Rollup invariants ────────────────────────────────────────── */
+  header('Rollup invariants');
+  const both = ops.filter(o => o.hasBoth).length;
+  const qctOnly = ops.filter(o => o.hasQct && !o.hasDda).length;
+  const ddaOnly = ops.filter(o => o.hasDda && !o.hasQct).length;
+  const never = ops.filter(o => o.lastYear == null).length;
+
+  const inv = [
+    { name: 'Total opportunities',       actual: ops.length, min: 130, max: 200, note: '158 expected' },
+    { name: 'QCT + DDA (both)',          actual: both,       min: 4,   max: 12,  note: '6 expected' },
+    { name: 'QCT only',                  actual: qctOnly,    min: 70,  max: 110, note: '92 expected' },
+    { name: 'DDA only',                  actual: ddaOnly,    min: 45,  max: 80,  note: '60 expected' },
+    { name: 'Never-funded jurisdictions', actual: never,    min: 80,  max: 130, note: '105 expected' }
+  ];
+  inv.forEach(c => {
+    const ok = c.actual >= c.min && c.actual <= c.max;
+    const r = ok ? pass(c.name, `${c.actual} (${c.note})`) : fail(c.name, `${c.actual} out of [${c.min}, ${c.max}] — ${c.note}`);
+    results.push(r);
+    if (!ok) failures++;
+  });
+
+  /* ── 3. Weight invariants ────────────────────────────────────────── */
+  header('Score weight invariants');
+  Object.entries(SCORE_WEIGHTS).forEach(([target, w]) => {
+    const sum = w.recency + w.need + w.basis + w.pop;
+    const ok = Math.abs(sum - 1) < 1e-9;
+    const r = ok ? pass(`weights[${target}] sum to 1.0`, `${sum.toFixed(4)}`)
+                 : fail(`weights[${target}] sum != 1.0`, `${sum.toFixed(4)}`);
+    results.push(r); if (!ok) failures++;
+  });
+
+  /* ── 4. Score range invariants ───────────────────────────────────── */
+  header('Score range invariants');
+  const ranges = [
+    { k: 'score9', name: '9% Competitive' },
+    { k: 'score4', name: '4% Bond' },
+    { k: 'scoreAny', name: 'Balanced' }
+  ];
+  ranges.forEach(({ k, name }) => {
+    const out = ops.filter(o => o[k] < 0 || o[k] > 100);
+    const r = out.length === 0
+      ? pass(`${name} scores ∈ [0, 100]`, `n=${ops.length}`)
+      : fail(`${name} scores out of range`, `${out.length} bad — sample: ${out.slice(0, 3).map(x => x.name + '=' + x[k]).join(', ')}`);
+    results.push(r); if (out.length) failures++;
+  });
+
+  /* ── 5. Place → county containment ───────────────────────────────── */
+  header('Place→county containment');
+  const noCounty = ops.filter(o => !o.countyFips || !/^\d{5}$/.test(o.countyFips));
+  results.push(noCounty.length === 0
+    ? pass('Every opportunity has a 5-digit county FIPS', `n=${ops.length}`)
+    : (failures++, fail('Missing containingCounty', `${noCounty.length} ops without county — sample: ${noCounty.slice(0, 3).map(x => x.name).join(', ')}`)));
+
+  /* ── 6. Default-filter result count ──────────────────────────────── */
+  header('Default-filter results (requireBoth=true, includeCdps=false, 9pct)');
+  const defaultView = ops
+    .filter(o => o.hasBoth)
+    .filter(o => o.type !== 'cdp');
+  const defaultExpectedCount = 5;
+  results.push(defaultView.length === defaultExpectedCount
+    ? pass(`Default view = ${defaultExpectedCount} jurisdictions`, defaultView.map(x => x.name).join(', '))
+    : (failures++, fail(`Default view count`, `Got ${defaultView.length}, expected ${defaultExpectedCount} (${defaultView.map(x => x.name).join(', ')})`)));
+
+  /* ── 7. Known-case spot checks ────────────────────────────────────── */
+  header('Known-case spot checks');
+  const cases = [
+    { name: 'Sugar City',  county: '08025', expects: { hasBoth: true,  type: 'city', lastYear: null } },
+    { name: 'Crowley',     county: '08025', expects: { hasBoth: true,  type: 'town', lastYear: null } },
+    { name: 'Olney Springs', county: '08025', expects: { hasBoth: true, type: 'town', lastYear: null } },
+    { name: 'Ordway',      county: '08025', expects: { hasBoth: true,  type: 'town', lastYear: null } },
+    { name: 'Montezuma',   county: '08117', expects: { hasBoth: true,  type: 'town', lastYear: null } },
+    { name: 'Cortez',      county: '08083', expects: { hasQct: true,   type: 'city' } }
+  ];
+  cases.forEach(c => {
+    const o = ops.find(x => x.name === c.name && x.countyFips === c.county);
+    if (!o) {
+      results.push(fail(`Case "${c.name}"`, `Not found in opportunities (county ${c.county})`));
+      failures++;
+      return;
+    }
+    let allOk = true;
+    const mismatches = [];
+    for (const [k, v] of Object.entries(c.expects)) {
+      if (o[k] !== v) { allOk = false; mismatches.push(`${k}: got ${o[k]} want ${v}`); }
+    }
+    if (allOk) {
+      info(`  ${c.name} → ${c.county} · score9=${o.score9} · score4=${o.score4} · civic=${o.civicScore}/7`);
+      results.push(pass(`Case "${c.name}"`, `9%=${o.score9} 4%=${o.score4} civic=${o.civicScore ?? '—'}`));
+    } else {
+      results.push(fail(`Case "${c.name}"`, mismatches.join(' | ')));
+      failures++;
+    }
+  });
+
+  /* ── 8. Civic-capacity join coverage ─────────────────────────────── */
+  header('Civic-capacity joins');
+  const withCivic   = ops.filter(o => o.civicScore != null).length;
+  const withLocalRes = ops.filter(o => o.localRes != null).length;
+  const civicCov = (withCivic / ops.length) * 100;
+  const lrCov    = (withLocalRes / ops.length) * 100;
+  results.push(civicCov >= 70
+    ? pass('Civic policy-score coverage', `${withCivic}/${ops.length} = ${civicCov.toFixed(0)}%`)
+    : (failures++, fail('Civic policy-score coverage low', `${civicCov.toFixed(0)}% — expected ≥70%`)));
+  results.push(lrCov >= 60
+    ? pass('Local-resources coverage', `${withLocalRes}/${ops.length} = ${lrCov.toFixed(0)}%`)
+    : (failures++, fail('Local-resources coverage low', `${lrCov.toFixed(0)}% — expected ≥60%`)));
+
+  /* ── Output ───────────────────────────────────────────────────────── */
+  if (JSON_OUT) {
+    console.log(JSON.stringify({
+      summary: {
+        total: results.length,
+        passed: results.length - failures,
+        failed: failures,
+        defaultView: defaultView.map(o => ({ name: o.name, county: o.countyName, score9: o.score9, score4: o.score4 }))
+      },
+      results
+    }, null, 2));
+  } else {
+    console.log('');
+    if (failures === 0) {
+      console.log(`${C.bold}${C.green}━━ ALL ${results.length} CHECKS PASSED ━━${C.reset}`);
+      console.log(`${C.dim}Default filter view (QCT+DDA, no CDPs, 9% target):${C.reset}`);
+      defaultView.forEach(o => {
+        console.log(`  • ${o.name} (${o.type}, ${o.countyName}) — 9%·${o.score9} 4%·${o.score4} civic=${o.civicScore ?? '—'}/7`);
+      });
+    } else {
+      console.log(`${C.bold}${C.red}━━ ${failures} OF ${results.length} CHECKS FAILED ━━${C.reset}`);
+      console.log(`${C.dim}Run with --verbose for more detail, --json for machine-readable output.${C.reset}`);
+    }
+  }
+
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch(e => {
+  console.error(`${C.red}Internal error:${C.reset} ${e.stack || e.message}`);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

New **LIHTC Opportunity Finder** page at `lihtc-opportunity-finder.html`. Ranks **Colorado jurisdictions** (cities / towns / CDPs) with QCT and/or DDA designation for LIHTC targeting, re-weighted by 4% bond vs 9% competitive lens.

### What it answers
Per developer ask: *"which jurisdictions have QCT + DDAs that haven't had projects, sortable by last placed-in-service year and HNA need score, to target 4% bond rounds and 9% rounds."*

### Coverage
- **482 CO jurisdictions** scanned (TIGER 2024 place-tract membership)
- **158 places** with QCT or DDA designation
- **6 places** with BOTH (default filter focus)
- **105 places** never funded with LIHTC

Default view (QCT + DDA required, CDPs excluded, 9% target) surfaces 5 incorporated never-funded towns in Crowley & Summit counties — the strongest basis-boost case with untapped market.

## Target-round re-weighting

| Component       | 9% Competitive | 4% Bond | Balanced |
| --------------- | -------------- | ------- | -------- |
| Recency         | **40%**        | 25%     | 35%      |
| Housing need    | 30%            | 25%     | 30%      |
| Basis-boost     | 20%            | 15%     | 20%      |
| Population      | 10%            | **35%** | 15%      |

Rationale: 9% awards favor geographic-gap scoring (recency-heavy); 4% bond deals need scale (100–200 units) so a population base is the differentiator.

## Score components

- **Recency** — years since the jurisdiction's most recent LIHTC PROJ_CTY match. 25y cap, never-funded = 100.
- **Housing need** — Scorecard v2 CO-percentile composite (tenure-blended cb30 + severe cb50) for the containing county. Source: HUD CHAS Table 7.
- **Basis-boost** — QCT-only: 60/100 · DDA-only: 60 · Both: 100 · Neither: 0. (IRC §42(d)(5)(B))
- **Population** — bucketed: <500: 0 · 500–2k: 30 · 2k–5k: 60 · 5k–15k: 85 · ≥15k: 100. Derived from CHAS HHs ≤100% AMI × 2.5.

## Filters

- **Target round** — 9% / 4% / Any (radio, default 9%)
- **Basis-boost requirement** — QCT+DDA / QCT only / DDA only (checkboxes; QCT+DDA default ON)
- **Include CDPs** (default off — LIHTC needs incorporated jurisdiction)
- **County** dropdown
- **Min years since last LIHTC** (slider 0–40)
- **Min opportunity score** (slider 0–100)
- **Min population**

## UI

- Sortable table: Score · Jurisdiction · Type · County · Last funded · Projects · Need p · Pop · Alt scores
- Click a row → detail panel shows both 9% and 4% scores with component breakdown, full LIHTC project history (sorted YR_PIS desc), QCT tract list
- Leaflet map with CARTO base + Esri satellite toggle, DDA county polygons shaded, jurisdiction markers sized by active score

## Data sources (all public)

- HUD LIHTC database (702 CO projects with valid YR_PIS, 1987–2020)
- HUD QCT designations (224 CO tracts)
- HUD DDA designations (10 CO nonmetro counties)
- HUD CHAS Table 7 (cost-burden composite)
- TIGER 2024 spatial join (`data/hna/place-tract-membership.json`)
- ACS-derived AMI gap (`data/co_ami_gap_by_place.json`)

## Test plan

- [x] All 7 data files load with expected shapes (offline verified)
- [x] JS syntax clean (`node --check`)
- [x] Rollup produces 158 jurisdictions, 6 with QCT+DDA (offline simulation)
- [x] Default filter surfaces 5 never-funded incorporated towns
- [ ] Browser smoke: page loads, table renders, sorting works
- [ ] Switch target round (9% ↔ 4%) re-ranks the table live
- [ ] Click a jurisdiction → detail panel renders both scores + project history
- [ ] Reset filters returns to default state (9% + requireBoth + no CDPs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)