### PR TITLE
feat(place): AMI-tier explainer on place profiles

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -542,9 +542,22 @@
     document.dispatchEvent(new CustomEvent('nav:rendered'));
   }
 
+  // Place-profile pages get a plain-language AMI-tier explainer, loaded on demand.
+  function loadPlaceProfileHelp() {
+    if (!document.getElementById('psTier100p')) return;            // place profiles only
+    if (document.getElementById('place-profile-help-script')) return;
+    var s = document.createElement('script');
+    s.id = 'place-profile-help-script';
+    s.src = (window.APP_BASE_PATH || relToRoot() || '') + 'js/place-profile-help.js';
+    s.defer = true;
+    document.head.appendChild(s);
+  }
+
+  function boot() { inject(); loadPlaceProfileHelp(); }
+
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', inject);
+    document.addEventListener('DOMContentLoaded', boot);
   } else {
-    inject();
+    boot();
   }
 })();

--- a/js/place-profile-help.js
+++ b/js/place-profile-help.js
@@ -1,0 +1,46 @@
+/**
+ * js/place-profile-help.js — adds a plain-language "What do these AMI tiers mean?"
+ * explainer to place-profile pages.
+ *
+ * Loaded on demand by navigation.js only on place profiles. Idempotent: skips if the
+ * static explainer (.place-explain, baked into places/_template.html) is already present,
+ * so it never double-renders once pages are regenerated from the updated template.
+ */
+(function () {
+  'use strict';
+
+  var tierRow = document.getElementById('psTier100p');
+  if (!tierRow) return;                                   // not a place profile
+  var card = tierRow.closest('.place-card');
+  if (!card || card.querySelector('.place-explain')) return; // already explained
+
+  if (!document.getElementById('place-explain-styles')) {
+    var st = document.createElement('style');
+    st.id = 'place-explain-styles';
+    st.textContent =
+      '.place-explain{margin-top:.75rem;font-size:.82rem;color:var(--muted)}' +
+      '.place-explain summary{cursor:pointer;color:var(--accent,#096e65);font-weight:600;font-size:.85rem}' +
+      '.place-explain p{margin:.5rem 0;line-height:1.5}' +
+      '.place-explain ul{margin:.4rem 0;padding-left:1.1rem}' +
+      '.place-explain li{margin:.15rem 0}';
+    document.head.appendChild(st);
+  }
+
+  var d = document.createElement('details');
+  d.className = 'place-explain';
+  d.innerHTML =
+    '<summary>What do these AMI tiers mean?</summary>' +
+    '<p><strong>AMI = Area Median Income</strong> — HUD’s annual median household income for the area. ' +
+    'Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>' +
+    '<ul>' +
+    '<li><strong>≤30% AMI</strong> — extremely low income</li>' +
+    '<li><strong>31-50% AMI</strong> — very low income</li>' +
+    '<li><strong>51-80% AMI</strong> — low income (the typical LIHTC band)</li>' +
+    '<li><strong>81-100% AMI</strong> — near the median</li>' +
+    '<li><strong>&gt;100% AMI</strong> — above the median</li>' +
+    '</ul>' +
+    '<p>Counts come from HUD’s CHAS file (2018-2022), apportioned to this place from its underlying ' +
+    'census tracts (see Methodology). A <strong>0</strong> means CHAS attributes essentially no renter ' +
+    'households in that band to this place — common for very small towns.</p>';
+  card.appendChild(d);
+})();

--- a/places/_template.html
+++ b/places/_template.html
@@ -39,6 +39,11 @@
     .place-stat .value.bad { color: var(--bad, #dc2626); }
     .place-stat .value.warn { color: var(--warn, #d97706); }
     .place-stat .value.good { color: var(--good, #16a34a); }
+    .place-explain { margin-top: .75rem; font-size: .82rem; color: var(--muted); }
+    .place-explain summary { cursor: pointer; color: var(--accent, #096e65); font-weight: 600; font-size: .85rem; }
+    .place-explain p { margin: .5rem 0; line-height: 1.5; }
+    .place-explain ul { margin: .4rem 0; padding-left: 1.1rem; }
+    .place-explain li { margin: .15rem 0; }
     .place-disclosure { margin: 1rem auto; max-width: 1100px; padding: .75rem 1rem; background: rgba(59, 130, 246, .08); border: 1px solid rgba(59, 130, 246, .3); border-radius: 6px; font-size: .88rem; line-height: 1.5; }
     .place-tools { max-width: 1100px; margin: 2rem auto; padding: 0 1.5rem; }
     .place-tools h2 { font-size: 1.1rem; margin-bottom: .5rem; }
@@ -79,6 +84,18 @@
         <div class="place-stat"><span class="label">51-80% AMI</span><span class="value" id="psTier5180">—</span></div>
         <div class="place-stat"><span class="label">81-100% AMI</span><span class="value" id="psTier81100">—</span></div>
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
+        <details class="place-explain">
+          <summary>What do these AMI tiers mean?</summary>
+          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <ul>
+            <li><strong>≤30% AMI</strong> — extremely low income</li>
+            <li><strong>31-50% AMI</strong> — very low income</li>
+            <li><strong>51-80% AMI</strong> — low income (the typical LIHTC band)</li>
+            <li><strong>81-100% AMI</strong> — near the median</li>
+            <li><strong>&gt;100% AMI</strong> — above the median</li>
+          </ul>
+          <p>Counts come from HUD's CHAS file (2018-2022), apportioned to this place from its underlying census tracts (see Methodology). A <strong>0</strong> means CHAS attributes essentially no renter households in that band to this place — common for very small towns.</p>
+        </details>
       </div>
       <div class="place-card">
         <h2>Methodology</h2>


### PR DESCRIPTION
Adds a collapsible **"What do these AMI tiers mean?"** explainer under the AMI-tier card on place profiles — AMI definition, the five income bands, the CHAS source, and why tiny towns (e.g. Kim) read 0.

- `places/_template.html` bakes it in for future regenerations; `js/place-profile-help.js` injects it on existing pages (loaded on demand by navigation.js, idempotent).
- **Deliberately does not regenerate the 464 pages** — the committed CHAS data has drifted from the live pages, so a regen would bundle an unvetted data refresh. This ships the explanation only.

Browser-verified on the Kim profile (no console errors); build + deploy-gate + artifact guard pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)