### PR TITLE
Give CO housing costs refresh more headroom

### DIFF
--- a/.github/workflows/update-co-housing-costs.yml
+++ b/.github/workflows/update-co-housing-costs.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build-co-housing-costs:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 60
 
     steps:
       - name: Checkout repo
@@ -25,6 +25,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
+          cache: 'pip'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- Increase the CO housing costs refresh job timeout from 25 to 60 minutes
- Enable setup-python pip caching so dependency install time does not eat into the data-refresh budget

## Tests
- Workflow-only change; inspected diff