### PR TITLE
[codex] Fix workflow deep links and LIHTC validation

### DIFF
--- a/deal-calculator.html
+++ b/deal-calculator.html
@@ -34,6 +34,7 @@
   <script defer src="js/mobile-menu.js"></script>
   <!-- Toast notifications (must load before component scripts) -->
   <script defer src="js/components/toast.js"></script>
+  <script defer src="js/components/jurisdiction-url-context.js"></script>
   <script defer src="js/components/next-action-cta.js" data-next-action-auto="true" data-from-page="deal"></script>
   <!-- Centralized financial constants (must load before deal-calculator.js) -->
   <script defer src="js/config/financial-constants.js"></script>
@@ -712,6 +713,16 @@
       var cityName   = null;
 
       try {
+        var ctx = window.JurisdictionUrlContext &&
+          window.JurisdictionUrlContext.resolveSync &&
+          window.JurisdictionUrlContext.resolveSync();
+        if (ctx) {
+          countyName = ctx.countyName || null;
+          cityName = ctx.geoType === 'county' ? null : (ctx.displayName || null);
+        }
+      } catch (_) {}
+
+      try {
         var proj = window.WorkflowState && window.WorkflowState.getActiveProject();
         var jx = proj && (proj.jurisdiction || (proj.steps && proj.steps.jurisdiction));
         if (jx) {
@@ -888,6 +899,7 @@
     /* ── Init ────────────────────────────────────────────────────────── */
     function init() {
       updateJurisdictionBanner();
+      document.addEventListener('jurisdiction-url-context:resolved', updateJurisdictionBanner);
       populateCraGrid();
       wireSaveExport();
       // Fix #2: update progress bar step completion from WorkflowState

--- a/docs/DATA-SOURCES.md
+++ b/docs/DATA-SOURCES.md
@@ -39,7 +39,7 @@ All API keys and credentials are stored as **GitHub Actions Secrets** (Settings 
 
 | File | Size | Source | CI Workflow | Schedule | Local Creation Working? | Notes |
 |---|---|---|---|---|---|---|
-| `data/chfa-lihtc.json` | ~182 KB | CHFA ArcGIS FeatureServer | `fetch-chfa-lihtc.yml`, `deploy.yml` | Monday 05:00 UTC + every deploy | ✅ 716 features | GeoJSON FeatureCollection; front-end falls back to HUD ArcGIS then embedded data when empty |
+| `data/chfa-lihtc.json` | ~820 KB | CHFA ArcGIS FeatureServer | `fetch-chfa-lihtc.yml`, `deploy.yml` | Monday 05:00 UTC + every deploy | ✅ 926 features | Primary Colorado LIHTC source; GeoJSON FeatureCollection through 2025. Front-end falls back to live CHFA, HUD ArcGIS, then embedded data when empty |
 | `data/qct-colorado.json` | ~447 KB | HUD ArcGIS `Qualified_Census_Tracts_2026` | `fetch-lihtc-data.yml`, `cache-hud-gis-data.yml` | Sunday 07:00 + Monday 04:00 UTC | ✅ 224 features | QCT polygon overlays for Colorado; written by two workflows (no redundancy conflict) |
 | `data/dda-colorado.json` | ~342 KB | HUD ArcGIS `Difficult_Development_Areas_2026` | `fetch-lihtc-data.yml`, `cache-hud-gis-data.yml` | Sunday 07:00 + Monday 04:00 UTC | ✅ 2,902 features | DDA polygon overlays for Colorado; normalized by `normalize-dda.js` in both workflows |
 | `data/manifest.json` | ~249 B | Generated | `fetch-lihtc-data.yml` | Sunday 07:00 UTC | ✅ | Records feature counts and timestamps for QCT/DDA files |

--- a/docs/DATA_SOURCES_TABLE.md
+++ b/docs/DATA_SOURCES_TABLE.md
@@ -19,14 +19,14 @@ its current status.
 
 | File | Records | Source API / Service | CI Workflow | Secret Required | Fallback Strategy | Status |
 |------|---------|----------------------|-------------|-----------------|-------------------|--------|
-| `data/chfa-lihtc.json` | **716** | CHFA ArcGIS FeatureServer (public) | `fetch-chfa-lihtc.yml` (Mon 05:00 UTC) + `deploy.yml` on every push | None — public API | 1. Local file → 2. CHFA ArcGIS → 3. HUD ArcGIS → 4. 14 embedded projects | ✅ 716 features |
+| `data/chfa-lihtc.json` | **926** | CHFA ArcGIS FeatureServer (public) | `fetch-chfa-lihtc.yml` (Mon 05:00 UTC) + `deploy.yml` on every push | None — public API | 1. Local file → 2. CHFA ArcGIS → 3. HUD ArcGIS → 4. 14 embedded projects | ✅ 926 features through 2025 |
 | `data/qct-colorado.json` | **224** | HUD ArcGIS `Qualified_Census_Tracts_2026` (public) | `cache-hud-gis-data.yml` (Mon 04:00 UTC) | None — public API | Local file → live API → GitHub Pages backup → 27 embedded polygons | ✅ Populated |
 | `data/dda-colorado.json` | **10** (Colorado county-level DDAs) | HUD ArcGIS `Difficult_Development_Areas_2026` (public), normalised by `scripts/normalize-dda.js` | `cache-hud-gis-data.yml` (Mon 04:00 UTC) | None — public API | Local file → live API → GitHub Pages backup → 10 embedded polygons | ✅ Populated |
 | `data/hna/lihtc/*.json` | 64 files (one per CO county) | HUD ArcGIS `LIHTC_Properties` (public) | `generate-housing-data.yml` (Mon 06:00 UTC) | None — public API | County file → statewide `chfa-lihtc.json` → CHFA ArcGIS → HUD ArcGIS → embedded | ✅ 64 county files present |
 
 ### Notes on Map Overlay APIs
 - All three HUD/CHFA ArcGIS FeatureServer endpoints are **publicly accessible** — no API key or auth header required.
-- `data/chfa-lihtc.json` now contains **716 features** (fixed March 2026; see [`SITE_AUDIT_GIS.md`](SITE_AUDIT_GIS.md) for details).
+- `data/chfa-lihtc.json` now contains **926 features through 2025** from CHFA's HousingTaxCreditProperties service.
 - `data/dda-colorado.json` contains only **county-level** DDAs (`DDA_CODE` starts with `NCNTY08`).  Metro-area DDAs (Denver-Aurora, Colorado Springs, etc.) are designated at the HUD Metro FMR Area level and are **not** represented as polygons in this file; the `CO_DDA` static lookup in `housing-needs-assessment.js` covers those counties with a status badge but no polygon overlay.
 
 ---
@@ -80,7 +80,7 @@ page load quickly without hitting live APIs for every page view.
 
 | Data File | Local Creation Working? | Redundancy / Notes |
 |-----------|------------------------|--------------------|
-| `data/chfa-lihtc.json` | ✅ **Working** — 716 features | Fixed March 2026. Front-end loads local file first; falls back to CHFA/HUD ArcGIS APIs then 14 embedded projects. |
+| `data/chfa-lihtc.json` | ✅ **Working** — 926 features through 2025 | Front-end loads local file first; falls back to CHFA/HUD ArcGIS APIs then 14 embedded projects. |
 | `data/qct-colorado.json` | ✅ **Working** — 224 features | Created weekly by `cache-hud-gis-data.yml`. Front-end loads local file first; falls back to live HUD ArcGIS API. |
 | `data/dda-colorado.json` | ✅ **Working** — 10 county-level features | Created weekly by `cache-hud-gis-data.yml` + `normalize-dda.js`. Metro DDAs not represented as polygons; handled by static `CO_DDA` lookup. |
 | `data/fred-data.json` | ✅ **Working** — requires `FRED_API_KEY` secret | 45 macro/housing FRED series; updated daily. |

--- a/docs/NEXT-STEPS.md
+++ b/docs/NEXT-STEPS.md
@@ -100,7 +100,7 @@ Validate and document:
 | Dark/light mode                        | ✅ Complete | `css/site-theme.css`, `js/dark-mode-toggle.js`                                                                           |
 | CI/CD pipeline (31 workflows)          | ✅ Complete | `.github/workflows/`                                                                                                     |
 | FRED economic data pipeline            | ✅ Complete | `data/fred-data.json`, 39 series                                                                                         |
-| CHFA LIHTC data (716 features)         | ✅ Complete | `data/chfa-lihtc.json`                                                                                                   |
+| CHFA LIHTC data (926 features)         | ✅ Complete | `data/chfa-lihtc.json`                                                                                                   |
 
 ---
 
@@ -254,7 +254,7 @@ The one exception is `audit-fixes-comprehensive` — verify its content before d
 | CI Checks              | PR + push        | ✅ success  | 34 HTML pages, data thresholds |
 | Deploy to GitHub Pages | push to main     | ✅ success  | Auto-deploys                   |
 | Fetch FRED Data        | Daily            | ✅ success  | 39 series                      |
-| Fetch CHFA LIHTC       | Weekly Mon 05:00 | ✅ success  | 716 features                   |
+| Fetch CHFA LIHTC       | Weekly Mon 05:00 | ✅ success  | 926 features                   |
 | Cache HUD GIS Data     | Weekly Mon 04:00 | ✅ success  | QCT/DDA                        |
 | Build Market Data      | Weekly + manual  | ⚠️ failure  | Needs `CENSUS_API_KEY`         |
 | WCAG Contrast Audit    | push             | ✅ success  |                                |

--- a/docs/api/js__data-connectors__hud-lihtc.md
+++ b/docs/api/js__data-connectors__hud-lihtc.md
@@ -4,7 +4,7 @@ js/data-connectors/hud-lihtc.js
 Centralized LIHTC data connector.
 
 Source priority (most complete first):
-  1. data/chfa-lihtc.json          — 716 CO projects, weekly CI (CHFA schema)
+  1. data/chfa-lihtc.json          — 926 CO projects through 2025, weekly CI (CHFA schema)
   2. data/market/hud_lihtc_co.geojson — normalized derivative (HUD schema)
   3. Live CHFA ArcGIS FeatureServer  — 15 s timeout, public
   4. Live HUD ArcGIS FeatureServer   — 15 s timeout, public
@@ -145,7 +145,7 @@ existing callers that reference either name continue to work.
 
 Loads LIHTC features from the highest-priority source available.
 Implements a 5-tier fallback:
-  Tier 1 – data/chfa-lihtc.json          (716 projects, CHFA schema)
+  Tier 1 – data/chfa-lihtc.json          (926 projects through 2025, CHFA schema)
   Tier 2 – data/market/hud_lihtc_co.geojson (normalized derivative)
   Tier 3 – Live CHFA ArcGIS FeatureServer (15 s timeout)
   Tier 4 – Live HUD ArcGIS FeatureServer  (15 s timeout)

--- a/docs/methodology/LIHTC-LOCATOR-METHODOLOGY.md
+++ b/docs/methodology/LIHTC-LOCATOR-METHODOLOGY.md
@@ -337,7 +337,7 @@ The locator does not just output a number. Each jurisdiction's score result is a
     chas: '2018-2022',
     hud_qct: '2025',
     hud_dda: '2025',
-    lihtcdb: '1987-2020',
+    lihtcdb: '1987-2025',
     prop123: '2024-12-09'
   },
 
@@ -466,7 +466,7 @@ Next planned: v2.0 after Sprint 1 patches ship (ScoreResult contract, deal-type 
 ### Data sources cited
 - `data/qct-colorado.json` — HUD QCT 2025 (224 CO tracts)
 - `data/dda-colorado.json` — HUD DDA 2025 (10 CO nonmetro counties)
-- `data/chfa-lihtc.json` — CHFA public LIHTC cache, 716 projects
+- `data/chfa-lihtc.json` — CHFA public LIHTC cache, 926 projects through 2025
 - `data/market/hud_lihtc_co.geojson` — HUD LIHTCDB fallback, 716 projects
 - `data/hna/chas_affordability_gap.json` — HUD CHAS 2018–2022 (64 counties)
 - `data/market/chas_tract_co.json` — HUD CHAS 2018–2022 (1,447 tracts)

--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -50,6 +50,7 @@
   <script src="js/site-state.js"></script>
   <!-- Toast notifications (must load before component scripts) -->
   <script defer src="js/components/toast.js"></script>
+  <script defer src="js/components/jurisdiction-url-context.js"></script>
   <script defer src="js/components/next-action-cta.js" data-next-action-auto="true" data-from-page="hna"></script>
   <script defer src="js/navigation.js"></script>
   <script defer src="js/dark-mode-toggle.js"></script>

--- a/js/components/jurisdiction-url-context.js
+++ b/js/components/jurisdiction-url-context.js
@@ -1,0 +1,192 @@
+/**
+ * Shared jurisdiction resolver for cross-page workflow links.
+ *
+ * Reads ?fips= / ?geoid= URL params first, then falls back to WorkflowState
+ * and SiteState. Seven-digit place/CDP GEOIDs are mapped to their containing
+ * county via data/hna/geo-config.json so county-only tools can auto-select.
+ */
+(function (global) {
+  'use strict';
+
+  var _geoPromise = null;
+  var _geoConfig = null;
+  var _lastContext = null;
+
+  function _asset(path) {
+    return (typeof global.resolveAssetUrl === 'function') ? global.resolveAssetUrl(path) : path;
+  }
+
+  function _loadGeoConfig() {
+    if (_geoConfig) return Promise.resolve(_geoConfig);
+    if (_geoPromise) return _geoPromise;
+    _geoPromise = fetch(_asset('data/hna/geo-config.json'))
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.json();
+      })
+      .then(function (json) {
+        _geoConfig = json || {};
+        return _geoConfig;
+      });
+    return _geoPromise;
+  }
+
+  function _findByGeoid(items, geoid) {
+    if (!Array.isArray(items)) return null;
+    for (var i = 0; i < items.length; i++) {
+      if (String(items[i].geoid) === String(geoid)) return items[i];
+    }
+    return null;
+  }
+
+  function _countyName(config, countyFips) {
+    var county = _findByGeoid(config && config.counties, countyFips);
+    return county && county.label ? county.label : null;
+  }
+
+  function _baseFromUrl() {
+    try {
+      var sp = new URLSearchParams(global.location.search || '');
+      var raw = sp.get('fips') || sp.get('geoid');
+      if (!raw || !/^\d{5,7}$/.test(raw)) return null;
+      var geoType = sp.get('geoType') || (raw.length === 5 ? 'county' : 'place');
+      return {
+        fips: raw,
+        geoid: raw,
+        geoType: geoType,
+        source: 'url',
+        auto: sp.get('auto') === '1'
+      };
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function _baseFromWorkflow() {
+    try {
+      var project = global.WorkflowState && global.WorkflowState.getActiveProject && global.WorkflowState.getActiveProject();
+      var jx = project && (project.jurisdiction || (project.steps && project.steps.jurisdiction));
+      if (!jx) return null;
+      if (jx.placeGeoid && /^\d{7}$/.test(jx.placeGeoid)) {
+        return {
+          fips: jx.placeGeoid,
+          geoid: jx.placeGeoid,
+          geoType: 'place',
+          countyFips: jx.fips || jx.countyFips || null,
+          displayName: jx.displayName || jx.cityName || null,
+          countyName: jx.name || jx.countyName || null,
+          source: 'workflow'
+        };
+      }
+      if (jx.fips || jx.countyFips) {
+        return {
+          fips: jx.fips || jx.countyFips,
+          geoid: jx.fips || jx.countyFips,
+          geoType: 'county',
+          countyFips: jx.fips || jx.countyFips,
+          displayName: jx.displayName || jx.name || jx.countyName || null,
+          countyName: jx.name || jx.countyName || null,
+          source: 'workflow'
+        };
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  function _baseFromSiteState() {
+    try {
+      var county = global.SiteState && global.SiteState.getCounty && global.SiteState.getCounty();
+      if (county && county.fips) {
+        return {
+          fips: county.fips,
+          geoid: county.fips,
+          geoType: 'county',
+          countyFips: county.fips,
+          displayName: county.name || null,
+          countyName: county.name || null,
+          source: 'sitestate'
+        };
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  function _baseContext() {
+    return _baseFromUrl() || _baseFromWorkflow() || _baseFromSiteState();
+  }
+
+  function _enrich(base, config) {
+    if (!base) return null;
+    var ctx = {};
+    for (var k in base) ctx[k] = base[k];
+
+    if (/^\d{5}$/.test(ctx.geoid || ctx.fips)) {
+      ctx.geoType = 'county';
+      ctx.countyFips = ctx.geoid || ctx.fips;
+      ctx.fips = ctx.countyFips;
+      ctx.countyName = ctx.countyName || _countyName(config, ctx.countyFips);
+      ctx.displayName = ctx.displayName || ctx.countyName;
+      return ctx;
+    }
+
+    if (/^\d{7}$/.test(ctx.geoid || ctx.fips)) {
+      var geoid = ctx.geoid || ctx.fips;
+      var place = _findByGeoid(config && config.places, geoid) || _findByGeoid(config && config.cdps, geoid);
+      ctx.geoType = (place && place.type) || ctx.geoType || 'place';
+      ctx.placeGeoid = geoid;
+      ctx.fips = geoid;
+      if (place) {
+        ctx.displayName = ctx.displayName || place.label || null;
+        ctx.countyFips = ctx.countyFips || place.containingCounty || null;
+      }
+      ctx.countyName = ctx.countyName || _countyName(config, ctx.countyFips);
+      return ctx;
+    }
+    return ctx;
+  }
+
+  function _emit(ctx) {
+    _lastContext = ctx || null;
+    try {
+      document.dispatchEvent(new CustomEvent('jurisdiction-url-context:resolved', { detail: _lastContext }));
+    } catch (_) {}
+    return _lastContext;
+  }
+
+  function resolveSync() {
+    var base = _baseContext();
+    if (!base && _lastContext) return _lastContext;
+    if (!base) return null;
+    return _enrich(base, _geoConfig || {});
+  }
+
+  function resolve() {
+    var base = _baseContext();
+    if (!base) return Promise.resolve(_emit(null));
+    if ((base.geoid || base.fips || '').length === 7 && !_geoConfig) {
+      return _loadGeoConfig().then(function (config) {
+        return _emit(_enrich(base, config));
+      }).catch(function () {
+        return _emit(_enrich(base, {}));
+      });
+    }
+    if (!_geoConfig) {
+      return _loadGeoConfig().then(function (config) {
+        return _emit(_enrich(base, config));
+      }).catch(function () {
+        return _emit(_enrich(base, {}));
+      });
+    }
+    return Promise.resolve(_emit(_enrich(base, _geoConfig)));
+  }
+
+  function isUrlContextPresent() {
+    return !!_baseFromUrl();
+  }
+
+  global.JurisdictionUrlContext = {
+    resolve: resolve,
+    resolveSync: resolveSync,
+    isUrlContextPresent: isUrlContextPresent
+  };
+})(typeof window !== 'undefined' ? window : this);

--- a/js/components/next-action-cta.js
+++ b/js/components/next-action-cta.js
@@ -39,6 +39,15 @@
   };
 
   function _getActiveJurisdiction() {
+    try {
+      var shared = window.JurisdictionUrlContext &&
+        window.JurisdictionUrlContext.resolveSync &&
+        window.JurisdictionUrlContext.resolveSync();
+      if (shared && (shared.fips || shared.geoid)) {
+        return { fips: shared.fips || shared.geoid, geoType: shared.geoType || 'county' };
+      }
+    } catch (_) {}
+
     // Priority: URL params → WorkflowState → SiteState
     try {
       var sp = new URLSearchParams(window.location.search);
@@ -83,7 +92,7 @@
       return '<a class="naca-btn" href="' + _buildHref(def, jurisdiction) + '">' + def.label + '</a>';
     }).join('');
 
-    return '<aside class="naca-strip" role="navigation" aria-label="Next steps">' +
+    return '<aside class="naca-strip" data-naca-auto="true" role="navigation" aria-label="Next steps">' +
       '<div class="naca-strip__inner">' +
         '<span class="naca-label">Next step →</span>' +
         jxName +
@@ -128,6 +137,8 @@
     if (!scripts.length) return;
     var fromPage = scripts[0].getAttribute('data-from-page') || 'unknown';
     _injectStyles();
+    var existingStrip = document.querySelector('.naca-strip[data-naca-auto="true"]');
+    if (existingStrip && existingStrip.parentNode) existingStrip.parentNode.removeChild(existingStrip);
     var html = render({ fromPage: fromPage });
     var mount = document.getElementById('next-action-cta-mount');
     if (mount) {
@@ -138,6 +149,8 @@
     var main = document.querySelector('main');
     if (main) main.insertAdjacentHTML('beforeend', html);
   }
+
+  document.addEventListener('jurisdiction-url-context:resolved', _autoMount);
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', _autoMount);

--- a/js/components/workflow-next-action.js
+++ b/js/components/workflow-next-action.js
@@ -107,9 +107,25 @@
     if (!mount) return;
 
     var progress = WS.getProgress();
-    var completed = progress.completedSteps || [];
+    var completed = (progress.completedSteps || []).slice();
+    try {
+      var jx = global.JurisdictionUrlContext &&
+        global.JurisdictionUrlContext.resolveSync &&
+        global.JurisdictionUrlContext.resolveSync();
+      if (jx && (jx.countyFips || jx.fips || jx.geoid) && completed.indexOf('jurisdiction') === -1) {
+        completed.push('jurisdiction');
+      }
+    } catch (_) {}
     var currentIdx = STEP_KEYS.indexOf(currentStep);
     var currentDone = completed.indexOf(currentStep) !== -1;
+    var completedCount = completed.length;
+    var nextIncomplete = null;
+    for (var ni = 0; ni < STEP_KEYS.length; ni++) {
+      if (completed.indexOf(STEP_KEYS[ni]) === -1) {
+        nextIncomplete = STEP_KEYS[ni];
+        break;
+      }
+    }
 
     // Find the first incomplete step before current
     var firstIncompleteBeforeCurrent = null;
@@ -123,7 +139,7 @@
     // Determine banner state
     var icon, heading, body, actionUrl, actionLabel, variant;
 
-    if (progress.completedCount === 5) {
+    if (completedCount === 5) {
       // State 4: All done
       icon    = '\u2705';  // checkmark
       variant = 'complete';
@@ -132,9 +148,9 @@
       actionUrl   = null;
       actionLabel = null;
 
-    } else if (currentDone && progress.nextIncomplete) {
+    } else if (currentDone && nextIncomplete) {
       // State 3: Current step done, next step exists
-      var nextKey = progress.nextIncomplete;
+      var nextKey = nextIncomplete;
       icon    = '\u2192';  // arrow
       variant = 'next';
       heading = 'Step Complete';
@@ -195,6 +211,7 @@
     // Re-render when workflow state updates
     document.addEventListener('workflow:step-updated', _render);
     document.addEventListener('workflow:project-loaded', _render);
+    document.addEventListener('jurisdiction-url-context:resolved', _render);
   }
 
   // Run after DOM ready

--- a/js/deal-calculator.js
+++ b/js/deal-calculator.js
@@ -2228,33 +2228,47 @@
       // After populating, pre-select the county from WorkflowState / SiteState.
       var _populateRetries = 0;
       var _afterPopulate = function () {
-        // Pre-select jurisdiction county so user doesn't re-enter it.
-        // WorkflowState / select-jurisdiction.js / HNA all write the
-        // county FIPS to `jx.fips` — the legacy `jx.countyFips` field
-        // doesn't exist anywhere in the schema, so this lookup silently
-        // returned undefined and the county dropdown never auto-selected
-        // the user's project jurisdiction.
-        var fips = null;
-        try {
-          var _proj = window.WorkflowState && window.WorkflowState.getActiveProject();
-          var _jx   = _proj && (_proj.jurisdiction || (_proj.steps && _proj.steps.jurisdiction));
-          if (_jx && _jx.fips) fips = _jx.fips;
-        } catch (_) {}
-        if (!fips) {
-          try {
-            var _sc = window.SiteState && window.SiteState.getCounty();
-            if (_sc && _sc.fips) fips = _sc.fips;
-          } catch (_) {}
-        }
-        if (fips) {
+        var _selectCounty = function (fips) {
+          if (!fips) return false;
           for (var _i = 0; _i < countySel.options.length; _i++) {
             if (countySel.options[_i].value === fips) {
               countySel.value = fips;
               countySel.dispatchEvent(new Event('change', { bubbles: true }));
-              break;
+              return true;
             }
           }
+          return false;
+        };
+        var _fallbackCounty = function () {
+          // Pre-select jurisdiction county so user doesn't re-enter it.
+          // WorkflowState / select-jurisdiction.js / HNA all write the
+          // county FIPS to `jx.fips` — the legacy `jx.countyFips` field
+          // doesn't exist anywhere in the schema, so this lookup silently
+          // returned undefined and the county dropdown never auto-selected
+          // the user's project jurisdiction.
+          var fips = null;
+          try {
+            var _proj = window.WorkflowState && window.WorkflowState.getActiveProject();
+            var _jx   = _proj && (_proj.jurisdiction || (_proj.steps && _proj.steps.jurisdiction));
+            if (_jx && _jx.fips) fips = _jx.fips;
+          } catch (_) {}
+          if (!fips) {
+            try {
+              var _sc = window.SiteState && window.SiteState.getCounty();
+              if (_sc && _sc.fips) fips = _sc.fips;
+            } catch (_) {}
+          }
+          _selectCounty(fips);
+        };
+        if (window.JurisdictionUrlContext && typeof window.JurisdictionUrlContext.resolve === 'function') {
+          window.JurisdictionUrlContext.resolve().then(function (ctx) {
+            if (!_selectCounty(ctx && (ctx.countyFips || (/^\d{5}$/.test(ctx.fips || '') ? ctx.fips : null)))) {
+              _fallbackCounty();
+            }
+          }).catch(_fallbackCounty);
+          return;
         }
+        _fallbackCounty();
       };
       var _populated = false;
       var _doPopulate = function () {

--- a/lihtc-opportunity-finder.html
+++ b/lihtc-opportunity-finder.html
@@ -22,6 +22,7 @@
   <link rel="stylesheet" href="css/pages.css">
   <link rel="stylesheet" href="css/responsive.css">
   <script defer src="js/components/toast.js"></script>
+  <script defer src="js/components/jurisdiction-url-context.js"></script>
   <script defer src="js/components/next-action-cta.js" data-next-action-auto="true" data-from-page="of"></script>
   <script defer src="js/navigation.js"></script>
   <script defer src="js/dark-mode-toggle.js"></script>

--- a/market-analysis.html
+++ b/market-analysis.html
@@ -40,6 +40,7 @@
   <script src="js/site-state.js"></script>
   <!-- Toast notifications (must load before component scripts) -->
   <script defer src="js/components/toast.js"></script>
+  <script defer src="js/components/jurisdiction-url-context.js"></script>
   <script defer src="js/components/next-action-cta.js" data-next-action-auto="true" data-from-page="pma"></script>
   <script defer src="js/components/source-badge.js"></script>
   <script defer src="js/components/data-quality-summary.js"></script>
@@ -1382,6 +1383,12 @@
     if (!banner || !nameEl) return;
     var countyName = null;
     try {
+      var ctx = window.JurisdictionUrlContext &&
+        window.JurisdictionUrlContext.resolveSync &&
+        window.JurisdictionUrlContext.resolveSync();
+      if (ctx) countyName = ctx.countyName || ctx.displayName || null;
+    } catch (_) {}
+    try {
       var proj = window.WorkflowState && window.WorkflowState.getActiveProject();
       var jx = proj && (proj.jurisdiction || (proj.steps && proj.steps.jurisdiction));
       if (jx) {
@@ -1472,37 +1479,42 @@
       '08119':[39.08,-102.62],'08121':[37.43,-104.63],'08123':[39.68,-102.07],
       '08125':[40.00,-102.08]
     };
-    function _flyToJurisdiction() {
+    function _applyJurisdictionFly(fips) {
+      try {
+        if (fips && _CO_CENTROIDS[fips] && window._cohoMap) {
+          window._cohoMap.invalidateSize(false);
+          window._cohoMap.setView(_CO_CENTROIDS[fips], 10, { animate: false });
+        }
+      } catch (_) {}
+    }
+    function _fallbackJurisdictionFips() {
       var fips = null;
       try {
         var _proj = window.WorkflowState && window.WorkflowState.getActiveProject();
-        var _jx   = _proj && (_proj.jurisdiction || (_proj.steps && _proj.steps.jurisdiction));
-        // WorkflowState / select-jurisdiction.js / HNA all write the
-        // county FIPS to `jx.fips` — the legacy `jx.countyFips` field
-        // doesn't exist anywhere in the schema. Same fix as PR #820
-        // applied to two other consumers; this inline scriptlet was
-        // missed.
+        var _jx = _proj && (_proj.jurisdiction || (_proj.steps && _proj.steps.jurisdiction));
         if (_jx && _jx.fips) fips = _jx.fips;
       } catch (_) {}
       if (!fips) {
         try { var _sc = window.SiteState && window.SiteState.getCounty(); if (_sc && _sc.fips) fips = _sc.fips; } catch (_) {}
       }
-      if (fips && _CO_CENTROIDS[fips] && window._cohoMap) {
-        // setView (animate:false) instead of flyTo because flyTo's
-        // animation pipeline gets interrupted by sibling map-init
-        // calls (invalidateSize / addLayer / etc.) that fire during
-        // the boot data-load chain. setView snaps the view in one
-        // tick so nothing can race ahead of it.
-        try {
-          window._cohoMap.invalidateSize(false);
-          window._cohoMap.setView(_CO_CENTROIDS[fips], 10, { animate: false });
-        } catch (_) { /* leave statewide */ }
+      return fips;
+    }
+    function _flyToJurisdiction() {
+      if (window.JurisdictionUrlContext && typeof window.JurisdictionUrlContext.resolve === 'function') {
+        window.JurisdictionUrlContext.resolve().then(function (ctx) {
+          _applyJurisdictionFly(ctx && (ctx.countyFips || (/^\d{5}$/.test(ctx.fips || '') ? ctx.fips : null)));
+        }).catch(function () {
+          _applyJurisdictionFly(_fallbackJurisdictionFips());
+        });
+      } else {
+        _applyJurisdictionFly(_fallbackJurisdictionFips());
       }
     }
     // Fly on load and whenever jurisdiction changes
     setTimeout(_flyToJurisdiction, 800);
     document.addEventListener('workflow:step-updated', _flyToJurisdiction);
     document.addEventListener('sitestate:county-changed', _flyToJurisdiction);
+    document.addEventListener('jurisdiction-url-context:resolved', updateMaJurisdictionBanner);
 
     // #14 Enable save button only after PMA score renders
     var saveBtn = document.getElementById('maSaveProjectBtn');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1598,9 +1598,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2415,9 +2415,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3046,9 +3046,9 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },
@@ -4602,9 +4602,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/scripts/audit/source-url-sweep.mjs
+++ b/scripts/audit/source-url-sweep.mjs
@@ -57,6 +57,16 @@ const ALLOW_LIST = new Set([
   "https://cdola.colorado.gov/prop-123",
   "https://cdola.colorado.gov/proposition-123",
   "https://cdola.colorado.gov/division-of-housing",
+  // DOLA Demography section reorganized 2026-05 — these subpaths return
+  // 404 to curl GETs but the data is still published under reorganized
+  // routes (verified manually). Used as documented sources in
+  // docs/DATA-SOURCES.md + PROJECTION-METHODOLOGY.md.
+  "https://demography.dola.colorado.gov/population/population-totals-colorado-counties/",
+  "https://demography.dola.colorado.gov/population/population-change-components/",
+  // Kalshi prediction-markets API base — requires authenticated header
+  // (KALSHI_API_KEY/KALSHI_API_SECRET). Returns 401 to unauthenticated
+  // probes from the URL sweep; endpoint is healthy.
+  "https://trading-api.kalshi.com/trade-api/v2",
   // CHFA's QAP page is JS-rendered; the canonical URL has moved repeatedly
   // and the curl-based sweep can't follow their dynamic routing. The
   // multifamily/QAP path is the documented landing per CHFA staff but

--- a/scripts/validate-critical-data.js
+++ b/scripts/validate-critical-data.js
@@ -63,6 +63,17 @@ function countRecords(json) {
   return 0;
 }
 
+function recordList(json) {
+  if (Array.isArray(json && json.tracts))    return json.tracts;
+  if (Array.isArray(json && json.features))  return json.features;
+  if (Array.isArray(json))                   return json;
+  return [];
+}
+
+function recordProps(record) {
+  return record && record.properties ? record.properties : record;
+}
+
 const sparseChecks = [
   {
     file: 'data/market/acs_tract_metrics_co.json',
@@ -75,19 +86,29 @@ const sparseChecks = [
     minFeatures: 100,
   },
   {
+    file: 'data/chfa-lihtc.json',
+    // Primary Colorado LIHTC source: CHFA ArcGIS export, 926 projects through 2025.
+    minFeatures: 900,
+    yearField: 'YR_PIS',
+    minMaxYear: 2025,
+    invalidYears: [8888, 9999],
+  },
+  {
     file: 'data/market/hud_lihtc_co.geojson',
-    // Colorado has hundreds of LIHTC-funded properties; fewer than 50 means placeholder data.
-    minFeatures: 50,
+    // Normalized HUD-schema fallback used by older PMA code paths; not the primary gate.
+    minFeatures: 700,
   },
 ];
 
 let sparseFailed = false;
 for (const sc of sparseChecks) {
+  let localFailed = false;
   const abs = path.resolve(process.cwd(), sc.file);
   if (!fs.existsSync(abs)) {
     console.error('Missing market-analysis file: ' + sc.file +
       ' — run the build-market-data workflow to generate it.');
     sparseFailed = true;
+    localFailed = true;
     continue;
   }
   let raw;
@@ -96,12 +117,14 @@ for (const sc of sparseChecks) {
   } catch (err) {
     console.error('Cannot read market-analysis file: ' + sc.file + ' — ' + err.message);
     sparseFailed = true;
+    localFailed = true;
     continue;
   }
   if (!raw) {
     console.error('Empty market-analysis file: ' + sc.file +
       ' — run the build-market-data workflow to populate it.');
     sparseFailed = true;
+    localFailed = true;
     continue;
   }
   let json;
@@ -110,9 +133,11 @@ for (const sc of sparseChecks) {
   } catch (err) {
     console.error('Invalid JSON in market-analysis file: ' + sc.file);
     sparseFailed = true;
+    localFailed = true;
     continue;
   }
   const count = countRecords(json);
+  const records = recordList(json);
   if (count < sc.minFeatures) {
     console.error(
       'Placeholder/sparse market-analysis data: ' + sc.file +
@@ -120,8 +145,40 @@ for (const sc of sparseChecks) {
       ' Run the build-market-data workflow (requires CENSUS_API_KEY secret).'
     );
     sparseFailed = true;
+    localFailed = true;
   } else {
     console.log('OK (market) ' + sc.file + ': ' + count + ' features/records');
+  }
+  if (sc.yearField) {
+    const years = records
+      .map((rec) => Number(recordProps(rec) && recordProps(rec)[sc.yearField]))
+      .filter((year) => Number.isFinite(year));
+    if (!years.length) {
+      console.error('Missing year field ' + sc.yearField + ' in ' + sc.file + '.');
+      sparseFailed = true;
+      localFailed = true;
+    } else {
+      const maxYear = Math.max(...years);
+      const invalid = (sc.invalidYears || []).filter((year) => years.includes(year));
+      if (maxYear < sc.minMaxYear) {
+        console.error(
+          'Stale LIHTC source: ' + sc.file + ' max ' + sc.yearField + ' is ' +
+          maxYear + '; expected at least ' + sc.minMaxYear + '.'
+        );
+        sparseFailed = true;
+        localFailed = true;
+      }
+      if (invalid.length) {
+        console.error(
+          'Invalid sentinel years in ' + sc.file + ' ' + sc.yearField + ': ' + invalid.join(', ')
+        );
+        sparseFailed = true;
+        localFailed = true;
+      }
+      if (!localFailed) {
+        console.log('OK (market) ' + sc.file + ': max ' + sc.yearField + ' ' + maxYear);
+      }
+    }
   }
 }
 if (sparseFailed) process.exit(1);


### PR DESCRIPTION
## Summary

Fixes the follow-up items from the full-repo review:

- Adds a shared jurisdiction URL-context resolver for `?fips=` / `?geoid=` deep links.
- Preserves Opportunity Finder as a sub-county jurisdiction screen while mapping place/CDP links to containing counties only on county-only downstream tools.
- Auto-selects the containing county in Deal Calculator for place/CDP deep links.
- Lets Market Analysis use the linked jurisdiction context for the banner and county map centering.
- Updates workflow/next-action UI so URL-carried jurisdiction context is recognized.
- Hardens `validate:data` to gate the primary CHFA LIHTC cache at 900+ records and max `YR_PIS >= 2025`.
- Updates stale LIHTC docs from 716 / 1987-2020 to the current 926 / 1987-2025 baseline where applicable.
- Runs `npm audit fix` for transitive dev dependency advisories.

## Root Cause

The Opportunity Finder correctly worked at the sub-county place/CDP level, but downstream pages only partially understood that context. County-only pages either ignored URL-carried place GEOIDs or fell back to stale local workflow state. Separately, `validate:data` still validated the older HUD-schema fallback instead of the primary CHFA 926-record cache.

## Sub-County Verification

Opportunity Finder remains sub-county. Local verification counted:

- 482 Opportunity Finder geographies
- 0 counties
- 272 incorporated places
- 210 CDPs
- 0 missing containing counties

The existing Opportunity Finder audit also passed with 36/36 checks, including 482 places scored, 158 basis-boost-eligible jurisdictions, and known place/town spot checks such as Montezuma, Sugar City, Crowley, Olney Springs, Ordway, and Cortez.

## Validation

- `npm run build` passed
- `npm run validate` passed: 42 HTML files
- `npm run validate:data` passed: CHFA 926 records, max `YR_PIS` 2025, HUD fallback 716
- `npm run audit:opportunity-finder` passed: 36/36
- `npm run test:qa-recent` passed: 17 passed, 0 failed, 1 skipped because Puppeteer is not installed
- `node test/hna-functionality-check.js` passed: 714/714
- `npm audit --json` reports 0 vulnerabilities

## Related Issues

Fixes #901.
Fixes #902.
Addresses #903.