### PR TITLE
fix(site-audit): tolerate expected CAR month-probe 404s

### DIFF
--- a/scripts/audit/site-audit.mjs
+++ b/scripts/audit/site-audit.mjs
@@ -87,6 +87,14 @@ const MAP_DATA_PATTERNS = [
   /\.json$/i,
 ];
 
+// Local resources the site probes optionally and handles gracefully — a 404 here is
+// expected behaviour, not a real failure. The CAR market-report loader
+// (js/housing-data-integration.js) tries the current month first and falls back through
+// older months, so a not-yet-generated current month legitimately 404s.
+const EXPECTED_OPTIONAL_LOCAL_404 = [
+  /\/data\/car-market-report-\d{4}-\d{2}\.json$/i,
+];
+
 function isLocalUrl(url) {
   return url.startsWith(BASE_URL) || url.startsWith('http://127.0.0.1') || url.startsWith('http://localhost');
 }
@@ -306,8 +314,10 @@ async function auditPage(browser, pageConfig) {
       result.mapDataRequests.push({ url: reqUrl, status });
     }
 
-    // Local 4xx = hard failure (missing local data)
-    if (isLocalUrl(reqUrl) && status >= 400 && status < 500) {
+    // Local 4xx = hard failure (missing local data) — except optional resources the
+    // site probes-and-falls-back on (see EXPECTED_OPTIONAL_LOCAL_404).
+    if (isLocalUrl(reqUrl) && status >= 400 && status < 500
+        && !EXPECTED_OPTIONAL_LOCAL_404.some(p => p.test(reqUrl))) {
       result.hardFailures.push(`Local resource missing (HTTP ${status}): ${reqUrl}`);
     }
 


### PR DESCRIPTION
**Problem:** `site-audit` is red site-wide because the CAR market-report loader probes the current month first (`car-market-report-2026-07.json`), which doesn't exist yet, gets a 404, then falls back to the newest available month. The app recovers fine, but site-audit counted that expected probe as a hard failure. This recurs every month rollover.

**Fix:** exempt `data/car-market-report-YYYY-MM.json` from the local-4xx hard-failure rule in `scripts/audit/site-audit.mjs`. All other local 404s still fail as before (verified: `place-chas.json` 404 → still flagged).

**Verify:** the `site-audit` CI check on this PR should now pass. No fake data manufactured; the loader's graceful fallback is unchanged.

Draft for owner review + Claude QA.