### PR TITLE
Fix soft funding status links

### DIFF
--- a/data/policy/soft-funding-status.json
+++ b/data/policy/soft-funding-status.json
@@ -108,7 +108,7 @@
       "eligibleExecution": ["9%", "4%"],
       "maxPerProject": 1500000,
       "description": "City of Denver AHTF — largest local fund in state. Strong preference for deep affordability (30% AMI).",
-      "contactUrl": "https://www.denver.gov/housing"
+      "contactUrl": "https://denvergov.org/Government/Agencies-Departments-Offices/Agencies-Departments-Offices-Directory/Department-of-Housing-Stability"
     },
     "Boulder-HTF": {
       "name": "Boulder County Housing Trust Fund",
@@ -156,7 +156,7 @@
       "eligibleExecution": ["9%", "4%", "non-LIHTC"],
       "maxPerProject": 1000000,
       "description": "Colorado Division of Housing (DOH) trust fund for gap financing. Supports new construction, acquisition/rehab, and preservation. DOH administers separately from CHFA — different application cycle. A Letter of Intent (LOI) is required ~45 days before the full application; LOI screens project scope, jurisdiction support, and threshold alignment.",
-      "contactUrl": "https://cdola.colorado.gov/division-of-housing",
+      "contactUrl": "https://doh.colorado.gov/",
       "adminEntity": "DOH"
     },
     "DOH-HDG": {
@@ -171,7 +171,7 @@
       "eligibleExecution": ["9%", "4%", "non-LIHTC"],
       "maxPerProject": 500000,
       "description": "DOH development grants for predevelopment, acquisition, and infrastructure related to affordable housing. Can be layered with LIHTC and other state sources. LOI submittal opens the NOFA cycle ~6 weeks before full applications close.",
-      "contactUrl": "https://cdola.colorado.gov/division-of-housing",
+      "contactUrl": "https://doh.colorado.gov/",
       "adminEntity": "DOH"
     },
     "DOH-HHPG": {
@@ -186,7 +186,7 @@
       "eligibleExecution": ["9%", "4%", "non-LIHTC"],
       "maxPerProject": 400000,
       "description": "DOH grants for permanent supportive housing and homeless prevention projects. Requires service partnership with local continuum of care. LOI required ~45 days before the full application.",
-      "contactUrl": "https://cdola.colorado.gov/division-of-housing",
+      "contactUrl": "https://doh.colorado.gov/",
       "adminEntity": "DOH",
       "amiTargeting": "30% AMI",
       "restrictions": [
@@ -231,7 +231,7 @@
       "eligibleExecution": ["9%", "4%", "non-LIHTC"],
       "maxPerProject": 2000000,
       "description": "State funds from Proposition 123 (2022 ballot measure) dedicating TABOR surplus to affordable housing. Administered by DOLA. Jurisdictions must opt in. Supports land banking, gap financing, and rental assistance. First full-year allocation cycle.",
-      "contactUrl": "https://cdola.colorado.gov/prop-123",
+      "contactUrl": "https://cdola.colorado.gov/prop123",
       "adminEntity": "DOLA",
       "note": "New program — first substantive awards expected Q3 2026. Participating jurisdictions listed in prop123_jurisdictions.json.",
       "restrictions": [
@@ -253,7 +253,7 @@
       "eligibleExecution": ["non-LIHTC"],
       "maxPerProject": 1500000,
       "description": "Dedicated Prop 123 subprogram for land acquisition and banking for future affordable housing development. Can reduce TDC in future LIHTC applications by removing land cost.",
-      "contactUrl": "https://cdola.colorado.gov/prop-123",
+      "contactUrl": "https://cdola.colorado.gov/prop123",
       "adminEntity": "DOLA",
       "restrictions": [
         "Land acquisition ONLY — cannot fund project construction or soft costs",


### PR DESCRIPTION
## Summary
- Replace stale DOH Division of Housing URLs with the current Division of Housing home at doh.colorado.gov.
- Replace stale Prop 123 hyphenated URLs with DOLA's current prop123 route.
- Replace non-resolving Denver housing URL with the current Denver Department of Housing Stability page.

## Scope
- Link-health only in data/policy/soft-funding-status.json.
- No dollar amounts, deadlines, capacities, descriptions, or program details changed.

## Verification
- node JSON parse for data/policy/soft-funding-status.json
- npm run test:soft-funding-tracker
- git diff --check
- Denver replacement URL verified with curl -I returning 200.
- DOH/Prop 123 replacements verified from current official DOLA/DOH pages; state CloudFront blocks bare curl probes with 403.