### PR TITLE
fix(ci): deploy Pages after bot data pushes

### DIFF
--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: data-commits
@@ -106,6 +107,7 @@ jobs:
             }
 
       - name: Commit refreshed data
+        id: data-commit
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -113,8 +115,23 @@ jobs:
           git add data/
           if git diff --cached --quiet; then
             echo "No data changes to commit"
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
           else
             git commit -m "chore: data refresh pipeline $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
             git pull --rebase --autostash -X theirs origin main
             git push
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Trigger Pages deploy
+        if: steps.data-commit.outputs.pushed == 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'deploy.yml',
+              ref: 'main'
+            });
+            core.notice('Dispatched deploy.yml for data-refresh commit.');

--- a/.github/workflows/weekly_housing_brief.yml
+++ b/.github/workflows/weekly_housing_brief.yml
@@ -27,6 +27,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: data-commits
@@ -137,6 +138,7 @@ jobs:
 
           if git diff --cached --quiet; then
             echo "No changes to commit."
+            echo "PUSHED=false" >> "$GITHUB_ENV"
           else
             git commit -m "chore: weekly policy briefs refresh $(date -u '+%Y-%m-%d')"
             # F161 — Rebase onto whatever's currently at origin/main before
@@ -148,4 +150,22 @@ jobs:
             # any unstaged transients from the network fetches.
             git pull --rebase --autostash origin main
             git push
+            echo "PUSHED=true" >> "$GITHUB_ENV"
           fi
+
+      # Bot pushes (GITHUB_TOKEN) do not trigger downstream push-event workflows.
+      # Explicitly dispatch deploy.yml so GitHub Pages stays current after each
+      # data-only commit. The watchdog (pages-deploy-watchdog.yml) fails if
+      # deploy.yml has no run for the latest main SHA.
+      - name: Trigger Pages deploy
+        if: env.PUSHED == 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'deploy.yml',
+              ref: 'main'
+            });
+            core.notice('Dispatched deploy.yml for latest main commit.');


### PR DESCRIPTION
## Summary
- dispatch deploy.yml after weekly policy-brief commits
- dispatch deploy.yml after daily data-refresh commits
- only dispatch when the workflow actually pushed a commit

GitHub does not emit downstream push-triggered workflows for commits made with GITHUB_TOKEN, so these explicit dispatches keep the public test site synchronized with automated data edits.

## Verification
- npm run test:pages (114 passed)
- workflow diffs are limited to permissions, push-output tracking, and deploy dispatch steps