### PR TITLE
Priority 7: disclose seasonal vacancy context in rankings

### DIFF
--- a/js/hna/hna-ranking-index.js
+++ b/js/hna/hna-ranking-index.js
@@ -304,6 +304,43 @@
     return (+val).toLocaleString('en-US');
   }
 
+  function numericMetric(entry, key) {
+    const value = entry && entry.metrics ? Number(entry.metrics[key]) : NaN;
+    return Number.isFinite(value) ? value : null;
+  }
+
+  function pctText(value) {
+    return value === null ? 'n/a' : fmt(value, 'percent');
+  }
+
+  function getSeasonalVacancyDisclosure(entry) {
+    if (!entry || entry.type === 'county') return null;
+    const rawRental = numericMetric(entry, 'raw_rental_vacancy_rate');
+    if (rawRental === null || rawRental <= 15) return null;
+
+    const activeMarket = numericMetric(entry, 'vacancy_rate');
+    const seasonalRate = numericMetric(entry, 'seasonal_vacancy_rate');
+    const seasonalShare = numericMetric(entry, 'seasonal_share_of_vacant');
+    const hasMaterialSeasonal = (seasonalRate !== null && seasonalRate >= 15) ||
+      (seasonalShare !== null && seasonalShare >= 50);
+
+    if (hasMaterialSeasonal) {
+      return {
+        kind: 'seasonal',
+        badge: 'Vacancy context',
+        title: `Raw rental vacancy ${pctText(rawRental)}; seasonal/recreational/occasional stock ${pctText(seasonalRate)} of units and ${pctText(seasonalShare)} of vacant units.`,
+        note: `Vacancy includes seasonal stock. ACS reports raw rental vacancy of ${pctText(rawRental)}; seasonal, recreational, or occasional-use vacant units account for ${pctText(seasonalRate)} of all units and ${pctText(seasonalShare)} of vacant units. This is real vacancy, but not all of it represents year-round housing supply. Scores and ranks are unchanged.`,
+      };
+    }
+
+    return {
+      kind: 'sample',
+      badge: 'Vacancy context',
+      title: `Raw rental vacancy ${pctText(rawRental)}; active-market vacancy ${pctText(activeMarket)}; seasonal stock ${pctText(seasonalRate)}.`,
+      note: `Raw rental vacancy is ${pctText(rawRental)}, while active-market vacancy is ${pctText(activeMarket)} and seasonal stock is ${pctText(seasonalRate)}. In small renter-base places this can be sample-sensitive context rather than year-round slack. Scores and ranks are unchanged.`,
+    };
+  }
+
   function getColumnCount() {
     return 5 + METRIC_COLUMNS.length + (isScenarioActive() ? 3 : 0);
   }
@@ -369,6 +406,10 @@
     const smallGeoBadge = (pop && pop > 0 && pop < 5000)
       ? `<span class="hca-dq-badge" title="Population ${Math.round(pop).toLocaleString()} — ACS estimates for geographies under 5,000 may have high margins of error (30-50%)" aria-label="Small geography" style="cursor:help;">📊</span>`
       : '';
+    const vacancyDisclosure = getSeasonalVacancyDisclosure(entry);
+    const vacancyBadge = vacancyDisclosure
+      ? `<span class="hca-dq-badge hca-vacancy-context-badge" title="${vacancyDisclosure.title}" aria-label="${vacancyDisclosure.badge}">${vacancyDisclosure.badge}</span>`
+      : '';
     const scenarioDelta = getScenarioDelta(entry);
     const rankMoveClass = scenarioDelta.rankMove > 0
       ? ' hca-rank-move--up'
@@ -386,7 +427,7 @@
     tr.innerHTML = [
       `<td class="hca-td hca-td-num" data-label="Rank"><span class="hca-rank ${badgeClass}">#${entry.rank}</span></td>`,
       ...scenarioCells,
-      `<td class="hca-td hca-td-name" data-label="Name"><a class="hca-hna-link" href="${hnaLink(entry)}" title="Open full HNA for ${entry.name}">${entry.name}</a>${dqBadge}${smallGeoBadge}</td>`,
+      `<td class="hca-td hca-td-name" data-label="Name"><a class="hca-hna-link" href="${hnaLink(entry)}" title="Open full HNA for ${entry.name}">${entry.name}</a>${dqBadge}${smallGeoBadge}${vacancyBadge}</td>`,
       `<td class="hca-td" data-label="Type"><span class="hca-type-badge ${typeClass}">${typeLabel(entry.type)}</span></td>`,
       `<td class="hca-td" data-label="Region">${entry.region || '—'}</td>`,
       ...METRIC_COLUMNS.map(col => {
@@ -579,6 +620,11 @@
       <div class="hca-detail-approx-note" role="note" style="margin-top:.75rem;padding:.6rem .8rem;border-radius:var(--radius);background:rgba(217,119,6,.08);border:1px solid rgba(217,119,6,.3);color:var(--text);font-size:.78rem;line-height:1.5;">
         <strong>Approximation:</strong> CHAS cost-burden tiers, AMI gap counts, in-commuters, and the 20-year projection for this ${typeLabel(entry.type).toLowerCase()} are scaled from its containing county. Actual values at this geography may differ — particularly if the ${typeLabel(entry.type).toLowerCase()}'s renter AMI mix or commute pattern diverges from the county as a whole. Cost-burden % and rent are from this geography's own ACS data.
       </div>` : '';
+    const vacancyDisclosure = getSeasonalVacancyDisclosure(entry);
+    const vacancyNoticeHtml = vacancyDisclosure ? `
+      <div class="hca-detail-approx-note hca-detail-vacancy-note" role="note" style="margin-top:.75rem;padding:.6rem .8rem;border-radius:var(--radius);background:rgba(9,110,101,.08);border:1px solid rgba(9,110,101,.3);color:var(--text);font-size:.78rem;line-height:1.5;">
+        <strong>${vacancyDisclosure.kind === 'seasonal' ? 'Seasonal vacancy context' : 'Vacancy sample context'}:</strong> ${vacancyDisclosure.note}
+      </div>` : '';
 
     // Demographic cost-burden stratification (CHAS)
     const hasDemog = metrics.pct_burdened_lte30 > 0 || metrics.pct_burdened_31to50 > 0 || metrics.pct_burdened_51to80 > 0;
@@ -656,6 +702,7 @@
         <div class="hca-detail-missing-tiers">${missingTiersHtml}</div>
       </div>
       ${demogHtml}
+      ${vacancyNoticeHtml}
       ${approxNoticeHtml}
       ${renderScorecardDetail(entry.geoid)}
       <a class="hca-detail-link" href="${hnaLink(entry)}">Open full HNA for ${entry.name} →</a>
@@ -1036,6 +1083,7 @@
     applyScenarioData,
     resetScenario,
     getScenarioDelta,
+    getSeasonalVacancyDisclosure,
     scenarioPath,
     exportCSV,
     getScorecardData: function () { return _scorecardData; },

--- a/test/hna-ranking-index.test.js
+++ b/test/hna-ranking-index.test.js
@@ -502,6 +502,59 @@ group('4. Detail panel — approximation notice (#647 regression guard)', () => 
   });
 });
 
+group('4b. Seasonal vacancy disclosure', () => {
+  test('resort places with high raw rental vacancy get seasonal-stock disclosure only', () => {
+    const disclosure = Ranking.getSeasonalVacancyDisclosure({
+      geoid: '0873825',
+      name: 'Steamboat Springs (city)',
+      type: 'place',
+      metrics: {
+        raw_rental_vacancy_rate: 27.1,
+        vacancy_rate: 7.8,
+        seasonal_vacancy_rate: 29.5,
+        seasonal_share_of_vacant: 71.4,
+      },
+    });
+    assert.ok(disclosure, 'Steamboat should receive a vacancy disclosure');
+    assert.equal(disclosure.kind, 'seasonal');
+    assert.ok(disclosure.note.includes('Vacancy includes seasonal stock'));
+    assert.ok(disclosure.note.includes('Scores and ranks are unchanged'));
+  });
+
+  test('high raw vacancy with low seasonal stock gets sample-sensitive context', () => {
+    const disclosure = Ranking.getSeasonalVacancyDisclosure({
+      geoid: '0850480',
+      name: 'Milliken (town)',
+      type: 'place',
+      metrics: {
+        raw_rental_vacancy_rate: 22.4,
+        vacancy_rate: 2.0,
+        seasonal_vacancy_rate: 0.5,
+        seasonal_share_of_vacant: 13.6,
+      },
+    });
+    assert.ok(disclosure, 'Milliken should receive a vacancy disclosure');
+    assert.equal(disclosure.kind, 'sample');
+    assert.ok(disclosure.note.includes('sample-sensitive context'));
+    assert.ok(disclosure.note.includes('Scores and ranks are unchanged'));
+  });
+
+  test('counties and low raw-vacancy places are not flagged', () => {
+    assert.equal(Ranking.getSeasonalVacancyDisclosure({
+      geoid: '08031',
+      name: 'Denver County',
+      type: 'county',
+      metrics: { raw_rental_vacancy_rate: 25, seasonal_vacancy_rate: 30 },
+    }), null);
+    assert.equal(Ranking.getSeasonalVacancyDisclosure({
+      geoid: '0807850',
+      name: 'Boulder (city)',
+      type: 'place',
+      metrics: { raw_rental_vacancy_rate: 13.8, seasonal_vacancy_rate: 33.9 },
+    }), null);
+  });
+});
+
 group('5. exportCSV', () => {
   test('exportCSV produces a non-empty CSV string when entries are loaded', () => {
     loadFixture();


### PR DESCRIPTION
## Summary
- Implements the 2026-07-06 owner decision for Priority 7: Option A, disclosure-only.
- Adds a ranking UI vacancy-context badge for non-county geographies with high raw rental vacancy.
- Adds detail-panel context for two cases:
  - structural seasonal/recreational stock, using the owner-approved phrase "Vacancy includes seasonal stock";
  - sample-sensitive high raw vacancy with low seasonal stock, covering the Milliken-style case.
- Leaves ranking scores, weights, ranking-index data, scenario data, and generated artifacts unchanged.

## Scope guard
- Touched only `js/hna/hna-ranking-index.js` and `test/hna-ranking-index.test.js`.
- Did not touch Affordable Ownership Need files or the HNA insertion point.
- Did not regenerate `data/hna/ranking-index.json`; Option B was explicitly not implemented.

## Validation
| Check | Result |
| --- | --- |
| `npm run validate` | Pass |
| `npm run test:hna-ranking-index` | Pass: 24 passed, 0 failed |

## Notes
- No open issue matched this Priority 7 topic, so this PR references `docs/audits/CODEX-HANDOFF-BACKLOG-2026-07.md` rather than closing a numbered issue.
- No merge performed; external QA should review first.
