### PR TITLE
Draft: Fix CAR monthly cron dependency loading

### DIFF
--- a/.github/workflows/car-data-update.yml
+++ b/.github/workflows/car-data-update.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Install Node.js dependencies
+        run: npm ci
+
       - name: Fetch CAR ShowingTime county data (best effort)
         run: node scripts/fetch-car-showingtime.mjs
 
@@ -57,6 +60,6 @@ jobs:
             echo "No changes to commit — CAR data is already up to date."
           else
             git commit -m "chore: update CAR market report data [$(date -u '+%Y-%m')]"
-            git pull --rebase --autostash -X theirs origin main
-            git push
+            git pull --rebase --autostash -X theirs origin "$GITHUB_REF_NAME"
+            git push origin HEAD:"$GITHUB_REF_NAME"
           fi

--- a/data/car-market-report-2026-05.json
+++ b/data/car-market-report-2026-05.json
@@ -1,6 +1,6 @@
 {
   "month": "2026-05",
-  "generated_at": "2026-07-03T15:24:32.893Z",
+  "generated_at": "2026-07-04T12:43:27.255Z",
   "source": "Colorado Association of REALTORS® (via ShowingTime, sourced from Colorado MLS)",
   "source_url": "https://marketstatsreports.showingtime.com/CAR-Colorado_hqac0/sst/202605/0SF.htm",
   "version": "1.1",

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,10 +1,10 @@
 {
-  "generated": "2026-07-04T09:24:41.273458Z",
+  "generated": "2026-07-04T12:43:33.400683Z",
   "files": {
     "data/_manifest.json": {
       "featureCount": 0,
       "placeholder": false,
-      "bytes": 754964
+      "bytes": 757227
     },
     "data/_qa-status.json": {
       "featureCount": 0,
@@ -4430,6 +4430,31 @@
       "featureCount": 0,
       "placeholder": false,
       "bytes": 1541893
+    },
+    "data/hna/ranking-scenarios/balanced.json": {
+      "featureCount": 0,
+      "placeholder": false,
+      "bytes": 50054
+    },
+    "data/hna/ranking-scenarios/commuter-pressure.json": {
+      "featureCount": 0,
+      "placeholder": false,
+      "bytes": 50074
+    },
+    "data/hna/ranking-scenarios/large-gap.json": {
+      "featureCount": 0,
+      "placeholder": false,
+      "bytes": 50065
+    },
+    "data/hna/ranking-scenarios/rate-sensitive.json": {
+      "featureCount": 0,
+      "placeholder": false,
+      "bytes": 50074
+    },
+    "data/hna/ranking-scenarios/rural-lens.json": {
+      "featureCount": 0,
+      "placeholder": false,
+      "bytes": 50076
     },
     "data/hna/scenarios/baseline.json": {
       "featureCount": 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "coho-analytics",
       "version": "2.0.0",
       "license": "MIT",
+      "dependencies": {
+        "jsdom": "^29.1.1"
+      },
       "devDependencies": {
         "@playwright/test": "^1.61.1",
         "chrome-launcher": "^1.2.1",
         "color": "^5.0.3",
         "glob": "^13.0.6",
-        "jsdom": "^29.1.1",
         "lighthouse": "^13.4.0",
         "node-fetch": "^2.7.0",
         "nodemailer": "^9.0.3",
@@ -32,7 +34,6 @@
       "version": "5.1.11",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
       "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/generational-cache": "^1.0.1",
@@ -49,7 +50,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
       "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/generational-cache": "^1.0.1",
@@ -66,7 +66,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
       "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -76,7 +75,6 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
@@ -108,7 +106,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
       "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "css-tree": "^3.0.0"
@@ -145,7 +142,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
       "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -165,7 +161,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
       "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -189,7 +184,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
       "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -217,7 +211,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -240,7 +233,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
       "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -265,7 +257,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -355,7 +346,6 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
       "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -1650,7 +1640,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -1903,7 +1892,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.27.1",
@@ -1940,7 +1928,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
@@ -1972,7 +1959,6 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/define-lazy-prop": {
@@ -2051,7 +2037,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
       "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20.19.0"
@@ -2496,7 +2481,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
@@ -2745,7 +2729,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-wsl": {
@@ -2819,7 +2802,6 @@
       "version": "29.1.1",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
@@ -3003,7 +2985,6 @@
       "version": "11.5.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
       "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -3031,7 +3012,6 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/meow": {
@@ -3314,7 +3294,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
       "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^8.0.0"
@@ -3615,7 +3594,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3769,7 +3747,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3871,7 +3848,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -4000,7 +3976,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4233,7 +4208,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/table": {
@@ -4279,7 +4253,6 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
       "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.4.2"
@@ -4292,7 +4265,6 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
       "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tldts-icann": {
@@ -4322,7 +4294,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -4335,7 +4306,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -4375,7 +4345,6 @@
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
       "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -4412,7 +4381,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -4449,7 +4417,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
@@ -4459,7 +4426,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -4469,7 +4435,6 @@
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.11.0",
@@ -4585,7 +4550,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -4595,7 +4559,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -91,12 +91,14 @@
     "audit:coverage:strict": "node scripts/coverage-audit.js --strict",
     "audit:data-sources": "python3 scripts/check-data-source-health.py --fail-on-error"
   },
+  "dependencies": {
+    "jsdom": "^29.1.1"
+  },
   "devDependencies": {
     "@playwright/test": "^1.61.1",
     "chrome-launcher": "^1.2.1",
     "color": "^5.0.3",
     "glob": "^13.0.6",
-    "jsdom": "^29.1.1",
     "lighthouse": "^13.4.0",
     "node-fetch": "^2.7.0",
     "nodemailer": "^9.0.3",

--- a/scripts/fetch-car-showingtime.mjs
+++ b/scripts/fetch-car-showingtime.mjs
@@ -8,8 +8,17 @@
 
 import fs from 'fs';
 import path from 'path';
+import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
-import { JSDOM } from 'jsdom';
+
+const require = createRequire(import.meta.url);
+let JSDOM = null;
+let jsdomLoadError = null;
+try {
+  ({ JSDOM } = require('jsdom'));
+} catch (err) {
+  jsdomLoadError = err;
+}
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -78,6 +87,9 @@ function loadCountyMap() {
 }
 
 function textFromNameCell(html) {
+  if (!JSDOM) {
+    throw new Error(`HTML parser unavailable: ${jsdomLoadError?.message || 'jsdom failed to load'}`);
+  }
   return JSDOM.fragment(String(html || '')).textContent
     .replace(/\s+/g, ' ')
     .trim();
@@ -295,6 +307,10 @@ async function tryMonth(month, args) {
 }
 
 async function main() {
+  if (!JSDOM) {
+    console.warn(`[car-showingtime] jsdom unavailable; best-effort exit without modifying CAR data: ${jsdomLoadError?.message || 'unknown import error'}`);
+    return;
+  }
   const args = parseArgs(process.argv);
   let month = args.month || defaultStartMonth();
   for (let i = 0; i < args.maxLookback; i++) {


### PR DESCRIPTION
## Summary
- Adds npm ci to the CAR monthly workflow before scripts/fetch-car-showingtime.mjs runs.
- Moves jsdom from devDependencies to dependencies because the shipped CAR cron fetcher uses it at runtime.
- Wraps jsdom loading in the fetcher so missing or broken parser dependencies log a best-effort warning and exit 0 without modifying CAR data.
- Makes the workflow commit step pull and push the active workflow ref so workflow_dispatch on a PR branch can update that branch instead of rebasing against main and hitting a non-fast-forward push.
- Includes the workflow-produced CAR refresh commit for data/car-market-report-2026-05.json plus data/manifest.json.

## Root cause
scripts/fetch-car-showingtime.mjs used a top-level jsdom import, but .github/workflows/car-data-update.yml did not install Node dependencies. On the runner, jsdom was absent, so the script failed at module load before its best-effort try/catch could run.

## Workflow edit flag
OWNER REVIEW REQUIRED: .github/workflows/car-data-update.yml now adds an Install Node.js dependencies step that runs npm ci after setup-node and before the CAR fetch step.

OWNER REVIEW REQUIRED: .github/workflows/car-data-update.yml now pushes commits back to the workflow branch using GITHUB_REF_NAME, so manual PR-branch dispatches and scheduled runs do not rebase the PR branch against main and then push the wrong ref.

## Validation
- No-local-node_modules smoke: node scripts/fetch-car-showingtime.mjs --month 2026-05 --fixture-dir test/fixtures/car-showingtime --min-populated 4 exited 0 and logged the jsdom-unavailable best-effort warning.
- node test/car-showingtime-fetcher.test.mjs passed.
- npm run test:ci passed on final PR head.
- git diff -- js/qap-simulator.js is empty.

## Dispatch
workflow_dispatch run 28706581057 completed GREEN on codex/car-cron-jsdom-fix. The runner hit HTTP 403 for 2026-06 0TC, then successfully populated 2026-05 with 64/64 counties and pushed chore: update CAR market report data [2026-07] to this branch. data/car-market-report-2026-07.json already existed, so the placeholder step skipped it.