### PR TITLE
Add combined QA findings report

### DIFF
--- a/docs/qa/codex-qa-2026-07-06.md
+++ b/docs/qa/codex-qa-2026-07-06.md
@@ -1,0 +1,131 @@
+# Codex QA Report — 2026-07-06
+
+Scope: Claude/Codex work merged after the 2026-07-04 handoff, PRs #1030-#1049 plus direct main commits noted in the work order. This report was run from `main` after Task 1 was fixed and squash-merged as PR #1050 (`f574efc58`).
+
+## Findings
+
+### [bug] Place AMI-gap demand can exceed all-household count for tiny places
+
+- `data/co_ami_gap_by_place.json:212` Air Force Academy has `households_le_ami_pct["30"] = 76` while `all_households_le_ami_pct["30"] = 71`.
+- `data/co_ami_gap_by_place.json:4496` Catherine has `households_le_ami_pct["30"] = 4` while `all_households_le_ami_pct["30"] = 0`.
+- `data/co_ami_gap_by_place.json:5567` Cokedale has `households_le_ami_pct["50"] = 6` while `all_households_le_ami_pct["50"] = 5`.
+- Throwaway invariant script found 10 place+tier violations total. This is small-count interpolation slack, but it violates the explicit invariant that renter demand households should not exceed all households at the same AMI threshold.
+
+### [bug] Alamosa County ranking gap is not clamped to zero
+
+- `data/hna/ranking-index.json:30003` Alamosa County (`08003`) has `metrics.housing_gap_units = 429` at `data/hna/ranking-index.json:30009`.
+- Work order expected the surplus county case to have `housing_gap_units == 0`, not an absolute surplus or nonzero deficit. No negative `housing_gap_units`, `ami_gap_50pct`, or `ami_gap_60pct` values were found.
+
+### [bug] Workflow probe still builds a full Census API URL with f-string interpolation
+
+- `.github/workflows/fetch-census-acs.yml:67` uses `base = f"https://api.census.gov/data/{year}/acs/acs5"`.
+- Task 3e asked for no full URL literals with f-string interpolation in workflow probe URLs because source-URL sweep extraction can truncate/interrogate them incorrectly.
+
+### [question] Work order geoid for Broomfield appears incorrect
+
+- The work order says “Broomfield `0807850`,” but `data/hna/geography-registry.json` identifies `0807850` as Boulder city.
+- Broomfield city is `0809280`; its place projection has `shares.blended = 1.0`, so the consolidated city-county projection invariant passes for the actual Broomfield geoid.
+
+### [question] Registry summary coverage gaps remain
+
+- `data/hna/geography-registry.json` has 30 geographies with no matching `data/hna/summary/<geoid>.json`.
+- Sample gaps: Englewood `0822465`, Parker `0852290`, Pueblo city `0855745`, Commerce City `0875140`, Dillon `0820730`, Frisco `0827565`, Glenwood Springs `0830475`, Gypsum `0835250`, Rifle `0866500`, Steamboat Springs `0873220`.
+- Per the work order, this is report-only; the fix path is the Build HNA Data Cache workflow, not hand-authored summary JSON.
+
+### [question] Census Reporter spot-check is now on ACS 2024 latest
+
+- Census Reporter API returned `release.id = acs2024_5yr` for Breckenridge `16000US0808400`.
+- Using Census Reporter B25003/B25004 latest data gives rental vacancy approximately `870 / (445 + 870) = 66.2%`, while the cached summary value is `63.6`.
+- I did not hand-edit data. This may be a vintage mismatch rather than a data error; Census Reporter did not accept the guessed older `acs2023_5yr` release slug in this environment.
+
+### [cosmetic] Stale prose still describes old place-need scaling
+
+- `docs/HNA_PROJECTION_ASSUMPTIONS.md:15` and `docs/HNA_PROJECTION_ASSUMPTIONS.md:22` still describe `share0`/`geo-derived.json` as the projection scaling basis.
+- `scripts/hna/build_permits.py:56`, `scripts/hna/build_permits.py:603`, and `scripts/hna/build_permits.py:665` still describe the fallback county-share path prominently. The code correctly reports `217 place-blend / 0 county-share-scaled` after rebuild, so this is stale prose/comment cleanup, not a runtime defect.
+
+## Pass Evidence
+
+### Task 1 Fix
+
+- Fixed in PR #1050 and squash-merged before this report.
+- Census variables metadata for ACS1 profile 2023 and 2024 shows the usable GRAPI bins are `DP04_0137PE` through `DP04_0142PE`; `DP04_0143PE` is present as the “Not computed” bucket, not the `20-24.9%` bin.
+- Checks passed: `node --check js/hna/hna-controller.js`, `node --check js/hna/hna-renderers.js`, `npm run test:hna`, `npm run test:hna-acs-coverage`, `node test/hna-dp04-codes.test.js`.
+
+### Task 2 Data Invariants
+
+- Ranking scenarios: all `metadata.based_on` values match `data/hna/ranking-index.json` `metadata.generatedAt = 2026-07-04T20:34:23Z`.
+- County AMI-gap file: all tier gaps equal `units - households`; coverage equals `round(units / households, 4)`.
+- Place AMI-gap file: all tier gaps equal `households - units`.
+- Place `households_le_ami_pct["100"] <= renter_households_total`: pass.
+- Denver city `0820000` matches Denver County `08031` for gap30 and gap50: `28477` and `17326`.
+- Eight remapped places agree across registry, `place_county_lookup.json`, and summary `geo.containingCounty`.
+- Place projections: 473 places, no county ledger sum above 1.0, `meta.normalization_factors = {}`.
+- Cross-county projections: 26 cross-county places; Erie `0824950` has `cross_county = true`, household share `0.043209`, permit share `0.136306`, blended share `0.089757`, 2030 incremental `1538.016`.
+- Denver `0820000` blended share is `1.0`; Broomfield `0809280` blended share is `1.0`.
+- Statewide place 2044 incremental sum `412652.406` is <= statewide county total `426887.597`.
+- Merge-preserve helper: nulling Milliken `DP04_0079E` and `DP02_0001E` restored both fields, preserved count `2`, `core_regression = True`, and source tag `merge_preserved_fields = 2`; changed non-null payload preserved count `0`.
+
+### Benchmark Table
+
+```text
+Jurisdiction            Anchor                  Repo        Consultant        Ratio   Caveat (abridged)
+--------------------------------------------------------------------------------------------------------------------------------------------------
+La Plata County         rental_gap_lte50_ami           912               963    0.95  Repo methodology v2 uses renter-household demand (B25118)...
+La Plata County         rental_gap_lte30_ami         1,328               651    2.04  Repo methodology v2 uses renter-household demand (B25118)...
+La Plata County         keepup_units_5yr               705             1,550    0.45  Root used a pre-revision SDO vintage (2030 pop 61,656); c...
+Pueblo County           total_need_10yr              1,691             9,561    0.18  GG+A layered 2021-era job growth (47% from Springs/Denver...
+City of Pueblo          rental_deficit_deep          3,938             2,637    1.49  Thresholds differ materially: GG+A's cut is <$375/mo (201...
+Town of Milliken        catchup_units                   39             47–79    0.62  NOT the same concept: Ayres measures market tightness (li...
+Town of Milliken        keepup_units_5yr               295           199–331    1.11  Repo place-level projection uses permit-share downscaling...
+City of Alamosa         total_need_5yr                 352           445–515    0.73  Consultant number bundles growth aspiration; DOLA has Ala...
+Town of Erie            unit_gap                       119   n/a (by design)       —  No consultant number exists to compare. Repo's restored p...
+```
+
+### Permits / Production-vs-Need
+
+Rebuild convergence command:
+
+```text
+python3 scripts/hna/build_permits.py &&
+python3 scripts/hna/build_place_projections.py &&
+python3 scripts/hna/build_permits.py &&
+python3 scripts/hna/build_place_pages.py
+```
+
+Evidence:
+
+- First and second `build_permits.py` runs both reported 64 counties, 217 places, `217 with need comparison: 217 place-blend, 0 county-share-scaled`, `0 unmatched BPS places`.
+- Both runs reported Alamosa 10-year average `45.6 units/yr`, need `6.8 units/yr`, ratio `6.06`.
+- Alamosa page `places/0801090.html` embeds `annual_need_10yr_dola = 6.8`; `data/hna/projections/places.json` gives `6.7597`, matching after one-decimal page rounding.
+- Only timestamp churn appeared in `data/hna/permits.json` and `data/hna/projections/places.json`; both were restored.
+
+### Grep Sweeps
+
+- No AMI-gap consumer computes `units_needed` via `Math.abs(gap_units_minus_households_le_ami_pct)`.
+- No user-facing copy found that claims the AMI-gap demand side is B19001/all households; B19001 references found were source-list, legacy-series, or glossary descriptions.
+- `.github/workflows/market_data_build.yml` has no `not-found` sentinel write to `census_cb_url`, includes `?dl=1` on the Census CB probe URL, drops the bad `gh pr create --label`, and does not blanket-swallow PR-create failures.
+
+### UI Spot-Checks
+
+Served with `npx http-server -p 8092 -c-1`.
+
+- `index.html`: statewide <=30% AMI deficit card includes `135,587`.
+- `colorado-deep-dive.html`: contains `Renter Households ≤ 100% AMI`; source text includes `B25118`.
+- `hna-comparative-analysis.html`: Boulder city “Units Needed (30% AMI)” rendered around `7,820`, within the requested `~7,831` tolerance; B25118 text was present in the page source/details.
+- `places/0815165.html`: Clifton says “permits are issued by Mesa County” and does not show county permit numbers.
+- `housing-needs-assessment.html` Milliken `0850480`: affordability gap panel says “Renter households,” source text includes `B25118`, seven AMI bands render, recent production `46/yr`, production/need `0.92×`, and need note says `50/50 blend ... permit share 1.4%`.
+- `housing-needs-assessment.html` Conejos CDP `0816715`: fallback note says need is scaled from the containing county DOLA projection; production stats remain blank.
+- Projection panel active-market vacancy rendered sanely for state and county paths: state showed observed active-market `22.4%`, county Adams `3.7%`, no `151458.0%` regression.
+
+### Workflow / Pipeline
+
+- `gh run list --workflow rebuild-bps-permits.yml` found recent successful main runs on 2026-07-05.
+- The actual data-chain commit `0672d91e6` touched only `data/hna/permits.json` and `data/hna/projections/places.json`.
+- `.github/workflows/build-hna-data.yml` includes a hard Census API key probe, merge-preserve protections in the build script, blocking Phase 7.6 digests/brief validation, and `data/jurisdiction-briefs` in the bot `git add` list.
+- `node scripts/sync-docs.mjs` run twice produced identical candidate output: no quarantine candidates, five deprecated-doc banners refreshed, generated inventory. Timestamp churn was restored.
+
+## Cleanup Candidates
+
+- Task 6a: Weekly BPS cron still appears capable of committing timestamp-only `meta.generated_at` churn; confirm by diffing data fields vs metadata in the workflow path before opening a cleanup PR.
+- Task 6b: `scripts/validate-critical-data.js` lower bound for `count_places_with_need` should be revisited now that `build_permits.py` reports all 217 places use `place_permit_blend`. Existing lower bound `140` is permissive.
+- Task 6c: stale `share0`/`geo-derived.json` projection prose in docs/comments is confirmed and suitable for a small docs/comment cleanup PR.


### PR DESCRIPTION
Adds docs/qa/codex-qa-2026-07-06.md for the combined QA work order. Confirmed findings include tiny-place AMI invariant violations, Alamosa County ranking gap clamp regression, a workflow f-string URL probe, registry summary coverage gaps, Census Reporter vintage caveat, and stale place-need prose cleanup candidates.