### PR TITLE
Phase 2.2: rename gated pipeline affordance to Deal Tracker

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -33,7 +33,7 @@
   <script defer src="js/components/inline-glossary.js"></script>
   <script defer src="js/dark-mode-toggle.js"></script>
   <script defer src="js/mobile-menu.js"></script>
-  <!-- F162 — Pipeline CRUD. Only hydrated for visitors with a live
+  <!-- F162 — gated CRM CRUD. Only hydrated for visitors with a live
        developer session; mount stays empty for the public visitor. -->
   <style>
     .cmp-wrap { max-width: 1400px; margin: 0 auto; padding: 1rem; }
@@ -211,12 +211,12 @@
         </details>
       </div>
 
-      <!-- F162 — Developer Pipeline add button (gated). Hydrated by the
+      <!-- F162 — gated CRM add button. Hydrated by the
            script block below; the picker keys off the first jurisdiction
            in the comparison set. Single mount, not per-column, so the
            button doesn't get duplicated as columns are added. Empty for
            public visitors. -->
-      <div id="cmpPipelineAddMount" style="margin:0 0 14px;"></div>
+      <div id="cmpDealTrackerMount" style="margin:0 0 14px;"></div>
 
       <div id="cmpControls" class="cmp-controls" hidden>
         <label for="cmpAddSel">Add jurisdiction:</label>
@@ -264,10 +264,10 @@
   <script src="js/rent-burden-reliability.js" defer></script>
   <script src="js/compare.js" defer></script>
 
-<!-- F162 — Developer Pipeline add button (public-page gated). Single
+<!-- F162 — gated CRM add button. Single
      mount near the top of the comparison; the button is always prefilled
      with the FIRST jurisdiction in the selected set, so an authed user
-     can drop the leading candidate into the pipeline without leaving the
+     can drop the leading candidate into the deal tracker without leaving the
      compare view. Tracks live state by reading the head row (filled by
      compare.js render()) and re-hydrating via MutationObserver. Public
      visitors never see it. -->
@@ -315,7 +315,7 @@
 
   var _lastKey = null;
   function _hydrate() {
-    var mount = document.getElementById('cmpPipelineAddMount');
+    var mount = document.getElementById('cmpDealTrackerMount');
     if (!mount) return;
     if (!_isIBAuthed() || !window.PipelineAddButton || !window.PipelineStore) {
       mount.innerHTML = '';

--- a/deal-calculator.html
+++ b/deal-calculator.html
@@ -110,7 +110,7 @@
   <script src="js/components/chfa-award-history.js"></script>
   <script src="js/components/qap-calendar.js"></script>
   <script src="js/components/resort-wfh.js"></script>
-  <!-- F162 — Pipeline CRUD. Hydrated for visitors with a live a developer
+  <!-- F162 — gated CRM CRUD. Hydrated for visitors with a live developer
        session; mount stays empty for the public underwriter. -->
 </head>
 <body data-page-last-updated="2026-04-01"
@@ -170,10 +170,10 @@
           <a href="select-jurisdiction.html" class="hna-jurisdiction-banner__change">Change</a>
         </div>
       </div>
-      <!-- F162 — "+ Add to Developer Pipeline" mount. Hydrated by the
+      <!-- F162 — gated CRM add mount. Hydrated by the
            script block at the bottom of this page, gated on the
            developer session cookie. Empty for public visitors. -->
-      <div id="dcPipelineAddMount" style="margin:.4rem 16px 0;"></div>
+      <div id="dcDealTrackerMount" style="margin:.4rem 16px 0;"></div>
     </div>
 
     <!-- ── Editorial header ───────────────────────────────────────────── -->
@@ -1187,7 +1187,7 @@
   }());
   </script>
 
-<!-- F162 — Developer Pipeline add button (public-page gated). Mounts only
+<!-- F162 — gated CRM add button. Mounts only
      when the visitor has a live developer session. Reads the active
      jurisdiction from WorkflowState → URL → SiteState so it updates
      whenever the underwriter swaps geography. -->
@@ -1249,7 +1249,7 @@
   }
 
   function _hydrate() {
-    var mount = document.getElementById('dcPipelineAddMount');
+    var mount = document.getElementById('dcDealTrackerMount');
     if (!mount) return;
     if (!_isIBAuthed() || !window.PipelineAddButton || !window.PipelineStore) {
       mount.innerHTML = '';

--- a/js/components/pipeline-add-button.js
+++ b/js/components/pipeline-add-button.js
@@ -1,10 +1,10 @@
 /**
  * js/components/pipeline-add-button.js — F161
  * ===============================================================
- * "Add to Developer Pipeline" button + inline form. Mounts on
+ * "Add to Deal Tracker" button + inline form. Mounts on
  * jurisdiction-context pages inside the developer gate (briefs,
  * where-should-I-build) so a single click adds the active
- * jurisdiction to a local-storage pipeline draft.
+ * jurisdiction to a local-storage deal-tracker draft.
  *
  * Usage:
  *   PipelineAddButton.attach(container, {
@@ -189,7 +189,7 @@
             '<button type="button" class="pab-form__cancel" data-pab-remove>Remove draft</button>' : '') +
           '<button type="button" class="pab-form__cancel" data-pab-cancel>Cancel</button>' +
           '<button type="button" class="pab-form__save" data-pab-save>' +
-            (status && (status.state === 'draft' || status.state === 'canonical') ? 'Save changes' : 'Add to pipeline') +
+            (status && (status.state === 'draft' || status.state === 'canonical') ? 'Save changes' : 'Add to deal tracker') +
           '</button>' +
         '</div>' +
         '<p class="pab-msg" data-pab-msg></p>' +
@@ -202,7 +202,7 @@
     _ensureStyles();
     if (!window.PipelineStore) {
       container.innerHTML = '<p style="font-size:.78rem;color:var(--muted)">' +
-        'Pipeline store not loaded — include js/components/pipeline-store.js first.</p>';
+        'Deal tracker store not loaded — include js/components/pipeline-store.js first.</p>';
       return;
     }
 
@@ -214,15 +214,15 @@
     function _render() {
       _currentStatusFor(opts.geoid).then(function (status) {
         var btnLabel, btnClass = 'pab-btn';
-        if (status.state === 'canonical') { btnLabel = '✓ In pipeline · Edit'; btnClass += ' pab-btn--inpipe'; }
+        if (status.state === 'canonical') { btnLabel = '✓ In Deal Tracker · Edit'; btnClass += ' pab-btn--inpipe'; }
         else if (status.state === 'draft') { btnLabel = '✎ Draft saved · Edit'; btnClass += ' pab-btn--draft'; }
-        else { btnLabel = '+ Add to Pipeline'; }
+        else { btnLabel = '+ Add to Deal Tracker'; }
 
         wrap.innerHTML = '<button type="button" class="' + btnClass + '" data-pab-open>' + btnLabel + '</button>' +
           (status.state === 'canonical' || status.state === 'draft'
             ? '<span class="pab-state">' + (status.state === 'canonical'
                 ? 'Stage: ' + _esc(status.row.stage || '—') + ' · IOI ' + _esc(status.row.ioi_score || '—')
-                : 'Local draft — export from the pipeline page to commit to CSV')
+                : 'Local draft — export from the Deal Tracker page to commit to CSV')
               + '</span>'
             : '');
 
@@ -256,7 +256,7 @@
     var removeBtn = form.querySelector('[data-pab-remove]');
     if (removeBtn) {
       removeBtn.addEventListener('click', function () {
-        if (!confirm('Remove this draft from local pipeline?')) return;
+        if (!confirm('Remove this draft from local deal tracker?')) return;
         window.PipelineStore.removeDraft(opts.geoid);
         form.remove();
         onChange();
@@ -283,10 +283,10 @@
           return;
         }
         window.PipelineStore.editCanonical(data.geoid, diff);
-        setMsg('Saved local edits to canonical row. Export from the pipeline page to commit.', true);
+        setMsg('Saved local edits to canonical row. Export from the Deal Tracker page to commit.', true);
       } else {
         window.PipelineStore.addDraft(data);
-        setMsg('Saved as local draft. Export from the pipeline page to commit to CSV.', true);
+        setMsg('Saved as local draft. Export from the Deal Tracker page to commit to CSV.', true);
       }
 
       setTimeout(function () { form.remove(); onChange(); }, 600);

--- a/market-analysis.html
+++ b/market-analysis.html
@@ -71,7 +71,7 @@
   <script defer src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
   <script defer src="js/components/workflow-next-action.js"></script>
   <script defer src="js/components/development-realism.js"></script>
-  <!-- F162 — Pipeline CRUD. Only hydrated for visitors with a live
+  <!-- F162 — gated CRM CRUD. Only hydrated for visitors with a live
        developer session; mount stays empty for the public visitor. -->
 </head>
 <body data-page-last-updated="2026-03-22" data-page-source="Census ACS · HUD LIHTC · FRED · CoStar (public)">
@@ -580,10 +580,10 @@
             <button class="pma-btn" id="pmaExportJsonBtn" type="button" title="Download full result snapshot as JSON for downstream analysis">Download JSON</button>
           </div>
 
-          <!-- F162 — "+ Add to Developer Pipeline" mount. Hydrated by the
+          <!-- F162 — gated CRM add mount. Hydrated by the
                script block at the bottom of this page, gated on the
                developer session cookie. Empty for public visitors. -->
-          <div id="pmaPipelineAddMount" style="margin-top:.55rem"></div>
+          <div id="pmaDealTrackerMount" style="margin-top:.55rem"></div>
 
           <!-- ── Progress bar (visible during analysis) ── -->
           <div id="pmaProgressWrap"
@@ -2185,7 +2185,7 @@
 }());
 </script>
 
-<!-- F162 — Developer Pipeline add button (public-page gated). Mounts only
+<!-- F162 — gated CRM add button. Mounts only
      when the visitor has a live developer session (inline 12-hour cookie
      check, no gate-script dependency). Reads the active jurisdiction from
      WorkflowState → SiteState → URL context so it stays in sync as the
@@ -2251,7 +2251,7 @@
   }
 
   function _hydrate() {
-    var mount = document.getElementById('pmaPipelineAddMount');
+    var mount = document.getElementById('pmaDealTrackerMount');
     if (!mount) return;
     if (!_isIBAuthed() || !window.PipelineAddButton || !window.PipelineStore) {
       mount.innerHTML = '';

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:html": "npx htmlhint '*.html'",
     "lint:css": "npx stylelint 'css/*.css'",
     "test": "npm run test:ci",
-    "test:ci": "npm run validate && npm run validate:data && npm run validate:rosters && npm run test:fetch-helper && npm run test:hna && npm run test:hna-ownership-need && npm run test:combined-geo && npm run test:validate && npm run test:pro-forma && npm run test:qap-simulator && npm run test:pma-competitive-set && npm run test:lihtc-deal-predictor && npm run test:lihtc-opportunity-finder-zori && npm run test:opportunity-finder-verifier-source && npm run test:pma-transit && npm run test:soft-funding-tracker && npm run test:hna-ranking-index && npm run test:ranking-fresh && npm run test:ranking-scenarios && npm run test:hna-home-values && npm run test:jurisdiction-metrics-digest && npm run test:place-pages && npm run test:place-pages-fresh && npm run test:car-showingtime && npm run test:hna-car-loader && npm run test:developer-geoids && npm run test:developer-brief-hna && npm run test:navigation-paths && npm run test:f116-r1 && npm run test:pill-contrast && npm run test:inline-contrast && npm run test:inline-heading-typography && npm run test:phantom-css-vars && npm run test:data-scope && npm run test:fetch-error-surface && npm run test:semantic-labels && npm run test:hna-acs-coverage && npm run test:nodemailer-v9 && npm run test:briefs && npm run test:public-build && npm run test:data-trust-center",
+    "test:ci": "npm run validate && npm run validate:data && npm run validate:rosters && npm run test:fetch-helper && npm run test:hna && npm run test:hna-ownership-need && npm run test:combined-geo && npm run test:validate && npm run test:pro-forma && npm run test:qap-simulator && npm run test:pma-competitive-set && npm run test:lihtc-deal-predictor && npm run test:lihtc-opportunity-finder-zori && npm run test:opportunity-finder-verifier-source && npm run test:pma-transit && npm run test:soft-funding-tracker && npm run test:hna-ranking-index && npm run test:ranking-fresh && npm run test:ranking-scenarios && npm run test:hna-home-values && npm run test:jurisdiction-metrics-digest && npm run test:place-pages && npm run test:place-pages-fresh && npm run test:car-showingtime && npm run test:hna-car-loader && npm run test:developer-geoids && npm run test:developer-brief-hna && npm run test:navigation-paths && npm run test:f116-r1 && npm run test:pill-contrast && npm run test:inline-contrast && npm run test:inline-heading-typography && npm run test:phantom-css-vars && npm run test:data-scope && npm run test:fetch-error-surface && npm run test:semantic-labels && npm run test:hna-acs-coverage && npm run test:nodemailer-v9 && npm run test:briefs && npm run test:public-build && npm run test:data-trust-center && npm run test:deal-tracker-wording",
     "test:developer-geoids": "node test/developer-geoids.test.js",
     "test:developer-brief-hna": "node test/developer-brief-hna.test.js",
     "test:navigation-paths": "node test/navigation-paths.test.js",
@@ -98,7 +98,8 @@
     "audit:data-sources": "python3 scripts/check-data-source-health.py --fail-on-error",
     "test:semantic-labels": "node test/semantic-label-guard.test.js",
     "test:opportunity-finder-verifier-source": "node test/opportunity-finder-verifier-source.test.mjs",
-    "test:data-trust-center": "node test/data-trust-center.test.js"
+    "test:data-trust-center": "node test/data-trust-center.test.js",
+    "test:deal-tracker-wording": "node test/deal-tracker-wording.test.js"
   },
   "dependencies": {
     "jsdom": "^29.1.1"

--- a/test/deal-tracker-wording.test.js
+++ b/test/deal-tracker-wording.test.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// test/deal-tracker-wording.test.js
+//
+// Phase 2.2: keep the public "Affordable Housing Pipeline" methodology
+// distinct from the gated internal Deal Tracker affordance.
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { JSDOM } = require('jsdom');
+
+const ROOT = path.resolve(__dirname, '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+const PUBLIC_MOUNTS = [
+  { page: 'compare.html', mountId: 'cmpDealTrackerMount' },
+  { page: 'deal-calculator.html', mountId: 'dcDealTrackerMount' },
+  { page: 'market-analysis.html', mountId: 'pmaDealTrackerMount' }
+];
+
+function scriptsFor(html) {
+  const scripts = [];
+  const re = /<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/gi;
+  let match;
+  while ((match = re.exec(html))) {
+    if (match[1].includes('PipelineAddButton.attach') && match[1].includes('_isIBAuthed')) {
+      scripts.push(match[1]);
+    }
+  }
+  return scripts;
+}
+
+for (const { page, mountId } of PUBLIC_MOUNTS) {
+  const html = read(page);
+
+  assert(!html.includes('Developer Pipeline add button'), `${page} no longer labels the gated mount Developer Pipeline`);
+  assert(!html.includes('Add to Developer Pipeline'), `${page} no longer contains the old gated button label`);
+  assert(!html.includes('Deal Tracker'), `${page} does not expose the renamed internal label in public HTML`);
+  assert(html.includes(`id="${mountId}"`), `${page} uses the renamed ${mountId} mount`);
+
+  const scripts = scriptsFor(html);
+  assert.equal(scripts.length, 1, `${page} has exactly one gated Deal Tracker hydration script`);
+
+  const dom = new JSDOM(`<!doctype html><body><div id="${mountId}">stale gated content</div></body>`, {
+    url: `https://cohoanalytics.com/${page}`,
+    runScripts: 'outside-only'
+  });
+  const { window } = dom;
+  window.PipelineAddButton = { attach() { throw new Error('logged-out page must not attach Deal Tracker'); } };
+  window.PipelineStore = {};
+  window.eval(scripts[0]);
+  window.document.dispatchEvent(new window.Event('DOMContentLoaded'));
+
+  assert.equal(
+    window.document.getElementById(mountId).innerHTML,
+    '',
+    `${page} clears the gated Deal Tracker mount for logged-out visitors`
+  );
+}
+
+const component = read('js/components/pipeline-add-button.js');
+assert(component.includes('+ Add to Deal Tracker'), 'gated button now says Add to Deal Tracker');
+assert(component.includes('In Deal Tracker'), 'canonical state now says In Deal Tracker');
+assert(!component.includes('Add to Developer Pipeline'), 'component no longer uses the old internal feature label');
+assert(!component.includes('+ Add to Pipeline'), 'component no longer uses the ambiguous short pipeline label');
+
+const hna = read('housing-needs-assessment.html');
+const opportunityFinder = read('lihtc-opportunity-finder.html');
+for (const [label, html] of [
+  ['housing-needs-assessment.html', hna],
+  ['lihtc-opportunity-finder.html', opportunityFinder]
+]) {
+  assert(
+    html.includes('The Affordable Housing Pipeline') && html.includes('pipeline.html'),
+    `${label} keeps the public Affordable Housing Pipeline methodology teaser`
+  );
+}
+
+console.log('Deal Tracker wording and public gating: PASS');

--- a/test/deal-tracker-wording.test.js
+++ b/test/deal-tracker-wording.test.js
@@ -22,7 +22,7 @@ const PUBLIC_MOUNTS = [
 
 function scriptsFor(html) {
   const scripts = [];
-  const re = /<script(?:\s[^>]*)?>([\s\S]*?)<\/script\s*>/gi;
+  const re = /<script(?:\s[^>]*)?>([\s\S]*?)<\/script[^>]*>/gi;
   let match;
   while ((match = re.exec(html))) {
     if (match[1].includes('PipelineAddButton.attach') && match[1].includes('_isIBAuthed')) {

--- a/test/deal-tracker-wording.test.js
+++ b/test/deal-tracker-wording.test.js
@@ -32,6 +32,33 @@ function scriptsFor(html) {
   return scripts;
 }
 
+function runHydrator({ page, mountId, body, beforeEval }) {
+  const html = read(page);
+  const scripts = scriptsFor(html);
+  assert.equal(scripts.length, 1, `${page} has exactly one gated Deal Tracker hydration script`);
+
+  const dom = new JSDOM(`<!doctype html><body>${body}</body>`, {
+    url: `https://cohoanalytics.com/${page}`,
+    runScripts: 'outside-only'
+  });
+  const { window } = dom;
+  const calls = [];
+  window.PipelineAddButton = {
+    attach(container, opts) {
+      calls.push({ id: container && container.id, opts });
+    }
+  };
+  window.PipelineStore = {};
+  if (beforeEval) beforeEval(window);
+  window.eval(scripts[0]);
+  window.document.dispatchEvent(new window.Event('DOMContentLoaded'));
+  return { window, calls };
+}
+
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
 for (const { page, mountId } of PUBLIC_MOUNTS) {
   const html = read(page);
 
@@ -40,24 +67,68 @@ for (const { page, mountId } of PUBLIC_MOUNTS) {
   assert(!html.includes('Deal Tracker'), `${page} does not expose the renamed internal label in public HTML`);
   assert(html.includes(`id="${mountId}"`), `${page} uses the renamed ${mountId} mount`);
 
-  const scripts = scriptsFor(html);
-  assert.equal(scripts.length, 1, `${page} has exactly one gated Deal Tracker hydration script`);
-
-  const dom = new JSDOM(`<!doctype html><body><div id="${mountId}">stale gated content</div></body>`, {
-    url: `https://cohoanalytics.com/${page}`,
-    runScripts: 'outside-only'
+  const { window, calls } = runHydrator({
+    page,
+    mountId,
+    body: `<div id="${mountId}">stale gated content</div>`
   });
-  const { window } = dom;
-  window.PipelineAddButton = { attach() { throw new Error('logged-out page must not attach Deal Tracker'); } };
-  window.PipelineStore = {};
-  window.eval(scripts[0]);
-  window.document.dispatchEvent(new window.Event('DOMContentLoaded'));
 
+  assert.equal(calls.length, 0, `${page} does not attach Deal Tracker for logged-out visitors`);
   assert.equal(
     window.document.getElementById(mountId).innerHTML,
     '',
     `${page} clears the gated Deal Tracker mount for logged-out visitors`
   );
+}
+
+const authed = (window) => {
+  window.sessionStorage.setItem('ib-auth-v1', JSON.stringify({ ts: Date.now() }));
+};
+
+{
+  const { calls } = runHydrator({
+    page: 'compare.html',
+    mountId: 'cmpDealTrackerMount',
+    body: `
+      <div id="cmpDealTrackerMount"></div>
+      <table><thead><tr id="cmpHeadRow">
+        <th><button class="cmp-rmBtn" data-geoid="0804000"></button><span class="cmp-name">Aurora</span></th>
+      </tr></thead></table>`,
+    beforeEval: authed
+  });
+  assert(calls.length >= 1, 'compare.html attaches Deal Tracker when authed and a comparison jurisdiction exists');
+  assert.equal(calls[0].id, 'cmpDealTrackerMount');
+  assert.deepEqual(plain(calls[0].opts), {
+    jurisdiction: 'Aurora',
+    geoid: '0804000',
+    defaults: { stage: 'Signal', notes: 'From Compare · top of set' }
+  });
+}
+
+for (const { page, mountId, expectedNotes } of [
+  { page: 'deal-calculator.html', mountId: 'dcDealTrackerMount', expectedNotes: 'From Deal Calculator · Aurora' },
+  { page: 'market-analysis.html', mountId: 'pmaDealTrackerMount', expectedNotes: 'From Market Analysis · Aurora' }
+]) {
+  const { calls } = runHydrator({
+    page,
+    mountId,
+    body: `<div id="${mountId}"></div>`,
+    beforeEval(window) {
+      authed(window);
+      window.WorkflowState = {
+        getActiveProject() {
+          return { jurisdiction: { type: 'city', placeGeoid: '0804000', displayName: 'Aurora (city)' } };
+        }
+      };
+    }
+  });
+  assert(calls.length >= 1, `${page} attaches Deal Tracker when authed and a jurisdiction exists`);
+  assert.equal(calls[0].id, mountId);
+  assert.deepEqual(plain(calls[0].opts), {
+    jurisdiction: 'Aurora',
+    geoid: '0804000',
+    defaults: { stage: 'Signal', notes: expectedNotes }
+  });
 }
 
 const component = read('js/components/pipeline-add-button.js');

--- a/test/deal-tracker-wording.test.js
+++ b/test/deal-tracker-wording.test.js
@@ -22,7 +22,7 @@ const PUBLIC_MOUNTS = [
 
 function scriptsFor(html) {
   const scripts = [];
-  const re = /<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/gi;
+  const re = /<script(?:\s[^>]*)?>([\s\S]*?)<\/script\s*>/gi;
   let match;
   while ((match = re.exec(html))) {
     if (match[1].includes('PipelineAddButton.attach') && match[1].includes('_isIBAuthed')) {


### PR DESCRIPTION
## Summary
- Implements Phase 2.2 from `docs/audits/CODEX-HANDOFF-AUDIT-PHASE2-2026-07.md`.
- Renames the gated internal CRM affordance from the ambiguous pipeline wording to Deal Tracker inside `js/components/pipeline-add-button.js`.
- Updates the three public-page gated mounts in `compare.html`, `deal-calculator.html`, and `market-analysis.html` to use renamed local mount IDs and non-pipeline F162 comments while preserving the logged-out empty-mount gate.
- Leaves public `pipeline.html` and the Affordable Housing Pipeline teaser banners untouched.
- Adds `test/deal-tracker-wording.test.js` and wires it into `test:ci`.

## Audit Finding
- Closes Phase 2.2 / public-internal pipeline wording from the July site audit handoff.

## Independent Verification
- Confirmed #1088 / Phase 2.1 is merged into `main` before starting this branch.
- Re-read the Phase 2 handoff and verified 2.2 scope before editing.
- Confirmed the public build excludes private developer pages and `js/components/pipeline-add-button.js`, so the public artifact only carries empty gated mounts for logged-out visitors.
- Confirmed public Affordable Housing Pipeline teaser copy in HNA and Opportunity Finder still links to `pipeline.html`.
- Confirmed built public pages do not contain `Deal Tracker`, `Add to Developer Pipeline`, `+ Add to Pipeline`, old mount IDs, `pipeline-add-button.js`, `pipeline-store.js`, or `developer-pipeline.html`.
- Confirmed the authed path still attaches when a jurisdiction is resolvable: compare via rendered table row; deal calculator / market analysis via `WorkflowState` jurisdiction. Auth without jurisdiction correctly remains empty.

## Tests
- `npm run test:deal-tracker-wording` PASS
- `npm run test:navigation-paths` PASS
- `npm run validate` PASS
- `npm run test:inline-heading-typography` PASS
- `npm run test:phantom-css-vars` PASS
- `npm run test:public-build` PASS (rerun with local sandbox escalation for `dist.lock` write)

## Known Limitations
- Underlying `PipelineStore` / `PipelineAddButton` API names remain unchanged intentionally; they are internal storage and component identifiers, and renaming them would broaden this PR beyond the Phase 2.2 wording task.
- Private developer pages still use existing pipeline/store terminology where they refer to the underlying data subsystem; this PR is limited to the public-page gated affordance and public/internal wording collision.