### PR TITLE
Priority 1: fix console audit errors

### DIFF
--- a/js/census-geo.js
+++ b/js/census-geo.js
@@ -12,6 +12,7 @@
  */
 (() => {
   const KEY      = (window.APP_CONFIG && window.APP_CONFIG.CENSUS_API_KEY) ? window.APP_CONFIG.CENSUS_API_KEY : "";
+  const HAS_CENSUS_KEY = !!KEY;
   const VINTAGES = ["2023", "2022", "2021", "2020"];
   const DATASET  = (v) => `https://api.census.gov/data/${v}/acs/acs5/profile`;
 
@@ -330,6 +331,20 @@
     });
   }
 
+  function renderApiKeyRequired(label, grid, vintageEl) {
+    if (vintageEl) {
+      vintageEl.textContent = label + " unavailable without CENSUS_API_KEY";
+    }
+    if (grid) {
+      grid.innerHTML = `
+        <div class="card" style="padding:14px" data-contrast-surface>
+          <div style="font-weight:800">Census API key required</div>
+          <div style="color:var(--muted);margin-top:6px">Cached state data remains available. Configure CENSUS_API_KEY for live national, county, or place Census profile lookups.</div>
+        </div>
+      `;
+    }
+  }
+
   /* ---- loaders ---- */
   async function loadNational() {
     const { vintage, data } = await getWorkingVintage("national", {});
@@ -407,17 +422,19 @@
     let statesInfo   = null;
     let nationalInfo = null;
 
-    Promise.allSettled([loadNational(), loadStates()]).then(([natResult, stResult]) => {
-      if (natResult.status === "fulfilled") nationalInfo = natResult.value;
-      if (stResult.status === "fulfilled") {
-        statesInfo = stResult.value;
-        // Only refill if we don't have cached data
-        if (!cachedStateData || !cachedStateData.length) {
-          fillOptions(stateEl, statesInfo.states, "Select a state…");
-          fillOptions(geoEl,   statesInfo.states, "Select a state…");
+    if (HAS_CENSUS_KEY) {
+      Promise.allSettled([loadNational(), loadStates()]).then(([natResult, stResult]) => {
+        if (natResult.status === "fulfilled") nationalInfo = natResult.value;
+        if (stResult.status === "fulfilled") {
+          statesInfo = stResult.value;
+          // Only refill if we don't have cached data
+          if (!cachedStateData || !cachedStateData.length) {
+            fillOptions(stateEl, statesInfo.states, "Select a state…");
+            fillOptions(geoEl,   statesInfo.states, "Select a state…");
+          }
         }
-      }
-    }).catch(err => console.warn("[census-geo] API pre-fetch:", err));
+      }).catch(err => console.warn("[census-geo] API pre-fetch:", err));
+    }
 
     const grid = $(".census-grid");
 
@@ -442,6 +459,10 @@
       if (lvl === "national") {
         showEl("censusStateWrap", false);
         showEl("censusGeoWrap", false);
+        if (!HAS_CENSUS_KEY) {
+          renderApiKeyRequired("National data", grid, vintageEl);
+          return;
+        }
         if (nationalInfo) {
           renderStats("United States", nationalInfo.record, nationalInfo.vintage);
         } else {
@@ -498,6 +519,14 @@
       showEl("censusStateWrap", true);
       showEl("censusGeoWrap", true);
       geoEl.innerHTML = `<option value="">Select a state first…</option>`;
+
+      if (!HAS_CENSUS_KEY) {
+        geoEl.disabled = true;
+        geoEl.innerHTML = `<option value="">Census API key required</option>`;
+        stateEl.onchange = () => renderApiKeyRequired(lvl === "county" ? "County data" : "Place data", grid, vintageEl);
+        renderApiKeyRequired(lvl === "county" ? "County data" : "Place data", grid, vintageEl);
+        return;
+      }
 
       stateEl.onchange = async () => {
         const st = stateEl.value;

--- a/js/data-source-discovery.js
+++ b/js/data-source-discovery.js
@@ -80,8 +80,6 @@
     'data/policy/county-ownership.json',
     'data/amenities/grocery_co.geojson',
     'data/hna/chas_affordability_gap.json',
-    'data/hna/municipal/municipal-config.json',
-    'data/hna/municipal/growth-rates.json',
     CONFIG_PATH
   ];
 

--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -1243,6 +1243,8 @@
    */
   async function fetchAcsB25009(geoType, geoid) {
     if (geoType !== 'place' && geoType !== 'cdp' && geoType !== 'county' && geoType !== 'state') return null;
+    const key = window.HNAUtils.censusKey();
+    if (!key) return null;
     _censusApiWarn();
     // Renter universe: B25009_010 (total) + 011-017 (HH size 1–7+)
     const vars = ['NAME','B25009_001E','B25009_010E','B25009_011E','B25009_012E','B25009_013E','B25009_014E','B25009_015E','B25009_016E','B25009_017E'];
@@ -1252,7 +1254,6 @@
         ? 'place:' + geoid.slice(2)
         : 'county:' + geoid.slice(2,5);
     const inParam = geoType === 'state' ? null : ('state:' + window.HNAUtils.STATE_FIPS_CO);
-    const key = window.HNAUtils.censusKey();
     function buildUrl(year) {
       const base = 'https://api.census.gov/data/' + year + '/acs/acs5';
       let qs = 'get=' + encodeURIComponent(vars.join(','));
@@ -1770,6 +1771,7 @@
         : 'place:' + geoid.slice(2);
     var inParam  = geoType === 'state' ? null : 'state:' + window.HNAUtils.STATE_FIPS_CO;
     var key      = window.HNAUtils.censusKey();
+    if (!key) return {};
     var year     = window.HNAUtils.ACS_YEAR_PRIMARY || 2023;
 
     function buildUrl(yr, vars) {

--- a/js/market-intelligence.js
+++ b/js/market-intelligence.js
@@ -803,7 +803,7 @@
     // The container has a fixed height, so appending inside would overflow.
     // Insert as the container's next sibling instead.
     function _renderTrendLegend() {
-      var container = canvas && canvas.parentNode;
+      var container = ctx && ctx.parentNode;
       var host = container && container.parentNode;
       if (!host) return;
       var prior = host.querySelector('.lihtc-trend-event-legend');


### PR DESCRIPTION
## Summary
- stop keyless Census API probes from surfacing console errors on the Economic Dashboard and HNA when cached data is available and CENSUS_API_KEY is intentionally blank
- remove known-missing optional municipal discovery probes that generated Data Review Hub 404 console errors
- fix the Market Intelligence LIHTC trend legend reference that threw canvas is not defined

## Console audit evidence
Fresh local run using the Console Error Audit reporter against http://127.0.0.1:8080:

| Metric | Count |
| --- | ---: |
| Pages audited | 35 |
| Pages with JS errors | 0 |
| Pages with warnings | 0 |
| Pages with load errors | 0 |
| Total console errors | 0 |
| Total console warnings | 0 |

Pre-fix reproduction on current main showed 21 errors across 4 pages: economic-dashboard keyless Census profile probes, housing-needs-assessment keyless extended ACS/B25009 probes, market-intelligence canvas is not defined, and data-review-hub optional municipal JSON 404 probes. Post-fix audit is clean.

## Issue evidence and disposition
- #919: stale 2026-05-18 console audit snapshot. Current reproduction found the live keyless Census, Data Review Hub probe, and Market Intelligence legend errors above; this PR resolves them and provides a 0-error fresh audit.
- #840: stale 2026-06-01 console audit snapshot. Same current audit run now reports 0 errors and 0 warnings across all audited pages.

## Tests
- npm run audit:console -> 35 pages, 0 errors, 0 warnings
- npm run validate -> passed
- npm run test:hna -> 730 passed, 0 failed

## Scope guard
Changed only js/census-geo.js, js/hna/hna-controller.js, js/data-source-discovery.js, and js/market-intelligence.js. No data files, workflows, page availability gates, or Affordable Ownership Need insertion points touched.