### PR TITLE
Fix ACS S0801 ETL assertions

### DIFF
--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -394,7 +394,7 @@
           <div class="stat"><div class="k">Tenure</div><div class="v" id="statTenure">—</div><div class="s" id="statTenureSrc">ACS DP04 0046/0047 · <a href="https://data.census.gov/table/ACSDP5Y2024.DP04" target="_blank" rel="noopener">data.census.gov</a></div></div>
           <div class="stat"><div class="k">Rent burdened (≥30%)</div><div class="v" id="statRentBurden">—</div><div class="s" id="statRentBurdenSrc">ACS DP04 GRAPI bins · <a href="https://data.census.gov/table/ACSDP5Y2024.DP04" target="_blank" rel="noopener">data.census.gov</a></div></div>
           <div class="stat"><div class="k">Income needed to buy (est.)</div><div class="v" id="statIncomeNeed">—</div><div class="s" id="statIncomeNeedNote">30% of income rule</div><div class="s" style="font-size:.68rem;opacity:.85">ACS DP04_0089E median home value · <a href="https://www.freddiemac.com/pmms" target="_blank" rel="noopener">Freddie Mac PMMS</a></div></div>
-          <div class="stat"><div class="k">Mean commute time</div><div class="v" id="statCommute">—</div><div class="s" id="statCommuteSrc">ACS S0801_C01_002E · <a href="https://data.census.gov/table/ACSST5Y2024.S0801" target="_blank" rel="noopener">data.census.gov</a></div></div>
+          <div class="stat"><div class="k">Mean commute time</div><div class="v" id="statCommute">—</div><div class="s" id="statCommuteSrc">ACS S0801 mean travel time (min) · <a href="https://data.census.gov/table/ACSST5Y2024.S0801" target="_blank" rel="noopener">data.census.gov</a></div></div>
         </div>
         <!-- Affordability Gap Coverage — 7 AMI bands sourced from ACS-derived
              co_ami_gap_by_county.json (preferred for granularity) with a

--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -1438,7 +1438,7 @@
       'S0801_C01_006E', // walked (%)
       'S0801_C01_007E', // taxicab, motorcycle, bicycle, or other means (%)
       'S0801_C01_008E', // worked at home (%)
-      'S0801_C01_018E', // mean travel time to work (minutes)
+      'S0801_C01_046E', // mean travel time to work (minutes)
     ];
 
     const forParam = geoType === 'county'

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -437,10 +437,16 @@
       }
     }
 
-    // Commute (S0801 mean travel time C01_002E)
+    // Commute (S0801 mean travel time C01_046E)
     if (s0801) {
-      const commute = safeNum(s0801.S0801_C01_002E || s0801.S0801_C01_002);
+      const commute = safeNum(s0801.S0801_C01_046E || s0801.S0801_C01_046);
       if (els.statCommute) els.statCommute.textContent = commute !== null ? `${Math.round(commute)} min` : '—';
+      if (els.statCommuteSrc) {
+        const sYear = s0801._acsYear || yr;
+        const sSeries = s0801._acsSeries || 'acs5';
+        els.statCommuteSrc.innerHTML =
+          U().srcLink('S0801 mean travel time (min)', sYear, sSeries, 'S0801', geoType, geoid);
+      }
     }
 
     // Narrative
@@ -1302,6 +1308,8 @@
     const t = chartTheme();
     const safeNum = U().safeNum;
     const safe = (k) => safeNum(s0801 && s0801[k]) || 0;
+    const modeYear = s0801 && s0801._acsYear ? s0801._acsYear : '';
+    const seriesLabel = s0801 && s0801._acsSeries === 'acs1' ? 'ACS 1-year' : 'ACS 5-year';
     const modes = [
       { label: 'Drive alone', v: safe('S0801_C01_003E') },
       { label: 'Carpool',     v: safe('S0801_C01_004E') },
@@ -1319,10 +1327,17 @@
       options: {
         responsive: true,
         maintainAspectRatio: false,
-        plugins: { legend: { display: false } },
+        plugins: {
+          legend: { display: false },
+          subtitle: {
+            display: true,
+            text: `${seriesLabel}${modeYear ? ' ' + modeYear : ''} mode shares (% of workers 16+)`,
+            color: t.muted,
+          },
+        },
         scales: {
           x: categoryAxis('Commute mode'),
-          y: pctAxis('% of workers'),
+          y: pctAxis('Mode Share (% of workers)'),
         },
       },
     });

--- a/scripts/fetch_census_state_hna.py
+++ b/scripts/fetch_census_state_hna.py
@@ -117,7 +117,7 @@ ACS_S0801_VARS = [
     'S0801_C01_006E',  # Walked (%)
     'S0801_C01_007E',  # Taxicab, motorcycle, bicycle, or other means (%)
     'S0801_C01_008E',  # Worked at home (%)
-    'S0801_C01_018E',  # Mean travel time to work (minutes)
+    'S0801_C01_046E',  # Mean travel time to work (minutes)
     'NAME',
 ]
 

--- a/scripts/hna/build_hna_data.py
+++ b/scripts/hna/build_hna_data.py
@@ -1011,7 +1011,7 @@ def fetch_acs_s0801(geo_type: str, geoid: str) -> dict | None:
         'S0801_C01_006E',  # Walked (%)
         'S0801_C01_007E',  # Taxicab, motorcycle, bicycle, or other means (%)
         'S0801_C01_008E',  # Worked at home (%)
-        'S0801_C01_018E',  # Mean travel time to work (minutes)
+        'S0801_C01_046E',  # Mean travel time to work (minutes)
         'NAME'
     ]
 

--- a/test/acs-etl.test.js
+++ b/test/acs-etl.test.js
@@ -481,30 +481,30 @@ test('build_hna_data.py: acs_s0801_endpoint uses s0801_year and s0801_series', (
   assert(src.includes('acs_s0801_endpoint'), 'acs_s0801_endpoint in source dict');
 });
 
-// ── housing-needs-assessment.js: commuting reliability & source labels ───────
+// ── HNA commuting reliability & source labels ───────────────────────────────
 
-test('housing-needs-assessment.js: S0801 commute source badge includes units', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'js/housing-needs-assessment.js'), 'utf8');
+test('hna-renderers.js: S0801 commute source badge includes units', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-renderers.js'), 'utf8');
   assert(src.includes('mean travel time (min)'),
     'commute source badge includes "mean travel time (min)"');
 });
 
-test('housing-needs-assessment.js: mode share chart subtitle includes year/series/units', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'js/housing-needs-assessment.js'), 'utf8');
+test('hna-renderers.js: mode share chart subtitle includes year/series/units', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-renderers.js'), 'utf8');
   assert(src.includes('mode shares (% of workers 16+)'),
     'mode share subtitle contains "mode shares (% of workers 16+)"');
   assert(src.includes('seriesLabel'), 'seriesLabel variable used in mode share subtitle');
   assert(src.includes('modeYear'),    'modeYear variable used in mode share subtitle');
 });
 
-test('housing-needs-assessment.js: CDP skips ACS1 S0801 probe', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'js/housing-needs-assessment.js'), 'utf8');
+test('hna-controller.js: CDP skips ACS1 S0801 probe', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-controller.js'), 'utf8');
   assert(src.includes("geoType !== 'cdp'"),
     'fetchAcsS0801 skips ACS1 probe for CDPs to avoid unnecessary failed requests');
 });
 
-test('housing-needs-assessment.js: mode share y-axis title includes units', () => {
-  const src = fs.readFileSync(path.join(ROOT, 'js/housing-needs-assessment.js'), 'utf8');
+test('hna-renderers.js: mode share y-axis title includes units', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-renderers.js'), 'utf8');
   assert(src.includes("'Mode Share (% of workers)'"),
     'y-axis title clarifies unit as "% of workers"');
 });

--- a/test/integration/housing-needs-assessment.test.js
+++ b/test/integration/housing-needs-assessment.test.js
@@ -245,7 +245,7 @@ test('ACS S0801: all required mode-share fields requested', () => {
   assert(hnaSrc.includes('S0801_C01_005E'), 'S0801_C01_005E (walked) in fetch');
   assert(hnaSrc.includes('S0801_C01_006E'), 'S0801_C01_006E (other means) in fetch');
   assert(hnaSrc.includes('S0801_C01_007E'), 'S0801_C01_007E (work from home) in fetch');
-  assert(hnaSrc.includes('S0801_C01_018E'), 'S0801_C01_018E (mean commute time) in fetch');
+  assert(hnaSrc.includes('S0801_C01_046E'), 'S0801_C01_046E (mean commute time) in fetch');
 });
 
 test('ACS S0801: renderModeShare function is defined', () => {
@@ -271,8 +271,8 @@ test('ACS S0801: renderModeShare has a null/missing-data guard', () => {
 test('ACS S0801: mean commute time populates statCommute element', () => {
   assert(hnaSrc.includes('statCommute'),
     'statCommute element is referenced in JS');
-  assert(hnaSrc.includes('S0801_C01_018E'),
-    'S0801_C01_018E (mean commute time) is used');
+  assert(hnaSrc.includes('S0801_C01_046E'),
+    'S0801_C01_046E (mean commute time) is used');
   // Confirm it's used to set text (either textContent or innerHTML)
   assert(hnaSrc.includes('els.statCommute.textContent'),
     'statCommute textContent is set from S0801 mean commute field');


### PR DESCRIPTION
## Summary
- retarget stale ACS ETL assertions from the legacy monolith to the split HNA controller/renderers
- restore the expected commute source badge, mode-share subtitle, and y-axis unit strings in the live renderer
- preserve the existing CDP ACS1 S0801 probe-skip in fetchAcsS0801
- correct mean commute time from stale/mislabeled S0801 fields to official S0801_C01_046E in live fetchers and integration guards

## Blame / verification notes
- stale assertions trace back before PRs #1056-#1058 and still referenced js/housing-needs-assessment.js
- current CDP probe-skip behavior is in js/hna/hna-controller.js and is retained, not weakened
- Census S0801 metadata identifies S0801_C01_046E as mean travel time to work in minutes; S0801_C01_018E is not that measure

## Tests
- node test/acs-etl.test.js -> 167 passed, 0 failed
- npm run test:hna -> 730 passed, 0 failed