### PR TITLE
Priority 3: add Fruita jurisdiction brief

### DIFF
--- a/data/jurisdiction-briefs/0828745.json
+++ b/data/jurisdiction-briefs/0828745.json
@@ -1,0 +1,293 @@
+{
+  "geoid": "0828745",
+  "jurisdiction": "City of Fruita",
+  "scope": "place",
+  "containing_county_fips": "08077",
+  "last_curated": "2026-07-06",
+  "curator": "Codex",
+  "published": true,
+  "summary": "Fruita's housing brief centers on a city housing authority created to support diverse housing options, a tax-abatement and LIHTC partnership role, Fruita Mews as the city's first Housing Tax Credit-supported development, and The Oaks as a proposed workforce-oriented rent-restricted redevelopment. The metrics profile is consistent with the benchmark note: a fast-growing, single-family-heavy market with a renter share near 20%, a median home-value estimate near $486,000, and a workforce squeeze visible in ownership affordability and in-commuting.",
+  "sections": [
+    {
+      "id": "local-housing-authority",
+      "heading": "Fruita Housing Authority",
+      "paragraphs": [
+        {
+          "text": "The Fruita Housing Authority's stated purpose is to assist the City of Fruita with housing for people who want to live in Fruita and to maintain multiple housing types in the city. The authority's listed tools include partnerships inside and outside the city, tax-abatement programming, and low-income housing tax credit financing projects.",
+          "cites": [
+            "s1"
+          ]
+        },
+        {
+          "text": "Fruita's official housing-authority page also ties the authority to the Fruita in Motion growth vision: a distinct Grand Valley city with small-town character, a thriving downtown, and connected neighborhoods that provide a variety of housing sizes, types, and styles.",
+          "cites": [
+            "s1"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "lihtc-and-workforce-pipeline",
+      "heading": "LIHTC and workforce pipeline",
+      "paragraphs": [
+        {
+          "text": "Fruita Mews is the authority's first Housing Tax Credit-supported development in Fruita. The official page describes a June 2023 special limited partnership with IndiBuild for the Fruita Mews development at 1601 K and 4/10th Road, says the development has 50 affordable units, and states that all residential units are reserved for residents earning at or below 100% of area median income.",
+          "cites": [
+            "s1"
+          ]
+        },
+        {
+          "text": "The Oaks is a second identified workforce-oriented project on the official page: the City of Fruita and Headwaters Housing Partners aim to redevelop the former Family Health West property at 805 West Ottley Avenue into long-term, rent-restricted apartments for essential local workers. The page says the plan would reduce the legacy assisted-living layout from 70 units to 62 units, including 51 one-bedroom and 11 two-bedroom apartments, while reusing existing foundations and utility infrastructure where possible to keep the project affordable for Fruita's workforce serving up to 100% of area median income.",
+          "cites": [
+            "s1"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "metric-digest",
+      "heading": "Metric Digest",
+      "paragraphs": [
+        {
+          "text": "The metric digest ranks City of Fruita at #139 with an overall housing-need score of 59.6. It identifies 94 deeply affordable units missing at <=30% AMI, equal to 32.9% of <=30% AMI households. 43.6% of renter households are cost burdened, and 3.4% of occupied households are overcrowded.",
+          "cites": [
+            "d1",
+            "d2",
+            "d3",
+            "d4",
+            "d5",
+            "d6"
+          ]
+        },
+        {
+          "text": "Market and supply context: the digest reports a ZHVI market estimate of $486,295 and median gross rent of $1,472. 20.1% of households rent, 2.9% of the housing stock is multifamily, and the active-market vacancy rate is 1.8%, reinforcing the benchmark characterization of a single-family-heavy, tight market.",
+          "cites": [
+            "d7",
+            "d8",
+            "d9",
+            "d10",
+            "d11"
+          ]
+        },
+        {
+          "text": "Demographics and demand: the population metric is 13,691. LEHD-based commuting signals show 1,952 in-commuters and a commute ratio of 68.2%. The digest's county-context projection shows 1,081 future units needed over 20 years, so that projection should be read as county context rather than a place trend.",
+          "cites": [
+            "d12",
+            "d13",
+            "d14",
+            "d15"
+          ]
+        },
+        {
+          "text": "Economic and service-worker context: the digest reports a workforce-housing pressure score of 57.3. A worker earning the containing county's LEHD earnings-bin wage estimate faces an ownership affordability gap of $63,558 and a rent affordability gap of $3,880. The county-context service-sector employment share is 44.8%, and county-context ACS cohorts show median gross rent changed 76.8% from 2009 to 2024 while median household income changed 47.1%. These county-context figures are economic context, not place-level sector or wage observations.",
+          "cites": [
+            "d16",
+            "d17",
+            "d18",
+            "d19",
+            "d20",
+            "d21"
+          ]
+        }
+      ]
+    }
+  ],
+  "sources": [
+    {
+      "id": "s1",
+      "label": "Fruita Housing Authority — City of Fruita",
+      "url": "https://www.fruita.org/694/Fruita-Housing-Authority",
+      "kind": "primary",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d1",
+      "label": "Ranking index rank - jurisdiction metrics digest (2026-07-06T11:51:41Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "rank",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d2",
+      "label": "Overall housing-need score - jurisdiction metrics digest (2026-07-06T11:51:41Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overall_need_score",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d3",
+      "label": "Deep-affordability housing gap units - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_units",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d4",
+      "label": "Deep-affordability gap rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_rate_lte30",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d5",
+      "label": "Renter cost-burden rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_cost_burdened",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d6",
+      "label": "Occupied-household overcrowding rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overcrowding_rate",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d7",
+      "label": "ZHVI market home-value estimate - jurisdiction metrics digest (2026-05-31)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "median_home_value",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d8",
+      "label": "Median gross rent - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "gross_rent_median",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d9",
+      "label": "Renter household share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_renters",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d10",
+      "label": "Multifamily housing-stock share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_multifamily",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d11",
+      "label": "Active-market vacancy rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "active_market_vacancy_rate",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d12",
+      "label": "Population - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "population",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d13",
+      "label": "In-commuters - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "in_commuters",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d14",
+      "label": "Commute ratio - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "commute_ratio",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d15",
+      "label": "Twenty-year future units needed - jurisdiction metrics digest (DOLA projection cache)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "future_units_needed_20yr",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d16",
+      "label": "Workforce housing pressure score - jurisdiction metrics digest (2026-07-06T11:51:41Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "workforce_housing_pressure_score",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d17",
+      "label": "Ownership wage-affordability gap - jurisdiction metrics digest (2026-07-06T11:51:41Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "wage_affordability_ownership_gap_dollars",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d18",
+      "label": "Rent wage-affordability gap - jurisdiction metrics digest (2026-07-06T11:51:41Z)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "wage_affordability_rent_gap_dollars",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d19",
+      "label": "County-context service-sector employment share - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "county_service_sector_share_pct",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d20",
+      "label": "County-context median gross-rent change - jurisdiction metrics digest (ACS cohorts 2009/2014/2024)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "county_trend_rent_change_2009_2024_pct",
+      "accessed": "2026-07-06"
+    },
+    {
+      "id": "d21",
+      "label": "County-context median household-income change - jurisdiction metrics digest (ACS cohorts 2009/2014/2024)",
+      "url": "data/hna/jurisdiction-metrics-digest/0828745.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "county_trend_income_change_2009_2024_pct",
+      "accessed": "2026-07-06"
+    }
+  ]
+}

--- a/data/jurisdiction-briefs/_verified/0828745.json
+++ b/data/jurisdiction-briefs/_verified/0828745.json
@@ -1,0 +1,44 @@
+{
+  "brief_geoid": "0828745",
+  "brief_jurisdiction": "City of Fruita",
+  "audited_at": "2026-07-06",
+  "audit_method": "Direct URL fetch with browser User-Agent via curl, followed by local text extraction from the fetched HTML. No WebSearch snippets were used for published claims; repository-owned data citations are auto-verified by scripts/validate-jurisdiction-briefs.py against data/hna/jurisdiction-metrics-digest/0828745.json.",
+  "rows": [
+    {
+      "section_id": "local-housing-authority",
+      "paragraph_index": 0,
+      "source_id": "s1",
+      "source_url": "https://www.fruita.org/694/Fruita-Housing-Authority",
+      "verdict": "supported",
+      "supporting_quote": "The purpose of the Fruita Housing Authority is to assist the City of Fruita in meeting its goals of housing for all those who want to live in Fruita and to maintain various types of housing within the City ... By fostering and coordinating cooperation with partners within and outside of the City of Fruita to create affordable housing through tax abatement programming (for instance through low-income housing tax credit financing (\"LIHTC\") projects).",
+      "notes": "Fetched directly from the official City of Fruita page on 2026-07-06 with a browser User-Agent."
+    },
+    {
+      "section_id": "local-housing-authority",
+      "paragraph_index": 1,
+      "source_id": "s1",
+      "source_url": "https://www.fruita.org/694/Fruita-Housing-Authority",
+      "verdict": "supported",
+      "supporting_quote": "Fruita is a distinct city within the Grand Valley. It is an efficiently laid-out community with small-town character situated among agricultural lands and a breathtaking desert landscape. It has a thriving downtown vibrant with businesses, residents, and civic gathering spaces. Surrounding the downtown are well-connected neighborhoods that provide a variety of housing sizes, types, and styles.",
+      "notes": "Official page quotes the Fruita in Motion Comprehensive Plan growth vision."
+    },
+    {
+      "section_id": "lihtc-and-workforce-pipeline",
+      "paragraph_index": 0,
+      "source_id": "s1",
+      "source_url": "https://www.fruita.org/694/Fruita-Housing-Authority",
+      "verdict": "supported",
+      "supporting_quote": "In June 2023, the Fruita Housing Authority (FHA) announced a special limited partnership with Indibuild for their Fruita Mews development located at 1601 K and 4/10th Road. Now, this 50-unit affordable housing development is almost ready to open its doors. This is the first development in Fruita to be supported with Housing Tax Credits ... All residential units at Fruita Mews will be reserved for residents earning at or below 100% of the area median income, ensuring long-term affordability for the local workforce.",
+      "notes": "Direct official-source support for project location, unit count, tax-credit status, and 100% AMI reservation."
+    },
+    {
+      "section_id": "lihtc-and-workforce-pipeline",
+      "paragraph_index": 1,
+      "source_id": "s1",
+      "source_url": "https://www.fruita.org/694/Fruita-Housing-Authority",
+      "verdict": "supported",
+      "supporting_quote": "The City of Fruita and Headwaters Housing Partners (\"HHP\") aim to redevelop the Family Health West (\"FHW\") property at 805 West Ottley Avenue (\"the Oaks\") to create long-term, rent-restricted apartments. This project seeks to provide affordable housing options in Fruita for essential local workers, including teachers, healthcare providers, City staff, and service employees ... The reprogrammed site will reduce the unit count from 70 to 62, including 51 one-bedrooms and 11 two-bedrooms.",
+      "notes": "Direct official-source support for The Oaks project, target users, site, rent-restricted framing, and proposed unit mix."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #990.

Priority 3 from `docs/audits/CODEX-HANDOFF-BACKLOG-2026-07.md`.

- Adds the published Fruita city jurisdiction brief for GEOID `0828745`.
- Adds the required source-verification report at `data/jurisdiction-briefs/_verified/0828745.json`.
- Keeps citations to sources that were actually read: one direct official City of Fruita source plus repository-owned jurisdiction-metrics digest data.
- Avoids JCHS/KCFed/DOLA citations entirely; no unreadable-source citations are included.

## Source evidence

Directly fetched/read source:

| Source | Method | Evidence used |
| --- | --- | --- |
| `https://www.fruita.org/694/Fruita-Housing-Authority` | Browser-UA direct URL fetch via `curl`, local text extraction | Housing Authority purpose; tax-abatement/LIHTC role; Fruita in Motion quoted growth vision; Fruita Mews; The Oaks |

Repository-owned data citations:

| Dataset | Evidence used |
| --- | --- |
| `data/hna/jurisdiction-metrics-digest/0828745.json` | Rank, need score, <=30% AMI gap, renter burden, overcrowding, ZHVI estimate, gross rent, renter share, multifamily share, active-market vacancy, population, in-commuters, commute ratio, county-context future units, workforce pressure, wage gaps, county-context service share, county rent/income trend context |

## Benchmark context covered

- Fast-growing/workforce context: population, in-commuters, commute ratio, county-context future units, workforce pressure, ownership/rent wage gaps.
- SF-heavy market: renter share `20.1%`, multifamily share `2.9%`, active-market vacancy `1.8%`.
- Home-price pressure: ZHVI market estimate `$486,295` and ownership wage-affordability gap `$63,558`.

## Validation

- `npm run test:briefs` ✅ (`[validate] OK — 13 brief(s) passed the QA gate.`)
- `npm run validate` ✅ (`All asset references resolved successfully.`)

## Scope guard

Only these files changed:

- `data/jurisdiction-briefs/0828745.json`
- `data/jurisdiction-briefs/_verified/0828745.json`

No page HTML, HNA scripts, Affordable Ownership Need files, URL-health files, workflows, `robots.txt`, sitemap, `CNAME`, or page-availability test files were touched.

## Merge note

Do not merge until external QA completes.
