### PR TITLE
Phase 2.1: consolidate Data Trust Center

### DIFF
--- a/dashboard-data-quality.html
+++ b/dashboard-data-quality.html
@@ -188,7 +188,7 @@
   <!-- Page Header -->
   <div class="page-header" style="margin-bottom:1.5rem;">
     <h1 class="page-title">Coverage QA <span style="font-size:.55em;font-weight:400;color:var(--muted);margin-left:.4rem">(was "Data Quality Dashboard")</span></h1>
-    <p class="page-subtitle">API configuration status, per-source coverage %, and place-CHAS apportionment audit. Use the <a href="data-review-hub.html">Data Hub</a> for the full source inventory.</p>
+    <p class="page-subtitle">API configuration status, per-source coverage %, and place-CHAS apportionment audit. The 5-layer QA status and place-coverage panels below are also summarized in the <a href="data-review-hub.html">Data Trust Center</a>'s QA Coverage tab; use this page for the full source inventory and maintainer tools (API keys, pipeline log).</p>
     <small id="dqTimestamp" class="data-timestamp"></small>
   </div>
 

--- a/data-review-hub.html
+++ b/data-review-hub.html
@@ -839,7 +839,7 @@
           come from a precise tract-level calculation or a broader county-level estimate.
         </p>
 
-        <h3 style="margin:0 0 .4rem;font-size:1rem;">What data is missing or estimated?</h3>
+        <h3 style="margin:0 0 .4rem;">What data is missing or estimated?</h3>
         <p class="drh-coverage-note">
           Every dataset runs through five automated checks — shape, row counts, numeric ranges,
           freshness against its own update schedule, and cross-source agreement — before it's
@@ -852,7 +852,7 @@
           <p id="drhQaStatusMeta" style="font-size:.78rem;color:var(--muted);margin:.5rem 0 0;">Status: loading…</p>
         </div>
 
-        <h3 style="margin:0 0 .4rem;font-size:1rem;">Is my place using precise or estimated data?</h3>
+        <h3 style="margin:0 0 .4rem;">Is my place using precise or estimated data?</h3>
         <p class="drh-coverage-note">
           Housing-need figures use two methodologies depending on the place: <strong>tract-aggregated</strong>
           (a TIGER 2024 spatial join — accurate for cross-county jurisdictions like Erie, Aurora, or Longmont)

--- a/data-review-hub.html
+++ b/data-review-hub.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="theme-color" content="#096e65" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="#0fd4cf" media="(prefers-color-scheme: dark)">
-  <title>Data Review &amp; Transparency Hub | COHO Analytics</title>
-  <meta name="description" content="Unified data source inventory, freshness monitoring, quality checks, and automated discovery for COHO Analytics.">
-  <meta property="og:title" content="Data Review &amp; Transparency Hub | COHO Analytics">
-  <meta property="og:description" content="Comprehensive data transparency: source inventory, freshness status, quality validation, and automated new-source discovery.">
+  <title>Data Trust Center | COHO Analytics</title>
+  <meta name="description" content="Where every COHO Analytics number comes from: source inventory, freshness monitoring, automated QA coverage, and place-level data provenance.">
+  <meta property="og:title" content="Data Trust Center | COHO Analytics">
+  <meta property="og:description" content="Where every number comes from: source inventory, freshness status, automated QA coverage, and place-level data provenance.">
   <meta property="og:type" content="website">
   <meta property="og:image" content="assets/og-image.png">
 
@@ -43,6 +43,7 @@
 
   <!-- Hub controllers (deferred so DOM is ready) -->
   <script defer src="js/discovery-ui-handler.js"></script>
+  <script defer src="js/place-chas-coverage-panel.js"></script>
   <script defer src="js/data-review-hub.js"></script>
 
   <style>
@@ -373,6 +374,32 @@
     .badge-error { display:inline-block;padding:.12rem .45rem;border-radius:1rem;background:var(--bad-dim); color:var(--bad); font-size:.75rem;font-weight:700; }
     .badge-loading { display:inline-block;padding:.12rem .45rem;border-radius:1rem;background:var(--bg2);color:var(--muted);font-size:.75rem;font-weight:700; }
 
+    /* ── QA Coverage tab (ported from dashboard-data-quality.html) ── */
+    .drh-qa-layer-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: .6rem;
+      margin-bottom: .5rem;
+    }
+    .drh-qa-layer-card {
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      padding: .6rem .75rem;
+    }
+    .drh-qa-layer-card--ok   { border-color: var(--good); background: var(--good-dim); }
+    .drh-qa-layer-card--fail { border-color: var(--bad);  background: var(--bad-dim); }
+    .drh-qa-layer-title { font-size: .95em; font-weight: 700; margin-bottom: .2rem; }
+    .drh-qa-layer-card--ok   .drh-qa-layer-title { color: var(--good); }
+    .drh-qa-layer-card--fail .drh-qa-layer-title { color: var(--bad); }
+    .drh-qa-layer-help    { font-size: .75rem; color: var(--muted); margin-bottom: .2rem; }
+    .drh-qa-layer-summary { font-size: .78rem; font-weight: 500; color: var(--text); }
+    .drh-coverage-note {
+      font-size: .85rem;
+      color: var(--muted);
+      margin: 0 0 .75rem;
+      line-height: 1.5;
+    }
+
     /* ── Pending discovery tab ── */
     .drh-pending-card {
       background: var(--card);
@@ -571,10 +598,11 @@
 
   <!-- Hero -->
   <div class="drh-hero">
-    <h1>Data Review &amp; Transparency Hub</h1>
+    <h1>Data Trust Center <span style="font-size:.55em;font-weight:400;color:var(--muted);margin-left:.4rem">(formerly Data Review Hub)</span></h1>
     <p>
-      Unified inventory of all COHO Analytics data sources — freshness status, quality checks,
-      attribute metadata, and automated discovery of new data files.
+      What's fresh, where it comes from, and what's estimated. Unified inventory of all COHO
+      Analytics data sources — freshness status, source-level QA checks, and automated
+      discovery of new data files.
       <small class="data-timestamp" id="drhTimestamp" style="display:block;margin-top:.2rem;opacity:.7"></small>
     </p>
     <!-- Monitoring status badge -->
@@ -685,6 +713,7 @@
         <button data-tab="overview"   role="tab" aria-selected="true"  tabindex="0"  class="drh-tab--active">📊 Overview</button>
         <button data-tab="sources"    role="tab" aria-selected="false" tabindex="-1">🗂 Sources</button>
         <button data-tab="quality"    role="tab" aria-selected="false" tabindex="-1">✅ Quality</button>
+        <button data-tab="coverage"   role="tab" aria-selected="false" tabindex="-1">🛡 QA Coverage</button>
         <button data-tab="discovery"  role="tab" aria-selected="false" tabindex="-1">🔍 Pending Discovery<span id="drhPendingCount" aria-live="polite"></span></button>
         <button data-tab="admin"      role="tab" aria-selected="false" tabindex="-1">⚙️ Admin</button>
       </div>
@@ -725,25 +754,28 @@
         </div>
 
         <div class="card" style="padding:1rem;margin-bottom:1rem;">
-          <h3 style="margin:0 0 .5rem;">About This Hub</h3>
+          <h3 style="margin:0 0 .5rem;">About This Page</h3>
           <p style="font-size:.85rem;color:var(--muted);margin:0;line-height:1.55;">
-            The Data Review &amp; Transparency Hub consolidates all COHO Analytics data source
-            information into a single, searchable interface. It shows where each dataset is used,
-            its current freshness status, quality validation results, and attribute metadata.
-            Automated daily scans detect new or unregistered data files and surface them in the
-            <strong>Pending Discovery</strong> tab for administrator review.
+            This is the single place to answer "can I trust this data?" — <strong>Sources</strong> shows
+            where every dataset comes from, <strong>Quality</strong> shows current freshness status,
+            and <strong>QA Coverage</strong> shows whether the data passed automated structural checks
+            and whether your place uses precise or estimated methodology. Automated daily scans detect
+            new or unregistered data files and surface them in the <strong>Pending Discovery</strong> tab
+            for administrator review.
           </p>
         </div>
 
         <div class="card" style="padding:1rem;">
-          <h3 style="margin:0 0 .75rem;">Quick Links</h3>
+          <h3 style="margin:0 0 .75rem;">Raw Files</h3>
           <ul style="font-size:.88rem;margin:0;padding-left:1.2rem;line-height:2;">
-            <li><a href="dashboard-data-sources-ui.html">Legacy: Data Sources Dashboard</a></li>
-            <li><a href="data-status.html">Legacy: Data Status</a></li>
             <li><a href="DATA-MANIFEST.json" target="_blank" rel="noopener">DATA-MANIFEST.json ↗</a></li>
             <li><a href="data/manifest.json" target="_blank" rel="noopener">data/manifest.json ↗</a></li>
             <li><a href="config/data-discovery-config.json" target="_blank" rel="noopener">Discovery config ↗</a></li>
           </ul>
+          <p style="font-size:.78rem;color:var(--muted);margin:.75rem 0 0;">
+            More detailed, maintainer-oriented views (API key setup, raw pipeline logs) are linked
+            at the bottom of this page.
+          </p>
         </div>
       </section>
 
@@ -796,6 +828,40 @@
             </tbody>
           </table>
         </div>
+      </section>
+
+      <!-- ── QA Coverage panel (ported from dashboard-data-quality.html) ── -->
+      <section data-panel="coverage" hidden role="tabpanel" aria-label="QA coverage and methodology">
+        <h2 style="margin:0 0 .5rem;">QA Coverage</h2>
+        <p class="drh-coverage-note">
+          Beyond per-source freshness (the Quality tab), this checks whether the site's data
+          <em>passes structural and plausibility checks</em>, and whether each place's numbers
+          come from a precise tract-level calculation or a broader county-level estimate.
+        </p>
+
+        <h3 style="margin:0 0 .4rem;font-size:1rem;">What data is missing or estimated?</h3>
+        <p class="drh-coverage-note">
+          Every dataset runs through five automated checks — shape, row counts, numeric ranges,
+          freshness against its own update schedule, and cross-source agreement — before it's
+          considered trustworthy. See <a href="https://github.com/pggLLC/Housing-Analytics/blob/main/docs/CONTRIBUTING.md#qaqc-layers" rel="noopener" target="_blank">CONTRIBUTING.md</a> for the full technical definition of each layer.
+        </p>
+        <div class="card" style="padding:1rem;margin-bottom:1.5rem;">
+          <div class="drh-qa-layer-grid" id="drhQaLayerGrid" aria-label="Automated QA layer status">
+            <div class="drh-qa-layer-card"><div class="drh-qa-layer-title">Loading…</div></div>
+          </div>
+          <p id="drhQaStatusMeta" style="font-size:.78rem;color:var(--muted);margin:.5rem 0 0;">Status: loading…</p>
+        </div>
+
+        <h3 style="margin:0 0 .4rem;font-size:1rem;">Is my place using precise or estimated data?</h3>
+        <p class="drh-coverage-note">
+          Housing-need figures use two methodologies depending on the place: <strong>tract-aggregated</strong>
+          (a TIGER 2024 spatial join — accurate for cross-county jurisdictions like Erie, Aurora, or Longmont)
+          and <strong>primary-county fallback</strong> (used when a place isn't in TIGER coverage, so it
+          inherits its containing county's rates). This panel shows which bucket every place falls into so the
+          provenance is auditable rather than implied.
+        </p>
+        <div id="placeChasCoverage">Loading coverage data&hellip;</div>
+        <p id="placeChasCoverageStatus" style="font-size:.75rem;color:var(--muted);margin-top:.5rem"></p>
       </section>
 
       <!-- ── Pending Discovery panel ── -->
@@ -887,8 +953,8 @@
         <div style="margin-top:3px;font-size:.74rem;color:var(--muted)">Live API freshness + 5-layer validation rollup. Same content this hub surfaces in roll-up form, broken out per source.</div>
       </a>
       <a href="dashboard-data-quality.html" style="display:block;padding:.6rem .75rem;border:1px solid var(--border);border-radius:8px;background:var(--bg2);color:var(--text);text-decoration:none">
-        <div style="font-weight:600;font-size:.86rem">🔍 Coverage QA</div>
-        <div style="margin-top:3px;font-size:.74rem;color:var(--muted)">Per-source coverage % + place-CHAS apportionment audit. Use when you need to verify "is this place actually covered or are we using a county fallback?"</div>
+        <div style="font-weight:600;font-size:.86rem">🔍 Coverage QA (full detail)</div>
+        <div style="margin-top:3px;font-size:.74rem;color:var(--muted)">API config, raw pipeline log, and the same 5-layer QA + place-coverage panels shown in this hub's QA Coverage tab, plus admin-only content.</div>
       </a>
     </div>
   </section>

--- a/data-status.html
+++ b/data-status.html
@@ -210,7 +210,7 @@
         <h1>Pipeline Status <span style="font-size:.55em;font-weight:400;color:var(--muted);margin-left:.4rem">(was "Data Status")</span></h1>
         <p class="sub">
           Live freshness check for all critical datasets powering COHO
-          Analytics dashboards. Use the <a href="data-review-hub.html">Data Hub</a>
+          Analytics dashboards. Use the <a href="data-review-hub.html">Data Trust Center</a>
           for the full source inventory.
         </p>
         <div

--- a/js/data-review-hub.js
+++ b/js/data-review-hub.js
@@ -575,6 +575,67 @@
     if (btn) btn.addEventListener('click', runQualityCheck);
   }
 
+  // ── QA Coverage tab (ported from dashboard-data-quality.html's renderQaLayers) ──
+
+  function initQaCoveragePanel() {
+    var grid = document.getElementById('drhQaLayerGrid');
+    var meta = document.getElementById('drhQaStatusMeta');
+    if (!grid || !meta) return;
+
+    var fetcher = (typeof window.safeFetchJSON === 'function')
+      ? window.safeFetchJSON
+      : function (url) {
+          return fetch(url).then(function (r) {
+            if (!r.ok) throw new Error('HTTP ' + r.status);
+            return r.json();
+          });
+        };
+
+    fetcher('data/_qa-status.json').then(function (status) {
+      var layerOrder = ['schema', 'sentinel', 'bounds', 'freshness', 'plausibility'];
+      var layerLabels = {
+        schema: 'Schema', sentinel: 'Sentinel', bounds: 'Bounds',
+        freshness: 'Freshness', plausibility: 'Plausibility'
+      };
+      var layerHelp = {
+        schema: 'JSON shape + key presence',
+        sentinel: 'Row-count thresholds',
+        bounds: 'Numeric values in expected range',
+        freshness: 'Files within SLA',
+        plausibility: 'Cross-source agreement'
+      };
+      var html = '';
+      layerOrder.forEach(function (key) {
+        var s = status.summary && status.summary[key];
+        var ok = s === 'pass';
+        var detail = (status.layers && status.layers[key]) || {};
+        var summary;
+        if (key === 'freshness' && detail.files) {
+          summary = detail.ok + ' OK · ' + detail.stale + ' stale · ' + detail.missing + ' missing';
+        } else if (key === 'plausibility') {
+          summary = (detail.passed || 0) + ' passed · ' + (detail.failed || 0) + ' failed';
+        } else {
+          summary = ok ? 'all checks pass' : 'see details';
+        }
+        html +=
+          '<div class="drh-qa-layer-card drh-qa-layer-card--' + (ok ? 'ok' : 'fail') + '">' +
+            '<div class="drh-qa-layer-title">' + (ok ? '✓' : '✗') + ' ' + _esc(layerLabels[key]) + '</div>' +
+            '<div class="drh-qa-layer-help">' + _esc(layerHelp[key]) + '</div>' +
+            '<div class="drh-qa-layer-summary">' + _esc(summary) + '</div>' +
+          '</div>';
+      });
+      grid.innerHTML = html;
+      meta.textContent = 'Overall: ' + (status.overall || 'unknown').toUpperCase() +
+                        ' · Generated ' + new Date(status.generated_at).toLocaleString();
+    }).catch(function (err) {
+      grid.innerHTML = '<div style="grid-column:1/-1;color:var(--muted);font-size:.85em;padding:.6rem;">' +
+        'QA status not available (' + _esc(err.message || String(err)) + '). ' +
+        'Run <code>node scripts/audit/qa-status-generator.mjs</code> locally or trigger the daily ' +
+        '<code>data-quality-check.yml</code> workflow.</div>';
+      meta.textContent = '';
+    });
+  }
+
   // ── Overview stats from freshness report ─────────────────────────────────
 
   function renderOverview(report) {
@@ -694,6 +755,7 @@
     initModal();
     initExports();
     initQualityPanel();
+    initQaCoveragePanel();
 
     loadSources().then(function (sources) {
       state.sources = sources;

--- a/js/data-section-banner.js
+++ b/js/data-section-banner.js
@@ -24,8 +24,8 @@
   // Single source of truth for the section. Mirrors js/navigation.js
   // GROUPS[].items for "Data" minus the isHeader separator.
   var PAGES = [
-    { href: 'data-review-hub.html',         label: 'Data Hub',
-      role: 'Start here · sources, freshness, quality monitoring, discovery',
+    { href: 'data-review-hub.html',         label: 'Data Trust Center',
+      role: 'Start here · sources, freshness, QA coverage, discovery',
       kind: 'primary', icon: '★' },
     { href: 'data-explorer.html',           label: 'File Browser',
       role: 'Inspect every JSON / GeoJSON / CSV in data/ with schema previews',
@@ -37,7 +37,7 @@
       role: 'Interactive map of every geographic dataset — LIHTC, QCT/DDA, OZ, amenities',
       kind: 'primary', icon: '🗺️' },
     // F182 — Pipeline Status + Coverage QA are no longer cross-linked
-    // here either. They're reachable from the Data Hub footer
+    // here either. They're reachable from the Data Trust Center's footer
     // "Operational pages" section so engineers who need them can find
     // them, but the cross-link strip stays focused on the 3 primary
     // pages a user actually picks between.

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -56,18 +56,23 @@
       // pages (Data Health / Data Quality / Data Review / Data Explorer
       // / Census Explorer — the last mislabeled, it's actually a
       // multifamily housing dashboard). Now organized around 3 roles:
-      //   1. Data Hub        — start here · sources + transparency
+      //   1. Data Trust Center — start here · sources + transparency
       //   2. File Browser    — raw exploration of every JSON/GeoJSON
       //   3. Multifamily Lens — analytical view (was Census Explorer)
       // Pipeline Status + Coverage QA are kept reachable but demoted
       // since they're operational/QA pages that 95% of users don't need.
       // F182 — Data section trimmed to 3 primary pages. The two
       // operational/diagnostic pages (Pipeline Status, Coverage QA)
-      // are no longer in the nav; they're reachable from the Data Hub
-      // footer "Operational pages" section. Net: 5 → 3 in nav.
+      // are no longer in the nav; they're reachable from the Data Trust
+      // Center's footer "Operational pages" section. Net: 5 → 3 in nav.
+      // Phase 2.1 (2026-07) — renamed "Data Hub" to "Data Trust Center"
+      // and added a QA Coverage tab (5-layer status + place-level
+      // methodology provenance) so the page answers "can I trust this
+      // data?" without visiting 3 separate pages. See
+      // docs/audits/CODEX-HANDOFF-AUDIT-PHASE2-2026-07.md item 2.1.
       label: "Data",
       items: [
-        { label: "Data Hub",              href: "data-review-hub.html",           desc: "Start here · sources, freshness, quality monitoring, and discovery" },
+        { label: "Data Trust Center",      href: "data-review-hub.html",           desc: "Start here · sources, freshness, QA coverage, and discovery" },
         { label: "File Browser",          href: "data-explorer.html",             desc: "Inspect every JSON / GeoJSON / CSV in data/ with schema previews" },
         { label: "Data Map",              href: "data-map-browser.html",          desc: "Interactive map of every geographic dataset — LIHTC, QCT/DDA, OZ, amenities, flood zones", isNew: true },
       ]

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:html": "npx htmlhint '*.html'",
     "lint:css": "npx stylelint 'css/*.css'",
     "test": "npm run test:ci",
-    "test:ci": "npm run validate && npm run validate:data && npm run validate:rosters && npm run test:fetch-helper && npm run test:hna && npm run test:hna-ownership-need && npm run test:combined-geo && npm run test:validate && npm run test:pro-forma && npm run test:qap-simulator && npm run test:pma-competitive-set && npm run test:lihtc-deal-predictor && npm run test:lihtc-opportunity-finder-zori && npm run test:opportunity-finder-verifier-source && npm run test:pma-transit && npm run test:soft-funding-tracker && npm run test:hna-ranking-index && npm run test:ranking-fresh && npm run test:ranking-scenarios && npm run test:hna-home-values && npm run test:jurisdiction-metrics-digest && npm run test:place-pages && npm run test:place-pages-fresh && npm run test:car-showingtime && npm run test:hna-car-loader && npm run test:developer-geoids && npm run test:developer-brief-hna && npm run test:navigation-paths && npm run test:f116-r1 && npm run test:pill-contrast && npm run test:inline-contrast && npm run test:inline-heading-typography && npm run test:phantom-css-vars && npm run test:data-scope && npm run test:fetch-error-surface && npm run test:semantic-labels && npm run test:hna-acs-coverage && npm run test:nodemailer-v9 && npm run test:briefs && npm run test:public-build",
+    "test:ci": "npm run validate && npm run validate:data && npm run validate:rosters && npm run test:fetch-helper && npm run test:hna && npm run test:hna-ownership-need && npm run test:combined-geo && npm run test:validate && npm run test:pro-forma && npm run test:qap-simulator && npm run test:pma-competitive-set && npm run test:lihtc-deal-predictor && npm run test:lihtc-opportunity-finder-zori && npm run test:opportunity-finder-verifier-source && npm run test:pma-transit && npm run test:soft-funding-tracker && npm run test:hna-ranking-index && npm run test:ranking-fresh && npm run test:ranking-scenarios && npm run test:hna-home-values && npm run test:jurisdiction-metrics-digest && npm run test:place-pages && npm run test:place-pages-fresh && npm run test:car-showingtime && npm run test:hna-car-loader && npm run test:developer-geoids && npm run test:developer-brief-hna && npm run test:navigation-paths && npm run test:f116-r1 && npm run test:pill-contrast && npm run test:inline-contrast && npm run test:inline-heading-typography && npm run test:phantom-css-vars && npm run test:data-scope && npm run test:fetch-error-surface && npm run test:semantic-labels && npm run test:hna-acs-coverage && npm run test:nodemailer-v9 && npm run test:briefs && npm run test:public-build && npm run test:data-trust-center",
     "test:developer-geoids": "node test/developer-geoids.test.js",
     "test:developer-brief-hna": "node test/developer-brief-hna.test.js",
     "test:navigation-paths": "node test/navigation-paths.test.js",
@@ -97,7 +97,8 @@
     "audit:coverage:strict": "node scripts/coverage-audit.js --strict",
     "audit:data-sources": "python3 scripts/check-data-source-health.py --fail-on-error",
     "test:semantic-labels": "node test/semantic-label-guard.test.js",
-    "test:opportunity-finder-verifier-source": "node test/opportunity-finder-verifier-source.test.mjs"
+    "test:opportunity-finder-verifier-source": "node test/opportunity-finder-verifier-source.test.mjs",
+    "test:data-trust-center": "node test/data-trust-center.test.js"
   },
   "dependencies": {
     "jsdom": "^29.1.1"

--- a/test/data-trust-center.test.js
+++ b/test/data-trust-center.test.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// test/data-trust-center.test.js
+//
+// Phase 2.1 (docs/audits/CODEX-HANDOFF-AUDIT-PHASE2-2026-07.md): asserts
+// data-review-hub.html is consolidated into a "Data Trust Center" with
+// Sources / Quality / QA Coverage tabs, that the QA Coverage tab actually
+// carries the 5-layer status + place-coverage panels (not just links out),
+// that the nav label matches, and that the pre-existing standalone pages
+// still exist (this is a consolidation, not a deletion).
+//
+// Usage: node test/data-trust-center.test.js
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+const hubHtml = read('data-review-hub.html');
+const hubJs = read('js/data-review-hub.js');
+const navJs = read('js/navigation.js');
+const bannerJs = read('js/data-section-banner.js');
+
+// ── Page identity ────────────────────────────────────────────────────────
+
+assert.match(hubHtml, /<title>Data Trust Center/, 'page title renamed to Data Trust Center');
+assert.match(hubHtml, /<h1>Data Trust Center/, 'H1 renamed to Data Trust Center');
+assert.match(
+  hubHtml,
+  /\(formerly Data Review Hub\)/,
+  'old name kept visible as a breadcrumb, matching the Coverage QA / Pipeline Status rename convention'
+);
+
+// ── QA Coverage tab exists and is real content, not just a link out ────────
+
+assert.match(hubHtml, /data-tab="coverage"/, 'QA Coverage tab button present');
+assert.match(hubHtml, /data-panel="coverage"/, 'QA Coverage tab panel present');
+assert.match(hubHtml, /id="drhQaLayerGrid"/, '5-layer QA status grid container present');
+assert.match(hubHtml, /id="placeChasCoverage"/, 'place-level coverage panel container present');
+assert.match(
+  hubHtml,
+  /<script defer src="js\/place-chas-coverage-panel\.js">/,
+  'place-chas-coverage-panel.js is loaded so the coverage panel actually renders'
+);
+
+assert.match(
+  hubJs,
+  /function initQaCoveragePanel/,
+  'initQaCoveragePanel is defined (ported 5-layer QA status renderer)'
+);
+// A plain substring/regex match on "initQaCoveragePanel();" would also match
+// a commented-out call (e.g. "// initQaCoveragePanel();"), which proves
+// nothing about wiring. Anchor to the exact non-commented call site right
+// after initQualityPanel() in init(), and separately assert it isn't commented out.
+assert.match(
+  hubJs,
+  /^\s*initQualityPanel\(\);\s*\n\s*initQaCoveragePanel\(\);/m,
+  'initQaCoveragePanel is called immediately after initQualityPanel() in init()'
+);
+assert(
+  !/\/\/\s*initQaCoveragePanel\(\);/.test(hubJs),
+  'the initQaCoveragePanel() call is not commented out'
+);
+assert.match(
+  hubJs,
+  /fetcher\('data\/_qa-status\.json'\)/,
+  'QA coverage panel reads the same data/_qa-status.json the standalone Coverage QA page reads'
+);
+
+// ── Sources and Quality tabs still exist (this is additive, not a rewrite) ─
+
+assert.match(hubHtml, /data-tab="sources"/, 'Sources tab still present');
+assert.match(hubHtml, /data-tab="quality"/, 'Quality tab still present');
+
+// ── Nav + cross-link banner renamed consistently ────────────────────────────
+
+assert.match(
+  navJs,
+  /label: "Data Trust Center",\s*href: "data-review-hub\.html"/,
+  'top nav "Data" group label renamed to Data Trust Center'
+);
+assert(!/label: "Data Hub"/.test(navJs), 'old "Data Hub" nav label fully replaced, not left as a second entry');
+
+assert.match(
+  bannerJs,
+  /label: 'Data Trust Center'/,
+  'shared cross-page Data-section banner (js/data-section-banner.js) also renamed'
+);
+
+// ── Consolidation, not deletion: legacy standalone pages still exist ────────
+
+for (const legacyPage of ['data-status.html', 'dashboard-data-quality.html', 'dashboard-data-sources-ui.html']) {
+  assert(fs.existsSync(path.join(ROOT, legacyPage)), `${legacyPage} still exists standalone (not deleted)`);
+}
+
+// data-status.html and dashboard-data-quality.html should still point at the
+// hub under its new name, not the stale "Data Hub" label.
+const dataStatusHtml = read('data-status.html');
+const dqHtml = read('dashboard-data-quality.html');
+assert(
+  /Data Trust Center/.test(dataStatusHtml),
+  'data-status.html cross-links to the renamed Data Trust Center'
+);
+assert(
+  /Data Trust Center/.test(dqHtml),
+  'dashboard-data-quality.html cross-links to the renamed Data Trust Center'
+);
+
+console.log('Data Trust Center consolidation (Phase 2.1): PASS');


### PR DESCRIPTION
## Summary

Implements Phase 2.1 from `docs/audits/CODEX-HANDOFF-AUDIT-PHASE2-2026-07.md`: consolidate `data-review-hub.html` (renamed "Data Trust Center") so a visitor can answer "can I trust this data?" in one place.

The page already had Overview/Sources/Quality/Pending Discovery/Admin tabs from earlier work. What was missing (per audit finding B-02) was the 5-layer QA status panel and place-level CHAS coverage panel, which only lived on the separate `dashboard-data-quality.html`. This adds a new **QA Coverage** tab pulling both in as real, live-rendering content — not just a link out.

## What changed

- **New QA Coverage tab** on `data-review-hub.html`: 5-layer status (schema/sentinel/bounds/freshness/plausibility, reading `data/_qa-status.json`) + place-level tract-vs-county-fallback coverage panel (reuses `js/place-chas-coverage-panel.js` unmodified).
- **Renamed "Data Hub" → "Data Trust Center"** consistently: `js/navigation.js`, `js/data-section-banner.js`, the page's own title/H1 (old name kept as a breadcrumb, matching the existing "Coverage QA (was Data Quality Dashboard)" convention already used elsewhere on the site).
- **Legacy pages kept alive standalone** — `data-status.html`, `dashboard-data-quality.html`, `dashboard-data-sources-ui.html` are not deleted, just reframed as detailed/maintainer views, with cross-links updated to the new name.
- **New `test/data-trust-center.test.js`**, wired into `test:ci`.

## Independent review

A fresh agent reviewed this adversarially (diff read, live browser drive in light+dark mode, ran the test suite, tried to break the new test) before this PR. It found two real issues, both fixed and re-verified here:

1. **Light-mode contrast failure** on the new QA-layer card title text — measured 4.26:1 (below AA 4.5:1) because the new section wasn't wrapped in the site's `.card` pattern like every other colored-badge usage on the page. Fixed by wrapping in `.card`; re-verified live: **5.48:1 light / 8.77:1 dark** (computed via `getComputedStyle` in a live preview, not estimated).
2. **Vacuous test assertion** — the original "wired into boot sequence" check used an unanchored regex that still matched a commented-out call. Fixed with an anchored regex + explicit not-commented-out check; proved non-vacuous by commenting out the real call, confirming the test now fails, then restoring it and confirming it passes again.

## Tests
- `node test/data-trust-center.test.js` — PASS
- `npm run test:navigation-paths` — PASS
- `npm run validate` — PASS (52 HTML files)
- `npm run test:phantom-css-vars` — PASS
- `npm run test:pill-contrast` — 46/46 PASS
- Manual: clicked through every tab (Overview/Sources/Quality/QA Coverage), no console errors, both new panels render live data on first load; confirmed `dashboard-data-quality.html` and `data-status.html` still render fully standalone with no console errors.

## Known limitations
- Items 2.2 (public/internal pipeline wording) and 2.3 (homepage job routing) are separate items, not addressed here.
- B-07's plain-language rewrite is applied to the new tab and the page's own framing copy, not a full rewrite of every operational string on the legacy standalone pages — appropriate since those are now explicitly framed as detailed/maintainer views, not the primary public path.