### PR TITLE
Harden HUD FMR and CHAS fetches

### DIFF
--- a/scripts/fetch_chas.py
+++ b/scripts/fetch_chas.py
@@ -174,7 +174,10 @@ def utc_now() -> str:
 def http_get(url: str, timeout: int = TIMEOUT) -> bytes:
     req = urllib.request.Request(url, headers={'User-Agent': 'HousingAnalytics/1.0'})
     with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return resp.read()
+        raw = resp.read()
+    if not raw:
+        raise RuntimeError(f'empty response body from {url}')
+    return raw
 
 
 def _int(value: str) -> int:
@@ -702,7 +705,10 @@ def _download_or_cache() -> bytes:
     if os.path.isfile(CACHE_PATH):
         print(f'  Using cached ZIP: {CACHE_PATH}')
         with open(CACHE_PATH, 'rb') as f:
-            return f.read()
+            raw = f.read()
+        if raw:
+            return raw
+        print(f'  ⚠ Ignoring empty cached ZIP: {CACHE_PATH}', file=sys.stderr)
 
     raw = None
     for url in (CHAS_STATE_URL, CHAS_STATE_URL_FALLBACK):

--- a/scripts/fetch_fmr_api.py
+++ b/scripts/fetch_fmr_api.py
@@ -42,7 +42,7 @@ OUT_TRACT_MAP   = os.path.join(_ROOT, 'data', 'market', 'fmr_tract_map_co.json')
 
 HUD_FMR_URL     = 'https://www.huduser.gov/hudapi/public/fmr/statedata/CO?year=2026'
 HUD_FMR_URL_PREV = 'https://www.huduser.gov/hudapi/public/fmr/statedata/CO?year=2025'
-HUD_IL_URL      = 'https://www.huduser.gov/hudapi/public/income/listCounties/08'  # FIPS 08 = CO
+HUD_IL_URL      = 'https://www.huduser.gov/hudapi/public/fmr/listCounties/08'  # FIPS 08 = CO
 HUD_IL_DATA_URL = 'https://www.huduser.gov/hudapi/public/fmr/il/data/{entityid}?year={year}'
 
 TIMEOUT  = 30

--- a/test/hud-fetch-hardening.test.py
+++ b/test/hud-fetch-hardening.test.py
@@ -39,7 +39,7 @@ def test_chas_http_get_rejects_empty_response() -> None:
     mod.urllib.request.urlopen = lambda req, timeout: EmptyResponse()
     try:
         try:
-            mod.http_get("https://example.test/empty.zip")
+            mod.http_get("data:application/octet-stream;base64,")
         except RuntimeError as exc:
             assert "empty response body" in str(exc)
         else:

--- a/test/hud-fetch-hardening.test.py
+++ b/test/hud-fetch-hardening.test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_script(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_fmr_county_list_endpoint_uses_live_hud_route() -> None:
+    mod = _load_script("fetch_fmr_api", ROOT / "scripts" / "fetch_fmr_api.py")
+
+    assert mod.HUD_IL_URL == "https://www.huduser.gov/hudapi/public/fmr/listCounties/08"
+
+
+def test_chas_http_get_rejects_empty_response() -> None:
+    mod = _load_script("fetch_chas", ROOT / "scripts" / "fetch_chas.py")
+
+    class EmptyResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return b""
+
+    original_urlopen = mod.urllib.request.urlopen
+    mod.urllib.request.urlopen = lambda req, timeout: EmptyResponse()
+    try:
+        try:
+            mod.http_get("https://example.test/empty.zip")
+        except RuntimeError as exc:
+            assert "empty response body" in str(exc)
+        else:
+            raise AssertionError("http_get should reject an empty response body")
+    finally:
+        mod.urllib.request.urlopen = original_urlopen
+
+
+if __name__ == "__main__":
+    test_fmr_county_list_endpoint_uses_live_hud_route()
+    test_chas_http_get_rejects_empty_response()


### PR DESCRIPTION
## Summary
- Move the Income Limits county-list fetch to HUD's reachable /fmr/listCounties route
- Reject zero-byte CHAS downloads before caching or parsing them
- Ignore empty cached CHAS ZIPs and retry upstream sources
- Add a focused standalone regression for the HUD endpoint and empty-body guard

## Tests
- python3 test/hud-fetch-hardening.test.py
- python3 tests/test_fmr_extractor.py
- python3 -m py_compile scripts/fetch_fmr_api.py scripts/fetch_chas.py test/hud-fetch-hardening.test.py