### PR TITLE
Fix Market Data artifacts-PR step: rerun push rejection + silent PR-creation failure

### DIFF
--- a/.github/workflows/market_data_build.yml
+++ b/.github/workflows/market_data_build.yml
@@ -254,17 +254,31 @@ jobs:
           fi
 
           BRANCH="chore/market-data-rebuild-$(date -u '+%Y%m%d')"
-          git checkout -b "$BRANCH"
+          # Fetch the branch first: in this fresh clone, --force-with-lease
+          # has no remote-tracking info, so a same-day rerun was rejected
+          # with "stale info" (run #28745267764). checkout -B tolerates the
+          # branch already existing locally too.
+          git fetch origin "$BRANCH" || true
+          git checkout -B "$BRANCH"
           git commit -m "chore(data): rebuild market data artifacts [skip ci]"
-          git push --force-with-lease --set-upstream origin "$BRANCH"
+          git push --force --set-upstream origin "$BRANCH"
 
-          gh pr create \
-            --title "chore(data): rebuild market data artifacts $(date -u '+%Y-%m-%d')" \
-            --body "Automated market data rebuild from the **Build Market Data** workflow run [#${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})." \
-            --base main \
-            --head "$BRANCH" \
-            --label "market-data" \
-            || echo "PR may already exist for this branch — skipping creation."
+          # Only create a PR when one isn't already open for this branch.
+          # NOTE: don't blanket-`|| echo` the create — that swallowed a real
+          # failure for weeks: `--label "market-data"` named a label that
+          # doesn't exist in this repo, so every artifacts PR silently failed
+          # to open and rebuilds rotted on orphan branches (20260628,
+          # 20260629, ...). Label dropped; failures now fail the step.
+          existing=$(gh pr list --head "$BRANCH" --state open --json number --jq 'length')
+          if [ "$existing" -gt 0 ]; then
+            echo "Open PR already exists for $BRANCH — branch updated, skipping creation."
+          else
+            gh pr create \
+              --title "chore(data): rebuild market data artifacts $(date -u '+%Y-%m-%d')" \
+              --body "Automated market data rebuild from the **Build Market Data** workflow run [#${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})." \
+              --base main \
+              --head "$BRANCH"
+          fi
 
   # ── Failure notification ────────────────────────────────────────────────────
   notify-failure:


### PR DESCRIPTION
Follow-up to #1045 / #1041. The verification run for the timeout fix ([#28745267764](https://github.com/pggLLC/Housing-Analytics/actions/runs/28745267764)) proved the build job now succeeds, but exposed two bugs in the downstream artifacts-PR step:

1. **Same-day rerun push rejection** — `--force-with-lease` in a fresh clone has no remote-tracking info, so pushing a branch that already exists on origin (created by an earlier run the same day) fails with `stale info`. Now fetches the branch first and force-pushes; the date-stamped branch is exclusively workflow-owned.
2. **PR creation has been silently failing for weeks** — `gh pr create --label "market-data"` references a label that doesn't exist (only `market-data-build-failure` does), and the blanket `|| echo "PR may already exist"` swallowed the error. Every successful rebuild pushed a branch and then failed to open its PR: `chore/market-data-rebuild-20260628`, `-20260629`, and `-20260705` are all orphaned with unmerged artifacts. Label dropped; existing-PR detection is now an explicit `gh pr list` check; genuine failures fail the step.

After this merges I'll open the PR for today's orphaned artifacts branch manually and clean up the stale June branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)