### PR TITLE
Fix county-data-as-place-data mislabeling in Housing Need Projection panel

### DIFF
--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -2929,13 +2929,24 @@
       }
     } catch (_) {}
 
-    // Housing need projections + AMI recommendation
+    // Housing need projections + AMI recommendation. countyData is always
+    // the containing county's row — for a place/CDP selection the numbers
+    // are county-scope, so the pill must disclose that (same pattern as
+    // the Neighborhood Context card's ncContextScope below) rather than
+    // presenting e.g. Garfield County's projection under a "New Castle" pill.
     if (window.HousingNeedProjector) {
       var pill     = document.getElementById('projectionGeoPill');
       var geoLabel = geoSelectEl.options[geoSelectEl.selectedIndex]
         ? geoSelectEl.options[geoSelectEl.selectedIndex].text : countyFips;
+      var _projCountyLabel = (typeof _countyName === 'string' && _countyName)
+        ? _countyName + ' County' : '';
+      if (geoType === 'place' || geoType === 'cdp') {
+        geoLabel += ' — county-scope projection' +
+          (_projCountyLabel ? ' (' + _projCountyLabel + ')' : '');
+      }
       if (pill) { pill.style.display = ''; pill.textContent = geoLabel; }
-      HousingNeedProjector.renderProjectionSection('hnpProjectionContainer', countyFips, countyData);
+      HousingNeedProjector.renderProjectionSection('hnpProjectionContainer', countyFips, countyData,
+        { geoType: geoType, countyName: _projCountyLabel || undefined });
       HousingNeedProjector.renderAmiRecommendation('hnpAmiContainer', countyData);
     }
 

--- a/js/components/housing-type-need.js
+++ b/js/components/housing-type-need.js
@@ -363,6 +363,7 @@
       type: 'deeplyAffordableRental',
       label: 'Deeply affordable rental',
       meta: '≤30% AMI · apartment · rent',
+      usesChas: true,
       indicators: indicators,
       score: agg.score,
       available: agg.available,
@@ -438,6 +439,7 @@
       type: 'workforceRental',
       label: 'Workforce rental',
       meta: '60–80% AMI · apartment / townhome · rent',
+      usesChas: true,
       indicators: indicators,
       score: agg.score,
       available: agg.available,
@@ -709,7 +711,7 @@
 
   // ── confidence calculation ────────────────────────────────────────────────
 
-  function deriveConfidence(category, acs) {
+  function deriveConfidence(category, acs, chasCountyFallback) {
     var n = category.available;
     var level = n >= 4 ? 'high' : (n >= 2 ? 'med' : 'low');
     var reasons = [];
@@ -717,6 +719,11 @@
     var smallSample = (acs.pop != null && acs.pop < 5000);
     if (smallSample) reasons.push('small place (pop < 5,000) — ACS MOE may be wide');
     if (!acs.hasBedroomMix) reasons.push('DP04 bedroom mix not available');
+    // Disclose county-CHAS substitution, but only on categories whose
+    // indicators actually consume CHAS — the others are unaffected.
+    if (chasCountyFallback && category.usesChas) {
+      reasons.push('county CHAS (place data unavailable)');
+    }
     if (smallSample && level === 'high') level = 'med';
     return { confidence: level, confidenceReason: reasons.join('; ') };
   }
@@ -741,7 +748,7 @@
 
     var results = categories.map(function (cat) {
       var level = scoreToLevel(cat.score);
-      var conf  = deriveConfidence(cat, acs);
+      var conf  = deriveConfidence(cat, acs, !!input.chasCountyFallback);
       // Surface top 3 contributing signals (by contribution).
       var topSignals = cat.indicators
         .filter(function (i) { return i.value != null; })

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -4543,6 +4543,11 @@
           && window.PlaceChas && typeof window.PlaceChas.lookup === 'function') {
         chasRecord = window.PlaceChas.lookup(geoid);
       }
+      // County fallback. Dormant today (place-CHAS coverage is 100%), but
+      // if it ever fires for a place/cdp the data is county-scope — flag it
+      // so the confidence chip discloses the substitution instead of
+      // presenting county CHAS as place data.
+      var chasCountyFallback = false;
       if (!chasRecord && chasData) {
         var countyFips = '';
         if (U() && typeof U().countyFromGeoid === 'function') {
@@ -4551,6 +4556,7 @@
         if (!countyFips && geoid && String(geoid).length === 5) countyFips = geoid;
         if (countyFips) {
           chasRecord = (chasData.counties || {})[countyFips] || null;
+          chasCountyFallback = !!chasRecord && (geoType === 'place' || geoType === 'cdp');
         }
       }
       var lihtcFeatures = (S() && S().allLihtcFeatures) || [];
@@ -4569,7 +4575,8 @@
         chasRows: chasRecord,
         hudIncomeLimits: hud,
         lihtcInventory: lihtcFeatures,
-        jurisdictionName: jurisdictionName
+        jurisdictionName: jurisdictionName,
+        chasCountyFallback: chasCountyFallback
       });
     } catch (e) {
       console.warn('[HNA] tryRenderHousingTypeNeedFromState failed', e);

--- a/js/housing-need-projector.js
+++ b/js/housing-need-projector.js
@@ -143,6 +143,11 @@
    * @param {Object}  [options]
    * @param {Object}  [options.dolaProj]   Parsed DOLA projections JSON
    * @param {string}  [options.countyName]
+   * @param {string}  [options.geoType]    Caller's selected geography type
+   *                  ('county' | 'place' | 'cdp'). Inputs are always county
+   *                  rows, so a place/cdp selection yields a county-scope
+   *                  result — stamped on the output as geoScope so callers
+   *                  can disclose the provenance.
    * @returns {ProjectionResult}
    */
   function project(fips, countyData, options) {
@@ -242,6 +247,11 @@
     return {
       fips: fips,
       countyName: countyName,
+      // Provenance: inputs are county rows, so the projection is always
+      // county-scope. 'county-for-place' flags that the user's selection
+      // was a place/cdp and the county numbers stand in for it.
+      geoScope: (options.geoType === 'place' || options.geoType === 'cdp')
+        ? 'county-for-place' : 'county',
       baseYear: 2024,
       scenarios: {
         low:      { yr5: lYr5,  yr10: lYr10,  yr20: lYr20  },
@@ -457,15 +467,23 @@
    * @param {string} containerId
    * @param {string} fips
    * @param {Object} countyData
+   * @param {Object} [options]
+   * @param {string} [options.geoType]  Caller's selected geography type —
+   *                 forwarded to project() so the county-scope provenance
+   *                 is stamped and disclosed for place/cdp selections.
+   * @param {string} [options.countyName]  Display name for the county —
+   *                 demographics rows keyed by name don't carry a .name
+   *                 field, so without this the intro shows the raw FIPS.
    */
-  function renderProjectionSection(containerId, fips, countyData) {
+  function renderProjectionSection(containerId, fips, countyData, options) {
     _injectStyles();
+    options = options || {};
 
     var container = document.getElementById(containerId);
     if (!container) return;
 
     var cd = countyData || {};
-    var countyName = cd.name || fips;
+    var countyName = options.countyName || cd.name || fips;
 
     /* Show loading placeholder */
     container.innerHTML = '<p style="color:var(--muted,#555);font-size:.85rem">Loading projections…</p>';
@@ -476,7 +494,8 @@
     function renderWithProj(dolaProj) {
       var result = project(fips, cd, {
         dolaProj: dolaProj,
-        countyName: countyName
+        countyName: countyName,
+        geoType: options.geoType
       });
       _injectProjectionHTML(container, result, countyName);
     }
@@ -506,6 +525,10 @@
       'Based on current housing gaps and low/baseline/high growth assumptions for ' +
       '<strong>' + countyName + '</strong>, the following projections estimate ' +
       'unmet housing demand over the next 20 years.' +
+      (result.geoScope === 'county-for-place'
+        ? ' Projections are computed at county granularity — figures below are ' +
+          'county-scope, not specific to the selected place.'
+        : '') +
       '</p>';
 
     var tableRows = [


### PR DESCRIPTION
## Problem

The Housing Need Projection panel on `housing-needs-assessment.html` always computes from the containing county's row in `co-county-demographics.json`, but for place/CDP selections the `#projectionGeoPill` showed only the place label — e.g. New Castle's page presented **Garfield County's** projection under a **"New Castle"** pill. Recurring place-vs-county masking class of bug.

## Fix (labeling/provenance only — no calculation changes)

- **Pill disclosure**: for place/cdp selections the pill now reads `New Castle (town) — county-scope projection (Garfield County)`, following the pattern the adjacent Neighborhood Context card already uses (`ncContextScope`).
- **Projector provenance**: `project()` / `renderProjectionSection()` accept `options.geoType` and stamp `geoScope: 'county' | 'county-for-place'` on the result; the rendered intro appends "Projections are computed at county granularity — figures below are county-scope, not specific to the selected place." when the selection was a place.
- **Intro county name**: `renderProjectionSection()` also accepts `options.countyName` — demographics rows keyed by name carry no `.name` field, so the intro previously showed the raw FIPS ("for **08045**"); it now shows "for **Garfield County**".
- **Dormant county-CHAS fallback labeled**: `tryRenderHousingTypeNeedFromState` threads a `chasCountyFallback` flag through to `HousingTypeNeed.compute()`. The fallback never fires today (place-CHAS coverage 513/513), but if it ever does for a place, the confidence chip discloses `county CHAS (place data unavailable)` — only on the two categories whose indicators actually consume CHAS (deeply affordable + workforce rental).

## Verification

- Browser-verified: New Castle → pill + intro disclose Garfield County scope; Garfield County selection unchanged (plain pill, no note); `chasCountyFallback: true` adds the note only to CHAS-consuming categories, `false` adds none. No console errors.
- `npm run test:hna` — 730 passed, 0 failed
- `npm run validate` — clean

Diff kept small (4 files, +56/−8) to avoid conflicts with the Codex Affordable Ownership Need module (`CODEX-HANDOFF-AFFORDABLE-OWNERSHIP.md`) — no changes near `housing-type-need-section`'s insertion point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)