### PR TITLE
fix(hna): close combined jurisdiction residuals

### DIFF
--- a/js/hna/combined-geo.js
+++ b/js/hna/combined-geo.js
@@ -290,6 +290,50 @@
     };
   }
 
+
+
+  function buildPairedCountyView(placeMember, countyMember, datasets) {
+    datasets = datasets || {};
+    var place = normalizeMember(placeMember || {}, datasets);
+    var county = normalizeMember(countyMember || {}, datasets);
+    if (!/^(place|cdp)$/.test(place.geoType) || !/^county$/.test(county.geoType)) {
+      return { valid: false, errors: ['Paired county view requires one place/CDP and one containing county.'] };
+    }
+    var placeRec = recordForMember(place, datasets);
+    var countyRec = recordForMember(county, datasets);
+    if (!placeRec || !countyRec) {
+      return { valid: false, errors: ['Missing CHAS record for paired county view.'] };
+    }
+    function row(member, rec, scope) {
+      var summary = rec.summary || {};
+      var renter = num(summary.total_renter_hh);
+      var owner = num(summary.total_owner_hh);
+      var renterCb = num(summary.renter_cb30_count);
+      var ownerCb = num(summary.owner_cb30_count);
+      return {
+        scope: scope,
+        geoType: member.geoType,
+        geoid: member.geoid,
+        name: rec.name || rec.county_name || rec.place_name || member.geoid,
+        total_renter_hh: renter,
+        total_owner_hh: owner,
+        renter_cb30_share: renter ? renterCb / renter : null,
+        owner_cb30_share: owner ? ownerCb / owner : null,
+        dataQuality: memberQuality(rec, member).quality,
+      };
+    }
+    return {
+      valid: true,
+      mode: 'paired-county',
+      aggregation: 'none',
+      rows: [
+        row(place, placeRec, 'selected jurisdiction'),
+        row(county, countyRec, 'containing county'),
+      ],
+      note: 'Side-by-side paired view only; place and county values are not aggregated.',
+    };
+  }
+
   function aggregate(members, datasets) {
     datasets = datasets || {};
     var validation = validateCombo(members, datasets);
@@ -325,6 +369,7 @@
     GAP_BANDS: GAP_BANDS,
     validateCombo: validateCombo,
     aggregate: aggregate,
+    buildPairedCountyView: buildPairedCountyView,
     resolveAlias: resolveAlias,
   };
 }());

--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -301,6 +301,7 @@
   function _syncCombinedPanel() {
     const on = !!(window.HNAState.els.combineGeosToggle && window.HNAState.els.combineGeosToggle.checked);
     if (window.HNAState.els.combinedGeosPanel) window.HNAState.els.combinedGeosPanel.hidden = !on;
+    if (on) _ensurePairedCountyView();
     _renderCombinedChips();
   }
 
@@ -316,6 +317,61 @@
     window.HNAState.state.combinedMembers = list.slice(0, 6);
     _renderCombinedChips();
     if (typeof window.__announceUpdate === 'function') window.__announceUpdate('Combined member added: ' + _labelForMember(member));
+  }
+
+
+  function _ensurePairedCountyView() {
+    var panel = window.HNAState.els.combinedGeosPanel;
+    if (!panel || document.getElementById('pairedCountyPanel')) return;
+    var wrap = document.createElement('div');
+    wrap.id = 'pairedCountyPanel';
+    wrap.style.cssText = 'margin-top:.55rem;border-top:1px solid var(--border);padding-top:.55rem;';
+    wrap.innerHTML =
+      '<button type="button" id="btnPairedCountyView" class="btn btn-secondary" style="font-size:.78rem;padding:.35rem .55rem;">Compare with County</button>' +
+      '<div id="pairedCountyResult" style="margin-top:.45rem;font-size:.82rem;color:var(--muted);" aria-live="polite"></div>';
+    panel.appendChild(wrap);
+    var btn = document.getElementById('btnPairedCountyView');
+    if (btn) btn.addEventListener('click', _renderPairedCountyView);
+  }
+
+  async function _renderPairedCountyView() {
+    var out = document.getElementById('pairedCountyResult');
+    if (!out) return;
+    var cur = window.HNAState.state.current || {};
+    if (!/^(place|cdp)$/.test(cur.geoType || '') || !cur.contextCounty) {
+      out.textContent = 'Select a place or CDP to compare it with its containing county.';
+      return;
+    }
+    try {
+      var datasets = await _loadCombinedDatasets();
+      var paired = window.HNACombinedGeo && window.HNACombinedGeo.buildPairedCountyView
+        ? window.HNACombinedGeo.buildPairedCountyView(
+            { geoType: cur.geoType, geoid: cur.geoid },
+            { geoType: 'county', geoid: cur.contextCounty },
+            datasets
+          )
+        : null;
+      if (!paired || !paired.valid) {
+        out.textContent = paired && paired.errors ? paired.errors.join(' ') : 'Paired county view unavailable.';
+        return;
+      }
+      out.innerHTML = '<div style="font-weight:700;color:var(--text);margin-bottom:.25rem;">Non-aggregating paired view</div>' +
+        '<table style="width:100%;border-collapse:collapse;"><thead><tr>' +
+        '<th style="text-align:left;padding:.25rem;border-bottom:1px solid var(--border);">Scope</th>' +
+        '<th style="text-align:right;padding:.25rem;border-bottom:1px solid var(--border);">Renter HH</th>' +
+        '<th style="text-align:right;padding:.25rem;border-bottom:1px solid var(--border);">Renter CB30</th>' +
+        '<th style="text-align:right;padding:.25rem;border-bottom:1px solid var(--border);">Owner CB30</th>' +
+        '</tr></thead><tbody>' + paired.rows.map(function (r) {
+          return '<tr><td style="padding:.25rem;border-bottom:1px solid var(--border);">' + r.name + ' <span style="color:var(--muted)">(' + r.scope + ')</span></td>' +
+            '<td style="text-align:right;padding:.25rem;border-bottom:1px solid var(--border);">' + window.HNAUtils.fmtNum(r.total_renter_hh) + '</td>' +
+            '<td style="text-align:right;padding:.25rem;border-bottom:1px solid var(--border);">' + window.HNAUtils.fmtPct((r.renter_cb30_share || 0) * 100) + '</td>' +
+            '<td style="text-align:right;padding:.25rem;border-bottom:1px solid var(--border);">' + window.HNAUtils.fmtPct((r.owner_cb30_share || 0) * 100) + '</td></tr>';
+        }).join('') + '</tbody></table>' +
+        '<div style="margin-top:.25rem;color:var(--muted);">' + paired.note + '</div>';
+    } catch (e) {
+      out.textContent = 'Paired county view unavailable.';
+      console.warn('[HNA] paired county view failed', e);
+    }
   }
 
   function _clearCombinedMapOverlays() {
@@ -630,7 +686,12 @@
     window.addEventListener('resize', function(){ window.HNAState.map.invalidateSize(); });
 
     // Update "LIHTC projects in area" panel whenever the map view changes
-    window.HNAState.map.on('moveend', window.HNARenderers.updateLihtcInfoPanel);
+    function updateLihtcInfoPanel() {
+      var cur = window.HNAState.state.current || {};
+      if (cur.geoType === 'combined') return;
+      window.HNARenderers.updateLihtcInfoPanel();
+    }
+    window.HNAState.map.on('moveend', updateLihtcInfoPanel);
   }
 
   // Boundary style tokens keyed by geoType — counties use a thinner/lighter stroke
@@ -2127,6 +2188,14 @@
 
   async function applyAssumptions(proj, selection){
     if (!proj) return;
+    if (selection && selection.geoType === 'combined') {
+      var unavailable = 'Not available for combined areas — view members individually.';
+      if (window.HNAState.els.statBaseUnits) window.HNAState.els.statBaseUnits.textContent = 'Not available';
+      if (window.HNAState.els.statBaseUnitsSrc) window.HNAState.els.statBaseUnitsSrc.textContent = unavailable;
+      if (window.HNAState.els.statUnitsNeed) window.HNAState.els.statUnitsNeed.textContent = 'Not available';
+      if (window.HNAState.els.statNetMig) window.HNAState.els.statNetMig.textContent = 'Not available';
+      return;
+    }
 
     const countyFips5 = proj?.countyFips || selection?.contextCounty || (selection?.geoType==='county' ? selection?.geoid : null);
 
@@ -2150,7 +2219,7 @@
 
     // If selection is a place/CDP, scale projections from containing county.
     // State-level: projections are loaded directly for '08', no scaling needed.
-    if (selection && selection.geoType !== 'county' && selection.geoType !== 'state'){
+    if (selection && selection.geoType !== 'county' && selection.geoType !== 'state' && selection.geoType !== 'combined'){
       const placePopNow = window.HNAUtils.safeNum(selection.profile?.DP05_0001E);
       const placeHhNow = window.HNAUtils.safeNum(selection.profile?.DP02_0001E);
       const placeUnitsNow = window.HNAUtils.safeNum(selection.profile?.DP04_0001E);
@@ -2223,7 +2292,7 @@
     }
 
     let placeProjectionRec = null;
-    if (selection && selection.geoType !== 'county' && selection.geoType !== 'state' && selection.geoid){
+    if (selection && selection.geoType !== 'county' && selection.geoType !== 'state' && selection.geoType !== 'combined' && selection.geoid){
       try {
         const placeDoc = await loadPlaceProjectionsDoc();
         placeProjectionRec = placeDoc?.places?.[selection.geoid] || null;
@@ -2249,14 +2318,14 @@
         const permitText = sh.permit == null ? 'permit share unavailable' : `permit share ${(sh.permit * 100).toFixed(1)}%`;
         projectionMethodNote = ` Place-level projection uses a 50/50 blend of ACS household share (${((sh.household || 0) * 100).toFixed(1)}%) and ${permitText} from Census BPS ${sh.permit_window || '2020-2024'}.`;
       }
-    } else if (selection && selection.geoType !== 'county' && selection.geoType !== 'state') {
+    } else if (selection && selection.geoType !== 'county' && selection.geoType !== 'state' && selection.geoType !== 'combined') {
       projectionMethodNote = ' Need is scaled from the containing county DOLA projection.';
     }
 
     // Net migration scaled for places/CDPs (share of county base).
     // State-level projections are loaded directly for '08' — no scaling needed.
     let net20 = window.HNAUtils.safeNum(proj?.net_migration_20y);
-    if (selection && selection.geoType !== 'county' && selection.geoType !== 'state' && baseCountyPop && basePop){
+    if (selection && selection.geoType !== 'county' && selection.geoType !== 'state' && selection.geoType !== 'combined' && baseCountyPop && basePop){
       const d = window.HNAState.state.derived?.geos?.[selection.geoid]?.derived || null;
       const placeShare = placeProjectionRec?.shares?.blended;
       const share0 = placeShare != null
@@ -3538,7 +3607,7 @@
 
     // Sync checklist state to compliance-dashboard.html on unload
     window.addEventListener('beforeunload', () => {
-      if (window.ComplianceChecklist && window.HNAState.state.current) {
+      if (window.ComplianceChecklist && window.HNAState.state.current && window.HNAState.state.current.geoType !== 'combined') {
         window.ComplianceChecklist.broadcastChecklistChange({
           geoType: window.HNAState.state.current.geoType,
           geoid:   window.HNAState.state.current.geoid,

--- a/js/hna/hna-export.js
+++ b/js/hna/hna-export.js
@@ -240,6 +240,44 @@
     } catch (_) { return null; }
   }
 
+
+
+  function _metricsFromCombinedResult(result) {
+    if (!result || !result.valid) return null;
+    var rec = result.pseudoChasRecord || {};
+    var summary = rec.summary || {};
+    var renter = Number(summary.total_renter_hh || 0);
+    var owner = Number(summary.total_owner_hh || 0);
+    var total = renter + owner;
+    var gap = result.amiGapEntry || {};
+    var cumulative = gap.gap_units_minus_households_le_ami_pct || {};
+    var households = gap.households_le_ami_pct || {};
+    function pct(n, d) { return d ? +((Number(n || 0) / d) * 100).toFixed(1) : null; }
+    function num(v) { var n = Number(v); return Number.isFinite(n) ? n : null; }
+    return {
+      population: null,
+      median_hh_income: null,
+      gross_rent_median: null,
+      pct_renters: pct(renter, total),
+      pct_cost_burdened: pct(summary.renter_cb30_count, renter),
+      pct_burdened_lte30: rec.renter_hh_by_ami && rec.renter_hh_by_ami.lte30 ? pct(rec.renter_hh_by_ami.lte30.cost_burdened_30pct, rec.renter_hh_by_ami.lte30.total) : null,
+      pct_burdened_31to50: rec.renter_hh_by_ami && rec.renter_hh_by_ami['31to50'] ? pct(rec.renter_hh_by_ami['31to50'].cost_burdened_30pct, rec.renter_hh_by_ami['31to50'].total) : null,
+      pct_burdened_51to80: rec.renter_hh_by_ami && rec.renter_hh_by_ami['51to80'] ? pct(rec.renter_hh_by_ami['51to80'].cost_burdened_30pct, rec.renter_hh_by_ami['51to80'].total) : null,
+      pct_burdened_81to100: rec.renter_hh_by_ami && rec.renter_hh_by_ami['81to100'] ? pct(rec.renter_hh_by_ami['81to100'].cost_burdened_30pct, rec.renter_hh_by_ami['81to100'].total) : null,
+      pct_burdened_100plus: rec.renter_hh_by_ami && rec.renter_hh_by_ami['100plus'] ? pct(rec.renter_hh_by_ami['100plus'].cost_burdened_30pct, rec.renter_hh_by_ami['100plus'].total) : null,
+      pct_owner_burdened_30plus: pct(summary.owner_cb30_count, owner),
+      housing_gap_units: result.availability && result.availability.amiGap && result.availability.amiGap.available ? num(cumulative['100']) : null,
+      ami_gap_30pct: result.availability && result.availability.amiGap && result.availability.amiGap.available ? num(cumulative['30']) : null,
+      ami_gap_50pct: result.availability && result.availability.amiGap && result.availability.amiGap.available ? num(cumulative['50']) : null,
+      ami_gap_60pct: result.availability && result.availability.amiGap && result.availability.amiGap.available ? num(cumulative['60']) : null,
+      missing_ami_tiers: result.availability && result.availability.amiGap && result.availability.amiGap.available ? [] : ['combined-member-missing-ami-gap'],
+      _chas_source: 'combined',
+      _ami_gap_source: result.availability && result.availability.amiGap && result.availability.amiGap.available ? 'combined' : 'unavailable',
+      combined_members: result.members || [],
+      combined_note: 'Combined screening area metrics are derived from the current combined result object, not ranking-index or stale single-geography state.',
+    };
+  }
+
   /**
    * Collects the currently rendered housing-needs assessment values from
    * the DOM AND from the loaded ranking-index entry for the selected
@@ -268,8 +306,9 @@
     // HNAState (the loaded ACS profile + CHAS county aggregate). Both
     // paths produce the same metrics shape so the export rows below
     // work uniformly.
-    var idxRec = _rankingEntry(geoid);
-    var m = (idxRec && idxRec.metrics) || _metricsFromHnaState(geoid) || {};
+    var combinedResult = current && current.geoType === 'combined' ? current.combinedResult : null;
+    var idxRec = combinedResult ? null : _rankingEntry(geoid);
+    var m = combinedResult ? (_metricsFromCombinedResult(combinedResult) || {}) : ((idxRec && idxRec.metrics) || _metricsFromHnaState(geoid) || {});
 
     return {
       exportedAt:    new Date().toISOString(),
@@ -282,6 +321,7 @@
         dola:         'DOLA SYA 2024',
         fmr:          'HUD FMR FY2025',
         rankingIndex: idxRec && idxRec._metadata && idxRec._metadata.builtAt || null,
+        combined: combinedResult ? 'current combined result' : null,
       },
       geography: {
         label:   geoLabel,

--- a/js/hna/hna-ownership-need.js
+++ b/js/hna/hna-ownership-need.js
@@ -114,6 +114,7 @@
   function sourceLabel(geoLevel, countyFallback) {
     if (countyFallback) return 'county-CHAS fallback';
     if (geoLevel === 'state') return 'state-CHAS';
+    if (geoLevel === 'combined') return 'combined-CHAS';
     return geoLevel === 'county' ? 'county-CHAS' : 'place-CHAS';
   }
 

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -7930,17 +7930,27 @@
     _combinedSetText('statCommute', 'Not available');
     _combinedSetText('statCommuteSrc', 'Not available for combined areas — view members individually.');
 
-    var amiGap = result.amiGapEntry || {};
-    var households = amiGap.households_le_ami_pct || {};
-    var prevHouseholds = 0;
-    ['30', '40', '50', '60', '70', '80', '100'].forEach(function (band) {
-      var demand = Number(households[band]);
-      var tierDemand = Number.isFinite(demand) ? Math.max(0, demand - prevHouseholds) : null;
-      _combinedSetText('statGap' + band, Number.isFinite(demand) ? _ownFmtNum(demand) : '—');
-      _combinedSetText('statTierGap' + band, tierDemand != null ? _ownFmtNum(tierDemand) : '—');
-      if (Number.isFinite(demand)) prevHouseholds = demand;
-    });
-    _combinedSetText('hnaGapConfidence', 'Combined · DERIVED');
+    var amiGapAvailable = !!(result.availability && result.availability.amiGap && result.availability.amiGap.available);
+    var amiGapMessage = 'Not available — one or more members missing AMI-gap data';
+    if (amiGapAvailable) {
+      var amiGap = result.amiGapEntry || {};
+      var households = amiGap.households_le_ami_pct || {};
+      var prevHouseholds = 0;
+      ['30', '40', '50', '60', '70', '80', '100'].forEach(function (band) {
+        var demand = Number(households[band]);
+        var tierDemand = Number.isFinite(demand) ? Math.max(0, demand - prevHouseholds) : null;
+        _combinedSetText('statGap' + band, Number.isFinite(demand) ? _ownFmtNum(demand) : '—');
+        _combinedSetText('statTierGap' + band, tierDemand != null ? _ownFmtNum(tierDemand) : '—');
+        if (Number.isFinite(demand)) prevHouseholds = demand;
+      });
+      _combinedSetText('hnaGapConfidence', 'Combined · DERIVED');
+    } else {
+      ['30', '40', '50', '60', '70', '80', '100'].forEach(function (band) {
+        _combinedSetText('statGap' + band, 'Not available');
+        _combinedSetText('statTierGap' + band, 'Not available');
+      });
+      _combinedSetText('hnaGapConfidence', amiGapMessage);
+    }
 
     var unavailable = 'Not available for combined areas — view members individually.';
     _combinedClearNonCanvasPanels(unavailable, result);

--- a/test/combined-geo.test.js
+++ b/test/combined-geo.test.js
@@ -246,6 +246,71 @@ test('zero-household member is tolerated without NaN or undefined', () => {
   walkNoBadValues(out);
 });
 
+
+
+test('Mode B paired county view is non-aggregating place plus containing county', () => {
+  const paired = Combined.buildPairedCountyView(
+    { geoType: 'place', geoid: '0800001' },
+    { geoType: 'county', geoid: '08009' },
+    fixtureDatasets()
+  );
+  assert.equal(paired.valid, true);
+  assert.equal(paired.mode, 'paired-county');
+  assert.equal(paired.aggregation, 'none');
+  assert.equal(paired.rows.length, 2);
+  assert.equal(paired.rows[0].scope, 'selected jurisdiction');
+  assert.equal(paired.rows[1].scope, 'containing county');
+  assert.equal(paired.rows[0].total_renter_hh, 100);
+  assert.equal(paired.rows[1].total_renter_hh, 200);
+});
+
+test('Mode B UI is mounted by controller without requiring template HTML edits', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-controller.js'), 'utf8');
+  assert(src.includes('btnPairedCountyView'), 'controller creates Compare with County button');
+  assert(src.includes('pairedCountyResult'), 'controller creates paired county result mount');
+  assert(src.includes('buildPairedCountyView'), 'controller calls combined paired-view helper');
+});
+
+test('combined AMI-gap rendering gates on availability flag', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-renderers.js'), 'utf8');
+  assert(src.includes('result.availability && result.availability.amiGap && result.availability.amiGap.available'), 'renderCombinedAssessment reads availability.amiGap.available');
+  assert(src.includes('Not available — one or more members missing AMI-gap data'), 'missing AMI gap message is rendered');
+  assert(src.includes("_combinedSetText('statGap' + band, 'Not available')"), 'statGap fields are masked when unavailable');
+  assert(src.includes("_combinedSetText('statTierGap' + band, 'Not available')"), 'statTierGap fields are masked when unavailable');
+});
+
+test('combined export reads current combined result instead of stale single-geography state', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-export.js'), 'utf8');
+  assert(src.includes('function _metricsFromCombinedResult'), 'combined export metrics helper exists');
+  assert(src.includes("current && current.geoType === 'combined' ? current.combinedResult : null"), 'buildReportData reads current.combinedResult');
+  assert(src.includes("_chas_source: 'combined'"), 'combined CHAS source is exported');
+  assert(src.includes("_ami_gap_source: result.availability && result.availability.amiGap"), 'combined AMI gap source honors availability');
+});
+
+test('ownership need labels combined areas as combined CHAS', () => {
+  const out = Combined.aggregate([
+    { geoType: 'place', geoid: '0800001' },
+    { geoType: 'place', geoid: '0800002' },
+  ], fixtureDatasets());
+  const ownership = Ownership.computeOwnershipNeed({
+    chasEntry: out.pseudoChasRecord,
+    geoLevel: 'combined',
+    geographyName: 'Fixture combo',
+    amiGapEntry: Object.assign({ ami_4person: 100000 }, out.amiGapEntry),
+    homeValueEntry: { value: 400000, source: 'fixture' },
+  });
+  assert.equal(ownership.rentalPressure.inputs.source, 'combined-CHAS');
+  assert.equal(ownership.ownershipPressure.inputs.source, 'combined-CHAS');
+  assert.equal(ownership.ownershipFit.inputs.source, 'combined-CHAS');
+});
+
+test('combined geoType is guarded at projection, map, and checklist call sites', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-controller.js'), 'utf8');
+  assert(src.includes("selection && selection.geoType === 'combined'"), 'applyAssumptions exits for combined selections');
+  assert(src.includes("if (cur.geoType === 'combined') return;"), 'moveend LIHTC refresh is gated for combined selections');
+  assert(src.includes("window.HNAState.state.current.geoType !== 'combined'"), 'beforeunload checklist broadcast skips combined selections');
+});
+
 test('preset config members resolve against registry and validate', () => {
   const registry = readJson('data/hna/geography-registry.json').geographies;
   const byGeoid = new Map(registry.map(g => [g.geoid, g]));


### PR DESCRIPTION
## Summary
- Implements Phase 0 item 0.4 from docs/audits/CODEX-HANDOFF-AUDIT-PHASE0-2026-07.md.
- Adds Mode B paired place/CDP + containing-county view as a non-aggregating controller-mounted panel.
- Masks combined AMI-gap stats when any member lacks AMI-gap data.
- Makes HNA exports source combined metrics from the current combined result instead of ranking-index/stale HNAState fallbacks.
- Labels Affordable Ownership Need combined CHAS inputs as combined-CHAS.
- Guards combined geoType at projection assumptions, map moveend LIHTC refresh, and beforeunload checklist broadcast.

## Audit/QA item
Closes Phase 0 item 0.4, the combined-jurisdictions residual fixes from the PR #1076 QA thread.

## Verification
Independently confirmed in current code before editing:
- renderCombinedAssessment read result.amiGapEntry but not result.availability.amiGap.available.
- buildReportData used ranking/HNAState paths that do not exist for combined geographies.
- sourceLabel() fell through combined to place-CHAS.
- applyAssumptions(), the moveend LIHTC info-panel listener, and beforeunload checklist broadcast lacked combined guards.
- Unknown/state member rejection and stale LIHTC overlay clearing were already fixed and not reworked.

## Tests
- node test/combined-geo.test.js: PASS, 18 passed / 0 failed
- npm run test:combined-geo: PASS, 18 passed / 0 failed
- npm run test:hna: PASS, 730 passed / 0 failed
- npm run test:hna-ownership-need: PASS, 16 passed / 0 failed
- node --check js/hna/hna-controller.js: PASS
- node --check js/hna/hna-export.js: PASS
- node --check js/hna/combined-geo.js: PASS
- git diff --check: PASS

## Known limitations
- I attempted a local Playwright browser repro, but this environment has no bundled Playwright Chromium installed and system Chrome aborted under the managed runtime. The PR therefore relies on expanded unit/static coverage plus HNA gates; external QA should still perform the requested rendered repros before merge.