### PR TITLE
Quarantine bot: report + tracking issue instead of silent deletion

### DIFF
--- a/.github/workflows/archive-audit-post-merge.yml
+++ b/.github/workflows/archive-audit-post-merge.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   actions: write
+  issues: write
 
 jobs:
   audit-and-docs:
@@ -51,6 +52,45 @@ jobs:
             sleep 2
           done
           echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Track quarantine candidates in an issue (human decides)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # sync-docs.mjs no longer moves unreferenced files (its old
+          # "archive to _audit/" was silent deletion — _audit/ is gitignored,
+          # so the copy died with the runner; it destroyed the places.json
+          # generator right after PR #1040). Instead it writes a report; this
+          # step keeps exactly one open tracking issue in sync with it.
+          report="data/audit/quarantine-candidates.json"
+          title="Quarantine candidates: unreferenced js/css/scripts files"
+          count=$(jq -r '.count // 0' "$report" 2>/dev/null || echo 0)
+          existing=$(gh issue list --state open --search "in:title \"$title\"" \
+                       --json number --jq '.[0].number // empty')
+          if [ "$count" -gt 0 ]; then
+            body=$(mktemp)
+            {
+              printf 'Automated report from `scripts/sync-docs.mjs` (post-merge audit).\n\n'
+              printf 'These files are referenced by name in no HTML/JS/MJS/CSS/MD/YML/PY file or package.json script. **Nothing is deleted automatically** — for each one, either delete it deliberately or add a reference (workflow, doc, npm script) if it is actually used. The list refreshes after every merge.\n\n'
+              jq -r '.candidates[] | "- [ ] `" + . + "`"' "$report"
+              printf '\nSource of truth: [`%s`](https://github.com/%s/blob/main/%s)\n' "$report" "$GITHUB_REPOSITORY" "$report"
+            } > "$body"
+            if [ -n "$existing" ]; then
+              gh issue edit "$existing" --body-file "$body"
+              echo "Updated issue #$existing ($count candidates)."
+            else
+              gh issue create --title "$title" --body-file "$body"
+              echo "Opened tracking issue ($count candidates)."
+            fi
+            rm -f "$body"
+          elif [ -n "$existing" ]; then
+            gh issue close "$existing" \
+              --comment "All previously-listed files are now referenced or deliberately removed — report is empty. Closing automatically."
+            echo "Closed issue #$existing (no candidates remain)."
+          else
+            echo "No quarantine candidates and no open issue — nothing to do."
+          fi
 
       - name: Dispatch Pages deploy for automation commit
         if: steps.commit_docs.outputs.changed == 'true'

--- a/.github/workflows/archive-audit-post-merge.yml
+++ b/.github/workflows/archive-audit-post-merge.yml
@@ -74,7 +74,7 @@ jobs:
               printf 'Automated report from `scripts/sync-docs.mjs` (post-merge audit).\n\n'
               printf 'These files are referenced by name in no HTML/JS/MJS/CSS/MD/YML/PY file or package.json script. **Nothing is deleted automatically** — for each one, either delete it deliberately or add a reference (workflow, doc, npm script) if it is actually used. The list refreshes after every merge.\n\n'
               jq -r '.candidates[] | "- [ ] `" + . + "`"' "$report"
-              printf '\nSource of truth: [`%s`](https://github.com/%s/blob/main/%s)\n' "$report" "$GITHUB_REPOSITORY" "$report"
+              printf '\nSource of truth: [`%s`](%s)\n' "$report" "https://github.com/$GITHUB_REPOSITORY/blob/main/$report"
             } > "$body"
             if [ -n "$existing" ]; then
               gh issue edit "$existing" --body-file "$body"

--- a/README.md
+++ b/README.md
@@ -463,7 +463,6 @@ This tool is provided for educational and research purposes. All economic data i
 
 ## Actionable Recommendations
 
-- Archived file: `_audit/scripts/hna/build_place_projections.py` — review and remove fully if unneeded.
 - Docs and site-audit pipeline are automatically updated after every merge.
 
 ## 

--- a/data/audit/quarantine-candidates.json
+++ b/data/audit/quarantine-candidates.json
@@ -1,0 +1,8 @@
+{
+  "generated_at": "2026-07-05T14:24:04.333Z",
+  "generator": "scripts/sync-docs.mjs",
+  "policy": "report-only — files are never moved or deleted automatically. To clear an entry: delete the file deliberately, or reference it from a workflow/doc/npm script if it is actually used.",
+  "heuristic": "basename appears in no .html/.js/.mjs/.css/.md/.yml/.yaml/.py file under docs/, test(s)/, .github/, or the repo root, and not in package.json.",
+  "count": 0,
+  "candidates": []
+}

--- a/scripts/sync-docs.mjs
+++ b/scripts/sync-docs.mjs
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 /**
- * sync-docs.mjs — Unified audit, quarantine, and doc updater
+ * sync-docs.mjs — Unified audit, quarantine-candidate report, and doc updater
  * - Generates docs/GENERATED-INVENTORY.md
- * - Moves unreferenced files to _audit/
+ * - Reports unreferenced js/css/scripts files to data/audit/quarantine-candidates.json
+ *   (REPORT ONLY — files are never moved or deleted; a human decides.
+ *   The old behavior moved them into gitignored _audit/, which on an
+ *   ephemeral CI runner is silent permanent deletion: it destroyed
+ *   scripts/hna/build_place_projections.py minutes after PR #1040 merged,
+ *   because nothing referenced that filename yet. See PR #1044.)
  * - Rewrites _tobedeleted/ to _audit/ everywhere
  * - Updates "Actionable Recommendations" in key doc files
  *
@@ -15,7 +20,7 @@
  * npm script: "docs:sync"
  */
 
-import { readFileSync, writeFileSync, statSync, readdirSync, existsSync, renameSync, mkdirSync } from 'fs';
+import { readFileSync, writeFileSync, statSync, readdirSync, existsSync, mkdirSync } from 'fs';
 import { join, relative, extname, basename, dirname } from 'path';
 import { glob } from 'glob';
 
@@ -197,33 +202,73 @@ function findFiles(dir, exts) {
   return res;
 }
 
-// Quarantine dead/unreferenced files
-function quarantineDeadFiles(dir, exts, docRefDirs) {
+// Detect dead/unreferenced files — REPORT ONLY, never move or delete.
+// The pre-#1044 version renameSync'd hits into _audit/, but _audit/ is
+// gitignored, so on the ephemeral CI runner "archiving" was actually
+// permanent deletion with no reviewable trace. A file can also be
+// legitimately unreferenced-by-name for a short window (e.g. a generator
+// merged before the workflow that calls it), which is exactly when
+// auto-deletion does the most damage.
+// Read a file for reference-scanning. Markdown gets its auto-generated
+// "## Actionable Recommendations" block stripped first — that block LISTS
+// the quarantine candidates, so counting it as a reference would clear
+// every candidate on the run after it was first reported (report → doc
+// mention → "referenced" → dropped → re-reported, oscillating each merge).
+function readForRefScan(path) {
+  const content = readFileSync(path, 'utf8');
+  if (!path.endsWith('.md')) return content;
+  return content.replace(/## Actionable Recommendations[\s\S]*?(?=\n## |$)/g, '');
+}
+
+function findDeadFiles(dir, exts, docRefDirs) {
   const files = findFiles(dir, exts);
-  const quarantine = [];
+  const candidates = [];
+  // npm scripts are a legal way to reference a script file; the directory
+  // scan below never reads package.json, so check it explicitly.
+  const pkgPath = join(ROOT, 'package.json');
+  const pkgJson = existsSync(pkgPath) ? readFileSync(pkgPath, 'utf8') : '';
   for (const f of files) {
     if (f.includes('_audit')) continue;
-    // Check if the file is referenced in HTML, JS, CSS, MD, YML, or Python files:
+    // Check if the file is referenced in HTML, JS, CSS, MD, YML, MJS,
+    // Python files, or package.json scripts:
     const basename_ = basename(f);
-    let referenced = false;
+    let referenced = pkgJson.includes(basename_);
     for (const d of docRefDirs) {
+      if (referenced) break;
       if (!existsSync(d)) continue;
-      for (const test of findFiles(d, ['.html', '.js', '.css', '.md', '.yml', '.yaml', '.py'])) {
-        if (readFileSync(test, 'utf8').includes(basename_)) {
+      for (const test of findFiles(d, ['.html', '.js', '.mjs', '.css', '.md', '.yml', '.yaml', '.py'])) {
+        if (readForRefScan(test).includes(basename_)) {
           referenced = true;
           break;
         }
       }
-      if (referenced) break;
     }
     if (!referenced) {
-      const dest = join(AUDIT_DIR, dir.replace(ROOT + '/', ''), relative(dir, f));
-      mkdirSync(dirname(dest), { recursive: true });
-      renameSync(f, dest);
-      quarantine.push(dest);
+      candidates.push(relative(ROOT, f));
     }
   }
-  return quarantine;
+  return candidates;
+}
+
+// Persist the candidate list where the post-merge workflow can read it to
+// open/refresh a tracking issue, and where the QA dashboard can display it.
+const QUARANTINE_REPORT = join(ROOT, 'data', 'audit', 'quarantine-candidates.json');
+
+function writeQuarantineReport(candidates) {
+  mkdirSync(dirname(QUARANTINE_REPORT), { recursive: true });
+  const payload = {
+    generated_at: now,
+    generator: 'scripts/sync-docs.mjs',
+    policy: 'report-only — files are never moved or deleted automatically. '
+      + 'To clear an entry: delete the file deliberately, or reference it '
+      + 'from a workflow/doc/npm script if it is actually used.',
+    heuristic: 'basename appears in no .html/.js/.mjs/.css/.md/.yml/.yaml/.py '
+      + 'file under docs/, test(s)/, .github/, or the repo root, and not in '
+      + 'package.json.',
+    count: candidates.length,
+    candidates,
+  };
+  writeFileSync(QUARANTINE_REPORT, JSON.stringify(payload, null, 2) + '\n');
 }
 
 // Update all _tobedeleted/ to _audit/
@@ -241,9 +286,14 @@ function rewriteReferences(rootDirs) {
 }
 
 // For docs: update actionable recommendations
-function generateRecommendations() {
+function generateRecommendations(deadFileCandidates) {
   let recs = [];
-  // Scan for files in _audit:
+  for (const f of deadFileCandidates) {
+    recs.push(`Quarantine candidate: \`${f}\` — no file references its name. `
+      + 'Delete it deliberately, or reference it (workflow/doc/npm script) if it is used.');
+  }
+  // Legacy: anything that survived in a committed _audit/ tree (the dir is
+  // gitignored now, so this is normally empty).
   for (const d of [JS_DIR, CSS_DIR, SCRIPTS_DIR]) {
     const auditDir = join(AUDIT_DIR, d.replace(ROOT + '/', ''));
     if (existsSync(auditDir)) {
@@ -375,15 +425,21 @@ function syncDeprecatedBanners(stats) {
 // ==== MAIN RUNNER ====
 
 async function main() {
-  // 1. Quarantine & fix references before inventory:
+  // 1. Detect unreferenced files (report only — see findDeadFiles) & fix references:
   const refDirs = [DOCS_DIR, ROOT, join(ROOT, 'test'), join(ROOT, 'tests'), join(ROOT, '.github')];
-  quarantineDeadFiles(JS_DIR, ['.js'], refDirs);
-  quarantineDeadFiles(CSS_DIR, ['.css'], refDirs);
-  quarantineDeadFiles(SCRIPTS_DIR, ['.py'], refDirs);
+  const deadFiles = [
+    ...findDeadFiles(JS_DIR, ['.js'], refDirs),
+    ...findDeadFiles(CSS_DIR, ['.css'], refDirs),
+    ...findDeadFiles(SCRIPTS_DIR, ['.py'], refDirs),
+  ].sort();
+  writeQuarantineReport(deadFiles);
+  console.log(deadFiles.length
+    ? `⚠️  ${deadFiles.length} quarantine candidate(s) → ${relative(ROOT, QUARANTINE_REPORT)}\n${deadFiles.map(f => `    - ${f}`).join('\n')}`
+    : '✓ No quarantine candidates (all js/css/scripts files are referenced).');
   rewriteReferences([ROOT, JS_DIR, CSS_DIR, SCRIPTS_DIR, DOCS_DIR, join(ROOT, '.github'), join(ROOT, 'test')]);
 
   // 2. Docs actionable recommendation auto-update:
-  const recommendations = generateRecommendations();
+  const recommendations = generateRecommendations(deadFiles);
   const mainDocs = [
     join(DOCS_DIR, 'implementation-status.md'),
     join(DOCS_DIR, 'repo-audit-summary.md'),


### PR DESCRIPTION
## Summary

The post-merge automation's quarantine step was effectively **silent permanent deletion**: `sync-docs.mjs` moved any `js/`, `css/`, or `scripts/` file whose filename appears in no other file into `_audit/` — but `_audit/` is gitignored, so on the ephemeral CI runner the "archive" copy evaporated with the checkout. It destroyed `scripts/hna/build_place_projections.py` (the generator for `data/hna/projections/places.json`, a live UI input) minutes after #1040 merged, purely because the PR hadn't referenced the script from any workflow or doc yet — which is exactly the window when a freshly-merged generator is most likely to be unreferenced. (#1043 restores that script.)

## Changes

**`scripts/sync-docs.mjs`** — detect, never delete:
- `findDeadFiles()` runs the same unreferenced-filename heuristic but only *reports*: candidates land in `data/audit/quarantine-candidates.json` (committed by the existing workflow commit step) and in the docs' "Actionable Recommendations" blocks.
- Two false-positive fixes to the reference scan: it now counts `.mjs` files and `package.json` npm scripts as reference sources (a script invoked only via `npm run …` was previously sweepable).
- One feedback-loop fix: the scan strips the auto-generated recommendations block from markdown before matching — otherwise the report itself "references" every candidate and the list oscillates on/off every merge (verified with a dummy file before the fix).

**`.github/workflows/archive-audit-post-merge.yml`** — human in the loop:
- New step keeps exactly **one** open tracking issue in sync with the report: creates it when candidates first appear, updates the checklist as the list changes, closes it automatically when the list empties. Deleting a file is always a deliberate human act; referencing the file (workflow/doc/npm script) clears it from the list on the next merge.
- Adds `issues: write` to the workflow permissions.

**`README.md`** — drops the stale pointer to the never-committed `_audit/` copy.

## Verification
- Dummy unreferenced script: flagged in report + README recs, file untouched on disk, stable across consecutive runs.
- Clean repo state: zero candidates, report written with `count: 0`, re-run is a no-op.
- Issue-step `jq`/shell body generation dry-run; workflow YAML parses; `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)