### PR TITLE
Fix Market Data Build 20-min timeout: sentinel URL leak + WAF-blocked probes

### DIFF
--- a/.github/workflows/market_data_build.yml
+++ b/.github/workflows/market_data_build.yml
@@ -68,7 +68,9 @@ jobs:
           }
           tw=$(probe "TIGERweb" "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/Tracts_Blocks/MapServer?f=json")
           hd=$(probe "HUD LIHTC" "https://hudgis-hud.opendata.arcgis.com/datasets/8c3c3b26-38f1-4e06-a8f7-a0f2a60cc4d2_0.geojson")
-          cb=$(probe "Census CB (2024)" "https://www2.census.gov/geo/tiger/GENZ2024/json/cb_2024_08_tract_500k.json")
+          # ?dl=1 dodges the census.gov WAF's bare-URL signature blocking
+          # (same workaround as census_scraper.py and the BPS pipeline).
+          cb=$(probe "Census CB (2024)" "https://www2.census.gov/geo/tiger/GENZ2024/json/cb_2024_08_tract_500k.json?dl=1")
           echo "tigerweb_ok=$tw"   >> "$GITHUB_OUTPUT"
           echo "hud_ok=$hd"        >> "$GITHUB_OUTPUT"
           echo "census_cb_ok=$cb"  >> "$GITHUB_OUTPUT"
@@ -109,10 +111,14 @@ jobs:
         id: census-cb
         run: |
           python3 scripts/market/census_scraper.py 2>&1 | tee /tmp/census_scraper.log || true
-          # Extract the found URL (last non-error line) for the summary
+          # Extract the found URL (last non-error line) for the summary.
+          # When the probe fails, emit an EMPTY output — the builder treats
+          # any non-http value as absent and uses its own candidates. The old
+          # sentinel "not-found" leaked into CENSUS_CB_URL and was fetched as
+          # a literal URL with a full retry ladder (run #28729844505 timeout).
           url=$(grep '^\[census_scraper\] Found:' /tmp/census_scraper.log | tail -1 | sed 's/\[census_scraper\] Found: //')
-          echo "census_cb_url=${url:-not-found}" >> "$GITHUB_OUTPUT"
-          echo "Detected census CB URL: ${url:-not-found}"
+          echo "census_cb_url=${url}" >> "$GITHUB_OUTPUT"
+          echo "Detected census CB URL: ${url:-<none — builder will use its own candidates>}"
 
       - name: Run market data builder
         id: build

--- a/scripts/market/build_public_market_data.py
+++ b/scripts/market/build_public_market_data.py
@@ -53,15 +53,23 @@ TIGERWEB_TRACTS = (
 )
 # Census Cartographic Boundary GeoJSON — used as fallback when TIGERweb returns 0 features.
 # 500k-resolution polygon file for Colorado tracts (≈3 MB, one request, no pagination).
-CENSUS_CB_TRACTS_URL = os.environ.get("CENSUS_CB_URL") or (
-    "https://www2.census.gov/geo/tiger/GENZ2024/json/cb_2024_08_tract_500k.json"
+# CENSUS_CB_URL is set by the workflow from census_scraper.py output. Accept
+# it only when it is an actual URL — the workflow used to export the literal
+# sentinel "not-found" when the probe failed, which then burned a full retry
+# ladder fetching the string "not-found" (the 2026-07-05 run #28729844505
+# timed out at 20 min on exactly this).
+_ENV_CB_URL = (os.environ.get("CENSUS_CB_URL") or "").strip()
+CENSUS_CB_TRACTS_URL = _ENV_CB_URL if _ENV_CB_URL.startswith("http") else (
+    "https://www2.census.gov/geo/tiger/GENZ2024/json/cb_2024_08_tract_500k.json?dl=1"
 )
 # Ordered fallback list (newest-first) used when the primary URL fails.
-# The build script tries these in order until one succeeds.
+# The build script tries these in order until one succeeds. ?dl=1 dodges the
+# census.gov WAF, which drops some bare-URL signatures (same workaround as
+# the BPS permits pipeline).
 _CENSUS_CB_FALLBACK_URLS = [
-    "https://www2.census.gov/geo/tiger/GENZ2024/json/cb_2024_08_tract_500k.json",
-    "https://www2.census.gov/geo/tiger/GENZ2023/json/cb_2023_08_tract_500k.json",
-    "https://www2.census.gov/geo/tiger/GENZ2022/json/cb_2022_08_tract_500k.json",
+    "https://www2.census.gov/geo/tiger/GENZ2024/json/cb_2024_08_tract_500k.json?dl=1",
+    "https://www2.census.gov/geo/tiger/GENZ2023/json/cb_2023_08_tract_500k.json?dl=1",
+    "https://www2.census.gov/geo/tiger/GENZ2022/json/cb_2022_08_tract_500k.json?dl=1",
 ]
 ACS_BASE = "https://api.census.gov/data/2023/acs/acs5"
 HUD_LIHTC_URL = (
@@ -515,7 +523,12 @@ def build_tract_boundaries() -> dict:
                 break
             try:
                 log(f"[boundary-fallback] Trying {cb_url} …")
-                raw_cb = fetch_url(cb_url)
+                # Fallback probes get a short retry budget: with the default
+                # 6-attempt exponential ladder, several unreachable candidates
+                # add up to ~4 minutes each and blew the workflow's 20-minute
+                # step timeout when census.gov was WAF-blocking everything.
+                # The existing-file fallback in main() is the real safety net.
+                raw_cb = fetch_url(cb_url, retries=2)
                 cb = json.loads(raw_cb)
                 cb_features = cb.get("features", [])
                 for f in cb_features:

--- a/scripts/market/census_scraper.py
+++ b/scripts/market/census_scraper.py
@@ -39,15 +39,38 @@ _CB_URL_TEMPLATE = (
 
 
 def _url_for_year(year: int) -> str:
-    return _CB_URL_TEMPLATE.format(year=year)
+    # The census.gov WAF hard-blocks some URL signatures (hangs or returns
+    # "Request Rejected" HTML at HTTP 200 — see the BPS permits pipeline,
+    # which hit the same wall on www2.census.gov). Appending a harmless
+    # query string changes the signature and gets through, so the probe AND
+    # the URL we hand to the builder both carry ?dl=1.
+    return _CB_URL_TEMPLATE.format(year=year) + "?dl=1"
 
 
 def probe_url(url: str, timeout: int = 10) -> bool:
-    """Return True if the URL responds with HTTP 200, False otherwise."""
+    """Return True if the URL serves what looks like GeoJSON.
+
+    Uses a ranged GET rather than HEAD: the census.gov WAF is more likely
+    to drop HEAD requests, and a 200 alone is not proof — the WAF returns
+    "Request Rejected" HTML with HTTP 200, so we check the payload starts
+    like a JSON document.
+    """
     try:
-        req = urllib.request.Request(url, method="HEAD", headers={"User-Agent": "pma-build/1.0"})
+        req = urllib.request.Request(
+            url,
+            headers={
+                "User-Agent": (
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) pma-build/1.0"
+                ),
+                "Range": "bytes=0-255",
+            },
+        )
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return resp.status == 200
+            if resp.status not in (200, 206):
+                return False
+            head = resp.read(256).lstrip()
+            return head.startswith(b"{")
     except urllib.error.HTTPError:
         return False
     except Exception:


### PR DESCRIPTION
Closes #1041.

## What actually failed

Run [#28729844505](https://github.com/pggLLC/Housing-Analytics/actions/runs/28729844505) didn't fail on the upstream outages — the builder's existing-file fallbacks handled TIGERweb's 500s and HUD's 403s correctly. The step **timed out at 20 minutes** consumed by retry ladders:

1. **Sentinel-as-URL**: `census_scraper.py` found no Cartographic Boundary vintage, the workflow exported the literal `not-found`, and `os.environ.get("CENSUS_CB_URL") or default` treated it as truthy — so the boundary fallback fetched the string `"not-found"` through a full 6-attempt exponential ladder.
2. **WAF-blocked probes**: the scraper probed with HEAD + `pma-build/1.0` UA; the census.gov WAF drops those signatures (every probe hung its full 10s timeout, no vintage ever found — same wall the BPS permits pipeline hit).
3. **Unbounded fallback ladder**: 4 CB candidates × 6 attempts with exponential backoff ≈ 4 min per unreachable URL = 16+ of the 20 minutes.

## Fixes

- Workflow emits an **empty** output when no CB URL is found; builder ignores any non-`http` `CENSUS_CB_URL` value.
- Scraper probes with ranged GET + `?dl=1` (BPS pipeline's proven WAF workaround) and validates the payload starts like JSON, since the WAF returns "Request Rejected" HTML at HTTP 200. The `?dl=1` form is applied consistently: scraper output, builder's hardcoded candidates, health-check probe.
- Boundary-fallback candidates capped at `retries=2` — the existing-file fallback in `main()` is the real safety net and is unchanged.

## Verification

- Sentinel guard unit-checked locally (`CENSUS_CB_URL="not-found"` → builder uses its default candidate).
- Scraper exits cleanly when nothing is reachable (sandbox can't reach www2.census.gov at all, so the WAF workaround itself needs the post-merge workflow re-run as its real test — I'll trigger one and watch it).
- Workflow YAML parses; smoke suite 73/73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)