### PR TITLE
Add semantic label evidence guard

### DIFF
--- a/data/schema/semantic-label-evidence.json
+++ b/data/schema/semantic-label-evidence.json
@@ -1,0 +1,155 @@
+{
+  "schema": "semantic-label-evidence/v1",
+  "description": "Evidence-type declarations for semantic labels whose names can imply analytical judgment.",
+  "allowed_evidence_types": [
+    "computed",
+    "curated",
+    "source-membership",
+    "modeled"
+  ],
+  "watched_files": [
+    "scripts/build-affordable-housing-properties.js",
+    "js/hna/hna-ownership-need.js",
+    "scripts/hna/build_jurisdiction_metrics_digest.mjs"
+  ],
+  "declarations": [
+    {
+      "file": "scripts/build-affordable-housing-properties.js",
+      "token": "preservation-candidate",
+      "evidence_type": "source-membership",
+      "rationale": "The tag records membership in CHFA/HUD/USDA/local preservation-source feeds, not a finding that restrictions are at risk."
+    },
+    {
+      "file": "scripts/build-affordable-housing-properties.js",
+      "token": "risk_status",
+      "evidence_type": "computed",
+      "rationale": "Derived mechanically from finite years_to_expiration buckets."
+    },
+    {
+      "file": "scripts/build-affordable-housing-properties.js",
+      "token": "preservationRiskStatus",
+      "evidence_type": "computed",
+      "rationale": "Helper that computes risk_status from restrictive-expiration timing."
+    },
+    {
+      "file": "js/hna/hna-ownership-need.js",
+      "token": "tenureMixRecommendation",
+      "evidence_type": "modeled",
+      "rationale": "Screening recommendation modeled from CHAS pressure tiers, ownership-fit inputs, and affordability test outputs."
+    },
+    {
+      "file": "js/hna/hna-ownership-need.js",
+      "token": "affordabilityClassification",
+      "evidence_type": "modeled",
+      "rationale": "Nested output copied from the modeled affordability classification."
+    },
+    {
+      "file": "js/hna/hna-ownership-need.js",
+      "token": "Usable home-value input was unavailable or flagged for review; affordability classification omitted.",
+      "evidence_type": "modeled",
+      "rationale": "Displayed caveat for the modeled affordability classification suppression path."
+    },
+    {
+      "file": "js/hna/hna-ownership-need.js",
+      "token": "fitScore",
+      "evidence_type": "computed",
+      "rationale": "Internal formula score used to compute ownership-fit tier."
+    },
+    {
+      "file": "js/hna/hna-ownership-need.js",
+      "token": "ownershipScore",
+      "evidence_type": "computed",
+      "rationale": "Internal formula score used to compute ownership pressure tier."
+    },
+    {
+      "file": "js/hna/hna-ownership-need.js",
+      "token": "rentalScore",
+      "evidence_type": "computed",
+      "rationale": "Internal formula score used to compute rental pressure tier."
+    },
+    {
+      "file": "js/hna/hna-ownership-need.js",
+      "token": "tierFromScore",
+      "evidence_type": "computed",
+      "rationale": "Helper maps computed scores into tier labels."
+    },
+    {
+      "file": "scripts/hna/build_jurisdiction_metrics_digest.mjs",
+      "token": "ownership_need_recommendation",
+      "evidence_type": "modeled",
+      "rationale": "Digest metric sourced from the Affordable Ownership Need screening module recommendation."
+    },
+    {
+      "file": "scripts/hna/build_jurisdiction_metrics_digest.mjs",
+      "token": "recommendation",
+      "evidence_type": "modeled",
+      "rationale": "Ownership digest record field sourced from tenureMixRecommendation."
+    },
+    {
+      "file": "scripts/hna/build_jurisdiction_metrics_digest.mjs",
+      "token": "Affordable Ownership Need recommendation",
+      "evidence_type": "modeled",
+      "rationale": "Brief-source label for the Affordable Ownership Need screening recommendation."
+    },
+    {
+      "file": "scripts/hna/build_jurisdiction_metrics_digest.mjs",
+      "token": "tenureMixRecommendation",
+      "evidence_type": "modeled",
+      "rationale": "Input field consumed from js/hna/hna-ownership-need.js."
+    },
+    {
+      "file": "scripts/hna/build_jurisdiction_metrics_digest.mjs",
+      "token": "affordability_classification",
+      "evidence_type": "modeled",
+      "rationale": "Digest/artifact field sourced from the modeled affordability classification, with flagged home values suppressed."
+    },
+    {
+      "file": "scripts/hna/build_jurisdiction_metrics_digest.mjs",
+      "token": "score",
+      "evidence_type": "computed",
+      "rationale": "Generic metric name emitted with measure_type/formula metadata in the digest builder."
+    },
+    {
+      "file": "scripts/hna/build_jurisdiction_metrics_digest.mjs",
+      "token": "amenity_access_score",
+      "evidence_type": "computed",
+      "rationale": "Ranking-index score carried into the digest with metric provenance."
+    },
+    {
+      "file": "scripts/hna/build_jurisdiction_metrics_digest.mjs",
+      "token": "commuter_pressure_score",
+      "evidence_type": "computed",
+      "rationale": "Ranking-index score carried into the digest with metric provenance."
+    },
+    {
+      "file": "scripts/hna/build_jurisdiction_metrics_digest.mjs",
+      "token": "cost_burden_pressure_score",
+      "evidence_type": "computed",
+      "rationale": "Ranking-index score carried into the digest with metric provenance."
+    },
+    {
+      "file": "scripts/hna/build_jurisdiction_metrics_digest.mjs",
+      "token": "future_pressure_score",
+      "evidence_type": "computed",
+      "rationale": "Ranking-index score carried into the digest with metric provenance."
+    },
+    {
+      "file": "scripts/hna/build_jurisdiction_metrics_digest.mjs",
+      "token": "qct_dda_score",
+      "evidence_type": "computed",
+      "rationale": "Ranking-index score carried into the digest with metric provenance."
+    },
+    {
+      "file": "scripts/hna/build_jurisdiction_metrics_digest.mjs",
+      "token": "walkability_score",
+      "evidence_type": "computed",
+      "rationale": "Ranking-index score carried into the digest with metric provenance."
+    },
+    {
+      "file": "scripts/hna/build_jurisdiction_metrics_digest.mjs",
+      "token": "workforce_housing_pressure_score",
+      "evidence_type": "computed",
+      "rationale": "Descriptive formula score explicitly labeled as not used for ranking."
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:html": "npx htmlhint '*.html'",
     "lint:css": "npx stylelint 'css/*.css'",
     "test": "npm run test:ci",
-    "test:ci": "npm run validate && npm run validate:data && npm run validate:rosters && npm run test:fetch-helper && npm run test:hna && npm run test:hna-ownership-need && npm run test:combined-geo && npm run test:validate && npm run test:pro-forma && npm run test:qap-simulator && npm run test:pma-competitive-set && npm run test:lihtc-deal-predictor && npm run test:lihtc-opportunity-finder-zori && npm run test:pma-transit && npm run test:soft-funding-tracker && npm run test:hna-ranking-index && npm run test:ranking-fresh && npm run test:ranking-scenarios && npm run test:hna-home-values && npm run test:jurisdiction-metrics-digest && npm run test:place-pages && npm run test:place-pages-fresh && npm run test:car-showingtime && npm run test:hna-car-loader && npm run test:developer-geoids && npm run test:developer-brief-hna && npm run test:navigation-paths && npm run test:f116-r1 && npm run test:pill-contrast && npm run test:inline-contrast && npm run test:inline-heading-typography && npm run test:phantom-css-vars && npm run test:data-scope && npm run test:fetch-error-surface && npm run test:hna-acs-coverage && npm run test:nodemailer-v9 && npm run test:briefs && npm run test:public-build",
+    "test:ci": "npm run validate && npm run validate:data && npm run validate:rosters && npm run test:fetch-helper && npm run test:hna && npm run test:hna-ownership-need && npm run test:combined-geo && npm run test:validate && npm run test:pro-forma && npm run test:qap-simulator && npm run test:pma-competitive-set && npm run test:lihtc-deal-predictor && npm run test:lihtc-opportunity-finder-zori && npm run test:pma-transit && npm run test:soft-funding-tracker && npm run test:hna-ranking-index && npm run test:ranking-fresh && npm run test:ranking-scenarios && npm run test:hna-home-values && npm run test:jurisdiction-metrics-digest && npm run test:place-pages && npm run test:place-pages-fresh && npm run test:car-showingtime && npm run test:hna-car-loader && npm run test:developer-geoids && npm run test:developer-brief-hna && npm run test:navigation-paths && npm run test:f116-r1 && npm run test:pill-contrast && npm run test:inline-contrast && npm run test:inline-heading-typography && npm run test:phantom-css-vars && npm run test:data-scope && npm run test:fetch-error-surface && npm run test:semantic-labels && npm run test:hna-acs-coverage && npm run test:nodemailer-v9 && npm run test:briefs && npm run test:public-build",
     "test:developer-geoids": "node test/developer-geoids.test.js",
     "test:developer-brief-hna": "node test/developer-brief-hna.test.js",
     "test:navigation-paths": "node test/navigation-paths.test.js",
@@ -95,7 +95,8 @@
     "test:smoke": "node test/smoke-f139.test.js",
     "audit:coverage": "node scripts/coverage-audit.js",
     "audit:coverage:strict": "node scripts/coverage-audit.js --strict",
-    "audit:data-sources": "python3 scripts/check-data-source-health.py --fail-on-error"
+    "audit:data-sources": "python3 scripts/check-data-source-health.py --fail-on-error",
+    "test:semantic-labels": "node test/semantic-label-guard.test.js"
   },
   "dependencies": {
     "jsdom": "^29.1.1"

--- a/test/semantic-label-guard.test.js
+++ b/test/semantic-label-guard.test.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const SCHEMA_PATH = path.join(ROOT, 'data/schema/semantic-label-evidence.json');
+const KEYWORD_RE = /(candidate|risk|recommendation|classification|score)/i;
+const STRING_RE = /['"`]([^'"`\n]{0,180})['"`]/g;
+const IDENT_RE = /\b[A-Za-z_][A-Za-z0-9_]*(?:candidate|risk|recommendation|classification|score)[A-Za-z0-9_]*\b/gi;
+
+function read(rel) {
+  return fs.readFileSync(path.join(ROOT, rel), 'utf8');
+}
+
+function stripComments(src) {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+function semanticTokens(src) {
+  const stripped = stripComments(src);
+  const tokens = new Set();
+  for (const match of stripped.matchAll(STRING_RE)) {
+    const token = match[1].trim();
+    if (KEYWORD_RE.test(token)) tokens.add(token);
+  }
+  for (const match of stripped.matchAll(IDENT_RE)) {
+    tokens.add(match[0]);
+  }
+  return Array.from(tokens).sort();
+}
+
+function declarationKey(file, token) {
+  return `${file}\u0000${token}`;
+}
+
+function missingEvidenceForSources(files, declarations) {
+  const declared = new Set(declarations.map((d) => declarationKey(d.file, d.token)));
+  const missing = [];
+  for (const [file, src] of Object.entries(files)) {
+    for (const token of semanticTokens(src)) {
+      if (!declared.has(declarationKey(file, token))) missing.push({ file, token });
+    }
+  }
+  return missing;
+}
+
+const schema = JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf8'));
+assert.strictEqual(schema.schema, 'semantic-label-evidence/v1');
+assert(Array.isArray(schema.watched_files) && schema.watched_files.length > 0, 'schema must list watched files');
+assert(Array.isArray(schema.declarations) && schema.declarations.length > 0, 'schema must declare semantic label evidence');
+
+const allowed = new Set(schema.allowed_evidence_types || []);
+for (const expected of ['computed', 'curated', 'source-membership', 'modeled']) {
+  assert(allowed.has(expected), `missing allowed evidence type ${expected}`);
+}
+
+const seen = new Set();
+for (const declaration of schema.declarations) {
+  assert(schema.watched_files.includes(declaration.file), `${declaration.token} points at unwatched file ${declaration.file}`);
+  assert(allowed.has(declaration.evidence_type), `${declaration.token} has invalid evidence_type ${declaration.evidence_type}`);
+  assert(declaration.rationale && declaration.rationale.length >= 20, `${declaration.token} needs a useful rationale`);
+  const key = declarationKey(declaration.file, declaration.token);
+  assert(!seen.has(key), `duplicate declaration for ${declaration.file} ${declaration.token}`);
+  seen.add(key);
+  assert(read(declaration.file).includes(declaration.token), `${declaration.file} no longer contains declared token ${declaration.token}`);
+}
+
+const watchedSources = Object.fromEntries(schema.watched_files.map((file) => [file, read(file)]));
+const missing = missingEvidenceForSources(watchedSources, schema.declarations);
+assert.deepStrictEqual(missing, [], `semantic labels missing evidence declarations:\n${missing.map((m) => `- ${m.file}: ${m.token}`).join('\n')}`);
+
+const oldPreservationBugFixture = {
+  'scripts/build-affordable-housing-properties.js': "return { program_type: ['preservation-candidate'], property_name: p.PROJECT || null };",
+};
+const oldBugDeclarations = schema.declarations.filter((d) => d.token !== 'preservation-candidate');
+const oldBugMissing = missingEvidenceForSources(oldPreservationBugFixture, oldBugDeclarations);
+assert(
+  oldBugMissing.some((m) => m.token === 'preservation-candidate'),
+  'guard should catch the pre-0.2 preservation-candidate source-membership bug when evidence is omitted',
+);
+
+const ownershipNeed = JSON.parse(read('data/hna/ownership-need.json'));
+const sampleRecord = Object.values(ownershipNeed.records || {}).find((r) => r && r.recommendation && r.affordability_classification);
+assert(sampleRecord, 'ownership artifact should include recommendation and affordability_classification labels');
+assert(seen.has(declarationKey('scripts/hna/build_jurisdiction_metrics_digest.mjs', 'ownership_need_recommendation')), 'ownership recommendation digest label must be declared');
+assert(seen.has(declarationKey('scripts/hna/build_jurisdiction_metrics_digest.mjs', 'affordability_classification')), 'affordability classification digest label must be declared');
+
+const properties = JSON.parse(read('data/affordable-housing/properties.json'));
+const preservation = (properties.properties || []).find((p) => (p.program_type || []).includes('preservation-candidate'));
+assert(preservation, 'properties artifact should include preservation-candidate source-membership labels');
+assert(seen.has(declarationKey('scripts/build-affordable-housing-properties.js', 'preservation-candidate')), 'preservation-candidate evidence type must be declared');
+assert.strictEqual(
+  schema.declarations.find((d) => d.file === 'scripts/build-affordable-housing-properties.js' && d.token === 'preservation-candidate').evidence_type,
+  'source-membership',
+  'preservation-candidate must remain source-membership, not risk/model output',
+);
+
+console.log('semantic-label-guard: ok');


### PR DESCRIPTION
## Summary
- Closes Phase 0 item 0.3 by adding a semantic-label evidence registry and guard test.
- Adds `data/schema/semantic-label-evidence.json` with allowed evidence types: `computed`, `curated`, `source-membership`, and `modeled`.
- Adds `test/semantic-label-guard.test.js`, which scans the Phase 0 target files for semantic label tokens containing `candidate`, `risk`, `recommendation`, `classification`, or `score` and fails if the token lacks a schema declaration.
- Wires the guard into `npm run test:ci` as `npm run test:semantic-labels`.

## Current-code verification
- Re-read Phase 0.3 in `docs/audits/CODEX-HANDOFF-AUDIT-PHASE0-2026-07.md` before changing files.
- Verified #1082 left `preservation-candidate` as a source-membership tag and added `risk_status` as the computed risk/expiration field.
- Verified `js/hna/hna-ownership-need.js` still emits modeled recommendation/classification labels (`tenureMixRecommendation`, `affordabilityClassification`, etc.).
- Verified `scripts/hna/build_jurisdiction_metrics_digest.mjs` already carries measure/provenance metadata for recommendation/classification/score metrics, then declared those labels in the new schema.

## Non-vacuous guard evidence
- The test includes a deliberately old-style fixture: `program_type: ['preservation-candidate']` with the `preservation-candidate` declaration removed.
- That fixture must produce a missing-evidence finding, proving the guard would catch the pre-0.2 bug instead of passing vacuously.

## Tests
- `node --check test/semantic-label-guard.test.js`
- `npm run test:semantic-labels`
- `npm run validate`
- `npm run test:jurisdiction-metrics-digest` — passed when rerun outside the sandbox; the first sandboxed attempt failed with EPERM during the test's intentional `rmSync`/regeneration of `data/hna/jurisdiction-metrics-digest`.

## Known limitations
- The scanner is intentionally scoped to the Phase 0.3 target files, not the whole repository, to avoid unrelated audit/test wording such as generic `recommendation` fields.
- Future modules with user-facing candidate/risk/recommendation/classification/score labels should either be added to `watched_files` or covered by a follow-up broader semantic-label pass.
