### PR TITLE
Unify HNA home-value source text

### DIFF
--- a/js/hna/hna-narratives.js
+++ b/js/hna/hna-narratives.js
@@ -61,6 +61,10 @@
       ? window.HNAUtils.safeNum
       : function (v) { var n = Number(v); return Number.isFinite(n) ? n : null; };
 
+    var homeInfo = window.HNAUtils && window.HNAUtils.homeValueInfo
+      ? window.HNAUtils.homeValueInfo(profile)
+      : { value: safeNum(profile.DP04_0089E), sourceText: 'ACS DP04_0089E', suppressIncomeToOwn: false };
+
     var ctx = {
       label: label || profile.NAME || 'this jurisdiction',
       geoType: profile._geoType || null,
@@ -68,7 +72,8 @@
       // ACS core
       pop: safeNum(profile.DP05_0001E),
       medianRent: safeNum(profile.DP04_0134E),
-      medianHomeVal: safeNum(profile.DP04_0089E),
+      medianHomeVal: homeInfo.value,
+      medianHomeValueInfo: homeInfo,
       medianIncome: safeNum(profile.DP03_0062E),
       avgHhSize: safeNum(profile.DP02_0016E),
       pctRenter: safeNum(profile.DP04_0047PE),
@@ -404,7 +409,7 @@
         _fmtMoney(incomeNeededRent) + ' to stay under the 30% rule' + rentVsIncome
       );
     }
-    if (ctx.medianHomeVal != null) {
+    if (ctx.medianHomeVal != null && !(ctx.medianHomeValueInfo && ctx.medianHomeValueInfo.suppressIncomeToOwn)) {
       // Mortgage rule of thumb: 30-yr fixed at ~7%, 20% down, taxes+ins ~28% of PITI.
       // Income needed ≈ home value × 0.20 (~payment per $100K) / 0.30. Keep simple.
       var incomeNeededHome = Math.round(ctx.medianHomeVal * 0.20);
@@ -417,8 +422,11 @@
       } else {
         homeClause = '.';
       }
+      var homeSourceText = ctx.medianHomeValueInfo && ctx.medianHomeValueInfo.sourceText
+        ? ctx.medianHomeValueInfo.sourceText
+        : 'ACS DP04_0089E';
       parts.push(
-        '<strong>Median home value ' + _fmtMoney(ctx.medianHomeVal) + ' (ACS 2020–2024)</strong> ' +
+        '<strong>Median home value ' + _fmtMoney(ctx.medianHomeVal) + ' (' + _esc(homeSourceText) + ')</strong> ' +
         'requires roughly ' + _fmtMoney(incomeNeededHome) + ' in income to afford the mortgage at current rates' +
         homeClause
       );

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -12,32 +12,7 @@
   function U() { return window.HNAUtils; }
 
   function homeValueInfo(profile) {
-    const safeNum = U().safeNum || ((v) => {
-      const n = Number(v);
-      return Number.isFinite(n) ? n : null;
-    });
-    const display = profile && profile.median_home_value && typeof profile.median_home_value === 'object'
-      ? profile.median_home_value
-      : null;
-    const value = display ? safeNum(display.value) : safeNum(profile && profile.DP04_0089E);
-    let sourceLabel = 'ACS DP04_0089E';
-    if (display) {
-      if (display.source === 'zhvi') sourceLabel = 'Zillow ZHVI city index';
-      else if (display.source === 'county_zhvi_adjusted') sourceLabel = 'County-adjusted Zillow/ACS estimate';
-      else if (display.source === 'acs_raw') sourceLabel = 'ACS DP04_0089E raw floor';
-      else sourceLabel = display.source || sourceLabel;
-    }
-    const lowConfidence = display && (display.confidence === 'low' || display.source === 'acs_raw' || display.source === 'county_zhvi_adjusted');
-    return {
-      display,
-      value,
-      sourceLabel,
-      asOf: display && display.as_of ? display.as_of : null,
-      confidence: display && display.confidence ? display.confidence : null,
-      lowConfidence,
-      suppressIncomeToOwn: !!(display && display.suppress_income_to_own),
-      suppressReason: display && display.suppress_reason ? display.suppress_reason : '',
-    };
+    return U().homeValueInfo ? U().homeValueInfo(profile) : { value: null, display: null, sourceLabel: 'ACS DP04_0089E', asOf: null };
   }
 
   /**
@@ -389,12 +364,10 @@
     if (els.statHomeValue) els.statHomeValue.textContent = homeVal !== null ? fmtMoney(homeVal) : '—';
     if (els.statHomeValueSrc) {
       if (homeInfo.display) {
-        const caveat = homeInfo.lowConfidence
-          ? ' · low confidence: no current city index'
-          : '';
-        els.statHomeValueSrc.textContent = homeInfo.sourceLabel + ' · ' + (homeInfo.asOf || 'unknown vintage') + ' · ' + (homeInfo.confidence || 'unknown') + caveat;
+        els.statHomeValueSrc.textContent = U().homeValueSourceText ? U().homeValueSourceText(homeInfo) : homeInfo.sourceText;
       } else {
-        els.statHomeValueSrc.innerHTML = U().srcLink('DP04', yr, sr, 'DP04', geoType, geoid);
+        const sourceLink = U().srcLink('DP04', yr, sr, 'DP04', geoType, geoid).replace(/^ACS(?:\s+\d{4})?\s+DP04/, '');
+        els.statHomeValueSrc.innerHTML = escHtml(homeInfo.sourceText || U().homeValueSourceText(homeInfo)) + sourceLink;
       }
     }
 

--- a/js/hna/hna-utils.js
+++ b/js/hna/hna-utils.js
@@ -352,6 +352,48 @@
   }
 
 
+  function homeValueInfo(profile) {
+    const display = profile && profile.median_home_value && typeof profile.median_home_value === 'object'
+      ? profile.median_home_value
+      : null;
+    const value = display ? safeNum(display.value) : safeNum(profile && profile.DP04_0089E);
+    let sourceLabel = 'ACS DP04_0089E';
+    if (display) {
+      if (display.source === 'zhvi') sourceLabel = 'Zillow ZHVI city index';
+      else if (display.source === 'county_zhvi_adjusted') sourceLabel = 'County-adjusted Zillow/ACS estimate';
+      else if (display.source === 'acs_raw') sourceLabel = 'ACS DP04_0089E raw floor';
+      else sourceLabel = display.source || sourceLabel;
+    }
+    const year = profile && profile._acsYear ? profile._acsYear : ACS_YEAR_PRIMARY;
+    const rawAsOf = year ? 'ACS ' + year + ' 5-year' : 'ACS 5-year';
+    const lowConfidence = !!(display && (display.confidence === 'low' || display.source === 'acs_raw' || display.source === 'county_zhvi_adjusted'));
+    const info = {
+      display,
+      value,
+      source: display && display.source ? display.source : 'DP04_0089E',
+      sourceLabel,
+      asOf: display && display.as_of ? display.as_of : rawAsOf,
+      confidence: display && display.confidence ? display.confidence : null,
+      lowConfidence,
+      suppressIncomeToOwn: !!(display && display.suppress_income_to_own),
+      suppressReason: display && display.suppress_reason ? display.suppress_reason : '',
+    };
+    info.sourceText = homeValueSourceText(info);
+    return info;
+  }
+
+  function homeValueSourceText(info) {
+    if (!info) return '';
+    const asOf = info.asOf || 'unknown vintage';
+    if (info.display) {
+      const confidence = info.confidence || 'unknown';
+      const caveat = info.lowConfidence ? ' · low confidence: no current city index' : '';
+      return info.sourceLabel + ' · ' + asOf + ' · ' + confidence + caveat;
+    }
+    return info.sourceLabel + ' · ' + asOf;
+  }
+
+
   /**
    * Map a Colorado geography (place / CDP / county / state) to its
    * containing 5-digit county FIPS.
@@ -1279,6 +1321,8 @@
     censusSourceUrl,
     srcLink,
     safeNum,
+    homeValueInfo,
+    homeValueSourceText,
     computeIncomeNeeded,
     computeActiveMarketTargetVacancy,
     rentBurden30Plus,

--- a/test/hna-home-value-cascade.test.js
+++ b/test/hna-home-value-cascade.test.js
@@ -9,6 +9,8 @@ const cascade = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/hna/home-value-
 const fruita = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/hna/summary/0828745.json'), 'utf8')).acsProfile;
 const fruitaHomeValue = fruita.median_home_value;
 const affordabilityPanel = fs.readFileSync(path.join(ROOT, 'js/affordability-metrics-panel.js'), 'utf8');
+const hnaUtils = fs.readFileSync(path.join(ROOT, 'js/hna/hna-utils.js'), 'utf8');
+const hnaNarratives = fs.readFileSync(path.join(ROOT, 'js/hna/hna-narratives.js'), 'utf8');
 const hnaRenderers = fs.readFileSync(path.join(ROOT, 'js/hna/hna-renderers.js'), 'utf8');
 
 assert(fruitaHomeValue, 'Fruita summary should be stamped with median_home_value');
@@ -35,7 +37,8 @@ const suppressedSummaries = adjustedSummaries
   .filter((profile) => profile.median_home_value.suppress_income_to_own);
 assert(suppressedSummaries.length > 0, 'Still implausible owner-value fallbacks should suppress income-to-own');
 
-assert(hnaRenderers.includes('function homeValueInfo'), 'HNA renderers should have a shared home-value cascade helper');
+assert(hnaUtils.includes('function homeValueInfo'), 'HNA utils should expose the shared home-value cascade helper');
+assert(/function homeValueInfo\(profile\) \{\n\s+return U\(\)\.homeValueInfo/.test(hnaRenderers), 'HNA renderers should delegate to the shared home-value cascade helper');
 assert(/function renderAffordChart[\s\S]*homeValueInfo\(profile\)/.test(hnaRenderers), 'Affordability chart should use the home-value cascade helper');
 assert(/function renderWageAffordability[\s\S]*homeValueInfo\(profile\)/.test(hnaRenderers), 'Wage affordability panel should use the home-value cascade helper');
 assert(!/function renderAffordChart[\s\S]{0,900}safeNum\(profile\.DP04_0089E\) \|\| 0/.test(hnaRenderers), 'Affordability chart should not fall back to raw DP04 directly');
@@ -61,5 +64,63 @@ assert.equal(panelMetric.home_price, cascade.places['0828745'].value, 'Panel hom
 assert.equal(panelMetric.home_value_source, 'zhvi', 'Panel should label Fruita home value as ZHVI');
 assert.equal(panelMetric.home_value_as_of, fruitaHomeValue.as_of, 'Panel should preserve Fruita ZHVI as_of vintage');
 assert(panelMetric.required_hhi_for_home > 0, 'Income-to-buy required HHI should compute from Fruita ZHVI');
+
+function loadHnaSurfaceContext() {
+  const ctx = {
+    window: {},
+    document: {
+      readyState: 'loading',
+      addEventListener() {},
+      getElementById() { return null; },
+    },
+    location: { search: '' },
+    URLSearchParams,
+    fetch() {
+      throw new Error('network should not be used by home-value narrative tests');
+    },
+  };
+  ctx.window.window = ctx.window;
+  ctx.window.document = ctx.document;
+  ctx.window.location = ctx.location;
+  ctx.window.URLSearchParams = URLSearchParams;
+  vm.createContext(ctx);
+  vm.runInContext(hnaUtils, ctx, { filename: 'js/hna/hna-utils.js' });
+  vm.runInContext(hnaNarratives, ctx, { filename: 'js/hna/hna-narratives.js' });
+  return ctx;
+}
+
+function assertNarrativeHomeValueAgreement(ctx, profile, label) {
+  const info = ctx.window.HNAUtils.homeValueInfo(profile);
+  const html = ctx.window.HNANarratives.buildExecutiveSummary(profile, label) || '';
+  if (info.suppressIncomeToOwn) {
+    assert(!html.includes('Median home value'), `${label}: suppressed home value should omit the home affordability sentence`);
+    assert(!html.includes(ctx.window.HNAUtils.fmtMoney(info.value)), `${label}: suppressed home value should not surface the affordability value`);
+    return;
+  }
+  assert(html.includes(ctx.window.HNAUtils.fmtMoney(info.value)), `${label}: narrative should use the shared home-value amount`);
+  assert(html.includes(info.sourceText), `${label}: narrative should use the shared home-value source/vintage`);
+  assert(!html.includes('ACS 2020–2024'), `${label}: narrative should not carry the old hard-coded ACS vintage`);
+}
+
+const surfaceCtx = loadHnaSurfaceContext();
+const rawAcsProfile = {
+  NAME: 'Raw ACS fixture',
+  _geoType: 'place',
+  _geoid: '0899999',
+  _acsYear: 2024,
+  DP04_0089E: 250000,
+  DP04_0134E: 1250,
+  DP03_0062E: 70000,
+};
+const zhviProfile = fruita;
+const adjustedProfile = adjustedSummaries[0];
+const suppressedProfile = suppressedSummaries[0];
+
+assertNarrativeHomeValueAgreement(surfaceCtx, rawAcsProfile, 'raw ACS fixture');
+assertNarrativeHomeValueAgreement(surfaceCtx, zhviProfile, 'Fruita ZHVI');
+assertNarrativeHomeValueAgreement(surfaceCtx, adjustedProfile, adjustedProfile.NAME || 'county-adjusted fixture');
+assertNarrativeHomeValueAgreement(surfaceCtx, suppressedProfile, suppressedProfile.NAME || 'suppressed fixture');
+assert.equal(surfaceCtx.window.HNAUtils.homeValueInfo(rawAcsProfile).sourceText, 'ACS DP04_0089E · ACS 2024 5-year', 'Raw ACS source text should carry the field and ACS vintage');
+assert.equal(surfaceCtx.window.HNAUtils.homeValueInfo(zhviProfile).sourceText, 'Zillow ZHVI city index · ' + fruitaHomeValue.as_of + ' · high', 'ZHVI source text should carry source, as_of, and confidence');
 
 console.log('hna-home-value-cascade: ok');


### PR DESCRIPTION
## Summary
- Closes Phase 0 item 0.1 / audit finding A-01 by moving the HNA home-value cascade decision into `HNAUtils.homeValueInfo()`.
- Makes the stat card and executive narrative consume the same value, source label, vintage/as-of text, confidence, and `suppress_income_to_own` flag.
- Preserves the narrative mortgage rule-of-thumb math and sentence structure; suppressed ownership-affordability inputs now omit the home affordability sentence.

## Current-code verification
- Re-checked `js/hna/hna-renderers.js`: the stat card previously preferred `profile.median_home_value` but owned its own local helper.
- Re-checked `js/hna/hna-narratives.js`: the narrative previously read raw `DP04_0089E` and hardcoded `ACS 2020–2024`.
- Confirmed this PR does not touch the separate mortgage formula follow-up; it only aligns displayed value/source/vintage.

## Real-jurisdiction spot check
- `0800320` ZHVI: stat `$573,180`; source `Zillow ZHVI city index · 2026-05-31 · high`; narrative matched amount and source.
- `0800760` ACS raw floor: stat `$96,400`; source `ACS DP04_0089E raw floor · ACS 2020-2024 5-year · low · low confidence: no current city index`; narrative matched amount and source.
- `0818750` county-adjusted: stat `$122,592`; source `County-adjusted Zillow/ACS estimate · ACS 2020-2024 5-year · low · low confidence: no current city index`; narrative matched amount and source.
- `0800620` suppressed county-adjusted: stat `$52,038`; narrative omitted the home affordability sentence as intended.

## Tests
- `node --check js/hna/hna-utils.js`
- `node --check js/hna/hna-renderers.js`
- `node --check js/hna/hna-narratives.js`
- `node test/hna-home-value-cascade.test.js`
- `npm run test:hna` — 730 passed, 0 failed
- `npm run validate`

## Known limitations
- This intentionally does not unify the site's three mortgage affordability formulas; Phase 0.1 calls that out as a separate follow-up.
