### PR TITLE
Fix GRAPI proxy bin semantics in Prop 123 baseline

### DIFF
--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -1409,10 +1409,6 @@
       DP04_0140PE: pct(si(raw.B25070_006E)),
       DP04_0141PE: pct(si(raw.B25070_007E)),
       DP04_0142PE: pct(burden35),
-      // Legacy aliases retained for older consumers still checking pre-2023 keys.
-      DP04_0144PE: pct(si(raw.B25070_006E)),
-      DP04_0145PE: pct(si(raw.B25070_007E)),
-      DP04_0146PE: pct(burden35),
       NAME: raw.NAME,
       _acsYear: bYear,
       _acsSeries: 'acs5',

--- a/js/hna/hna-utils.js
+++ b/js/hna/hna-utils.js
@@ -820,9 +820,14 @@
    *   DP04_0002E  - Occupied housing units (NOT 0003E — that's vacant)
    *   DP04_0047E  - Renter-occupied (count, preferred)
    *   DP04_0047PE - Renter-occupied (%)
-   *   DP04_0144PE - GRAPI <15%
-   *   DP04_0145PE - GRAPI 15-19.9%
-   *   DP04_0146PE - GRAPI 20-24.9%  (not burdened)
+   *   DP04_0137PE - GRAPI <15%
+   *   DP04_0138PE - GRAPI 15-19.9%
+   *   DP04_0139PE - GRAPI 20-24.9%  (not burdened)
+   *
+   * Legacy pre-2020 DP04 profiles used DP04_0144PE/0145PE/0146PE for
+   * those same not-burdened bins. Current ACS profiles use those slots for
+   * different GRAPI bins or do not expose them, so the legacy keys are only
+   * consulted when the current 0137-0139 keys are entirely absent.
    *
    * @param {object} profile - ACS profile (DP04 fields)
    * @returns {{baseline60Ami, totalRentals, pctOfStock, method}|null}
@@ -859,11 +864,23 @@
     const totalRentals = Math.round(totalUnits * (renterPct / 100));
     if (totalRentals <= 0) return null;
 
-    // GRAPI bins: <15%, 15-19.9%, 20-24.9% are not-burdened (paying <30% income)
-    // Use these as a proxy for affordability at ≤60% AMI (conservative estimate)
-    const grapi_lt15   = Number(profile.DP04_0144PE);
-    const grapi_15_20  = Number(profile.DP04_0145PE);
-    const grapi_20_25  = Number(profile.DP04_0146PE);
+    // Current ACS 2023+ GRAPI bins: <15%, 15-19.9%, 20-24.9% are
+    // not-burdened (paying <25% of income). Use these as a proxy for
+    // affordability at ≤60% AMI (conservative estimate).
+    let grapi_lt15   = Number(profile.DP04_0137PE);
+    let grapi_15_20  = Number(profile.DP04_0138PE);
+    let grapi_20_25  = Number(profile.DP04_0139PE);
+    let grapiMethod = 'acs-grapi-proxy';
+
+    if (!Number.isFinite(grapi_lt15) && !Number.isFinite(grapi_15_20) && !Number.isFinite(grapi_20_25)) {
+      // Legacy pre-2020 ACS DP04 numbering only: these keys meant
+      // <15%, 15-19.9%, and 20-24.9%. Do not mix this branch with current
+      // profiles, where 0144-0146 have different semantics.
+      grapi_lt15   = Number(profile.DP04_0144PE);
+      grapi_15_20  = Number(profile.DP04_0145PE);
+      grapi_20_25  = Number(profile.DP04_0146PE);
+      grapiMethod = 'acs-grapi-proxy-legacy';
+    }
 
     let baseline60Ami = null;
     let method = 'estimate';
@@ -880,7 +897,7 @@
       // conduct a formal housing needs assessment using ACS B25106 cross-tabulations or local data.
       var amiFactor = (countyFips && REGIONAL_AMI_FACTORS[String(countyFips).padStart(5, '0')]) || DEFAULT_AMI_FACTOR;
       baseline60Ami = Math.round(totalRentals * (notBurdenedPct / 100) * amiFactor);
-      method = 'acs-grapi-proxy';
+      method = grapiMethod;
     } else {
       // Fallback national average: roughly 40% of renter-occupied units are estimated to be
       // affordable at ≤60% AMI based on national ACS income/rent cross-tabulations (HUD

--- a/test/hna-dp04-codes.test.js
+++ b/test/hna-dp04-codes.test.js
@@ -126,6 +126,13 @@ if (calcBaseline) {
   assert(/DP04_0002E/.test(body),
     'calculateBaseline references DP04_0002E (the actual Occupied code)');
 }
+const fullCalcBaseline = utilsSrc.match(/function calculateBaseline[\s\S]*?return \{ baseline60Ami/);
+assert(fullCalcBaseline !== null,
+  'can locate full calculateBaseline body');
+if (fullCalcBaseline) {
+  assert(/DP04_0137PE/.test(fullCalcBaseline[0]),
+    'calculateBaseline references DP04_0137PE (current GRAPI <15% code)');
+}
 
 console.log('\n[test] Sanity: ACS 2023 reference comments present in fix-touched files');
 assert(/ACS 2023.*DP04_0007E.*1-unit detached/i.test(renderersSrc) ||


### PR DESCRIPTION
## Summary
- Read current ACS GRAPI not-burdened bins DP04_0137PE-DP04_0139PE in calculateBaseline
- Keep DP04_0144PE-DP04_0146PE only as a pre-2020 fallback when current bins are absent
- Remove misleading live B-series fallback aliases for DP04_0144PE-DP04_0146PE
- Extend the DP04 code guard to lock calculateBaseline to DP04_0137PE

## Sanity demo
La Plata summary data/hna/summary/08067.json has DP04_0137PE=13.5, DP04_0138PE=9.6, DP04_0139PE=13.6, so notBurdened=36.7.

After this change calculateBaseline(profile, '08067') returns method acs-grapi-proxy with totalRentals=8436 and baseline60Ami=2167. Simulating the old DP04_0144PE-DP04_0146PE read returns method national-avg-proxy and baseline60Ami=3374 because those keys are absent.

## Tests
- node test/hna-dp04-codes.test.js
- node test/hna-functionality-check.js
- node test/hna-acs-var-coverage.test.js
- npm run test:ci