### PR TITLE
Draft: B2 brief metric-digest section

### DIFF
--- a/data/jurisdiction-briefs/0803620.json
+++ b/data/jurisdiction-briefs/0803620.json
@@ -162,6 +162,48 @@
           ]
         }
       ]
+    },
+    {
+      "id": "metric-digest",
+      "heading": "Metric Digest",
+      "paragraphs": [
+        {
+          "text": "The metric digest ranks City of Aspen at #92 with an overall housing-need score of 69.3. It identifies 805 deeply affordable units missing at <=30% AMI, equal to 88.9% of <=30% AMI households. 67.6% of renter households are cost burdened, and 1.1% of occupied households are overcrowded.",
+          "cites": [
+            "d1",
+            "d2",
+            "d3",
+            "d4",
+            "d5",
+            "d6"
+          ]
+        },
+        {
+          "text": "Market and supply context: the digest reports a median home value of $3,431,712 and median gross rent of $2,081. 42.9% of households rent, and 54.6% of the housing stock is multifamily.",
+          "cites": [
+            "d7",
+            "d8",
+            "d9",
+            "d10"
+          ]
+        },
+        {
+          "text": "Demographics and demand: the population metric is 6,756. LEHD-based commuting signals show 7,028 in-commuters and a commute ratio of 73.5%. The digest's county-context projection shows -1 future units needed over 20 years, so that projection should be read as county context rather than a place trend.",
+          "cites": [
+            "d11",
+            "d12",
+            "d13",
+            "d14"
+          ]
+        },
+        {
+          "text": "Opportunity context: the digest gives an opportunity score of 60.4 and a walkability score of 66.7. These are current digest levels, not trends.",
+          "cites": [
+            "d15",
+            "d16"
+          ]
+        }
+      ]
     }
   ],
   "sources": [
@@ -297,6 +339,150 @@
       "url": "https://www.chfainfo.com/chfa-news/05212026-2026-r1-housing-tax-credits",
       "kind": "primary",
       "accessed": "2026-06-16"
+    },
+    {
+      "id": "d1",
+      "label": "Ranking index rank - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0803620.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "rank",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d2",
+      "label": "Overall housing-need score - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0803620.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overall_need_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d3",
+      "label": "Deep-affordability housing gap units - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0803620.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_units",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d4",
+      "label": "Deep-affordability gap rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0803620.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_rate_lte30",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d5",
+      "label": "Renter cost-burden rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0803620.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_cost_burdened",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d6",
+      "label": "Occupied-household overcrowding rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0803620.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overcrowding_rate",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d7",
+      "label": "Median home value - jurisdiction metrics digest (2026-05-31)",
+      "url": "data/hna/jurisdiction-metrics-digest/0803620.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "median_home_value",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d8",
+      "label": "Median gross rent - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0803620.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "gross_rent_median",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d9",
+      "label": "Renter household share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0803620.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_renters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d10",
+      "label": "Multifamily housing-stock share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0803620.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_multifamily",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d11",
+      "label": "Population - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0803620.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "population",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d12",
+      "label": "In-commuters - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0803620.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "in_commuters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d13",
+      "label": "Commute ratio - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0803620.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "commute_ratio",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d14",
+      "label": "Twenty-year future units needed - jurisdiction metrics digest (DOLA projection cache)",
+      "url": "data/hna/jurisdiction-metrics-digest/0803620.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "future_units_needed_20yr",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d15",
+      "label": "Opportunity score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0803620.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "opportunity_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d16",
+      "label": "Walkability score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0803620.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "walkability_score",
+      "accessed": "2026-07-03"
     }
   ]
 }

--- a/data/jurisdiction-briefs/08045.json
+++ b/data/jurisdiction-briefs/08045.json
@@ -159,6 +159,48 @@
           ]
         }
       ]
+    },
+    {
+      "id": "metric-digest",
+      "heading": "Metric Digest",
+      "paragraphs": [
+        {
+          "text": "The metric digest ranks Garfield County at #186 with an overall housing-need score of 54.5. It identifies 2,399 deeply affordable units missing at <=30% AMI, equal to 43.7% of <=30% AMI households. 46.2% of renter households are cost burdened, and 2% of occupied households are overcrowded.",
+          "cites": [
+            "d1",
+            "d2",
+            "d3",
+            "d4",
+            "d5",
+            "d6"
+          ]
+        },
+        {
+          "text": "Market and supply context: the digest reports a median home value of $527,800 and median gross rent of $1,637. 30.4% of households rent, and 13.2% of the housing stock is multifamily.",
+          "cites": [
+            "d7",
+            "d8",
+            "d9",
+            "d10"
+          ]
+        },
+        {
+          "text": "Demographics and demand: the population metric is 62,479. LEHD-based commuting signals show 6,981 in-commuters and a commute ratio of 30.7%. The digest's county-context projection shows 6,247 future units needed over 20 years, so that projection should be read as county context rather than a place trend.",
+          "cites": [
+            "d11",
+            "d12",
+            "d13",
+            "d14"
+          ]
+        },
+        {
+          "text": "Opportunity context: the digest gives an opportunity score of 60.8 and a walkability score of 37.0. These are current digest levels, not trends.",
+          "cites": [
+            "d15",
+            "d16"
+          ]
+        }
+      ]
     }
   ],
   "sources": [
@@ -329,6 +371,150 @@
       "url": "https://www.chfainfo.com/chfa-news/05212026-2026-r1-housing-tax-credits",
       "kind": "primary",
       "accessed": "2026-06-16"
+    },
+    {
+      "id": "d1",
+      "label": "Ranking index rank - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/08045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "rank",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d2",
+      "label": "Overall housing-need score - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/08045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overall_need_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d3",
+      "label": "Deep-affordability housing gap units - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/08045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_units",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d4",
+      "label": "Deep-affordability gap rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/08045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_rate_lte30",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d5",
+      "label": "Renter cost-burden rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/08045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_cost_burdened",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d6",
+      "label": "Occupied-household overcrowding rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/08045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overcrowding_rate",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d7",
+      "label": "Median home value - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/08045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "median_home_value",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d8",
+      "label": "Median gross rent - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/08045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "gross_rent_median",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d9",
+      "label": "Renter household share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/08045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_renters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d10",
+      "label": "Multifamily housing-stock share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/08045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_multifamily",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d11",
+      "label": "Population - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/08045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "population",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d12",
+      "label": "In-commuters - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/08045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "in_commuters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d13",
+      "label": "Commute ratio - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/08045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "commute_ratio",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d14",
+      "label": "Twenty-year future units needed - jurisdiction metrics digest (DOLA projection cache)",
+      "url": "data/hna/jurisdiction-metrics-digest/08045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "future_units_needed_20yr",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d15",
+      "label": "Opportunity score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/08045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "opportunity_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d16",
+      "label": "Walkability score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/08045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "walkability_score",
+      "accessed": "2026-07-03"
     }
   ],
   "_unpublished_reason": "Pending source-verification audit (2026-06-12). The original research-agent batch was found to contain at least one fabricated source-to-claim mapping (Carbondale s9). All briefs in this batch are unpublished until each citation is verified against the source URL."

--- a/data/jurisdiction-briefs/08097.json
+++ b/data/jurisdiction-briefs/08097.json
@@ -155,6 +155,48 @@
           ]
         }
       ]
+    },
+    {
+      "id": "metric-digest",
+      "heading": "Metric Digest",
+      "paragraphs": [
+        {
+          "text": "The metric digest ranks Pitkin County at #246 with an overall housing-need score of 48.0. It identifies 1,055 deeply affordable units missing at <=30% AMI, equal to 39.2% of <=30% AMI households. 53.3% of renter households are cost burdened, and 1% of occupied households are overcrowded.",
+          "cites": [
+            "d1",
+            "d2",
+            "d3",
+            "d4",
+            "d5",
+            "d6"
+          ]
+        },
+        {
+          "text": "Market and supply context: the digest reports a median home value of $1,139,100 and median gross rent of $2,004. 37.2% of households rent, and 38.1% of the housing stock is multifamily.",
+          "cites": [
+            "d7",
+            "d8",
+            "d9",
+            "d10"
+          ]
+        },
+        {
+          "text": "Demographics and demand: the population metric is 16,985. LEHD-based commuting signals show 9,682 in-commuters and a commute ratio of 58.6%. The digest's county-context projection shows -3 future units needed over 20 years, so that projection should be read as county context rather than a place trend.",
+          "cites": [
+            "d11",
+            "d12",
+            "d13",
+            "d14"
+          ]
+        },
+        {
+          "text": "Opportunity context: the digest gives an opportunity score of 55.4 and a walkability score of 62.6. These are current digest levels, not trends.",
+          "cites": [
+            "d15",
+            "d16"
+          ]
+        }
+      ]
     }
   ],
   "sources": [
@@ -325,6 +367,150 @@
       "url": "https://www.chfainfo.com/chfa-news/05212026-2026-r1-housing-tax-credits",
       "kind": "primary",
       "accessed": "2026-06-16"
+    },
+    {
+      "id": "d1",
+      "label": "Ranking index rank - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/08097.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "rank",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d2",
+      "label": "Overall housing-need score - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/08097.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overall_need_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d3",
+      "label": "Deep-affordability housing gap units - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/08097.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_units",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d4",
+      "label": "Deep-affordability gap rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/08097.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_rate_lte30",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d5",
+      "label": "Renter cost-burden rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/08097.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_cost_burdened",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d6",
+      "label": "Occupied-household overcrowding rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/08097.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overcrowding_rate",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d7",
+      "label": "Median home value - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/08097.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "median_home_value",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d8",
+      "label": "Median gross rent - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/08097.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "gross_rent_median",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d9",
+      "label": "Renter household share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/08097.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_renters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d10",
+      "label": "Multifamily housing-stock share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/08097.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_multifamily",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d11",
+      "label": "Population - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/08097.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "population",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d12",
+      "label": "In-commuters - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/08097.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "in_commuters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d13",
+      "label": "Commute ratio - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/08097.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "commute_ratio",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d14",
+      "label": "Twenty-year future units needed - jurisdiction metrics digest (DOLA projection cache)",
+      "url": "data/hna/jurisdiction-metrics-digest/08097.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "future_units_needed_20yr",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d15",
+      "label": "Opportunity score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/08097.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "opportunity_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d16",
+      "label": "Walkability score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/08097.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "walkability_score",
+      "accessed": "2026-07-03"
     }
   ]
 }

--- a/data/jurisdiction-briefs/0812045.json
+++ b/data/jurisdiction-briefs/0812045.json
@@ -141,6 +141,48 @@
           ]
         }
       ]
+    },
+    {
+      "id": "metric-digest",
+      "heading": "Metric Digest",
+      "paragraphs": [
+        {
+          "text": "The metric digest ranks Town of Carbondale at #147 with an overall housing-need score of 60.7. It identifies 463 deeply affordable units missing at <=30% AMI, equal to 81.7% of <=30% AMI households. 42.8% of renter households are cost burdened, and 0.9% of occupied households are overcrowded.",
+          "cites": [
+            "d1",
+            "d2",
+            "d3",
+            "d4",
+            "d5",
+            "d6"
+          ]
+        },
+        {
+          "text": "Market and supply context: the digest reports a median home value of $900,600 and median gross rent of $2,167. 36.3% of households rent, and 12% of the housing stock is multifamily.",
+          "cites": [
+            "d7",
+            "d8",
+            "d9",
+            "d10"
+          ]
+        },
+        {
+          "text": "Demographics and demand: the population metric is 6,637. LEHD-based commuting signals show 2,288 in-commuters and a commute ratio of 79.3%. The digest's county-context projection shows 656 future units needed over 20 years, so that projection should be read as county context rather than a place trend.",
+          "cites": [
+            "d11",
+            "d12",
+            "d13",
+            "d14"
+          ]
+        },
+        {
+          "text": "Opportunity context: the digest gives an opportunity score of 59.5 and a walkability score of 63.4. These are current digest levels, not trends.",
+          "cites": [
+            "d15",
+            "d16"
+          ]
+        }
+      ]
     }
   ],
   "sources": [
@@ -262,6 +304,150 @@
       "url": "https://www.chfainfo.com/chfa-news/05212026-2026-r1-housing-tax-credits",
       "kind": "primary",
       "accessed": "2026-06-16"
+    },
+    {
+      "id": "d1",
+      "label": "Ranking index rank - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0812045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "rank",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d2",
+      "label": "Overall housing-need score - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0812045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overall_need_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d3",
+      "label": "Deep-affordability housing gap units - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0812045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_units",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d4",
+      "label": "Deep-affordability gap rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0812045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_rate_lte30",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d5",
+      "label": "Renter cost-burden rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0812045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_cost_burdened",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d6",
+      "label": "Occupied-household overcrowding rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0812045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overcrowding_rate",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d7",
+      "label": "Median home value - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0812045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "median_home_value",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d8",
+      "label": "Median gross rent - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0812045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "gross_rent_median",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d9",
+      "label": "Renter household share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0812045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_renters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d10",
+      "label": "Multifamily housing-stock share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0812045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_multifamily",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d11",
+      "label": "Population - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0812045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "population",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d12",
+      "label": "In-commuters - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0812045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "in_commuters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d13",
+      "label": "Commute ratio - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0812045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "commute_ratio",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d14",
+      "label": "Twenty-year future units needed - jurisdiction metrics digest (DOLA projection cache)",
+      "url": "data/hna/jurisdiction-metrics-digest/0812045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "future_units_needed_20yr",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d15",
+      "label": "Opportunity score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0812045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "opportunity_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d16",
+      "label": "Walkability score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0812045.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "walkability_score",
+      "accessed": "2026-07-03"
     }
   ]
 }

--- a/data/jurisdiction-briefs/0816000.json
+++ b/data/jurisdiction-briefs/0816000.json
@@ -130,6 +130,48 @@
           ]
         }
       ]
+    },
+    {
+      "id": "metric-digest",
+      "heading": "Metric Digest",
+      "paragraphs": [
+        {
+          "text": "The metric digest ranks City of Colorado Springs at #43 with an overall housing-need score of 77.1. It identifies 26,927 deeply affordable units missing at <=30% AMI, equal to 83.7% of <=30% AMI households. 54.6% of renter households are cost burdened, and 2.1% of occupied households are overcrowded.",
+          "cites": [
+            "d1",
+            "d2",
+            "d3",
+            "d4",
+            "d5",
+            "d6"
+          ]
+        },
+        {
+          "text": "Market and supply context: the digest reports a median home value of $450,850 and median gross rent of $1,699. 42.8% of households rent, and 24% of the housing stock is multifamily.",
+          "cites": [
+            "d7",
+            "d8",
+            "d9",
+            "d10"
+          ]
+        },
+        {
+          "text": "Demographics and demand: the population metric is 493,540. LEHD-based commuting signals show 103,081 in-commuters and a commute ratio of 45.5%. The digest's county-context projection shows 47,470 future units needed over 20 years, so that projection should be read as county context rather than a place trend.",
+          "cites": [
+            "d11",
+            "d12",
+            "d13",
+            "d14"
+          ]
+        },
+        {
+          "text": "Opportunity context: the digest gives an opportunity score of 61.6 and a walkability score of 58.2. These are current digest levels, not trends.",
+          "cites": [
+            "d15",
+            "d16"
+          ]
+        }
+      ]
     }
   ],
   "sources": [
@@ -244,6 +286,150 @@
       "url": "https://enterprisecommunity.org/sites/default/files/2026-02/Curbing-the-Insurance-Spiral.pdf",
       "kind": "secondary",
       "accessed": "2026-06-16"
+    },
+    {
+      "id": "d1",
+      "label": "Ranking index rank - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0816000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "rank",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d2",
+      "label": "Overall housing-need score - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0816000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overall_need_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d3",
+      "label": "Deep-affordability housing gap units - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0816000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_units",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d4",
+      "label": "Deep-affordability gap rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0816000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_rate_lte30",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d5",
+      "label": "Renter cost-burden rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0816000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_cost_burdened",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d6",
+      "label": "Occupied-household overcrowding rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0816000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overcrowding_rate",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d7",
+      "label": "Median home value - jurisdiction metrics digest (2026-05-31)",
+      "url": "data/hna/jurisdiction-metrics-digest/0816000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "median_home_value",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d8",
+      "label": "Median gross rent - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0816000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "gross_rent_median",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d9",
+      "label": "Renter household share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0816000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_renters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d10",
+      "label": "Multifamily housing-stock share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0816000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_multifamily",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d11",
+      "label": "Population - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0816000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "population",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d12",
+      "label": "In-commuters - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0816000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "in_commuters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d13",
+      "label": "Commute ratio - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0816000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "commute_ratio",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d14",
+      "label": "Twenty-year future units needed - jurisdiction metrics digest (DOLA projection cache)",
+      "url": "data/hna/jurisdiction-metrics-digest/0816000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "future_units_needed_20yr",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d15",
+      "label": "Opportunity score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0816000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "opportunity_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d16",
+      "label": "Walkability score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0816000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "walkability_score",
+      "accessed": "2026-07-03"
     }
   ]
 }

--- a/data/jurisdiction-briefs/0817375.json
+++ b/data/jurisdiction-briefs/0817375.json
@@ -109,6 +109,48 @@
           ]
         }
       ]
+    },
+    {
+      "id": "metric-digest",
+      "heading": "Metric Digest",
+      "paragraphs": [
+        {
+          "text": "The metric digest ranks City of Cortez at #179 with an overall housing-need score of 55.3. It identifies 755 deeply affordable units missing at <=30% AMI, equal to 84.8% of <=30% AMI households. 55.9% of renter households are cost burdened, and 1.5% of occupied households are overcrowded.",
+          "cites": [
+            "d1",
+            "d2",
+            "d3",
+            "d4",
+            "d5",
+            "d6"
+          ]
+        },
+        {
+          "text": "Market and supply context: the digest reports a median home value of $345,260 and median gross rent of $984. 34.4% of households rent, and 7.8% of the housing stock is multifamily.",
+          "cites": [
+            "d7",
+            "d8",
+            "d9",
+            "d10"
+          ]
+        },
+        {
+          "text": "Demographics and demand: the population metric is 8,976. LEHD-based commuting signals show 2,919 in-commuters and a commute ratio of 61.2%. The digest's county-context projection shows -8 future units needed over 20 years, so that projection should be read as county context rather than a place trend.",
+          "cites": [
+            "d11",
+            "d12",
+            "d13",
+            "d14"
+          ]
+        },
+        {
+          "text": "Opportunity context: the digest gives an opportunity score of 46.4 and a walkability score of 44.0. These are current digest levels, not trends.",
+          "cites": [
+            "d15",
+            "d16"
+          ]
+        }
+      ]
     }
   ],
   "sources": [
@@ -216,6 +258,150 @@
       "url": "https://www.chfainfo.com/chfa-news/05212026-2026-r1-housing-tax-credits",
       "kind": "primary",
       "accessed": "2026-06-16"
+    },
+    {
+      "id": "d1",
+      "label": "Ranking index rank - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0817375.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "rank",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d2",
+      "label": "Overall housing-need score - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0817375.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overall_need_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d3",
+      "label": "Deep-affordability housing gap units - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0817375.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_units",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d4",
+      "label": "Deep-affordability gap rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0817375.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_rate_lte30",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d5",
+      "label": "Renter cost-burden rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0817375.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_cost_burdened",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d6",
+      "label": "Occupied-household overcrowding rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0817375.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overcrowding_rate",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d7",
+      "label": "Median home value - jurisdiction metrics digest (2026-05-31)",
+      "url": "data/hna/jurisdiction-metrics-digest/0817375.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "median_home_value",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d8",
+      "label": "Median gross rent - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0817375.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "gross_rent_median",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d9",
+      "label": "Renter household share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0817375.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_renters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d10",
+      "label": "Multifamily housing-stock share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0817375.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_multifamily",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d11",
+      "label": "Population - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0817375.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "population",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d12",
+      "label": "In-commuters - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0817375.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "in_commuters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d13",
+      "label": "Commute ratio - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0817375.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "commute_ratio",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d14",
+      "label": "Twenty-year future units needed - jurisdiction metrics digest (DOLA projection cache)",
+      "url": "data/hna/jurisdiction-metrics-digest/0817375.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "future_units_needed_20yr",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d15",
+      "label": "Opportunity score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0817375.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "opportunity_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d16",
+      "label": "Walkability score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0817375.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "walkability_score",
+      "accessed": "2026-07-03"
     }
   ]
 }

--- a/data/jurisdiction-briefs/0820000.json
+++ b/data/jurisdiction-briefs/0820000.json
@@ -160,6 +160,48 @@
           ]
         }
       ]
+    },
+    {
+      "id": "metric-digest",
+      "heading": "Metric Digest",
+      "paragraphs": [
+        {
+          "text": "The metric digest ranks City of Denver at #95 with an overall housing-need score of 68.9. It identifies 46,291 deeply affordable units missing at <=30% AMI, equal to 72.5% of <=30% AMI households. 49.5% of renter households are cost burdened, and 3.2% of occupied households are overcrowded.",
+          "cites": [
+            "d1",
+            "d2",
+            "d3",
+            "d4",
+            "d5",
+            "d6"
+          ]
+        },
+        {
+          "text": "Market and supply context: the digest reports a median home value of $539,712 and median gross rent of $1,870. 51.9% of households rent, and 46.6% of the housing stock is multifamily.",
+          "cites": [
+            "d7",
+            "d8",
+            "d9",
+            "d10"
+          ]
+        },
+        {
+          "text": "Demographics and demand: the population metric is 729,019. LEHD-based commuting signals show 381,335 in-commuters and a commute ratio of 69.9%. The digest's county-context projection shows 47,959 future units needed over 20 years, so that projection should be read as county context rather than a place trend.",
+          "cites": [
+            "d11",
+            "d12",
+            "d13",
+            "d14"
+          ]
+        },
+        {
+          "text": "Opportunity context: the digest gives an opportunity score of 58.0 and a walkability score of 71.1. These are current digest levels, not trends.",
+          "cites": [
+            "d15",
+            "d16"
+          ]
+        }
+      ]
     }
   ],
   "sources": [
@@ -330,6 +372,150 @@
       "url": "https://www.chfainfo.com/chfa-news/05212026-2026-r1-housing-tax-credits",
       "kind": "primary",
       "accessed": "2026-06-16"
+    },
+    {
+      "id": "d1",
+      "label": "Ranking index rank - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0820000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "rank",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d2",
+      "label": "Overall housing-need score - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0820000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overall_need_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d3",
+      "label": "Deep-affordability housing gap units - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0820000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_units",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d4",
+      "label": "Deep-affordability gap rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0820000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_rate_lte30",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d5",
+      "label": "Renter cost-burden rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0820000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_cost_burdened",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d6",
+      "label": "Occupied-household overcrowding rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0820000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overcrowding_rate",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d7",
+      "label": "Median home value - jurisdiction metrics digest (2026-05-31)",
+      "url": "data/hna/jurisdiction-metrics-digest/0820000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "median_home_value",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d8",
+      "label": "Median gross rent - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0820000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "gross_rent_median",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d9",
+      "label": "Renter household share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0820000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_renters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d10",
+      "label": "Multifamily housing-stock share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0820000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_multifamily",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d11",
+      "label": "Population - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0820000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "population",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d12",
+      "label": "In-commuters - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0820000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "in_commuters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d13",
+      "label": "Commute ratio - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0820000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "commute_ratio",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d14",
+      "label": "Twenty-year future units needed - jurisdiction metrics digest (DOLA projection cache)",
+      "url": "data/hna/jurisdiction-metrics-digest/0820000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "future_units_needed_20yr",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d15",
+      "label": "Opportunity score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0820000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "opportunity_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d16",
+      "label": "Walkability score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0820000.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "walkability_score",
+      "accessed": "2026-07-03"
     }
   ]
 }

--- a/data/jurisdiction-briefs/0827425.json
+++ b/data/jurisdiction-briefs/0827425.json
@@ -155,6 +155,48 @@
           ]
         }
       ]
+    },
+    {
+      "id": "metric-digest",
+      "heading": "Metric Digest",
+      "paragraphs": [
+        {
+          "text": "The metric digest ranks City of Fort Collins at #14 with an overall housing-need score of 82.5. It identifies 11,853 deeply affordable units missing at <=30% AMI, equal to 78.2% of <=30% AMI households. 59.2% of renter households are cost burdened, and 0.9% of occupied households are overcrowded.",
+          "cites": [
+            "d1",
+            "d2",
+            "d3",
+            "d4",
+            "d5",
+            "d6"
+          ]
+        },
+        {
+          "text": "Market and supply context: the digest reports a median home value of $568,335 and median gross rent of $1,720. 49% of households rent, and 30% of the housing stock is multifamily.",
+          "cites": [
+            "d7",
+            "d8",
+            "d9",
+            "d10"
+          ]
+        },
+        {
+          "text": "Demographics and demand: the population metric is 170,927. LEHD-based commuting signals show 48,393 in-commuters and a commute ratio of 58.9%. The digest's county-context projection shows 10,917 future units needed over 20 years, so that projection should be read as county context rather than a place trend.",
+          "cites": [
+            "d11",
+            "d12",
+            "d13",
+            "d14"
+          ]
+        },
+        {
+          "text": "Opportunity context: the digest gives an opportunity score of 72.0 and a walkability score of 61.7. These are current digest levels, not trends.",
+          "cites": [
+            "d15",
+            "d16"
+          ]
+        }
+      ]
     }
   ],
   "sources": [
@@ -346,6 +388,150 @@
       "url": "https://www.chfainfo.com/chfa-news/05212026-2026-r1-housing-tax-credits",
       "kind": "primary",
       "accessed": "2026-06-16"
+    },
+    {
+      "id": "d1",
+      "label": "Ranking index rank - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0827425.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "rank",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d2",
+      "label": "Overall housing-need score - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0827425.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overall_need_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d3",
+      "label": "Deep-affordability housing gap units - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0827425.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_units",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d4",
+      "label": "Deep-affordability gap rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0827425.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_rate_lte30",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d5",
+      "label": "Renter cost-burden rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0827425.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_cost_burdened",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d6",
+      "label": "Occupied-household overcrowding rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0827425.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overcrowding_rate",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d7",
+      "label": "Median home value - jurisdiction metrics digest (2026-05-31)",
+      "url": "data/hna/jurisdiction-metrics-digest/0827425.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "median_home_value",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d8",
+      "label": "Median gross rent - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0827425.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "gross_rent_median",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d9",
+      "label": "Renter household share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0827425.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_renters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d10",
+      "label": "Multifamily housing-stock share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0827425.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_multifamily",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d11",
+      "label": "Population - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0827425.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "population",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d12",
+      "label": "In-commuters - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0827425.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "in_commuters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d13",
+      "label": "Commute ratio - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0827425.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "commute_ratio",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d14",
+      "label": "Twenty-year future units needed - jurisdiction metrics digest (DOLA projection cache)",
+      "url": "data/hna/jurisdiction-metrics-digest/0827425.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "future_units_needed_20yr",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d15",
+      "label": "Opportunity score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0827425.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "opportunity_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d16",
+      "label": "Walkability score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0827425.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "walkability_score",
+      "accessed": "2026-07-03"
     }
   ]
 }

--- a/data/jurisdiction-briefs/0830780.json
+++ b/data/jurisdiction-briefs/0830780.json
@@ -151,6 +151,48 @@
           ]
         }
       ]
+    },
+    {
+      "id": "metric-digest",
+      "heading": "Metric Digest",
+      "paragraphs": [
+        {
+          "text": "The metric digest ranks City of Glenwood Springs at #54 with an overall housing-need score of 75.4. It identifies 662 deeply affordable units missing at <=30% AMI, equal to 77.1% of <=30% AMI households. 47.6% of renter households are cost burdened, and 0.3% of occupied households are overcrowded.",
+          "cites": [
+            "d1",
+            "d2",
+            "d3",
+            "d4",
+            "d5",
+            "d6"
+          ]
+        },
+        {
+          "text": "Market and supply context: the digest reports a median home value of $877,139 and median gross rent of $1,867. 45.3% of households rent, and 25.9% of the housing stock is multifamily.",
+          "cites": [
+            "d7",
+            "d8",
+            "d9",
+            "d10"
+          ]
+        },
+        {
+          "text": "Demographics and demand: the population metric is 10,241. LEHD-based commuting signals show 7,152 in-commuters and a commute ratio of 78.9%. The digest's county-context projection shows 1,013 future units needed over 20 years, so that projection should be read as county context rather than a place trend.",
+          "cites": [
+            "d11",
+            "d12",
+            "d13",
+            "d14"
+          ]
+        },
+        {
+          "text": "Opportunity context: the digest gives an opportunity score of 78.0 and a walkability score of 53.4. These are current digest levels, not trends.",
+          "cites": [
+            "d15",
+            "d16"
+          ]
+        }
+      ]
     }
   ],
   "sources": [
@@ -328,6 +370,150 @@
       "url": "https://www.chfainfo.com/chfa-news/05212026-2026-r1-housing-tax-credits",
       "kind": "primary",
       "accessed": "2026-06-16"
+    },
+    {
+      "id": "d1",
+      "label": "Ranking index rank - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0830780.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "rank",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d2",
+      "label": "Overall housing-need score - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0830780.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overall_need_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d3",
+      "label": "Deep-affordability housing gap units - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0830780.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_units",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d4",
+      "label": "Deep-affordability gap rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0830780.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_rate_lte30",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d5",
+      "label": "Renter cost-burden rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0830780.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_cost_burdened",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d6",
+      "label": "Occupied-household overcrowding rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0830780.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overcrowding_rate",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d7",
+      "label": "Median home value - jurisdiction metrics digest (2026-05-31)",
+      "url": "data/hna/jurisdiction-metrics-digest/0830780.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "median_home_value",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d8",
+      "label": "Median gross rent - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0830780.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "gross_rent_median",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d9",
+      "label": "Renter household share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0830780.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_renters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d10",
+      "label": "Multifamily housing-stock share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0830780.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_multifamily",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d11",
+      "label": "Population - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0830780.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "population",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d12",
+      "label": "In-commuters - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0830780.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "in_commuters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d13",
+      "label": "Commute ratio - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0830780.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "commute_ratio",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d14",
+      "label": "Twenty-year future units needed - jurisdiction metrics digest (DOLA projection cache)",
+      "url": "data/hna/jurisdiction-metrics-digest/0830780.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "future_units_needed_20yr",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d15",
+      "label": "Opportunity score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0830780.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "opportunity_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d16",
+      "label": "Walkability score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0830780.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "walkability_score",
+      "accessed": "2026-07-03"
     }
   ]
 }

--- a/data/jurisdiction-briefs/0864255.json
+++ b/data/jurisdiction-briefs/0864255.json
@@ -68,6 +68,48 @@
           ]
         }
       ]
+    },
+    {
+      "id": "metric-digest",
+      "heading": "Metric Digest",
+      "paragraphs": [
+        {
+          "text": "The metric digest ranks City of Rifle at #293 with an overall housing-need score of 42.5. It identifies 300 deeply affordable units missing at <=30% AMI, equal to 57.8% of <=30% AMI households. 39.3% of renter households are cost burdened, and 1.9% of occupied households are overcrowded.",
+          "cites": [
+            "d1",
+            "d2",
+            "d3",
+            "d4",
+            "d5",
+            "d6"
+          ]
+        },
+        {
+          "text": "Market and supply context: the digest reports a median home value of $413,500 and median gross rent of $1,308. 33.6% of households rent, and 14.6% of the housing stock is multifamily.",
+          "cites": [
+            "d7",
+            "d8",
+            "d9",
+            "d10"
+          ]
+        },
+        {
+          "text": "Demographics and demand: the population metric is 10,570. LEHD-based commuting signals show 2,545 in-commuters and a commute ratio of 71.6%. The digest's county-context projection shows 1,045 future units needed over 20 years, so that projection should be read as county context rather than a place trend.",
+          "cites": [
+            "d11",
+            "d12",
+            "d13",
+            "d14"
+          ]
+        },
+        {
+          "text": "Opportunity context: the digest gives an opportunity score of 44.8 and a walkability score of 21.0. These are current digest levels, not trends.",
+          "cites": [
+            "d15",
+            "d16"
+          ]
+        }
+      ]
     }
   ],
   "sources": [
@@ -119,6 +161,150 @@
       "url": "https://www.chfainfo.com/chfa-news/05212026-2026-r1-housing-tax-credits",
       "kind": "primary",
       "accessed": "2026-06-16"
+    },
+    {
+      "id": "d1",
+      "label": "Ranking index rank - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0864255.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "rank",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d2",
+      "label": "Overall housing-need score - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0864255.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overall_need_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d3",
+      "label": "Deep-affordability housing gap units - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0864255.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_units",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d4",
+      "label": "Deep-affordability gap rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0864255.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_rate_lte30",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d5",
+      "label": "Renter cost-burden rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0864255.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_cost_burdened",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d6",
+      "label": "Occupied-household overcrowding rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0864255.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overcrowding_rate",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d7",
+      "label": "Median home value - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0864255.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "median_home_value",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d8",
+      "label": "Median gross rent - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0864255.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "gross_rent_median",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d9",
+      "label": "Renter household share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0864255.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_renters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d10",
+      "label": "Multifamily housing-stock share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0864255.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_multifamily",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d11",
+      "label": "Population - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0864255.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "population",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d12",
+      "label": "In-commuters - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0864255.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "in_commuters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d13",
+      "label": "Commute ratio - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0864255.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "commute_ratio",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d14",
+      "label": "Twenty-year future units needed - jurisdiction metrics digest (DOLA projection cache)",
+      "url": "data/hna/jurisdiction-metrics-digest/0864255.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "future_units_needed_20yr",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d15",
+      "label": "Opportunity score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0864255.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "opportunity_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d16",
+      "label": "Walkability score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0864255.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "walkability_score",
+      "accessed": "2026-07-03"
     }
   ]
 }

--- a/data/jurisdiction-briefs/0867280.json
+++ b/data/jurisdiction-briefs/0867280.json
@@ -131,6 +131,48 @@
           ]
         }
       ]
+    },
+    {
+      "id": "metric-digest",
+      "heading": "Metric Digest",
+      "paragraphs": [
+        {
+          "text": "The metric digest ranks City of Salida at #116 with an overall housing-need score of 66.7. It identifies 367 deeply affordable units missing at <=30% AMI, equal to 87.8% of <=30% AMI households. 58% of renter households are cost burdened, and 0.4% of occupied households are overcrowded.",
+          "cites": [
+            "d1",
+            "d2",
+            "d3",
+            "d4",
+            "d5",
+            "d6"
+          ]
+        },
+        {
+          "text": "Market and supply context: the digest reports a median home value of $710,351 and median gross rent of $1,292. 36.6% of households rent, and 7.6% of the housing stock is multifamily.",
+          "cites": [
+            "d7",
+            "d8",
+            "d9",
+            "d10"
+          ]
+        },
+        {
+          "text": "Demographics and demand: the population metric is 5,861. LEHD-based commuting signals show 2,361 in-commuters and a commute ratio of 60.9%. The digest's county-context projection shows 197 future units needed over 20 years, so that projection should be read as county context rather than a place trend.",
+          "cites": [
+            "d11",
+            "d12",
+            "d13",
+            "d14"
+          ]
+        },
+        {
+          "text": "Opportunity context: the digest gives an opportunity score of 56.7 and a walkability score of 47.0. These are current digest levels, not trends.",
+          "cites": [
+            "d15",
+            "d16"
+          ]
+        }
+      ]
     }
   ],
   "sources": [
@@ -259,6 +301,150 @@
       "url": "https://www.chfainfo.com/chfa-news/05212026-2026-r1-housing-tax-credits",
       "kind": "primary",
       "accessed": "2026-06-16"
+    },
+    {
+      "id": "d1",
+      "label": "Ranking index rank - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0867280.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "rank",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d2",
+      "label": "Overall housing-need score - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0867280.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overall_need_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d3",
+      "label": "Deep-affordability housing gap units - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0867280.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_units",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d4",
+      "label": "Deep-affordability gap rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0867280.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_rate_lte30",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d5",
+      "label": "Renter cost-burden rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0867280.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_cost_burdened",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d6",
+      "label": "Occupied-household overcrowding rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0867280.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overcrowding_rate",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d7",
+      "label": "Median home value - jurisdiction metrics digest (2026-05-31)",
+      "url": "data/hna/jurisdiction-metrics-digest/0867280.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "median_home_value",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d8",
+      "label": "Median gross rent - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0867280.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "gross_rent_median",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d9",
+      "label": "Renter household share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0867280.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_renters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d10",
+      "label": "Multifamily housing-stock share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0867280.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_multifamily",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d11",
+      "label": "Population - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0867280.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "population",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d12",
+      "label": "In-commuters - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0867280.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "in_commuters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d13",
+      "label": "Commute ratio - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0867280.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "commute_ratio",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d14",
+      "label": "Twenty-year future units needed - jurisdiction metrics digest (DOLA projection cache)",
+      "url": "data/hna/jurisdiction-metrics-digest/0867280.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "future_units_needed_20yr",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d15",
+      "label": "Opportunity score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0867280.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "opportunity_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d16",
+      "label": "Walkability score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0867280.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "walkability_score",
+      "accessed": "2026-07-03"
     }
   ]
 }

--- a/data/jurisdiction-briefs/0870195.json
+++ b/data/jurisdiction-briefs/0870195.json
@@ -14,11 +14,15 @@
       "paragraphs": [
         {
           "text": "Silt's principal dedicated affordable property is Silt Senior Housing at 701 Home Avenue, a 20-unit apartment building (16 one-bedroom and 4 studio units) operated on project-based vouchers and managed by the county housing authority. It is restricted to low-income seniors aged 62 and older and disabled residents aged 55 and older, with a preference for households that live or work in the county.",
-          "cites": ["s1"]
+          "cites": [
+            "s1"
+          ]
         },
         {
           "text": "The county housing authority's 2024 report to county commissioners flagged that the project-based vouchers attached to Silt Senior Housing will sunset in 2027 under the 40-year HUD contract limit, a looming risk to the town's only project-based affordable stock.",
-          "cites": ["s2"]
+          "cites": [
+            "s2"
+          ]
         }
       ]
     },
@@ -28,11 +32,15 @@
       "paragraphs": [
         {
           "text": "Silt has no municipal housing authority; its affordable programs run through the Garfield County Housing Authority, which reported managing 240 affordable housing units and 35 deed-restricted rentals countywide in 2024, assisting roughly 559 families per month across mainstream, housing-choice, and emergency voucher programs, and paying $4,476,468 to local landlords in rental assistance.",
-          "cites": ["s2"]
+          "cites": [
+            "s2"
+          ]
         },
         {
           "text": "In 2024 the authority issued $77,400 in interest-free down-payment-assistance loans and recorded 16 deed-restricted home sales, while warning that a $700,000 HUD recapture would halt new voucher issuance until year-end. Its project-based-voucher pipeline is concentrated outside Silt: 7 units at Benedict in Glenwood Springs and 14 at Rifle Apartments in 2025, with 8 projected for Aster Place in Parachute and 20 for Canyon Vista in Glenwood Springs in 2026-27.",
-          "cites": ["s2"]
+          "cites": [
+            "s2"
+          ]
         }
       ]
     },
@@ -42,11 +50,15 @@
       "paragraphs": [
         {
           "text": "The county's Community Housing program requires new development to contribute affordable units and allocates them by priority tier: first to applicants employed full-time (32+ hours per week) by a Garfield County employer, then to full-time county residents, then to those becoming residents through the program. Eligibility spans four income categories, from Category One at 80% of Area Median Income to Category Four at 120% AMI.",
-          "cites": ["s3"]
+          "cites": [
+            "s3"
+          ]
         },
         {
           "text": "The program's deed-restricted ownership communities, capped at a maximum resale price that appreciates 3% per year (tied to the regional Consumer Price Index), are all in the eastern, higher-cost end of the county: Midland Point near Carbondale, Blue Creek Ranch, Valley View West in West Glenwood, and Ironbridge outside Glenwood Springs. None are in Silt.",
-          "cites": ["s3"]
+          "cites": [
+            "s3"
+          ]
         }
       ]
     },
@@ -56,7 +68,9 @@
       "paragraphs": [
         {
           "text": "Growth approved around Silt has skewed market-rate and low-density. In November 2025 county commissioners approved the Mountain View subdivision about two miles north of town: five large lots of 3.9 to 6.8 acres on a 27-acre rural parcel by developer Red Dog LLC, for owner-built single-family homes with optional accessory dwelling units. The approval carried no deed-restriction or affordability component.",
-          "cites": ["s4"]
+          "cites": [
+            "s4"
+          ]
         }
       ]
     },
@@ -66,7 +80,9 @@
       "paragraphs": [
         {
           "text": "The Town of Silt's comprehensive plan, which the town has been updating, frames housing in general terms, pledging to promote a range of attainable housing choices, to support downtown residential vitality, and to make infill and redevelopment the first priority for future growth, but it sets no numeric affordable-housing target or dedicated funding mechanism.",
-          "cites": ["s5"]
+          "cites": [
+            "s5"
+          ]
         }
       ]
     },
@@ -76,19 +92,29 @@
       "paragraphs": [
         {
           "text": "The biggest near-term change in affordable supply for western Garfield County is being built in Rifle rather than Silt: Habitat for Humanity of the Roaring Fork Valley's modular-home production plant at 2515 Centennial Parkway, in the Rifle Energy Innovation Center off U.S. Highway 6. Habitat's president told the City of Rifle the roughly $16 million facility will, 'within the next several years, be producing up to 200 homes (units) a year and hiring 64 employees,' turning out net-zero, all-electric modular homes for the valley — a pipeline Silt's infill lots and future deed-restricted projects can draw on.",
-          "cites": ["s6", "s7"]
+          "cites": [
+            "s6",
+            "s7"
+          ]
         },
         {
           "text": "The plant is large and purpose-built. EVstudio, the project architect, describes a 63,000-square-foot 'Modular Production and Advanced Manufacturing Training Facility' measuring 210 by 300 feet, designed around 'net-zero, all-electric, and sustainable practices.' (One news account rounded it to 66,000 square feet; the architect's 63,000 is the design figure.)",
-          "cites": ["s8"]
+          "cites": [
+            "s8"
+          ]
         },
         {
           "text": "It doubles as a workforce-training site. Habitat runs the floor in 'partnership with the Colorado River BOCES and Colorado Mountain College (CMC) to train and certify a local workforce,' with the goal of 'educating up to 100 high school and post-graduate students per year' in advanced manufacturing.",
-          "cites": ["s6", "s7"]
+          "cites": [
+            "s6",
+            "s7"
+          ]
         },
         {
           "text": "State law is shifting to support the model. Colorado's SB25-002 (2025), 'Regional Building Codes for Factory-Built Structures,' provides that once the state housing board adopts factory-built rules, 'the state plumbing board, the state electrical board, and the state fire suppression administrator do not have jurisdiction over' factory-built structures — consolidating them under a single statewide factory-built code due by July 1, 2026, which is meant to speed siting of certified modular units like Rifle's.",
-          "cites": ["s9"]
+          "cites": [
+            "s9"
+          ]
         }
       ]
     },
@@ -98,19 +124,27 @@
       "paragraphs": [
         {
           "text": "Silt's own 2026 planning docket is about subdivision and PUD expansion, not standalone tax-credit projects: the early-2026 Planning and Zoning packets are filled with annexations, preliminary plats, and use permits, with no LIHTC development on the agenda.",
-          "cites": ["s10"]
+          "cites": [
+            "s10"
+          ]
         },
         {
           "text": "Heron's Nest, reviewed in February 2026, is a 27.468-acre annexation and major-subdivision sketch plan on the southwest edge of town, south of Interstate 70. Town staff describe a phased build-out — the first phase 'expected to begin in 2-3 years, pending financing and permits' — with the PUD's dimensional standards, including a 650-square-foot minimum unit size, still being aligned with the annexation agreement.",
-          "cites": ["s10"]
+          "cites": [
+            "s10"
+          ]
         },
         {
           "text": "Riverview, which replaces the former Ferguson Crossing PUD on a roughly 15-acre site, advanced through the March and April 2026 agendas as a mixed commercial and multifamily plan; by the April packet it carried about 198 multifamily units and roughly 28,550 square feet of commercial space, the commercial footprint refined as the residential unit count was settled.",
-          "cites": ["s11"]
+          "cites": [
+            "s11"
+          ]
         },
         {
           "text": "On funding, Silt has opted in to Proposition 123, the 2023 state ballot measure that ties access to state affordable-housing dollars to a local commitment to grow the affordable housing stock — a county-level benchmark the commissioners set at roughly 41 affordable units a year over the next two years.",
-          "cites": ["s12"]
+          "cites": [
+            "s12"
+          ]
         }
       ]
     },
@@ -120,19 +154,69 @@
       "paragraphs": [
         {
           "text": "When the Board of Trustees reviewed the Heron's Nest sketch plan on February 9, 2026, affordability was named but never pinned down: the board's discussion 'included ... affordable housing and its definition' alongside phasing, the bike trail, and sidewalks, and Resolution No. 7 passed unanimously with no AMI target, deed restriction, or affordable-unit requirement attached. Residents pushed on the housing's income mix — neighbors objected that the project would not 'help their property values with the potential lower income housing,' and another resident 'asked how it was going to benefit the citizens of town.'",
-          "cites": ["s13"]
+          "cites": [
+            "s13"
+          ]
         },
         {
           "text": "The Heron's Nest applicant pitches the project as attainable — a roughly 98-home 'Affordable Housing District' of single-family manufactured homes for 'moderate income residents' — but that affordability rests on grant funding the applicant is pursuing with the town, not on a deed restriction, and the staff-recommended conditions set no income target (the word 'deed' does not appear in the packet).",
-          "cites": ["s10"]
+          "cites": [
+            "s10"
+          ]
         },
         {
           "text": "Affordability has surfaced as a possible incentive rather than a requirement. In the same February 9 meeting, weighing future impact fees for the town's facilities needs, the board noted it would have to consider 'whether there would be a break given to affordable housing developments' — an acknowledgment that Silt has no affordability policy lever locked in yet.",
-          "cites": ["s13"]
+          "cites": [
+            "s13"
+          ]
         },
         {
           "text": "By contrast, the town's largest active proposal — Riverview, at roughly 198 multifamily units — advanced through Planning & Zoning and toward Board approval in spring 2026 with no affordability target discussed in its packets: a full read turns up no 'affordable,' 'attainable,' 'AMI,' 'inclusionary,' or 'deed-restricted' condition on the project.",
-          "cites": ["s11"]
+          "cites": [
+            "s11"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "metric-digest",
+      "heading": "Metric Digest",
+      "paragraphs": [
+        {
+          "text": "The metric digest ranks Town of Silt at #119 with an overall housing-need score of 66.0. It identifies 157 deeply affordable units missing at <=30% AMI, equal to 91.8% of <=30% AMI households. 51.2% of renter households are cost burdened, and 1.3% of occupied households are overcrowded.",
+          "cites": [
+            "d1",
+            "d2",
+            "d3",
+            "d4",
+            "d5",
+            "d6"
+          ]
+        },
+        {
+          "text": "Market and supply context: the digest reports a median home value of $618,776 and median gross rent of $1,859. 26.2% of households rent, and 3% of the housing stock is multifamily.",
+          "cites": [
+            "d7",
+            "d8",
+            "d9",
+            "d10"
+          ]
+        },
+        {
+          "text": "Demographics and demand: the population metric is 3,642. LEHD-based commuting signals show 443 in-commuters and a commute ratio of 84.7%. The digest's county-context projection shows 360 future units needed over 20 years, so that projection should be read as county context rather than a place trend.",
+          "cites": [
+            "d11",
+            "d12",
+            "d13",
+            "d14"
+          ]
+        },
+        {
+          "text": "Opportunity context: the digest gives an opportunity score of 53.3 and a walkability score of 24.0. These are current digest levels, not trends.",
+          "cites": [
+            "d15",
+            "d16"
+          ]
         }
       ]
     }
@@ -228,6 +312,150 @@
       "url": "https://townofsilt.org/i/u/2017580/f/bot_minutes/2026%20BOT%20Minutes/E_BOT_Minutes_2-9-26.pdf",
       "kind": "primary",
       "accessed": "2026-06-20"
+    },
+    {
+      "id": "d1",
+      "label": "Ranking index rank - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0870195.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "rank",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d2",
+      "label": "Overall housing-need score - jurisdiction metrics digest (2026-07-02T20:43:24Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0870195.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overall_need_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d3",
+      "label": "Deep-affordability housing gap units - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0870195.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_units",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d4",
+      "label": "Deep-affordability gap rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0870195.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_rate_lte30",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d5",
+      "label": "Renter cost-burden rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0870195.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_cost_burdened",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d6",
+      "label": "Occupied-household overcrowding rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0870195.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overcrowding_rate",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d7",
+      "label": "Median home value - jurisdiction metrics digest (2026-05-31)",
+      "url": "data/hna/jurisdiction-metrics-digest/0870195.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "median_home_value",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d8",
+      "label": "Median gross rent - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0870195.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "gross_rent_median",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d9",
+      "label": "Renter household share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0870195.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_renters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d10",
+      "label": "Multifamily housing-stock share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0870195.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_multifamily",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d11",
+      "label": "Population - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0870195.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "population",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d12",
+      "label": "In-commuters - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0870195.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "in_commuters",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d13",
+      "label": "Commute ratio - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0870195.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "commute_ratio",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d14",
+      "label": "Twenty-year future units needed - jurisdiction metrics digest (DOLA projection cache)",
+      "url": "data/hna/jurisdiction-metrics-digest/0870195.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "future_units_needed_20yr",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d15",
+      "label": "Opportunity score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0870195.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "opportunity_score",
+      "accessed": "2026-07-03"
+    },
+    {
+      "id": "d16",
+      "label": "Walkability score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0870195.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "walkability_score",
+      "accessed": "2026-07-03"
     }
   ]
 }

--- a/data/jurisdiction-briefs/_schema.json
+++ b/data/jurisdiction-briefs/_schema.json
@@ -27,7 +27,7 @@
     "published": {
       "type": "boolean",
       "default": false,
-      "description": "Gate the brief from public-facing renders. Defaults to false — the brief stays internal until every paragraph is sourced (no needs_source flags) and a human has flipped this to true. The validator enforces: published=true implies zero needs_source paragraphs and zero kind=='search' sources."
+      "description": "Gate the brief from public-facing renders. Defaults to false — the brief stays internal until every paragraph is sourced (no needs_source flags) and a human has flipped this to true. The validator enforces: published=true implies zero needs_source paragraphs and zero kind=='search' sources. kind=='data' sources are allowed for repository-owned datasets and are auto-verified by the validator."
     },
     "sections": {
       "type": "array",
@@ -70,12 +70,20 @@
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["id", "label", "url", "kind"],
+        "required": ["id", "label", "kind"],
         "properties": {
-          "id": { "type": "string", "pattern": "^s[0-9]+$" },
+          "id": { "type": "string", "pattern": "^[sd][0-9]+$" },
           "label": { "type": "string", "minLength": 3 },
           "url": { "type": "string", "format": "uri" },
-          "kind": { "enum": ["primary", "secondary", "press", "search"] },
+          "kind": { "enum": ["primary", "secondary", "press", "search", "data"] },
+          "dataset": {
+            "type": "string",
+            "description": "Repository-owned dataset key for kind='data' citations."
+          },
+          "field": {
+            "type": "string",
+            "description": "Metric field inside the referenced repository-owned dataset for kind='data' citations."
+          },
           "accessed": {
             "type": "string",
             "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"

--- a/js/components/jurisdiction-brief.js
+++ b/js/components/jurisdiction-brief.js
@@ -80,6 +80,7 @@
       '.jbrief__kind--secondary { background:rgba(37,99,235,.16);  color:#1d4ed8; }',
       '.jbrief__kind--press     { background:rgba(217,119,6,.16);  color:#92400e; }',
       '.jbrief__kind--search    { background:rgba(99,102,241,.15); color:#4338ca; }',
+      '.jbrief__kind--data      { background:rgba(8,145,178,.16);  color:#0e7490; }',
       // Dark-mode overrides — site uses OS preference (prefers-color-scheme:
       // dark) for the base theme AND an html.dark-mode class for the manual
       // toggle. Cover both so cite badges + kind chips have adequate contrast
@@ -93,6 +94,7 @@
       '  .jbrief__kind--secondary { background:rgba(96,165,250,.22); color:#bfdbfe; }',
       '  .jbrief__kind--press   { background:rgba(251,191,36,.22);  color:#fde68a; }',
       '  .jbrief__kind--search  { background:rgba(165,180,252,.22); color:#c7d2fe; }',
+      '  .jbrief__kind--data    { background:rgba(34,211,238,.22); color:#a5f3fc; }',
       '}',
       'html.dark-mode .jbrief__cite          { background:rgba(165,180,252,.22); color:#e0e7ff; }',
       'html.dark-mode .jbrief__cite:hover    { background:rgba(165,180,252,.34); }',
@@ -102,6 +104,7 @@
       'html.dark-mode .jbrief__kind--secondary { background:rgba(96,165,250,.22); color:#bfdbfe; }',
       'html.dark-mode .jbrief__kind--press   { background:rgba(251,191,36,.22);  color:#fde68a; }',
       'html.dark-mode .jbrief__kind--search  { background:rgba(165,180,252,.22); color:#c7d2fe; }',
+      'html.dark-mode .jbrief__kind--data    { background:rgba(34,211,238,.22); color:#a5f3fc; }',
       '.jbrief__meta { font-size:.7rem; color:var(--faint,#888); margin-top:.6rem; }',
       '.jbrief__missing {',
       '  border:1px dashed var(--border,#ccc); border-radius:6px;',
@@ -343,11 +346,15 @@
                       : s.kind === 'secondary' ? 'jbrief__kind--secondary'
                       : s.kind === 'press'     ? 'jbrief__kind--press'
                       : s.kind === 'search'    ? 'jbrief__kind--search'
+                      : s.kind === 'data'      ? 'jbrief__kind--data'
                       : '';
+          var labelHtml = s.url
+            ? '<a href="' + _esc(s.url) + '" target="_blank" rel="noopener">' +
+                _esc(s.label) + '</a>'
+            : '<span>' + _esc(s.label) + '</span>';
           return '<li id="jbrief-src-' + _esc(s.id) + '">' +
                    '<strong>[' + (i + 1) + ']</strong> ' +
-                   '<a href="' + _esc(s.url) + '" target="_blank" rel="noopener">' +
-                     _esc(s.label) + '</a>' +
+                   labelHtml +
                    '<span class="jbrief__kind ' + kindCls + '">' +
                      _esc(s.kind || '') + '</span>' +
                  '</li>';

--- a/scripts/generate-brief-metric-digest-sections.mjs
+++ b/scripts/generate-brief-metric-digest-sections.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * Add or refresh the Metric Digest section in curated jurisdiction briefs.
+ *
+ * The section consumes data/hna/jurisdiction-metrics-digest/<geoid>.json.
+ * It does not rebuild rankings or recompute metrics.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const BRIEFS_DIR = path.join(ROOT, "data", "jurisdiction-briefs");
+const DIGEST_DIR = path.join(ROOT, "data", "hna", "jurisdiction-metrics-digest");
+
+const DATA_SOURCES = [
+  ["d1", "rank", "Ranking index rank"],
+  ["d2", "overall_need_score", "Overall housing-need score"],
+  ["d3", "housing_gap_units", "Deep-affordability housing gap units"],
+  ["d4", "housing_gap_rate_lte30", "Deep-affordability gap rate"],
+  ["d5", "pct_cost_burdened", "Renter cost-burden rate"],
+  ["d6", "overcrowding_rate", "Occupied-household overcrowding rate"],
+  ["d7", "median_home_value", "Median home value"],
+  ["d8", "gross_rent_median", "Median gross rent"],
+  ["d9", "pct_renters", "Renter household share"],
+  ["d10", "pct_multifamily", "Multifamily housing-stock share"],
+  ["d11", "population", "Population"],
+  ["d12", "in_commuters", "In-commuters"],
+  ["d13", "commute_ratio", "Commute ratio"],
+  ["d14", "future_units_needed_20yr", "Twenty-year future units needed"],
+  ["d15", "opportunity_score", "Opportunity score"],
+  ["d16", "walkability_score", "Walkability score"],
+];
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function writeJson(file, data) {
+  fs.writeFileSync(file, JSON.stringify(data, null, 2) + "\n");
+}
+
+function metric(digest, field) {
+  const value = digest.metrics && digest.metrics[field];
+  if (!value || value.value === null || value.value === undefined) {
+    throw new Error(`${digest.geography.geoid}: missing digest metric ${field}`);
+  }
+  return value;
+}
+
+function num(value, digits = 0) {
+  return Number(value).toLocaleString("en-US", {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  });
+}
+
+function valueText(digest, field, style = "number") {
+  const value = metric(digest, field).value;
+  if (style === "money") return `$${num(value)}`;
+  if (style === "pct") return `${num(value, Number.isInteger(value) ? 0 : 1)}%`;
+  if (style === "score") return num(value, 1);
+  return num(value, Number.isInteger(value) ? 0 : 1);
+}
+
+function sourceFor(geoid, id, field, label) {
+  const m = readJson(path.join(DIGEST_DIR, `${geoid}.json`)).metrics[field];
+  return {
+    id,
+    label: `${label} - jurisdiction metrics digest (${m.as_of})`,
+    url: `data/hna/jurisdiction-metrics-digest/${geoid}.json`,
+    kind: "data",
+    dataset: "jurisdiction-metrics-digest",
+    field,
+    accessed: "2026-07-03",
+  };
+}
+
+function sectionFor(brief, digest) {
+  const jurisdiction = brief.jurisdiction || digest.geography.name;
+  return {
+    id: "metric-digest",
+    heading: "Metric Digest",
+    paragraphs: [
+      {
+        text:
+          `The metric digest ranks ${jurisdiction} at #${valueText(digest, "rank")} ` +
+          `with an overall housing-need score of ${valueText(digest, "overall_need_score", "score")}. ` +
+          `It identifies ${valueText(digest, "housing_gap_units")} deeply affordable units missing at <=30% AMI, ` +
+          `equal to ${valueText(digest, "housing_gap_rate_lte30", "pct")} of <=30% AMI households. ` +
+          `${valueText(digest, "pct_cost_burdened", "pct")} of renter households are cost burdened, ` +
+          `and ${valueText(digest, "overcrowding_rate", "pct")} of occupied households are overcrowded.`,
+        cites: ["d1", "d2", "d3", "d4", "d5", "d6"],
+      },
+      {
+        text:
+          `Market and supply context: the digest reports a median home value of ` +
+          `${valueText(digest, "median_home_value", "money")} and median gross rent of ` +
+          `${valueText(digest, "gross_rent_median", "money")}. ` +
+          `${valueText(digest, "pct_renters", "pct")} of households rent, and ` +
+          `${valueText(digest, "pct_multifamily", "pct")} of the housing stock is multifamily.`,
+        cites: ["d7", "d8", "d9", "d10"],
+      },
+      {
+        text:
+          `Demographics and demand: the population metric is ` +
+          `${valueText(digest, "population")}. LEHD-based commuting signals show ` +
+          `${valueText(digest, "in_commuters")} in-commuters and a commute ratio of ` +
+          `${valueText(digest, "commute_ratio", "pct")}. The digest's county-context projection ` +
+          `shows ${valueText(digest, "future_units_needed_20yr")} future units needed over 20 years, ` +
+          `so that projection should be read as county context rather than a place trend.`,
+        cites: ["d11", "d12", "d13", "d14"],
+      },
+      {
+        text:
+          `Opportunity context: the digest gives an opportunity score of ` +
+          `${valueText(digest, "opportunity_score", "score")} and a walkability score of ` +
+          `${valueText(digest, "walkability_score", "score")}. These are current digest levels, not trends.`,
+        cites: ["d15", "d16"],
+      },
+    ],
+  };
+}
+
+function updateBrief(file) {
+  const brief = readJson(file);
+  const geoid = brief.geoid;
+  const digest = readJson(path.join(DIGEST_DIR, `${geoid}.json`));
+
+  brief.sections = (brief.sections || []).filter((section) => section.id !== "metric-digest");
+  brief.sections.push(sectionFor(brief, digest));
+
+  const dataSourceIds = new Set(DATA_SOURCES.map(([id]) => id));
+  brief.sources = (brief.sources || []).filter((source) => !dataSourceIds.has(source.id));
+  for (const [id, field, label] of DATA_SOURCES) {
+    brief.sources.push(sourceFor(geoid, id, field, label));
+  }
+
+  writeJson(file, brief);
+}
+
+function main() {
+  const files = fs.readdirSync(BRIEFS_DIR)
+    .filter((file) => /^08\d{3}(\d{2})?\.json$/.test(file))
+    .sort()
+    .map((file) => path.join(BRIEFS_DIR, file));
+
+  for (const file of files) updateBrief(file);
+  console.log(`[metric-digest-briefs] updated ${files.length} brief(s)`);
+}
+
+main();

--- a/scripts/validate-jurisdiction-briefs.py
+++ b/scripts/validate-jurisdiction-briefs.py
@@ -23,10 +23,12 @@ import json
 import re
 import sys
 from pathlib import Path
+from typing import Optional
 
 ROOT       = Path(__file__).resolve().parent.parent
 BRIEFS_DIR = ROOT / "data" / "jurisdiction-briefs"
 REGISTRY   = ROOT / "data" / "hna" / "geography-registry.json"
+DIGEST_DIR = ROOT / "data" / "hna" / "jurisdiction-metrics-digest"
 
 
 def load_co_place_names() -> set[str]:
@@ -76,6 +78,87 @@ ENTITY_SUFFIX_PATTERN = (
 REGIONAL_SECTION_PREFIXES = ("coalition-", "regional-")
 
 
+def load_metric_digest(geoid: str) -> dict:
+    path = DIGEST_DIR / f"{geoid}.json"
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return {}
+
+
+def format_metric_variants(value, field: str = "") -> set[str]:
+    variants = {str(value)}
+    money_field = bool(re.search(r"(value|rent|income|price|cost|dollar)", field or ""))
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if float(value).is_integer():
+            n = int(value)
+            variants.add(f"{n:,}")
+            if money_field:
+                variants.add(f"${n:,}")
+        else:
+            variants.add(f"{value:,.1f}")
+            variants.add(f"{value:,.2f}")
+            variants.add(f"{value:,.1f}%")
+            variants.add(f"{value:,.2f}%")
+            if money_field:
+                variants.add(f"${value:,.0f}")
+                variants.add(f"${value:,.1f}")
+    return {v for v in variants if v}
+
+
+def auto_verify_data_source(
+    brief: dict,
+    section_id: str,
+    paragraph_index: int,
+    paragraph_text: str,
+    source: dict,
+    digest: dict,
+) -> tuple[Optional[dict], Optional[str]]:
+    dataset = source.get("dataset")
+    field = source.get("field")
+    geoid = brief.get("geoid") or ""
+    if source.get("kind") != "data":
+        return None, None
+    if dataset != "jurisdiction-metrics-digest":
+        return None, (
+            f"{geoid}.json: data source '{source.get('id')}' has unsupported "
+            f"dataset '{dataset}'."
+        )
+    metrics = digest.get("metrics") or {}
+    metric = metrics.get(field)
+    if not isinstance(metric, dict):
+        return None, (
+            f"{geoid}.json: data source '{source.get('id')}' references missing "
+            f"metric field '{field}' in jurisdiction-metrics-digest/{geoid}.json."
+        )
+    value = metric.get("value")
+    variants = format_metric_variants(value, field)
+    if not any(v in paragraph_text for v in variants):
+        sample = ", ".join(sorted(variants)[:5])
+        return None, (
+            f"{geoid}.json: section '{section_id}' paragraph {paragraph_index} "
+            f"cites data source '{source.get('id')}' ({field}) but does not state "
+            f"the digest value {value!r}. Accepted text variants include: {sample}."
+        )
+    source_url = source.get("url") or f"data/hna/jurisdiction-metrics-digest/{geoid}.json"
+    return {
+        "section_id": section_id,
+        "paragraph_index": paragraph_index,
+        "source_id": source.get("id"),
+        "source_url": source_url,
+        "verdict": "supported",
+        "supporting_quote": (
+            f"jurisdiction-metrics-digest/{geoid}.json {field} = {value}"
+        ),
+        "notes": (
+            "Auto-verified by scripts/validate-jurisdiction-briefs.py against "
+            "the repository-owned jurisdiction metrics digest."
+        ),
+    }, None
+
+
 def validate_brief(path: Path, co_places: set[str]) -> list[str]:
     errors: list[str] = []
     try:
@@ -99,7 +182,10 @@ def validate_brief(path: Path, co_places: set[str]) -> list[str]:
     sections = brief.get("sections") or []
     sources  = brief.get("sources")  or []
     source_ids = {s.get("id") for s in sources if isinstance(s, dict)}
+    source_by_id = {s.get("id"): s for s in sources if isinstance(s, dict)}
     cited_ids: set[str] = set()
+    auto_verified_data_rows: list[dict] = []
+    digest = load_metric_digest(expected)
     own_name = re.sub(r"^(town|city|county) of ", "",
                       (brief.get("jurisdiction") or "").lower()).strip()
     own_name_stripped = re.sub(r"\s+(county|town|city|cdp)$", "",
@@ -122,6 +208,16 @@ def validate_brief(path: Path, co_places: set[str]) -> list[str]:
                 if c not in source_ids:
                     errors.append(f"{path.name}: section '{sid}' paragraph "
                                   f"{p_idx} cites unknown source id '{c}'")
+                else:
+                    src = source_by_id.get(c) or {}
+                    if src.get("kind") == "data":
+                        row, err = auto_verify_data_source(
+                            brief, sid, p_idx, p.get("text") or "", src, digest
+                        )
+                        if err:
+                            errors.append(err)
+                        elif row:
+                            auto_verified_data_rows.append(row)
                 cited_ids.add(c)
 
             # 7. single-jurisdiction QA on non-regional sections.
@@ -211,7 +307,8 @@ def validate_brief(path: Path, co_places: set[str]) -> list[str]:
                     "Regenerate it before publishing."
                 )
             else:
-                report_rows = report.get("rows") or []
+                report_rows = list(report.get("rows") or [])
+                report_rows.extend(auto_verified_data_rows)
                 expected_pairs = {
                     (sec.get("id") or "", p_idx, cid)
                     for sec in sections


### PR DESCRIPTION
## Summary
- Adds a source-cited `Metric Digest` section to the 12 jurisdiction brief JSON files using `data/hna/jurisdiction-metrics-digest/<geoid>.json`.
- Adds `kind: "data"` sources to the brief schema and validator, with auto-verification against repository-owned digest values.
- Updates the jurisdiction brief renderer so data sources render as non-link source chips.
- Adds `scripts/generate-brief-metric-digest-sections.mjs` to regenerate the section from the live digest.

## QA / Verification
- Negative check: temporarily flipped Silt `housing_gap_units` from `157` to `158`; `npm run test:briefs` failed as expected, then the value was reverted.
- `npm run test:briefs` passed: 12/12.
- `npm run test:ci` passed.
- `kind="search"` count across jurisdiction briefs remains `0`.
- `git diff -- data/hna/ranking-index.json` is empty.
- `git diff -- js/qap-simulator.js` is empty.

## Owner Notes
- Owner-gated draft PR; do not merge without owner review.
- No workflow files changed.
- `08045` remains `published: false`; it received the same generated Metric Digest section because it is one of the 12 brief files covered by the current brief QA gate.
