### PR TITLE
Use production Opportunity Finder weights in verifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:html": "npx htmlhint '*.html'",
     "lint:css": "npx stylelint 'css/*.css'",
     "test": "npm run test:ci",
-    "test:ci": "npm run validate && npm run validate:data && npm run validate:rosters && npm run test:fetch-helper && npm run test:hna && npm run test:hna-ownership-need && npm run test:combined-geo && npm run test:validate && npm run test:pro-forma && npm run test:qap-simulator && npm run test:pma-competitive-set && npm run test:lihtc-deal-predictor && npm run test:lihtc-opportunity-finder-zori && npm run test:pma-transit && npm run test:soft-funding-tracker && npm run test:hna-ranking-index && npm run test:ranking-fresh && npm run test:ranking-scenarios && npm run test:hna-home-values && npm run test:jurisdiction-metrics-digest && npm run test:place-pages && npm run test:place-pages-fresh && npm run test:car-showingtime && npm run test:hna-car-loader && npm run test:developer-geoids && npm run test:developer-brief-hna && npm run test:navigation-paths && npm run test:f116-r1 && npm run test:pill-contrast && npm run test:inline-contrast && npm run test:inline-heading-typography && npm run test:phantom-css-vars && npm run test:data-scope && npm run test:fetch-error-surface && npm run test:semantic-labels && npm run test:hna-acs-coverage && npm run test:nodemailer-v9 && npm run test:briefs && npm run test:public-build",
+    "test:ci": "npm run validate && npm run validate:data && npm run validate:rosters && npm run test:fetch-helper && npm run test:hna && npm run test:hna-ownership-need && npm run test:combined-geo && npm run test:validate && npm run test:pro-forma && npm run test:qap-simulator && npm run test:pma-competitive-set && npm run test:lihtc-deal-predictor && npm run test:lihtc-opportunity-finder-zori && npm run test:opportunity-finder-verifier-source && npm run test:pma-transit && npm run test:soft-funding-tracker && npm run test:hna-ranking-index && npm run test:ranking-fresh && npm run test:ranking-scenarios && npm run test:hna-home-values && npm run test:jurisdiction-metrics-digest && npm run test:place-pages && npm run test:place-pages-fresh && npm run test:car-showingtime && npm run test:hna-car-loader && npm run test:developer-geoids && npm run test:developer-brief-hna && npm run test:navigation-paths && npm run test:f116-r1 && npm run test:pill-contrast && npm run test:inline-contrast && npm run test:inline-heading-typography && npm run test:phantom-css-vars && npm run test:data-scope && npm run test:fetch-error-surface && npm run test:semantic-labels && npm run test:hna-acs-coverage && npm run test:nodemailer-v9 && npm run test:briefs && npm run test:public-build",
     "test:developer-geoids": "node test/developer-geoids.test.js",
     "test:developer-brief-hna": "node test/developer-brief-hna.test.js",
     "test:navigation-paths": "node test/navigation-paths.test.js",
@@ -96,7 +96,8 @@
     "audit:coverage": "node scripts/coverage-audit.js",
     "audit:coverage:strict": "node scripts/coverage-audit.js --strict",
     "audit:data-sources": "python3 scripts/check-data-source-health.py --fail-on-error",
-    "test:semantic-labels": "node test/semantic-label-guard.test.js"
+    "test:semantic-labels": "node test/semantic-label-guard.test.js",
+    "test:opportunity-finder-verifier-source": "node test/opportunity-finder-verifier-source.test.mjs"
   },
   "dependencies": {
     "jsdom": "^29.1.1"

--- a/scripts/audit/verify-opportunity-finder.mjs
+++ b/scripts/audit/verify-opportunity-finder.mjs
@@ -40,8 +40,10 @@
  */
 
 import fs from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT      = path.resolve(__dirname, '..', '..');
@@ -51,24 +53,82 @@ const JSON_OUT  = ARGV.has('--json');
 
 const CURRENT_YEAR = 2026;
 
-/* ── Score weights — must match js/lihtc-opportunity-finder.js ────── */
-// 5-dimension weighting per methodology §4. Each target sums to 1.0.
-// F9 (2026-05-26): civic bumped on 9pct/4pct/workforce_resort to reflect
-// real CHFA QAP signals (Prop 123 commitment, housing authority infra).
-// Must match SCORE_WEIGHTS in js/lihtc-opportunity-finder.js exactly.
-const SCORE_WEIGHTS = {
-  '9pct':              { need: 0.30, recency: 0.22, basis: 0.15, pop: 0.15, civic: 0.18 },
-  '4pct':              { need: 0.25, recency: 0.12, basis: 0.15, pop: 0.30, civic: 0.18 },
-  'preservation':      { need: 0.20, recency: 0.15, basis: 0.35, pop: 0.10, civic: 0.20 },
-  'workforce_resort':  { need: 0.25, recency: 0.15, basis: 0.15, pop: 0.25, civic: 0.20 },
-  'prop123_local':     { need: 0.25, recency: 0.10, basis: 0.20, pop: 0.15, civic: 0.30 },
-  'any':               { need: 0.25, recency: 0.20, basis: 0.15, pop: 0.20, civic: 0.20 }
-};
+/* ── Score weights — extracted from production source ─────────────── */
+// Keep the verifier structurally tied to js/lihtc-opportunity-finder.js.
+// The browser module is an IIFE, so this script extracts the literals rather
+// than maintaining a second copy that can drift.
+export const EXPECTED_SCORE_TARGETS = ['9pct', '4pct', 'preservation', 'workforce_resort', 'prop123_local', 'any'];
+export const EXPECTED_SCORE_FACTORS = ['need', 'recency', 'basis', 'pop', 'civic'];
 
-// F9: CDP penalty applied on incorporation-sensitive targets. Must match
-// CDP_PENALTY + CDP_PENALTY_TARGETS in js/lihtc-opportunity-finder.js.
-const CDP_PENALTY = -8;
-const CDP_PENALTY_TARGETS = new Set(['9pct', '4pct', 'workforce_resort', 'any']);
+function _extractBalancedLiteral(source, name) {
+  const assignment = new RegExp('(?:var|const|let)\\s+' + name + '\\s*=\\s*', 'm');
+  const match = assignment.exec(source);
+  if (!match) throw new Error('Cannot find ' + name + ' assignment in js/lihtc-opportunity-finder.js');
+  let i = match.index + match[0].length;
+  while (/\s/.test(source[i])) i++;
+  if (source[i] !== '{') {
+    const scalar = /^[^;]+/.exec(source.slice(i));
+    if (!scalar) throw new Error('Cannot parse scalar assignment for ' + name);
+    return scalar[0].trim();
+  }
+  let depth = 0;
+  let quote = null;
+  for (let j = i; j < source.length; j++) {
+    const ch = source[j];
+    const prev = source[j - 1];
+    if (quote) {
+      if (ch === quote && prev !== '\\') quote = null;
+      continue;
+    }
+    if (ch === '\'' || ch === '"' || ch === '`') { quote = ch; continue; }
+    if (ch === '{') depth++;
+    if (ch === '}') {
+      depth--;
+      if (depth === 0) return source.slice(i, j + 1);
+    }
+  }
+  throw new Error('Unbalanced object literal for ' + name);
+}
+
+function _evalLiteral(literal, name) {
+  try {
+    return vm.runInNewContext('(' + literal + ')', Object.create(null), { timeout: 1000 });
+  } catch (err) {
+    throw new Error('Cannot evaluate ' + name + ' literal: ' + err.message);
+  }
+}
+
+export function extractOpportunityFinderConfig(source) {
+  const weights = _evalLiteral(_extractBalancedLiteral(source, 'SCORE_WEIGHTS'), 'SCORE_WEIGHTS');
+  const penalty = Number(_extractBalancedLiteral(source, 'CDP_PENALTY'));
+  const penaltyTargetsObject = _evalLiteral(_extractBalancedLiteral(source, 'CDP_PENALTY_TARGETS'), 'CDP_PENALTY_TARGETS');
+  const penaltyTargets = Object.keys(penaltyTargetsObject).filter((key) => penaltyTargetsObject[key]);
+
+  if (!Number.isFinite(penalty)) throw new Error('CDP_PENALTY is not finite');
+  for (const target of EXPECTED_SCORE_TARGETS) {
+    if (!weights[target]) throw new Error('SCORE_WEIGHTS missing target ' + target);
+    for (const factor of EXPECTED_SCORE_FACTORS) {
+      if (!Number.isFinite(weights[target][factor])) {
+        throw new Error('SCORE_WEIGHTS.' + target + '.' + factor + ' is not finite');
+      }
+    }
+  }
+  return {
+    scoreWeights: JSON.parse(JSON.stringify(weights)),
+    cdpPenalty: penalty,
+    cdpPenaltyTargets: penaltyTargets,
+  };
+}
+
+export function loadOpportunityFinderConfig(rootDir = ROOT) {
+  const source = readFileSync(path.join(rootDir, 'js/lihtc-opportunity-finder.js'), 'utf8');
+  return extractOpportunityFinderConfig(source);
+}
+
+const OPPORTUNITY_FINDER_CONFIG = loadOpportunityFinderConfig();
+const SCORE_WEIGHTS = OPPORTUNITY_FINDER_CONFIG.scoreWeights;
+const CDP_PENALTY = OPPORTUNITY_FINDER_CONFIG.cdpPenalty;
+const CDP_PENALTY_TARGETS = new Set(OPPORTUNITY_FINDER_CONFIG.cdpPenaltyTargets);
 
 /* ── Pretty printing ──────────────────────────────────────────────── */
 
@@ -542,7 +602,9 @@ async function main() {
   process.exit(failures === 0 ? 0 : 1);
 }
 
-main().catch(e => {
-  console.error(`${C.red}Internal error:${C.reset} ${e.stack || e.message}`);
-  process.exit(2);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(e => {
+    console.error(`${C.red}Internal error:${C.reset} ${e.stack || e.message}`);
+    process.exit(2);
+  });
+}

--- a/test/opportunity-finder-verifier-source.test.mjs
+++ b/test/opportunity-finder-verifier-source.test.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  EXPECTED_SCORE_FACTORS,
+  EXPECTED_SCORE_TARGETS,
+  extractOpportunityFinderConfig,
+} from '../scripts/audit/verify-opportunity-finder.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const sourcePath = path.join(ROOT, 'js/lihtc-opportunity-finder.js');
+const source = fs.readFileSync(sourcePath, 'utf8');
+const config = extractOpportunityFinderConfig(source);
+
+assert.deepEqual(Object.keys(config.scoreWeights).sort(), EXPECTED_SCORE_TARGETS.slice().sort(), 'verifier should extract all production score targets');
+for (const target of EXPECTED_SCORE_TARGETS) {
+  assert.deepEqual(Object.keys(config.scoreWeights[target]).sort(), EXPECTED_SCORE_FACTORS.slice().sort(), `${target} should have all score factors`);
+  const sum = EXPECTED_SCORE_FACTORS.reduce((acc, factor) => acc + config.scoreWeights[target][factor], 0);
+  assert(Math.abs(sum - 1.0) < 1e-9, `${target} weights should sum to 1.0; got ${sum}`);
+}
+
+assert.deepEqual(config.scoreWeights['4pct'], {
+  need: 0.30,
+  recency: 0.17,
+  basis: 0.15,
+  pop: 0.20,
+  civic: 0.18,
+}, '4pct verifier weights should come from the F254b production row');
+assert.equal(config.cdpPenalty, -8, 'verifier should extract production CDP penalty');
+assert.deepEqual(config.cdpPenaltyTargets.sort(), ['4pct', '9pct', 'any', 'workforce_resort'].sort(), 'verifier should extract production CDP penalty targets');
+
+const mutatedSource = source.replace(
+  "'4pct':              { need: 0.30, recency: 0.17, basis: 0.15, pop: 0.20, civic: 0.18 }",
+  "'4pct':              { need: 0.31, recency: 0.16, basis: 0.15, pop: 0.20, civic: 0.18 }",
+);
+assert.notEqual(mutatedSource, source, 'mutation fixture should alter the production source string');
+const mutatedConfig = extractOpportunityFinderConfig(mutatedSource);
+assert.equal(mutatedConfig.scoreWeights['4pct'].need, 0.31, 'extractor should observe a production-source weight edit');
+assert.notDeepEqual(mutatedConfig.scoreWeights['4pct'], config.scoreWeights['4pct'], 'guard should catch production/verifier weight drift');
+
+console.log('opportunity-finder-verifier-source: ok');


### PR DESCRIPTION
## Summary
- Closes Phase 1 item 1.1 by removing the duplicated Opportunity Finder weight table from the verifier.
- `scripts/audit/verify-opportunity-finder.mjs` now extracts `SCORE_WEIGHTS`, `CDP_PENALTY`, and `CDP_PENALTY_TARGETS` from `js/lihtc-opportunity-finder.js` at runtime.
- Adds `test/opportunity-finder-verifier-source.test.mjs` and wires it into `test:ci` as `npm run test:opportunity-finder-verifier-source`.

## Current-code verification
- Re-read `docs/audits/CODEX-HANDOFF-AUDIT-PHASE1-2026-07.md` before changing code.
- Confirmed production `4pct` weights are `{ need: 0.30, recency: 0.17, basis: 0.15, pop: 0.20, civic: 0.18 }`.
- Confirmed the verifier had the stale pre-F254b `4pct` row `{ need: 0.25, recency: 0.12, basis: 0.15, pop: 0.30, civic: 0.18 }` before this PR.
- Confirmed all six target rows are now extracted from production source and still sum to 1.0.

## Non-vacuousness proof
- Temporarily edited production `js/lihtc-opportunity-finder.js` locally to change the `4pct` row to `{ need: 0.31, recency: 0.16, basis: 0.15, pop: 0.20, civic: 0.18 }`.
- `npm run test:opportunity-finder-verifier-source` failed on the `4pct` assertion and showed the changed `need`/`recency` values.
- Reverted the temporary edit and reran the test; it passed.

## Tests
- `node --check scripts/audit/verify-opportunity-finder.mjs`
- `node --check test/opportunity-finder-verifier-source.test.mjs`
- `npm run test:opportunity-finder-verifier-source`
- `npm run test:lihtc-opportunity-finder-zori`
- `npm run audit:opportunity-finder` — all 36 checks passed
- `npm run validate`

## Known limitations
- This keeps production `js/lihtc-opportunity-finder.js` as the single source of truth instead of introducing a shared runtime module. If the browser file stops using straightforward literal assignments for these config objects, the verifier extractor will fail loudly rather than silently passing.
