### PR TITLE
chore(seo): canonical surface → cohoanalytics.com [cutover-gated, DO NOT MERGE early]

### DIFF
--- a/css/print.css
+++ b/css/print.css
@@ -213,7 +213,7 @@
      12. BRAND FOOTER FOR PRINT
      ---------------------------------------------------------------- */
   body::after {
-    content: "COHO Analytics — pggllc.github.io/Housing-Analytics";
+    content: "COHO Analytics — cohoanalytics.com";
     display: block;
     text-align: center;
     font-size: 8pt;

--- a/js/geo-search.js
+++ b/js/geo-search.js
@@ -17,7 +17,7 @@
     return fetch(url, {
       headers: {
         'Accept-Language': 'en',
-        'User-Agent': 'HousingAnalyticsCO/1.0 (https://pggllc.github.io/Housing-Analytics/)',
+        'User-Agent': 'HousingAnalyticsCO/1.0 (https://cohoanalytics.com/)',
       },
     })
       .then(function (r) { return r.json(); })

--- a/robots.txt
+++ b/robots.txt
@@ -9,4 +9,4 @@ Disallow: /test/
 Disallow: /tools/
 Disallow: /Housing-Analytics/private/
 
-Sitemap: https://pggllc.github.io/Housing-Analytics/sitemap.xml
+Sitemap: https://cohoanalytics.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,127 +1,127 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/index.html</loc>
+    <loc>https://cohoanalytics.com/index.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/about.html</loc>
+    <loc>https://cohoanalytics.com/about.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/dashboard.html</loc>
+    <loc>https://cohoanalytics.com/dashboard.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/LIHTC-dashboard.html</loc>
+    <loc>https://cohoanalytics.com/LIHTC-dashboard.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/state-allocation-map.html</loc>
+    <loc>https://cohoanalytics.com/state-allocation-map.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/market-intelligence.html</loc>
+    <loc>https://cohoanalytics.com/market-intelligence.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/market-analysis.html</loc>
+    <loc>https://cohoanalytics.com/market-analysis.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/economic-dashboard.html</loc>
+    <loc>https://cohoanalytics.com/economic-dashboard.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/census-dashboard.html</loc>
+    <loc>https://cohoanalytics.com/census-dashboard.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/colorado-deep-dive.html</loc>
+    <loc>https://cohoanalytics.com/colorado-deep-dive.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/colorado-market.html</loc>
+    <loc>https://cohoanalytics.com/colorado-market.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/chfa-portfolio.html</loc>
+    <loc>https://cohoanalytics.com/chfa-portfolio.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/regional.html</loc>
+    <loc>https://cohoanalytics.com/regional.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/construction-commodities.html</loc>
+    <loc>https://cohoanalytics.com/construction-commodities.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/housing-needs-assessment.html</loc>
+    <loc>https://cohoanalytics.com/housing-needs-assessment.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/housing-legislation-2026.html</loc>
+    <loc>https://cohoanalytics.com/housing-legislation-2026.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/insights.html</loc>
+    <loc>https://cohoanalytics.com/insights.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/article-pricing.html</loc>
-    <lastmod>2026-03-04</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/lihtc-guide-for-stakeholders.html</loc>
+    <loc>https://cohoanalytics.com/article-pricing.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/lihtc-enhancement-ahcia.html</loc>
+    <loc>https://cohoanalytics.com/lihtc-guide-for-stakeholders.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://pggllc.github.io/Housing-Analytics/cra-expansion-analysis.html</loc>
+    <loc>https://cohoanalytics.com/lihtc-enhancement-ahcia.html</loc>
+    <lastmod>2026-03-04</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://cohoanalytics.com/cra-expansion-analysis.html</loc>
     <lastmod>2026-03-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>


### PR DESCRIPTION
## What
Points the public SEO/canonical surface at the **cohoanalytics.com** custom domain (served at root) instead of the `pggllc.github.io/Housing-Analytics` project sub-path.

- `sitemap.xml` — all 21 `<loc>` URLs → `https://cohoanalytics.com/...`
- `robots.txt` — `Sitemap:` line → `https://cohoanalytics.com/sitemap.xml`
- `css/print.css` — print footer label → `cohoanalytics.com`
- `js/geo-search.js` — Nominatim `User-Agent` contact URL → `cohoanalytics.com`

Page `<link rel="canonical">` / `og:url` tags are **already relative**, so they need no change.

## Deliberately left on github.io (cross-origin data fallbacks, *not* canonical)
- `LIHTC-dashboard.html` / `lihtc-allocations.html` Tier-3 topology backup (line ~922) — primary fetch on line 918 is already relative.
- `js/hna/hna-utils.js` `GITHUB_PAGES_BASE` — documented third-tier data fallback.
- `docs/DATA-SOURCES.md` backup-tier references.

## ⚠️ Merge timing — cutover-gated
Per `docs/security/GODADDY-TO-CLOUDFLARE-DOMAIN-MIGRATION.md`: **do not make `cohoanalytics.com` canonical until it returns 200** (i.e. DNS is cut over and GitHub Pages serves the site). Merging earlier points the sitemap/robots at a domain still serving Wix. Kept as **draft** until then.

## ⚠️ Separate cutover task (not in this PR)
The deployed site calls the Cloudflare Worker APIs (`co-ami-gap`, `colorado-demographics`, `hud-markets`), which allow CORS only from `https://pggllc.github.io`. Set their `CORS_ORIGIN` to `https://cohoanalytics.com` **before** cutover or those data features break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)