### PR TITLE
fix(site): add favicon (replaces stale Wix tab icon)

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#096e65"/>
+  <path d="M16 6 27 15h-3v10h-6v-6h-4v6H8V15H5z" fill="#fff"/>
+</svg>

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -553,7 +553,18 @@
     document.head.appendChild(s);
   }
 
-  function boot() { inject(); loadPlaceProfileHelp(); }
+  // Site favicon — injected here so every page gets it, replacing the stale
+  // cached favicon from the old host. Skipped if the page declares its own.
+  function ensureFavicon() {
+    if (document.querySelector('link[rel~="icon"]')) return;
+    var l = document.createElement('link');
+    l.rel = 'icon';
+    l.type = 'image/svg+xml';
+    l.href = (window.APP_BASE_PATH || relToRoot() || '') + 'favicon.svg';
+    document.head.appendChild(l);
+  }
+
+  function boot() { ensureFavicon(); inject(); loadPlaceProfileHelp(); }
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', boot);

--- a/scripts/build-public-site.mjs
+++ b/scripts/build-public-site.mjs
@@ -23,7 +23,8 @@ const PUBLIC_ROOT_FILES = new Set([
   'sitemap.xml',
   'sitemap.html',
   '_headers',
-  'LICENSE'
+  'LICENSE',
+  'favicon.svg'
 ]);
 
 const PUBLIC_DIRECTORIES = new Set([


### PR DESCRIPTION
cohoanalytics.com had no favicon, so browsers kept showing the Wix one cached from the old host (`/favicon.ico` → 404). Adds `favicon.svg` (brand-teal house), ships it as a public root file, and injects `<link rel=icon>` site-wide via navigation.js. Build + deploy-gate + guard pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)