### PR TITLE
fix(ci): de-pin deploy-gate sitemap assertion (repo reliability)

### DIFF
--- a/test/pages-availability-check.js
+++ b/test/pages-availability-check.js
@@ -199,7 +199,21 @@ test('robots.txt: public crawler policy does not pretend to protect private path
         !/Disallow:\s*\/(scripts|serverless|cloudflare-worker|test|tools|Housing-Analytics)/.test(robots),
         'robots.txt has no stale private/source-path Disallow blocks'
     );
-    assert(robots.includes('Sitemap: https://cohoanalytics.com/sitemap.xml'), 'robots.txt advertises sitemap');
+    // De-pinned from a literal URL: assert a well-formed Sitemap line whose host matches the live
+    // custom domain in CNAME. Pinning the exact URL here broke EVERY deploy when robots.txt was
+    // repointed to cohoanalytics.com (#975, fixed in #977) — this test runs inside deploy.yml.
+    // Deriving the host from CNAME keeps the invariant (sitemap host == custom domain) without a
+    // hard-coded value that a future domain change would silently break.
+    const sitemapLine = robots.match(/^Sitemap:\s*(https:\/\/\S+\/sitemap\.xml)\s*$/m);
+    assert(sitemapLine, 'robots.txt advertises an https .../sitemap.xml URL');
+    const cnamePath = path.join(ROOT, 'CNAME');
+    if (fs.existsSync(cnamePath)) {
+        const domain = fs.readFileSync(cnamePath, 'utf8').trim();
+        assert(
+            sitemapLine[1] === `https://${domain}/sitemap.xml`,
+            `robots.txt sitemap host matches custom domain from CNAME (${domain})`
+        );
+    }
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Removes the repo's one real reliability weakness surfaced this session: `test/pages-availability-check.js` runs inside `deploy.yml` and pinned the literal `robots.txt` Sitemap URL, so a one-line robots edit (#975) silently broke every deploy until #977.

Now asserts the **invariant** — a well-formed `Sitemap: https://.../sitemap.xml` line whose host equals the custom domain in `CNAME` — instead of a hard-coded string. Verified: **114 passed / 0 failed**, and a negative test confirms it still fails on a real host mismatch. Clears the runway for the Codex sitemap work (Phase 2), which touches this exact gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)