### PR TITLE
Fix dead county-scope disclosure + 100x need-composite display in Opportunity Finder

### DIFF
--- a/js/lihtc-opportunity-finder.js
+++ b/js/lihtc-opportunity-finder.js
@@ -1532,7 +1532,10 @@
         regionalRecencyAnchor_state_credit: regional_recency_anchor_state_credit,
         regionalRecencyAnchor_competitive:  regional_recency_anchor_competitive,
         needScore:    needPct,
-        needCompositePct: needComposite != null ? Math.round(needComposite * 100) : null,
+        // needCompositeFor already returns percent (both branches convert
+        // shares ×100 / use pct_* fields) — a further ×100 rendered e.g.
+        // Gunnison's 28.1% composite as "2810%" in the detail panel.
+        needCompositePct: needComposite != null ? Math.round(needComposite * 10) / 10 : null,
         // F223 — provenance for the need component: 'place' = place-level CHAS;
         // 'county' = containing-county CHAS fallback; null = unavailable.
         needSource:   needSource,
@@ -2540,7 +2543,10 @@
           // F223 — Disclosure pill when need came from the containing county
           // rather than place-level CHAS. Helps users know two places in the
           // same county aren't being scored as if they're literally identical.
-          (op.type === 'place' && op.needSource === 'county'
+          // NOTE: op.type is 'city' | 'town' | 'cdp' (never 'place'), and all
+          // ops are sub-county jurisdictions — needSource alone is the gate.
+          // The original `op.type === 'place'` guard made this pill dead code.
+          (op.needSource === 'county'
             ? ' <span style="display:inline-block;font-size:.62rem;padding:1px 4px;border-radius:3px;background:var(--warn-dim);color:var(--warn);margin-left:3px;" title="No place-level CHAS available — this jurisdiction\'s need score is the containing county\'s CHAS composite, applied to every place in the county.">scaled</span>'
             : '') +
         '</td>' +
@@ -3593,6 +3599,13 @@
       '</dd>' +
       '<dt>HNA need composite</dt><dd>' + (op.needCompositePct != null ? op.needCompositePct + '% ' : '') +
         '<span style="color:var(--muted);font-size:.78rem">(CO percentile rank: p' + op.needScore + ')</span>' +
+        // F223 follow-up — the list row discloses county-sourced need with a
+        // "scaled" pill; mirror it here so the detail panel doesn't present
+        // the county CHAS composite as place data. Fires for places whose
+        // place-CHAS record is missing or low_confidence (needCompositeFor).
+        (op.needSource === 'county'
+          ? ' <span style="display:inline-block;font-size:.62rem;padding:1px 4px;border-radius:3px;background:var(--warn-dim);color:var(--warn);" title="No reliable place-level CHAS available — this jurisdiction\'s need composite is the containing county\'s CHAS composite, applied to every place in the county.">county CHAS (place data unavailable)</span>'
+          : '') +
         ' &nbsp;<a href="' + escHtml(hnaUrlForPlace(op.placeGeoid)) + '" target="_blank" rel="noopener" ' +
           'style="font-size:.78rem;font-weight:600">View full HNA →</a>' +
         // F207c — CHAS reliability badge slot. Async-filled after the


### PR DESCRIPTION
## Context

Follow-up to #1060: a proactive sweep of the recurring place-vs-county masking bug class across the Opportunity Finder found one disclosure gap, and verifying it surfaced two more defects in the same code path. All three are labeling/display fixes — **no scoring changes**.

## Fixes

1. **F223 "scaled" pill was dead code** ([js/lihtc-opportunity-finder.js:2543](../blob/main/js/lihtc-opportunity-finder.js)): the guard checked `op.type === 'place'`, but `op.type` is only ever `'city' | 'town' | 'cdp'` — the pill never fired, even when `needCompositeFor()` fell back to county CHAS (missing or `low_confidence` place record). All ops are sub-county jurisdictions, so `needSource === 'county'` alone is the gate now.
2. **Detail panel had no disclosure at all**: the "HNA need composite" row presented county-sourced composites as place data. Added a `county CHAS (place data unavailable)` pill mirroring the list row, phrased to match the HNA housing-type-need confidence chip from #1060.
3. **100× display bug**: `needCompositePct` multiplied the composite by 100, but `needCompositeFor()` already returns percent in both branches — every detail panel showed e.g. Gunnison as "**2810%**" instead of "**28.1%**". Only the display consumes this field; percentile ranking uses the raw composite and is unchanged.

## Verification

- Browser-verified: clean op renders sane % with no pill; forcing `needSource='county'` in state surfaces both the list-row "scaled" pill (with tooltip) and the detail-panel disclosure; median composite across 482 ops is now 25.5 (was 2551). No console errors.
- `npm run test:lihtc-opportunity-finder-zori`, `npm run test:hna` (730 passed), `npm run validate` — all green.

Note: the county fallback is currently dormant in live data (0 of 482 ops county-sourced), but the 100× bug was live on every detail panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)