### PR TITLE
Handle local paths in source liveness

### DIFF
--- a/scripts/check-source-liveness.py
+++ b/scripts/check-source-liveness.py
@@ -15,6 +15,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
 from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -87,6 +88,34 @@ def classify_error(exc: BaseException) -> str:
     return "other"
 
 
+def is_http_url(url: str) -> bool:
+    return urlparse(url).scheme in {"http", "https"}
+
+
+def check_local_path(url: str, checked_at: str) -> dict:
+    parsed = urlparse(url)
+    rel_path = parsed.path
+    if not rel_path:
+        exists = False
+        final_url = url
+    else:
+        candidate = (ROOT / rel_path).resolve()
+        try:
+            final_url = str(candidate.relative_to(ROOT))
+        except ValueError:
+            exists = False
+            final_url = url
+        else:
+            exists = candidate.is_file()
+
+    return {
+        "status_code": 200 if exists else 404,
+        "final_url": final_url,
+        "last_checked": checked_at,
+        "error_type": "ok" if exists else "client_error",
+    }
+
+
 def check_url(url: str, checked_at: str) -> dict:
     if not url:
         return {
@@ -95,6 +124,9 @@ def check_url(url: str, checked_at: str) -> dict:
             "last_checked": checked_at,
             "error_type": "other",
         }
+
+    if not is_http_url(url):
+        return check_local_path(url, checked_at)
 
     redirect_handler = TrackingRedirectHandler()
     opener = build_opener(redirect_handler)

--- a/test/source-liveness-local-path.test.py
+++ b/test/source-liveness-local-path.test.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check-source-liveness.py"
+
+spec = importlib.util.spec_from_file_location("check_source_liveness", SCRIPT)
+assert spec and spec.loader
+check_source_liveness = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check_source_liveness)
+
+
+def test_repo_relative_file_is_ok() -> None:
+    result = check_source_liveness.check_url(
+        "data/hna/jurisdiction-metrics-digest/0804000.json",
+        "2026-07-05T00:00:00Z",
+    )
+
+    assert result["status_code"] == 200
+    assert result["error_type"] == "ok"
+    assert result["final_url"] == "data/hna/jurisdiction-metrics-digest/0804000.json"
+
+
+def test_missing_repo_relative_file_is_client_error() -> None:
+    result = check_source_liveness.check_url(
+        "data/hna/jurisdiction-metrics-digest/does-not-exist.json",
+        "2026-07-05T00:00:00Z",
+    )
+
+    assert result["status_code"] == 404
+    assert result["error_type"] == "client_error"
+
+
+def test_parent_traversal_is_rejected() -> None:
+    result = check_source_liveness.check_url("../outside.json", "2026-07-05T00:00:00Z")
+
+    assert result["status_code"] == 404
+    assert result["error_type"] == "client_error"
+    assert result["final_url"] == "../outside.json"
+
+
+if __name__ == "__main__":
+    test_repo_relative_file_is_ok()
+    test_missing_repo_relative_file_is_client_error()
+    test_parent_traversal_is_rejected()


### PR DESCRIPTION
## Summary
- Treat non-HTTP source entries as repo-relative files instead of passing them to urllib
- Reject traversal outside the repo root and report missing local files as client errors
- Add a targeted regression script for local source paths

## Tests
- python3 test/source-liveness-local-path.test.py
- python3 -m py_compile scripts/check-source-liveness.py test/source-liveness-local-path.test.py