### PR TITLE
fix(ci): unbreak deploy — sitemap assertion → cohoanalytics.com

### DIFF
--- a/test/pages-availability-check.js
+++ b/test/pages-availability-check.js
@@ -199,7 +199,7 @@ test('robots.txt: public crawler policy does not pretend to protect private path
         !/Disallow:\s*\/(scripts|serverless|cloudflare-worker|test|tools|Housing-Analytics)/.test(robots),
         'robots.txt has no stale private/source-path Disallow blocks'
     );
-    assert(robots.includes('Sitemap: https://pggllc.github.io/Housing-Analytics/sitemap.xml'), 'robots.txt advertises sitemap');
+    assert(robots.includes('Sitemap: https://cohoanalytics.com/sitemap.xml'), 'robots.txt advertises sitemap');
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
**Hotfix: deploys have been failing since #975 merged.**

`deploy.yml` runs `test/pages-availability-check.js`, whose robots.txt test pinned the old `pggllc.github.io/Housing-Analytics/sitemap.xml` URL. #975 changed robots.txt's `Sitemap:` line to `cohoanalytics.com`, so the assertion failed → the *Run pages availability checks* step failed → every deploy failed (`2be9ac15`, `c987effd`, `e789416f` all red). Net effect: the canonical sitemap/robots never published to the live site.

One-line fix to align the assertion with the merged `robots.txt`. Local run: **113 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)