### PR TITLE
docs: add July 2026 full site audit

### DIFF
--- a/docs/qa/site-audit-2026-07/00-executive-summary.md
+++ b/docs/qa/site-audit-2026-07/00-executive-summary.md
@@ -1,0 +1,73 @@
+# COHO Analytics Full Site And Repo Audit — Executive Summary
+
+Audit date: 2026-07-07  
+Scope: full site/repo audit, audit-only. No application code or data was changed. Reports were written only under `docs/qa/site-audit-2026-07/`. Browser rendering was not run; any visual/mobile/blank-state conclusion is marked `UNRENDERED` in the detail reports.
+
+## Bottom Line
+
+The site is much more stable than the older audit docs imply. The allowed gates are green, HNA modularization is substantially covered, and several older methodology concerns are now fixed or honestly disclosed. The remaining high-risk issues are not broad breakage; they are trust/lineage issues where the site can say the right kind of thing from the wrong path.
+
+The two must-fix classes are:
+
+1. **One metric, multiple paths:** HNA median home value can display one value/source in the stat card and a different raw ACS value/vintage in narrative prose.
+2. **Analytical label overclaim:** `preservation-candidate` currently means “member of a preservation/subsidized source feed,” but the UI explains it as an at-risk/expiring classification.
+
+## Top 25 Findings
+
+| Rank | ID | Severity | Finding | First action |
+|---:|---|---:|---|---|
+| 1 | A-01 | P0 | HNA median home value stat and narrative use different data paths and labels. | Centralize home-value display metadata and assert stat/narrative agreement. |
+| 2 | A-02 | P0 | `preservation-candidate` overstates source membership as risk classification. | Split source inventory from true risk/candidate flags. |
+| 3 | C-01 | P0 | Tests do not guard cross-surface metric equality/source-vintage agreement. | Add sample cross-surface tests for repeated headline metrics. |
+| 4 | C-02 | P0 | Tests do not guard semantic labels like candidate/risk/recommendation. | Add schema/semantic checks for label type and evidence. |
+| 5 | A-03 | P1 | Opportunity Finder verifier hard-codes stale 4% weights while app/docs use newer weights. | Share or extract weights from production source. |
+| 6 | B-01 | P1 | Too many peer-level first steps in navigation. | Reframe IA around user jobs. |
+| 7 | B-02 | P1 | Diagnostics pages read as product pages, not a trust center. | Consolidate as Data Trust Center. |
+| 8 | B-03 | P1 | Public pages mix pipeline methodology with gated/internal workflow concepts. | Decide public vs internal pipeline language. |
+| 9 | C-04 | P1 | Source-grep tests remain brittle after modularization. | Retire or replace legacy implementation-string tests. |
+| 10 | C-05 | P1 | HNA compatibility stub still anchors some old tests. | Move tests to `js/hna/*` modules/rendered behavior. |
+| 11 | C-06 | P1 | Soft-funding file needs freshness/URL-specific guardrails beyond tracker behavior. | Add SLA and URL sweep coverage for `contactUrl`s. |
+| 12 | A-04 | P1 | Preservation overclaim appears downstream in compare/market contexts. | Rename copy until risk model exists. |
+| 13 | A-05 | P2 | Lightweight deal predictor remains placeholder concept screening. | Keep finance outputs in full calculator or share primitives. |
+| 14 | A-06 | P2 | DOLA vintage check passes but warns on 12 county deltas beyond +/-5%. | Add warning table to data-refresh QA review. |
+| 15 | A-07 | P2 | Hardcoded ACS vintage labels remain risky where values can come from non-ACS cascade. | Use source metadata for cascade-backed values. |
+| 16 | A-08 | P2 | PMA method boundary is now honestly disclosed, but rendering not validated. | Preserve disclaimer and run rendered QA. |
+| 17 | A-09 | P2 | HNA benchmark ratios show meaningful consultant-method deltas. | Maintain as calibration dashboard with owner notes. |
+| 18 | B-04 | P2 | Homepage “every stat is sourced” claim can overpromise cross-surface consistency. | Narrow to sourced/monitored and link limitations. |
+| 19 | B-05 | P2 | HNA page is dense for first-time users. | Add a compact decision strip above detailed sections. |
+| 20 | B-06 | P2 | Place pages should be primary entry points, not secondary generated artifacts. | Route homepage search to profiles first. |
+| 21 | B-07 | P2 | Data quality copy uses maintainer language. | Translate to public trust questions. |
+| 22 | C-07 | P2 | Public/internal docs and workflow boundaries are still mixed. | Decide build exposure for QA/audit docs. |
+| 23 | C-09 | P2 | Placeholder/stub language remains without universal retirement criteria. | Create a placeholder inventory. |
+| 24 | C-10 | P2 | 228 iCloud duplicate JSON files can distort repo sweeps/counts. | Add hygiene guard or cleanup process. |
+| 25 | A-10/C-11 | P3 | Browser/mobile/visual behavior is `UNRENDERED`. | Run a rendered QA pass after this audit. |
+
+## What Is Stable
+
+| Area | Status |
+|---|---|
+| HNA core test suite | `npm run test:hna` passed 730/0. |
+| ACS ETL/source badges | `node test/acs-etl.test.js` passed 167/0. |
+| Critical data/schema gates | `npm run validate:data`, `node scripts/validate-schemas.js`, and DP04 code tests passed. |
+| DOLA projection vintage | Check runs against official source; warnings are review items, not gate failure. |
+| PMA disclaimers | Source text clearly says screening-only and not formal CHFA PMA. |
+| Deal calculator | Full calculator contains DSCR and supportable first mortgage sections. |
+
+## Simplification Map
+
+| Keep as core | Consolidate | Demote / gate |
+|---|---|---|
+| Jurisdiction profiles | Data status + data sources + QA coverage into Data Trust Center | Legacy diagnostic dashboards from primary nav |
+| HNA | Compare summary paths into HNA/profile flows where possible | Internal developer pipeline UI unless authenticated |
+| Opportunity Finder | Preservation inventory into Finder/Profiles with corrected labels | Old audit docs from public user journeys |
+| PMA + Deal Calculator | Deal predictor concept screening with full calculator finance outputs | Compatibility-stub-era tests |
+
+## PR-Safe Next Move
+
+Open a sequence of small PRs, not a broad rewrite:
+
+1. P0 lineage PR: home-value stat/narrative shared source and tests.
+2. P0 semantic-label PR: preservation inventory/risk split and downstream copy.
+3. P1 test-harness PR: Opportunity Finder shared weights and legacy grep retirement plan.
+4. P1 IA PR: Data Trust Center consolidation and public/internal pipeline wording.
+5. P2 rendered QA PR: browser screenshots/console/mobile checks for HNA, profiles, OF, PMA, and diagnostics.

--- a/docs/qa/site-audit-2026-07/01-calculations-and-lineage.md
+++ b/docs/qa/site-audit-2026-07/01-calculations-and-lineage.md
@@ -1,0 +1,57 @@
+# Pass A — Calculations And Lineage Audit
+
+Audit date: 2026-07-07  
+Scope: audit only; no code or data changed. Browser rendering was not run, so visual/mobile/blank-state checks are `UNRENDERED` and limited to source inspection.
+
+## Gate Evidence
+
+| Gate | Result | Evidence |
+|---|---:|---|
+| `npm run test:hna-benchmarks` | PASS | Benchmark harness completed and printed calibration ratios for La Plata, Pueblo County/City, Milliken, Alamosa, and Erie. Ratios are explicitly calibration signals, not pass/fail gates. |
+| `npm run check:dola-vintage` | PASS with warnings | Official SDO forecast detected as Vintage 2023, Prepared October 2024. 64 counties compared; median diff -1.4%; 12 counties beyond +/-5% warning threshold. |
+| `npm run test:hna` | PASS | 730 passed, 0 failed. |
+| `npm run validate:data` | PASS | Critical data, numeric bounds, and county AMI distinct-value checks passed. |
+| `node scripts/validate-schemas.js` | PASS | 85 passed, 0 failed. |
+| `node test/hna-dp04-codes.test.js` | PASS | 27 passed, 0 failed. |
+| `node test/acs-etl.test.js` | PASS | 167 passed, 0 failed. |
+
+Known pre-existing failures from the work order were not rerun as blockers: `python3 scripts/qa_stage1.py`, the `pytest` place CHAS `acs_anchor` schema failure, and `node test/integration/housing-needs-assessment.test.js` six failures against the compatibility-stub era.
+
+## A0 Cross-Surface Sweep
+
+| Surface | Primary source paths inspected | Lineage status | Notes |
+|---|---|---|---|
+| HNA live page | `housing-needs-assessment.html`, `js/hna/*`, `data/hna/summary/*`, `data/hna/home-value-cascade.json` | Mixed | Most HNA metrics are now modularized and tested, but median home value still has two live render paths with different source selection and vintage labels. |
+| Generated place pages | `places/_template.html`, `places/*.html`, `scripts/hna/build_place_pages.py` | Mostly aligned | Affordable Ownership is no longer absent in current main, so absence was not audited. Source inspection only; real page rendering is `UNRENDERED`. |
+| Jurisdiction metrics digest | `scripts/hna/build_jurisdiction_metrics_digest.mjs`, `data/hna/jurisdiction-metrics-digest/*.json` | Mostly aligned | Prior county/place ownership labeling issue appears fixed in current main. No forbidden digest freshness command was run. |
+| Compare page | `compare.html`, `js/compare.js` | Partial risk | Preservation counts use `preservation-candidate` as a substantive market signal even though the tag is source-membership based. |
+| PMA / market analysis | `market-analysis.html`, `js/pma-*`, `js/market-analysis*`, `docs/guides/pma-analysis.md` | Improved but still screening-level | Capture/absorption language is surfaced; circular-buffer and screening disclaimers are present. |
+| Deal calculator | `deal-calculator.html`, `js/deal-calculator.js`, `js/lihtc-deal-predictor.js` | Improved | Full calculator has DSCR/first-mortgage sizing. The lightweight deal predictor still says its capital stack is placeholder and not permanent-debt underwriting. |
+| Opportunity Finder | `lihtc-opportunity-finder.html`, `js/lihtc-opportunity-finder.js`, `docs/methodology/LIHTC-LOCATOR-METHODOLOGY.md`, `scripts/audit/verify-opportunity-finder.mjs` | Drift in audit harness | Production 4% weights and methodology agree; the verification harness hard-codes old 4% weights. |
+| Preservation / affordable housing layer | `preservation.html`, `js/components/affordable-housing-layer.js`, `scripts/build-affordable-housing-properties.js`, `data/affordable-housing/properties.json` | Label mismatch | `preservation-candidate` is applied from source membership, then explained in UI as at-risk/expiring. |
+| Tier 3 dashboards | `LIHTC-dashboard.html`, `chfa-portfolio.html`, `compliance-dashboard.html`, `construction-commodities.html`, `economic-dashboard.html` | Generally bounded | Diagnostics and source links are present in source. Runtime visual/blank behavior is `UNRENDERED`. |
+
+## Findings
+
+| ID | Severity | Class | Finding | Evidence | Recommendation |
+|---|---:|---|---|---|---|
+| A-01 | P0 | A: multiple data paths | HNA median home value can contradict itself on the same page. The stat card prefers `profile.median_home_value` cascade, including ZHVI and county-adjusted estimates, then falls back to `DP04_0089E`; the narrative reads raw `DP04_0089E` directly and hardcodes `(ACS 2020–2024)`. | `js/hna/hna-renderers.js:14-40`, `js/hna/hna-renderers.js:384-397`; `js/hna/hna-narratives.js:64-72`, `js/hna/hna-narratives.js:407-426`. | Centralize the display home-value object and source/vintage formatter. The narrative should consume the same `{value, source, as_of, confidence, suppress_*}` structure as the stat card. Add a cross-surface assertion for equality and label agreement. |
+| A-02 | P0 | B: analytical label mirrors source membership | `preservation-candidate` is not a risk classification. The build marks CHFA Preservation, HUD MF Assisted, USDA RD, and local PBV records as `preservation-candidate`; 1,822 of 1,920 property records carry the tag, but only 109 have `years_to_expiration`. The map legend describes it as “Property at risk of losing affordability restrictions.” | `scripts/build-affordable-housing-properties.js:137-158`, `:171-192`, `:208-230`; count command over `data/affordable-housing/properties.json`; `js/components/affordable-housing-layer.js:124-128`. | Rename the broad tag to a source-membership label such as `subsidized-inventory` or add a separate true-risk flag based on expiration, troubled/compliance status, covenant age, or owner-reviewed risk rules. |
+| A-03 | P1 | QA drift | Opportunity Finder’s production 4% weights were rebalanced to `{need:.30, recency:.17, basis:.15, pop:.20, civic:.18}`, and the methodology text says the same. The verifier says weights “must match” source exactly but still hard-codes old 4% weights `{need:.25, recency:.12, basis:.15, pop:.30, civic:.18}`. | `js/lihtc-opportunity-finder.js:297-311`; `docs/methodology/LIHTC-LOCATOR-METHODOLOGY.md:261-266`; `scripts/audit/verify-opportunity-finder.mjs:54-66`. | Make the verifier import/extract production weights or regenerate its expectation from a shared JSON/module. This is a guardrail bug: it can validate the wrong model while the app and docs agree. |
+| A-04 | P1 | Methodology wording | Preservation candidate counts appear in multiple downstream contexts as market opportunity/at-risk inventory, but current data only guarantees membership in CHFA/HUD/USDA/PBV feeds. | `js/components/affordable-housing-layer.js:124-128`; `js/compare.js:720-722`; `js/market-analysis/market-report-renderers.js:244-264`. | Until A-02 is fixed, downstream copy should say “tracked subsidized/preservation-source inventory” and reserve “at risk” for records with an actual risk signal. |
+| A-05 | P2 | Screen vs pro forma boundary | `js/lihtc-deal-predictor.js` is honest in comments that it does not model permanent debt underwriting and produces placeholder sources/uses; however it is still invoked inside the deal workflow, where the fuller calculator now contains DSCR and supportable first mortgage panels. | `js/lihtc-deal-predictor.js:14`, `:584-604`; `js/deal-calculator.js:1370-1418`, `:2389-2401`; `docs/guides/deal-predictor.md:16`, `:104`. | Keep the lightweight predictor as “concept screening.” Do not let its placeholder capital stack be described as underwriting. Longer term, either route users to the full calculator for finance outputs or share the calculator’s debt-sizing primitives. |
+| A-06 | P2 | Vintage warning | DOLA vintage check reports 12 counties beyond +/-5% against official 2030 forecast even though median drift is small. This is not a failure, but it deserves visible owner review because Broomfield (-11.7%), Custer (-10.8%), and San Juan (+15.4%) are large relative deltas. | `npm run check:dola-vintage` output, 2026-07-07. | Add the warning table to the next data-refresh QA note; decide whether deltas are expected from the repo’s projection method or require updated population inputs. |
+| A-07 | P2 | Hardcoded vintage | HNA page markup and narrative include several static `ACS 2020–2024` labels. Many are acceptable for chart boxes, but the narrative hardcoding is dangerous when the value path may be ZHVI/current-market or county-adjusted. | `housing-needs-assessment.html:673-738`, `:975-1018`; `js/hna/hna-narratives.js:421`. | For values that can come from the cascade, use the source object’s `as_of`. Static chart-box vintages are acceptable when tied to ACS-only charts. |
+| A-08 | P2 | PMA method boundary | PMA source text now explicitly says screening-only and circular-buffer. That resolves older methodology overclaim risk, but runtime render and mobile behavior are `UNRENDERED` in this audit. | `market-analysis.html:148-163`, `:263-292`; `docs/guides/pma-analysis.md:3-20`, `:108-109`. | Preserve the disclaimer as a first-viewport or near-control affordance during future redesigns. |
+| A-09 | P2 | HNA benchmarks | Benchmarks pass but show large calibration deltas for some consultant comparisons, e.g. Pueblo County total need 1,691 vs 9,561 (0.18 ratio) and La Plata <=30% AMI gap 1,328 vs 651 (2.04 ratio). | `npm run test:hna-benchmarks` output, 2026-07-07. | Treat benchmark ratios as a recurring calibration dashboard, not a failing test. Add owner notes where methodology intentionally differs. |
+| A-10 | P3 | Rendering not validated | Tier 3 pages and generated place pages were inspected by source only. Blank states, mobile layout, chart drawing, and console behavior are `UNRENDERED`. | Work order allowed no browser requirement; no Playwright/browser run performed. | Schedule a follow-up rendered smoke pass after this audit PR if visual confidence is needed. |
+
+## Stale Audit Reconciliation
+
+| Prior audit item | Current disposition |
+|---|---|
+| Deal calculator lacked DSCR / first mortgage support | Mostly addressed in `js/deal-calculator.js`; lightweight predictor still intentionally screening-only. |
+| Opportunity Finder civic/weight methodology drift | Production and methodology mostly aligned, but verifier drift remains (A-03). |
+| PMA capture/absorption absent | Absorption/capture is now rendered in `js/pma-ui-controller.js:523-551`; keep as screening, not formal PMA. |
+| Preservation candidates overclaimed | Still current and elevated to P0 due cross-surface impact. |
+| HNA source/vintage drift | Current P0 for home value narrative/stat contradiction. |

--- a/docs/qa/site-audit-2026-07/02-ia-ux-copy.md
+++ b/docs/qa/site-audit-2026-07/02-ia-ux-copy.md
@@ -1,0 +1,59 @@
+# Pass B — IA, UX, And Copy Audit
+
+Audit date: 2026-07-07  
+Method: source inspection only. Browser rendering, mobile layout, keyboard behavior, chart rendering, and blank-state visuals are `UNRENDERED`.
+
+## IA Snapshot
+
+| Area | Observed source | Assessment |
+|---|---|---|
+| Homepage | `index.html` | Strong public positioning around housing analytics, but it mixes product onboarding, proof/audit posture, and many next steps. First-time user path could be simpler. |
+| Core analytical tools | `housing-needs-assessment.html`, `lihtc-opportunity-finder.html`, `market-analysis.html`, `deal-calculator.html`, `compare.html` | Tool surfaces are substantial and generally disclose methodology, but the hierarchy asks users to understand several overlapping “where/what/feasibility” tools. |
+| Data/diagnostics | `data-review-hub.html`, `data-status.html`, `dashboard-data-quality.html`, `dashboard-data-sources-ui.html` | Good for maintainers; too prominent for ordinary public users unless framed as “trust center.” |
+| Internal/developer workflow | `developer.html`, `developer-pipeline.html`, `developer-brief.html`, gated mounts in public pages | Mostly gated by `developer-gate.js` or session checks. Public pages still contain visible “Developer Pipeline” teaser strips. |
+| Generated place pages | `places/_template.html`, `places/*.html` | Place profiles are now a key public entry point. Ownership module absence is not audited; current main appears to include it. Runtime is `UNRENDERED`. |
+
+## User-Impact Framing For Pass A Findings
+
+| Finding | User-facing impact | Copy/UX implication |
+|---|---|---|
+| HNA home-value contradiction | A planner/developer can see one median home value in the top stats and another in the executive narrative, with different implied vintage/currentness. | Treat “median home value” as one reusable source-aware component. Do not let prose recompute it. |
+| Preservation candidate overclaim | A user may infer that nearly all listed subsidized properties are objectively “at risk” when most are simply in source inventories. | Rename the visible category or split “tracked inventory” from “at-risk/expiring.” |
+| Opportunity Finder verifier drift | Users may not notice directly, but maintainers can get false confidence from a stale audit harness. | In methodology pages, avoid saying a harness asserts something unless the harness consumes the same source of truth. |
+| Deal predictor placeholder boundary | Users can treat a concept recommendation as finance feasibility if the surrounding workflow feels calculator-like. | Keep concept recs visually and verbally separate from DSCR/mortgage/pro forma outputs. |
+
+## Navigation And Information Architecture Findings
+
+| ID | Severity | Finding | Evidence | Recommendation |
+|---|---:|---|---|---|
+| B-01 | P1 | The site has too many peer-level “start here” paths for new users: HNA, Opportunity Finder, PMA, Compare, Deal Calculator, data dashboards, and Pipeline. | `index.html:431` links to all data sources; core tools appear across nav/components; `js/navigation.js:30-65` demotes diagnostics but keeps them reachable. | Recast the top IA around four jobs: Understand need, Find opportunities, Test a site/deal, Verify data. Put diagnostics inside “Verify data.” |
+| B-02 | P1 | Diagnostic pages are useful but read as product surfaces instead of a trust center. | `data-review-hub.html:741-742`, `data-status.html:274-275`, `dashboard-data-quality.html:191-233`. | Rename/cluster as “Data Trust Center” with three tabs: Freshness, Sources, QA Coverage. Keep legacy dashboards linked from there. |
+| B-03 | P1 | Public pages contain visible developer-pipeline teasers and gated mounts. They are not inherently wrong, but they blend public methodology with internal business workflow. | `housing-needs-assessment.html:258-264`; `lihtc-opportunity-finder.html:1513-1518`; `market-analysis.html:74-75`, `:2188-2266`. | Decide whether “Affordable Housing Pipeline” is a public methodology or internal CRM. If public, rename internal mounts separately; if internal, hide teasers unless authenticated. |
+| B-04 | P2 | Homepage proof language says every stat is sourced and links to a demo-mode audit. That is useful, but it can overpromise while Pass A found source-path contradictions. | `index.html:356-360`. | Keep the trust claim but make it narrower: “Sourced and monitored” rather than implying every repeated metric is cross-surface reconciled. |
+| B-05 | P2 | HNA page is rich but dense. Many cards, callouts, charts, and methodology notes compete for attention. | `housing-needs-assessment.html` has many sections and source/meta blocks; source inspection only. | Add an executive “decision strip” near top: Need severity, affordability pressure, production gap, ownership feasibility, data confidence. Let details remain below. |
+| B-06 | P2 | Place pages should be treated as a primary SEO/user landing experience, not just generated factsheets. | 484 place HTML files counted in `places/`; `sitemap.xml` prior work lists place pages. | Make place pages the public first step: search/select jurisdiction -> profile -> choose HNA/OF/PMA/deal follow-up. |
+| B-07 | P2 | Data quality dashboards use operational language (“Pipeline log,” “QA layer,” “coverage QA”) that may be obscure to non-maintainers. | `dashboard-data-quality.html:191-233`, `:279-307`. | Add public-facing labels: “What data is fresh?”, “What data is missing?”, “What is estimated?” Keep technical detail expandable. |
+| B-08 | P2 | Preservation copy says “candidate” and “at risk” where the data only proves inventory/source membership. | `js/components/affordable-housing-layer.js:124-125`; `js/compare.js:720-722`. | Copy should say “tracked subsidized inventory” until a true risk model exists. |
+| B-09 | P3 | `UNRENDERED`: mobile and chart blank states were not validated. | No browser run. | Add a rendered QA pass for the revised IA, especially HNA and place pages. |
+
+## Revised Top Navigation Proposal
+
+| Proposed nav item | Contains | Why |
+|---|---|---|
+| Jurisdiction Profiles | Search + generated place/county profile pages | Best first step for most public users. |
+| Housing Need | HNA and compare | Answers “what is the need here?” |
+| Opportunity Finder | LIHTC locator + preservation inventory | Answers “where should we look?” |
+| Site And Deal Feasibility | PMA, deal calculator, land value | Answers “can a site/deal work?” |
+| Data Trust Center | Sources, freshness, QA, methodology | Keeps transparency visible without making diagnostics a primary product path. |
+| Methodology | Pipeline article, guides, glossary | Explains assumptions and limitations. |
+
+## Homepage Wireframe Outline Only
+
+1. Jurisdiction search as the first interactive element.
+2. Three job cards: Understand need, Find opportunity, Test feasibility.
+3. Compact statewide snapshot with explicit source/vintage labels.
+4. “Data Trust” strip: last refresh, source count, known limitations link.
+5. Recent methodology/brief links, not a long tool catalog.
+6. Footer with diagnostics, docs, and repository links.
+
+No marketing copy was drafted per work order.

--- a/docs/qa/site-audit-2026-07/03-hygiene-boundary-testing.md
+++ b/docs/qa/site-audit-2026-07/03-hygiene-boundary-testing.md
@@ -1,0 +1,61 @@
+# Pass C — Hygiene, Boundary, And Testing Audit
+
+Audit date: 2026-07-07  
+Method: source inspection and allowed gates only. No mutating freshness/regeneration commands were run.
+
+## Repo Map
+
+Counts are approximate source-tree counts from 2026-07-07. `data/* 2.json` iCloud duplicates were counted, not deleted, because this is audit-only.
+
+| Area | Count / examples | Notes |
+|---|---:|---|
+| Root HTML pages | 53 | Public tools, dashboards, articles, redirects, internal gated pages. |
+| Generated place pages | 484 | Includes `places/_template.html` plus generated profiles. |
+| JavaScript files | 246 | Modular HNA, PMA, calculators, components, dashboards. |
+| Scripts | 244 | Build, fetch, validation, audit, generation pipelines. |
+| Tests | 163 | Mix of DOM/source-grep/unit/integration tests. |
+| iCloud duplicate JSON files | 228 | Work order notes these can break file counts; not removed in this audit. |
+
+## Hygiene Findings
+
+| ID | Severity | Finding | Evidence | Recommendation |
+|---|---:|---|---|---|
+| C-01 | P0 | There is no automated guard for cross-surface value equality and source/vintage agreement. The HNA median home-value contradiction survives even with `npm run test:hna` green. | A-01 evidence; `npm run test:hna` passed 730/0. | Add a small test that renders or calls both stat and narrative paths for sample geographies and asserts identical value/source/vintage, with exceptions explicitly declared. |
+| C-02 | P0 | There is no automated guard distinguishing analytical labels from source-membership tags. `preservation-candidate` overclaim survives current data/test gates. | A-02 evidence; `test/smoke-f139.test.js:51` only asserts Silt includes the tag; no risk-definition test found. | Add a schema or semantic test requiring any “risk/candidate/recommendation/classification” label to document whether it is computed, source membership, or owner-curated. |
+| C-03 | P1 | Opportunity Finder verifier copied production weights and drifted from the app. | `scripts/audit/verify-opportunity-finder.mjs:54-66`; `js/lihtc-opportunity-finder.js:297-311`. | Use a shared source of truth. At minimum, add a test that extracts both weight objects and fails on mismatch. |
+| C-04 | P1 | Several tests are source-grep assertions over implementation text rather than behavior. This is sometimes useful for static guards, but brittle after modularization. | `test/prop123-historical.test.js:176-193`; `test/integration/compliance-dashboard.test.js:155-171`; `test/tigerweb-timeout.test.js:57-105`; `test/hna-functionality-check.js:405-408`. | Keep source-grep tests only for static contract checks; move behavior to module-level or DOM-render tests. Mark legacy-grep tests with retirement criteria. |
+| C-05 | P1 | `js/housing-needs-assessment.js` remains a compatibility stub but legacy tests still point at it. Some known failures are from this old contract. | `js/housing-needs-assessment.js:2-12`; `housing-needs-assessment.html:145`; `test/integration/housing-needs-assessment.test.js:47-62`; `test/hna-functionality-check.js:4-18`. | Keep the stub until external links stabilize, but migrate tests to `js/hna/*` modules and rendered HNA page behavior. Then retire stub assertions. |
+| C-06 | P1 | Soft-funding link health was fixed separately, but freshness and embedded URL guardrails remain weak for the program status file. The file still declares `lastUpdated: 2026-04-07` in current working tree inspected during this audit. | `data/policy/soft-funding-status.json:2`, `:346`; URL health workflows exist at `.github/workflows/source-url-sweep.yml` and `url-health-weekly.yml`; `test/test_soft_funding_tracker.js` checks tracker behavior but not all embedded URLs/current quarter. | Add a data-specific guard: every non-null `contactUrl` is included in source-url/url-health sweeps; `lastUpdated` must be within an owner-defined SLA or explicitly waived. Do not broaden content refresh in a link-health PR. |
+| C-07 | P2 | Public/internal boundary is better than earlier audits but still mixed. Developer pages are gated, while public pages contain pipeline teasers and repo docs expose internal work-order history. | `developer.html:9`; `developer-brief.html:1233-1317`; `compare.html:36-37`; `market-analysis.html:2188-2266`; `docs/qa/*`, `docs/audits/*`. | Decide whether `docs/qa`/`docs/audits` are public artifacts. If public, scrub operational phrasing; if internal, exclude from public build/docs index. |
+| C-08 | P2 | Diagnostics pages are publicly reachable and useful, but they should be categorized as trust/ops, not ordinary user journeys. | `data-review-hub.html:741-742`; `data-status.html:274-275`; `dashboard-data-quality.html:191-233`. | Centralize under Data Trust Center and remove duplicate legacy paths from primary nav. |
+| C-09 | P2 | Placeholder/stub language remains in a few user-facing or docs-adjacent places. Some is intentional, but not all has retirement criteria. | `hna-comparative-analysis.html:191`; `developer-where.html:215-219`; `docs/guides/deal-predictor.md:16`, `:104`; `docs/api/js__pma-provenance.md:12-36`. | Add a placeholder inventory with owner, public visibility, and “acceptable until” criteria. |
+| C-10 | P2 | iCloud duplicate JSON files can distort counts and sweeps. Work order notes `find data -name "* 2.json" -delete` before counting; audit found 228 such files. | `find data -name '* 2.json' | wc -l` -> 228. | Add a repo hygiene guard that fails on `* 2.json` outside allowed fixtures, or add `.gitignore`/cleanup guidance. |
+| C-11 | P3 | Runtime visual, console, and mobile boundary tests were not run in this audit. | No browser command run. | Run `npm run audit:console`/site-audit or targeted Playwright screenshots in a separate rendered QA pass. |
+
+## Boundary Review
+
+| Boundary | Current status | Risk |
+|---|---|---|
+| Public analytical claims vs methodology | Mostly strong, except home-value and preservation labels. | High if screenshots/reports are used externally. |
+| Public tools vs internal pipeline | Mixed but partly gated. | Medium: public visitors can see internal-workflow concepts without context. |
+| Source data vs modeled outputs | Many source badges exist; Class A/B contradictions show guard gaps. | High for repeated metrics and classification labels. |
+| Docs/QA/audits in public repo | Extensive, useful for traceability, but operationally noisy. | Medium: public readers may treat work orders as product documentation. |
+
+## Test Inventory Notes
+
+| Test type | Examples | Assessment |
+|---|---|---|
+| Static contract/source-grep | `test/acs-etl.test.js`, `test/tigerweb-timeout.test.js`, `test/prop123-historical.test.js` | Good for checking files/strings, weak for behavior and cross-surface consistency. |
+| Module/unit | `test/hna-home-value-cascade.test.js`, `test/pma-competitive-set.test.js`, `test/soft-funding-tracker.test.js` | Stronger where modules expose pure functions/data. |
+| Generated artifact freshness | `test:ranking-fresh`, `test:place-pages-fresh`, digest freshness | Powerful but some are mutating/read-only-looking per work order; not run here. |
+| Browser/rendered | site audit scripts exist | Not run. Needed for visual/mobile/blank-state confidence. |
+
+## Prior Audit Reconciliation
+
+| Prior theme | Disposition |
+|---|---|
+| Console errors | Recently worked in PRs around #1064; not re-audited with browser here. |
+| Broken source links | Separate PR #1078 addressed link-health only. This audit does not re-fix links. |
+| HNA ranking/seasonal vacancy | Settled owner decision per backlog; not reflagged. |
+| Affordable Ownership module | In-flight conflict fence respected; absence not audited. Current main appears to have it. |
+| CAR data ingest | Settled design decision; not reflagged. |

--- a/docs/qa/site-audit-2026-07/04-plan.md
+++ b/docs/qa/site-audit-2026-07/04-plan.md
@@ -1,0 +1,72 @@
+# Pass D — Implementation Plan
+
+Audit date: 2026-07-07  
+Principle: small PRs, one behavior boundary at a time. Do not bundle IA redesign with calculation fixes.
+
+## Phase 0 — Guardrails Before More Features
+
+| PR | Priority | Scope | Deliverables | Regression gate |
+|---|---:|---|---|---|
+| 0.1 Home-value single source | P0 | HNA home-value stat/narrative only | Shared display metadata helper; narrative consumes same value/source/vintage as stat; examples for raw ACS, ZHVI, county-adjusted, suppressed values. | `npm run test:hna`, `node test/hna-home-value-cascade.test.js`, new cross-surface test. |
+| 0.2 Preservation label split | P0 | Affordable housing property build/render/copy only | Rename broad source-membership tag or add `risk_status`; update legend/compare/market copy; keep existing inventory counts. | Property schema test plus targeted render/source tests. |
+| 0.3 Semantic label guard | P0 | Tests/schema only | Guard for labels containing candidate/risk/recommendation/classification to declare evidence type: computed, curated, source membership, or modeled. | New semantic-label test. |
+
+## Phase 1 — QA Harness Reliability
+
+| PR | Priority | Scope | Deliverables | Regression gate |
+|---|---:|---|---|---|
+| 1.1 Opportunity Finder verifier source-of-truth | P1 | `js/lihtc-opportunity-finder.js`, `scripts/audit/verify-opportunity-finder.mjs`, optional shared JSON | Remove copied stale 4% weights; verifier reads shared weights or extracts them deterministically. | `npm run test:lihtc-opportunity-finder-zori`, `npm run audit:opportunity-finder` if available. |
+| 1.2 HNA stub-era test retirement | P1 | Tests only | Inventory tests still reading `js/housing-needs-assessment.js`; migrate high-value assertions to `js/hna/*` or rendered DOM; mark remaining stub checks as compatibility-only. | `npm run test:hna`, targeted migrated tests. |
+| 1.3 Soft-funding freshness guard | P1 | Data QA scripts/tests only | All non-null `contactUrl`s swept; `lastUpdated` SLA asserted or owner-waived; no program amount/deadline refresh. | `npm run validate:data`, URL sweep dry/diff mode as appropriate. |
+
+## Phase 2 — IA Cleanup
+
+| PR | Priority | Scope | Deliverables | Gate |
+|---|---:|---|---|---|
+| 2.1 Data Trust Center | P1 | Data/diagnostic pages and nav | Consolidate `data-status`, `data-review-hub`, data sources, QA coverage under a single public trust entry. Preserve legacy pages but demote. | Navigation path tests, public build. |
+| 2.2 Public/internal pipeline wording | P1 | Public HNA/OF/PMA teasers and developer-gated mounts | Decide naming: public methodology vs internal CRM. Hide or relabel gated mounts accordingly. | Public build, navigation tests. |
+| 2.3 Homepage job routing | P2 | `index.html` and nav only | Jurisdiction search first; route to Profiles, Housing Need, Opportunity Finder, Site/Deal Feasibility, Data Trust. | Screenshot/rendered QA required. |
+
+## Phase 3 — Rendered QA
+
+| PR | Priority | Scope | Deliverables | Gate |
+|---|---:|---|---|---|
+| 3.1 Core rendered smoke | P2 | Tests/audit scripts only | Browser smoke for HNA, one county profile, one place profile, OF, PMA, Data Trust. Capture console errors, blank cards, mobile overflow. | Playwright/site-audit output attached to PR. |
+| 3.2 Screenshot evidence pack | P2 | Docs/QA only | Desktop/mobile screenshots and disposition table for the core flows. | Manual QA evidence. |
+
+## Phase 4 — Calibration And Owner Decisions
+
+| Item | Priority | Decision needed |
+|---|---:|---|
+| DOLA warning deltas | P2 | Are 12 county +/-5% warnings acceptable under current projection method, or do inputs need refresh? |
+| HNA benchmark ratios | P2 | Which consultant deltas are expected method differences versus model drift? |
+| Public docs boundary | P2 | Should `docs/qa` and `docs/audits` remain public-facing, or be excluded/demoted? |
+| Placeholder inventory | P2 | Which placeholders are acceptable public limitations vs unfinished product promises? |
+
+## Revised IA Target
+
+| Top-level | Primary question | Main pages |
+|---|---|---|
+| Jurisdiction Profiles | “What is true here?” | Search, generated place/county profiles. |
+| Housing Need | “How severe is need?” | HNA, compare. |
+| Opportunity Finder | “Where should we look?” | LIHTC locator, preservation/source inventory. |
+| Site And Deal Feasibility | “Can this site/deal work?” | PMA, deal calculator, land value. |
+| Data Trust Center | “Can I trust the data?” | Freshness, sources, QA coverage, methodology. |
+| Methodology | “How is this calculated?” | Guides, glossary, pipeline explainer. |
+
+## Homepage Wireframe Outline
+
+1. Jurisdiction search and “start with a place” route.
+2. Three task buttons: Understand need, Find opportunity, Test feasibility.
+3. Compact statewide signal strip with source/vintage labels.
+4. Data Trust strip with last refresh and known limitations.
+5. Methodology/guide links below the fold.
+6. Footer with diagnostics and repo/docs links.
+
+## Definition Of Done For Follow-Up PRs
+
+- One PR per task.
+- PR description includes before/after evidence and exact tests run.
+- No broad data refresh hidden inside link/copy/test PRs.
+- New claims identify whether values are raw, transformed, modeled, source-membership, or owner-curated.
+- Rendered UI changes include desktop/mobile screenshots or explicit `UNRENDERED` deferral.


### PR DESCRIPTION
## Summary
- Adds the audit-only report set under docs/qa/site-audit-2026-07/.
- Covers Pass A calculations/lineage, Pass B IA/UX/copy, Pass C hygiene/boundary/testing, plus executive summary and follow-up plan.
- No application code or data files changed.

## Gate evidence
- npm run test:hna-benchmarks: PASS
- npm run check:dola-vintage: PASS with warnings; 64 counties compared, median diff -1.4%, 12 beyond +/-5%
- npm run test:hna: PASS, 730 passed / 0 failed
- npm run validate:data: PASS
- node scripts/validate-schemas.js: PASS, 85 passed / 0 failed
- node test/hna-dp04-codes.test.js: PASS, 27 passed / 0 failed
- node test/acs-etl.test.js: PASS, 167 passed / 0 failed

## Notes
- Browser/mobile/visual observations are marked UNRENDERED because no browser pass was run.
- Known pre-existing failures from the work order are cited as context only, not blockers.
- No sensitive/security findings were written to the public reports.