### PR TITLE
Curated housing-history brief: Town of Silt (0870195)

### DIFF
--- a/data/jurisdiction-briefs/0870195.json
+++ b/data/jurisdiction-briefs/0870195.json
@@ -1,0 +1,111 @@
+{
+  "geoid": "0870195",
+  "jurisdiction": "Town of Silt",
+  "scope": "place",
+  "containing_county_fips": "08045",
+  "last_curated": "2026-06-18",
+  "curator": "Claude (AI draft)",
+  "published": true,
+  "summary": "Silt's dedicated affordable footprint centers on the 20-unit, project-based-voucher Silt Senior Housing (vouchers sunset 2027) under the countywide Garfield County Housing Authority. The county's deed-restricted ownership communities and its project-based-voucher pipeline sit east and west toward Glenwood Springs and Rifle rather than in Silt, and recent development approved near town has been market-rate large-lot subdivision.",
+  "sections": [
+    {
+      "id": "silt-senior-housing",
+      "heading": "Silt Senior Housing: the town's affordable anchor",
+      "paragraphs": [
+        {
+          "text": "Silt's principal dedicated affordable property is Silt Senior Housing at 701 Home Avenue, a 20-unit apartment building (16 one-bedroom and 4 studio units) operated on project-based vouchers and managed by the county housing authority. It is restricted to low-income seniors aged 62 and older and disabled residents aged 55 and older, with a preference for households that live or work in the county.",
+          "cites": ["s1"]
+        },
+        {
+          "text": "The county housing authority's 2024 report to county commissioners flagged that the project-based vouchers attached to Silt Senior Housing will sunset in 2027 under the 40-year HUD contract limit, a looming risk to the town's only project-based affordable stock.",
+          "cites": ["s2"]
+        }
+      ]
+    },
+    {
+      "id": "regional-gcha",
+      "heading": "The Garfield County Housing Authority's countywide role",
+      "paragraphs": [
+        {
+          "text": "Silt has no municipal housing authority; its affordable programs run through the Garfield County Housing Authority, which reported managing 240 affordable housing units and 35 deed-restricted rentals countywide in 2024, assisting roughly 559 families per month across mainstream, housing-choice, and emergency voucher programs, and paying $4,476,468 to local landlords in rental assistance.",
+          "cites": ["s2"]
+        },
+        {
+          "text": "In 2024 the authority issued $77,400 in interest-free down-payment-assistance loans and recorded 16 deed-restricted home sales, while warning that a $700,000 HUD recapture would halt new voucher issuance until year-end. Its project-based-voucher pipeline is concentrated outside Silt: 7 units at Benedict in Glenwood Springs and 14 at Rifle Apartments in 2025, with 8 projected for Aster Place in Parachute and 20 for Canyon Vista in Glenwood Springs in 2026-27.",
+          "cites": ["s2"]
+        }
+      ]
+    },
+    {
+      "id": "regional-deed-restriction",
+      "heading": "Garfield County's deed-restriction framework",
+      "paragraphs": [
+        {
+          "text": "The county's Community Housing program requires new development to contribute affordable units and allocates them by priority tier: first to applicants employed full-time (32+ hours per week) by a Garfield County employer, then to full-time county residents, then to those becoming residents through the program. Eligibility spans four income categories, from Category One at 80% of Area Median Income to Category Four at 120% AMI.",
+          "cites": ["s3"]
+        },
+        {
+          "text": "The program's deed-restricted ownership communities, capped at a maximum resale price that appreciates 3% per year (tied to the regional Consumer Price Index), are all in the eastern, higher-cost end of the county: Midland Point near Carbondale, Blue Creek Ranch, Valley View West in West Glenwood, and Ironbridge outside Glenwood Springs. None are in Silt.",
+          "cites": ["s3"]
+        }
+      ]
+    },
+    {
+      "id": "regional-development-near-silt",
+      "heading": "Recent development near Silt has been market-rate",
+      "paragraphs": [
+        {
+          "text": "Growth approved around Silt has skewed market-rate and low-density. In November 2025 county commissioners approved the Mountain View subdivision about two miles north of town: five large lots of 3.9 to 6.8 acres on a 27-acre rural parcel by developer Red Dog LLC, for owner-built single-family homes with optional accessory dwelling units. The approval carried no deed-restriction or affordability component.",
+          "cites": ["s4"]
+        }
+      ]
+    },
+    {
+      "id": "town-policy",
+      "heading": "The Town's own housing posture",
+      "paragraphs": [
+        {
+          "text": "The Town of Silt's comprehensive plan, which the town has been updating, frames housing in general terms, pledging to promote a range of attainable housing choices, to support downtown residential vitality, and to make infill and redevelopment the first priority for future growth, but it sets no numeric affordable-housing target or dedicated funding mechanism.",
+          "cites": ["s5"]
+        }
+      ]
+    }
+  ],
+  "sources": [
+    {
+      "id": "s1",
+      "label": "Silt Senior Housing — Garfield County Housing Authority",
+      "url": "https://garfieldhousing.com/silt-senior-housing/",
+      "kind": "primary",
+      "accessed": "2026-06-18"
+    },
+    {
+      "id": "s2",
+      "label": "Garfield County Housing Authority presents 2024 report to county commissioners — Post Independent",
+      "url": "https://www.postindependent.com/news/garfield-county-housing-authority-presents-2024-report-to-county-commissioners/",
+      "kind": "press",
+      "accessed": "2026-06-18"
+    },
+    {
+      "id": "s3",
+      "label": "Garfield County Community Housing guidelines — Garfield County Housing Authority",
+      "url": "https://garfieldhousing.com/garfield-county-guidelines/",
+      "kind": "primary",
+      "accessed": "2026-06-18"
+    },
+    {
+      "id": "s4",
+      "label": "County commissioners approve preliminary plan for major subdivision near Silt — Post Independent",
+      "url": "https://www.postindependent.com/news/county-commissioners-approve-preliminary-plan-for-major-subdivision-near-silt/",
+      "kind": "press",
+      "accessed": "2026-06-18"
+    },
+    {
+      "id": "s5",
+      "label": "Town of Silt Comprehensive Plan — Town of Silt",
+      "url": "https://www.townofsilt.org/comprehensive_plan",
+      "kind": "primary",
+      "accessed": "2026-06-18"
+    }
+  ]
+}

--- a/data/jurisdiction-briefs/_verified/0870195.json
+++ b/data/jurisdiction-briefs/_verified/0870195.json
@@ -1,0 +1,80 @@
+{
+  "brief_geoid": "0870195",
+  "brief_jurisdiction": "Town of Silt",
+  "audited_at": "2026-06-18",
+  "audit_method": "Direct URL fetch via WebFetch (markdown extraction), 2026-06-18. Each source URL was fetched directly; no WebSearch snippets were used for published claims. Numeric rows drawn from the Garfield County Housing Authority 2024 report are marked 'partial' because figures were captured via model extraction of the fetched page rather than verbatim transcription — a curator should re-confirm exact dollar/unit counts before relying on them.",
+  "rows": [
+    {
+      "section_id": "silt-senior-housing",
+      "paragraph_index": 0,
+      "source_id": "s1",
+      "source_url": "https://garfieldhousing.com/silt-senior-housing/",
+      "verdict": "supported",
+      "supporting_quote": "20 Project Based Voucher apartment building consisting of 16 one bedroom and 4 studio units ... 701 Home Ave in Silt, CO ... Managed by the Garfield County Housing Authority ... open to any low-income Senior (62+) and Disabled (55+) residents. Residency preference: must currently live, work, or be hired to work in Garfield County.",
+      "notes": "Direct URL fetch via WebFetch."
+    },
+    {
+      "section_id": "silt-senior-housing",
+      "paragraph_index": 1,
+      "source_id": "s2",
+      "source_url": "https://www.postindependent.com/news/garfield-county-housing-authority-presents-2024-report-to-county-commissioners/",
+      "verdict": "supported",
+      "supporting_quote": "In 2027, project-based vouchers at Silt Senior Housing will sunset, due to the 40-year HUD limit.",
+      "notes": "Direct URL fetch via WebFetch; the only Silt-specific item in the 2024 GCHA report."
+    },
+    {
+      "section_id": "regional-gcha",
+      "paragraph_index": 0,
+      "source_id": "s2",
+      "source_url": "https://www.postindependent.com/news/garfield-county-housing-authority-presents-2024-report-to-county-commissioners/",
+      "verdict": "partial",
+      "supporting_quote": "240 affordable housing units managed by the authority; 35 deed-restricted rentals; approximately 559 county families assisted monthly through mainstream, housing choice, and emergency housing voucher programs; $4,476,468 paid to local landlords through HUD rental assistance.",
+      "notes": "Figures captured via WebFetch extraction of the report; curator should re-confirm exact counts verbatim."
+    },
+    {
+      "section_id": "regional-gcha",
+      "paragraph_index": 1,
+      "source_id": "s2",
+      "source_url": "https://www.postindependent.com/news/garfield-county-housing-authority-presents-2024-report-to-county-commissioners/",
+      "verdict": "partial",
+      "supporting_quote": "$77,400 in new interest-free down-payment assistance loans provided in 2024; 16 deed-restricted units sold in 2024; No new HUD vouchers will be issued until year-end due to a $700,000 recapture by HUD; 7 project-based vouchers to Benedict (Glenwood Springs, 2025); 14 for Rifle Apartments (2025); 8 projected for Aster Place (Parachute, 2026-27); 20 projected for Canyon Vista (Glenwood Springs, 2026-27).",
+      "notes": "Figures captured via WebFetch extraction; pipeline locations confirm none are in Silt. Curator should re-confirm exact counts verbatim."
+    },
+    {
+      "section_id": "regional-deed-restriction",
+      "paragraph_index": 0,
+      "source_id": "s3",
+      "source_url": "https://garfieldhousing.com/garfield-county-guidelines/",
+      "verdict": "supported",
+      "supporting_quote": "Priority One: Applicants that are employed full-time by a Garfield County-based employment source; Priority Two: full-time residents of Garfield County; Priority Three: Applicants who will become full-time residents ... Full-time is defined as a minimum of 32 hours per week ... four Category Income levels ... ranging from Category One at 80% AMI Income thru Category 4 at 120% AMI Income.",
+      "notes": "Direct URL fetch via WebFetch."
+    },
+    {
+      "section_id": "regional-deed-restriction",
+      "paragraph_index": 1,
+      "source_id": "s3",
+      "source_url": "https://garfieldhousing.com/garfield-county-guidelines/",
+      "verdict": "supported",
+      "supporting_quote": "Four communities feature deed restrictions with a maximum resale price with a 3% annual appreciation based on the Consumer Price Index for Garfield County: Midland Point (near Carbondale), Blue Creek Ranch, Valley View West (West Glenwood), Ironbridge (outside Glenwood Springs).",
+      "notes": "Direct URL fetch via WebFetch; none of the four are in Silt."
+    },
+    {
+      "section_id": "regional-development-near-silt",
+      "paragraph_index": 0,
+      "source_id": "s4",
+      "source_url": "https://www.postindependent.com/news/county-commissioners-approve-preliminary-plan-for-major-subdivision-near-silt/",
+      "verdict": "supported",
+      "supporting_quote": "Subdivision Name: Mountain View. Location: Approximately two miles north of Silt on a 27-acre rural zone district property. Five lots ranging from 3.9 to 6.8 acres each. Developer: Red Dog LLC. Approval Date: Monday, November 19, 2025. Single-family houses ... with the option to add an accessory dwelling unit. No deed-restricted or affordable housing is mentioned in the article.",
+      "notes": "Direct URL fetch via WebFetch."
+    },
+    {
+      "section_id": "town-policy",
+      "paragraph_index": 0,
+      "source_id": "s5",
+      "source_url": "https://www.townofsilt.org/comprehensive_plan",
+      "verdict": "supported",
+      "supporting_quote": "Promote a range of attainable housing choices ... Promote residential opportunities downtown and maintain downtown vitality ... Promote infill/redevelopment which should be the first priority for future growth.",
+      "notes": "Direct URL fetch via WebFetch; plan framework language. Exact adoption year not asserted (page history ambiguous)."
+    }
+  ]
+}


### PR DESCRIPTION
First curated jurisdiction housing-history brief for the **Town of Silt** (geoid `0870195`, Garfield County), produced via the source-first workflow. Adds `data/jurisdiction-briefs/0870195.json` + the mandatory `data/jurisdiction-briefs/_verified/0870195.json` report.

## What it covers (5 sections, all paragraphs cited)
- **Silt Senior Housing** — 20-unit project-based-voucher building (16 one-bed + 4 studio), 701 Home Ave; vouchers **sunset 2027** (40-yr HUD limit).
- **`regional-gcha`** — the countywide Garfield County Housing Authority (240 units / 35 deed-restricted rentals; ~559 families/mo; $4.48M to landlords; $700K HUD recapture pausing vouchers); PBV pipeline is in Glenwood/Rifle/Parachute, **none in Silt**.
- **`regional-deed-restriction`** — county Community Housing tiers + 80–120% AMI; the four deed-restricted ownership communities are all east-county, **none in Silt**.
- **`regional-development-near-silt`** — the Mountain View subdivision (Nov 2025) near town is market-rate large-lot, no affordability component.
- **`town-policy`** — Silt comp-plan housing language (attainable choices, infill-first); no numeric target or dedicated funding.

## Sourcing
5 sources, **all direct WebFetch, no `search` sources**: Silt Senior Housing + county guidelines (primary), Post Independent GCHA report + Mountain View (press), Town of Silt comp plan (primary). Validator is **clean for 0870195**.

## ⚠️ Reviewer notes before final sign-off
- `curator` is flagged **`Claude (AI draft)`** — rename to `PG` on acceptance.
- Two GCHA numeric rows are marked **`partial`** in the verification report because the figures were captured via fetch extraction, not verbatim transcription. Please re-confirm the exact dollar/unit counts against the [Post Independent article](https://www.postindependent.com/news/garfield-county-housing-authority-presents-2024-report-to-county-commissioners/) before relying on them.
- `published: true` (renders on the gated developer surface; jurisdiction briefs are excluded from the public artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)