### PR TITLE
Phase 2.3: add homepage job routing

### DIFF
--- a/css/pages/home.css
+++ b/css/pages/home.css
@@ -75,71 +75,62 @@
   border-bottom-color: currentColor;
 }
 
-/* F73: 6-step onboarding rail under the hero. Light-mode and dark-mode
-   contrast were calculated for var(--card2) bg + var(--text) body + the
-   accent-tinted step circle. Numbers stay legible at 4.5:1 minimum in
-   both modes. */
-.home-onboarding {
-  list-style: none;
+/* F2.3: Job-routing rail under the jurisdiction-first CTA. The detailed
+   six-step LIHTC workflow remains lower on the page; this rail answers
+   "what are you here to do?" for first-time visitors. */
+.home-job-routes {
   margin: var(--sp5) 0 0;
   padding: 0;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: var(--sp3);
-  max-width: 100%;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--sp2);
 }
-.home-onboarding li {
+.home-job-route {
   background: var(--card2);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: var(--sp3) var(--sp3);
+  color: var(--text);
+  display: grid;
+  gap: var(--sp2);
+  min-height: 152px;
+  padding: var(--sp3);
+  text-decoration: none;
+}
+.home-job-route__kicker {
+  display: block;
+  font-family: monospace;
+  font-size: var(--tiny);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.home-job-route strong {
+  display: block;
+  font-size: 0.98rem;
+  line-height: 1.25;
+  color: var(--text-strong);
+}
+.home-job-route > span:not(.home-job-route__kicker):not(.home-job-route__links) {
+  display: block;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  color: var(--muted);
+}
+.home-job-route__links {
+  align-self: end;
   display: flex;
-  align-items: flex-start;
+  flex-wrap: wrap;
   gap: var(--sp2);
 }
-.home-onboarding__num {
-  flex-shrink: 0;
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  background: var(--accent);
-  /* Light mode: white on dark teal accent (#096e65) ≈ 7:1 ✓
-     Dark mode:  the accent flips to bright cyan #0fd4cf, on which
-                 white text drops to ~1.7:1 and FAILS AA. Override below. */
-  color: var(--on-accent, #fff);
-  font-weight: 800;
-  font-size: 0.95rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  line-height: 1;
-}
-@media (prefers-color-scheme: dark) {
-  .home-onboarding__num { color: #0d1f35; }  /* dark text on bright cyan ≈ 6.2:1 */
-}
-html.dark-mode .home-onboarding__num { color: #0d1f35; }
-.home-onboarding h4 {
-  margin: 0 0 4px;
-  font-size: 0.95rem;
-  font-weight: 700;
-  color: var(--text);
-}
-.home-onboarding p {
-  margin: 0 0 6px;
-  font-size: 0.82rem;
-  color: var(--text);  /* full text, not muted, to keep contrast solid */
-  line-height: 1.4;
-}
-.home-onboarding a {
-  font-size: 0.85rem;
-  font-weight: 600;
+.home-job-route__links a {
   color: var(--accent);
+  font-size: 0.82rem;
+  font-weight: 700;
   text-decoration: none;
-  border-bottom: 1px solid transparent;
-  transition: border-color 0.15s;
 }
-.home-onboarding a:hover {
-  border-bottom-color: currentColor;
+.home-job-route__links a:hover {
+  text-decoration: underline;
 }
 
 
@@ -787,6 +778,14 @@ html.dark-mode .home-onboarding__num { color: #0d1f35; }
     margin-top: var(--sp4);
   }
 
+  .home-job-routes {
+    grid-template-columns: 1fr;
+  }
+
+  .home-job-route {
+    min-height: 0;
+  }
+
   .home-audience__grid {
     grid-template-columns: repeat(2, 1fr);
   }
@@ -809,6 +808,16 @@ html.dark-mode .home-onboarding__num { color: #0d1f35; }
   .home-opening__actions {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .home-opening__actions .btn {
+    box-sizing: border-box;
+    max-width: 100%;
+    white-space: normal;
+  }
+
+  .home-opening__actions .btn span:last-child {
+    line-height: 1.25;
   }
 
   .home-audience__grid {

--- a/index.html
+++ b/index.html
@@ -57,11 +57,10 @@
           Educational; not a substitute for lender underwriting or legal advice.
         </p>
         <div class="home-opening__actions">
-          <!-- F205 — Hero "Start Here" CTA. Audit flagged the 6 ordered steps
-               below competed equally with no clear entry point. Bumped the
-               primary button to large + boxed it so cold visitors see exactly
-               where to start. Secondary explore link remains as the "I'm not
-               sure" off-ramp. -->
+          <!-- F205/F2.3 — Hero "Start Here" CTA remains the first interactive
+               element. Phase 2.3 routes visitors by job immediately after this
+               jurisdiction-first entry point; the detailed six-step workflow
+               stays lower on the page as process documentation. -->
           <a href="select-jurisdiction.html" class="btn"
              style="display:inline-flex;align-items:center;gap:.5rem;
                     padding:14px 28px;font-size:1.05rem;font-weight:800;
@@ -75,61 +74,52 @@
              style="display:block;margin-top:.5rem;font-size:.92rem;">
             Not sure where to start? Explore all 645 Colorado jurisdictions →
           </a>
+          <a href="places/index.html" class="home-opening__explore"
+             style="display:block;margin-top:.5rem;font-size:.92rem;">
+            Browse local housing profiles →
+          </a>
         </div>
 
-        <!-- F73: New-user onboarding. The platform has 6 ordered tools; users
-             land here cold and don't know where to begin. Lay the funnel
-             out visually so they see the path before they pick a tool. -->
-        <ol class="home-onboarding" aria-label="Workflow at a glance">
-          <li>
-            <span class="home-onboarding__num">1</span>
-            <div>
-              <h4>Find a jurisdiction</h4>
-              <p>Rank 645 places by LIHTC opportunity.</p>
-              <a href="lihtc-opportunity-finder.html">Opportunity Finder →</a>
-            </div>
-          </li>
-          <li>
-            <span class="home-onboarding__num">2</span>
-            <div>
-              <h4>Lock it in</h4>
-              <p>Confirm the county / city you're analyzing.</p>
-              <a href="select-jurisdiction.html">Select Jurisdiction →</a>
-            </div>
-          </li>
-          <li>
-            <span class="home-onboarding__num">3</span>
-            <div>
-              <h4>Size the need</h4>
-              <p>Cost burden, AMI gap, supply.</p>
-              <a href="housing-needs-assessment.html">Needs Assessment →</a>
-            </div>
-          </li>
-          <li>
-            <span class="home-onboarding__num">4</span>
-            <div>
-              <h4>Run the market</h4>
-              <p>Site-level PMA + competition.</p>
-              <a href="market-analysis.html">Market Analysis →</a>
-            </div>
-          </li>
-          <li>
-            <span class="home-onboarding__num">5</span>
-            <div>
-              <h4>Project demand</h4>
-              <p>20-year scenarios + AMI mix.</p>
-              <a href="hna-scenario-builder.html">Scenarios →</a>
-            </div>
-          </li>
-          <li>
-            <span class="home-onboarding__num">6</span>
-            <div>
-              <h4>Model the deal</h4>
-              <p>Stack, pro forma, IC packet.</p>
-              <a href="deal-calculator.html">Deal Calculator →</a>
-            </div>
-          </li>
-        </ol>
+        <!-- F2.3 — Job routing. The homepage now orients new visitors around
+             the jobs they came to do before showing the full LIHTC workflow. -->
+        <nav class="home-job-routes" aria-label="Choose a housing analysis path">
+          <div class="home-job-route">
+            <span class="home-job-route__kicker">Understand need</span>
+            <strong>Size the affordability gap</strong>
+            <span>Cost burden, AMI gaps, tenure, projections, and recommended targeting.</span>
+            <span class="home-job-route__links">
+              <a href="housing-needs-assessment.html">Needs Assessment</a>
+              <a href="hna-comparative-analysis.html">Compare</a>
+            </span>
+          </div>
+          <div class="home-job-route">
+            <span class="home-job-route__kicker">Find opportunity</span>
+            <strong>Rank jurisdictions and preservation signals</strong>
+            <span>Compare LIHTC opportunity, basis boost, CHFA history, and local capacity.</span>
+            <span class="home-job-route__links">
+              <a href="lihtc-opportunity-finder.html">Opportunity Finder</a>
+              <a href="preservation.html">Preservation</a>
+            </span>
+          </div>
+          <div class="home-job-route">
+            <span class="home-job-route__kicker">Test feasibility</span>
+            <strong>Check a site or deal</strong>
+            <span>Run market analysis, land-value context, and deal-calculator screening.</span>
+            <span class="home-job-route__links">
+              <a href="market-analysis.html">Market Analysis</a>
+              <a href="deal-calculator.html">Deal Calculator</a>
+              <a href="land-value.html">Land Value</a>
+            </span>
+          </div>
+          <div class="home-job-route">
+            <span class="home-job-route__kicker">Verify data</span>
+            <strong>Review sources and freshness</strong>
+            <span>Open the Data Trust Center for freshness, sources, QA coverage, and limitations.</span>
+            <span class="home-job-route__links">
+              <a href="data-review-hub.html">Data Trust Center</a>
+            </span>
+          </div>
+        </nav>
         <!-- Data vintage badge — shows when the statewide ranking data was last
              rebuilt. Switches to a stale-warning pill once past the 10-day SLA
              (matches build-hna-data.yml cadence + data-freshness-check.yml). -->
@@ -353,11 +343,10 @@
     <section class="home-snapshot" role="region" aria-label="Colorado housing data at a glance">
       <div class="home-container home-container--wide">
         <span class="home-snapshot__label">Colorado at a glance</span>
-        <!-- F118 — banner asserts the audit outcome: every stat across the site
-             now either fetches live from a public source, carries a STATIC
-             snapshot badge with a sourced link, or is explicitly flagged QUAL
-             when it's an editorial judgment. No fabricated numbers remain. -->
-        <span class="home-snapshot__note-global"><span style="color:var(--good);font-weight:700;">LIVE</span> · No demo data — every stat is sourced. <a href="docs/demo-mode-audit.csv" style="color:inherit;text-decoration:underline;">See audit</a></span>
+        <!-- F118/F2.3 — banner points readers to the Data Trust Center instead
+             of overclaiming cross-surface reconciliation. Public stats should
+             be sourced and monitored, with freshness/coverage limits visible. -->
+        <span class="home-snapshot__note-global"><span style="color:var(--good);font-weight:700;">LIVE</span> · Public datasets are sourced and monitored; freshness, coverage, and limitations are tracked in the <a href="data-review-hub.html" style="color:inherit;text-decoration:underline;">Data Trust Center</a>.</span>
         <div class="home-snapshot__grid" role="list">
 
           <!-- Removed: "9% Credit Rate — 9.00%" card. The rate is
@@ -428,7 +417,7 @@
           <div class="home-snapshot__item" role="listitem">
             <span class="home-snapshot__key">Data vintage</span>
             <span class="home-snapshot__val" id="snapVintage">—</span>
-            <span class="home-snapshot__note"><a href="dashboard-data-sources-ui.html">All data sources →</a></span>
+            <span class="home-snapshot__note"><a href="data-review-hub.html">Data Trust Center →</a></span>
           </div>
 
         </div>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:html": "npx htmlhint '*.html'",
     "lint:css": "npx stylelint 'css/*.css'",
     "test": "npm run test:ci",
-    "test:ci": "npm run validate && npm run validate:data && npm run validate:rosters && npm run test:fetch-helper && npm run test:hna && npm run test:hna-ownership-need && npm run test:combined-geo && npm run test:validate && npm run test:pro-forma && npm run test:qap-simulator && npm run test:pma-competitive-set && npm run test:lihtc-deal-predictor && npm run test:lihtc-opportunity-finder-zori && npm run test:opportunity-finder-verifier-source && npm run test:pma-transit && npm run test:soft-funding-tracker && npm run test:hna-ranking-index && npm run test:ranking-fresh && npm run test:ranking-scenarios && npm run test:hna-home-values && npm run test:jurisdiction-metrics-digest && npm run test:place-pages && npm run test:place-pages-fresh && npm run test:car-showingtime && npm run test:hna-car-loader && npm run test:developer-geoids && npm run test:developer-brief-hna && npm run test:navigation-paths && npm run test:f116-r1 && npm run test:pill-contrast && npm run test:inline-contrast && npm run test:inline-heading-typography && npm run test:phantom-css-vars && npm run test:data-scope && npm run test:fetch-error-surface && npm run test:semantic-labels && npm run test:hna-acs-coverage && npm run test:nodemailer-v9 && npm run test:briefs && npm run test:public-build && npm run test:data-trust-center && npm run test:deal-tracker-wording",
+    "test:ci": "npm run validate && npm run validate:data && npm run validate:rosters && npm run test:fetch-helper && npm run test:hna && npm run test:hna-ownership-need && npm run test:combined-geo && npm run test:validate && npm run test:pro-forma && npm run test:qap-simulator && npm run test:pma-competitive-set && npm run test:lihtc-deal-predictor && npm run test:lihtc-opportunity-finder-zori && npm run test:opportunity-finder-verifier-source && npm run test:pma-transit && npm run test:soft-funding-tracker && npm run test:hna-ranking-index && npm run test:ranking-fresh && npm run test:ranking-scenarios && npm run test:hna-home-values && npm run test:jurisdiction-metrics-digest && npm run test:place-pages && npm run test:place-pages-fresh && npm run test:car-showingtime && npm run test:hna-car-loader && npm run test:developer-geoids && npm run test:developer-brief-hna && npm run test:navigation-paths && npm run test:f116-r1 && npm run test:pill-contrast && npm run test:inline-contrast && npm run test:inline-heading-typography && npm run test:phantom-css-vars && npm run test:data-scope && npm run test:fetch-error-surface && npm run test:semantic-labels && npm run test:hna-acs-coverage && npm run test:nodemailer-v9 && npm run test:briefs && npm run test:public-build && npm run test:data-trust-center && npm run test:deal-tracker-wording && npm run test:homepage-job-routing",
     "test:developer-geoids": "node test/developer-geoids.test.js",
     "test:developer-brief-hna": "node test/developer-brief-hna.test.js",
     "test:navigation-paths": "node test/navigation-paths.test.js",
@@ -99,7 +99,8 @@
     "test:semantic-labels": "node test/semantic-label-guard.test.js",
     "test:opportunity-finder-verifier-source": "node test/opportunity-finder-verifier-source.test.mjs",
     "test:data-trust-center": "node test/data-trust-center.test.js",
-    "test:deal-tracker-wording": "node test/deal-tracker-wording.test.js"
+    "test:deal-tracker-wording": "node test/deal-tracker-wording.test.js",
+    "test:homepage-job-routing": "node test/homepage-job-routing.test.js"
   },
   "dependencies": {
     "jsdom": "^29.1.1"

--- a/test/homepage-job-routing.test.js
+++ b/test/homepage-job-routing.test.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// test/homepage-job-routing.test.js
+//
+// Phase 2.3: homepage source-order and link guard for jurisdiction-first
+// entry, job routing, and Data Trust Center transparency.
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+const index = fs.readFileSync(path.join(ROOT, 'index.html'), 'utf8');
+
+function pos(needle) {
+  const idx = index.indexOf(needle);
+  assert(idx >= 0, `index.html must include ${needle}`);
+  return idx;
+}
+
+function assertLinkExists(href) {
+  const target = path.join(ROOT, href);
+  assert(fs.existsSync(target), `homepage route target must exist: ${href}`);
+}
+
+const jurisdictionCta = pos('href="select-jurisdiction.html" class="btn"');
+const profileLink = pos('href="places/index.html"');
+const jobRoutes = pos('class="home-job-routes"');
+const workflow = pos('class="home-workflow"');
+
+assert(jurisdictionCta < jobRoutes, 'jurisdiction CTA must remain before job routing');
+assert(profileLink < jobRoutes, 'place-profile route must be offered before job routing');
+assert(jobRoutes < workflow, 'job routing must appear before the detailed six-step workflow');
+
+for (const label of ['Understand need', 'Find opportunity', 'Test feasibility', 'Verify data']) {
+  assert(index.includes(label), `homepage job routing must include "${label}"`);
+}
+
+for (const href of [
+  'select-jurisdiction.html',
+  'places/index.html',
+  'housing-needs-assessment.html',
+  'lihtc-opportunity-finder.html',
+  'market-analysis.html',
+  'data-review-hub.html',
+  'deal-calculator.html',
+  'land-value.html'
+]) {
+  assert(index.includes(`href="${href}"`), `homepage must link to ${href}`);
+  assertLinkExists(href);
+}
+
+assert(
+  index.includes('Public datasets are sourced and monitored') &&
+  index.includes('href="data-review-hub.html"'),
+  'homepage data snapshot must use narrowed trust language and link Data Trust Center'
+);
+assert(!index.includes('every stat is sourced'), 'homepage must not overclaim that every stat is sourced');
+assert(!index.includes('docs/demo-mode-audit.csv'), 'homepage trust claim must not point public readers to the old demo-mode audit');
+
+console.log('Homepage job routing (Phase 2.3): PASS');


### PR DESCRIPTION
## Summary
- Implements Phase 2.3 from `docs/audits/CODEX-HANDOFF-AUDIT-PHASE2-2026-07.md`.
- Recasts the top of `index.html` around jurisdiction-first entry, place profiles, and four job routes: Understand need, Find opportunity, Test feasibility, and Verify data.
- Keeps the full six-step LIHTC workflow lower on the page as process documentation rather than the first routing surface.
- Links the homepage data snapshot trust copy to the Data Trust Center and narrows the prior “every stat is sourced” language to “sourced and monitored.”
- Adds `test/homepage-job-routing.test.js` and wires it into `test:ci`.

## Audit Findings
- Addresses B-01 / Phase 2.3 homepage job routing.
- Addresses B-04 by narrowing the homepage trust claim and routing readers to the Data Trust Center.
- Helps B-06 by adding a first-screen link to generated local housing profiles.

## Independent Verification
- Confirmed #1089 / Phase 2.2 was merged before starting this branch.
- Re-read the Phase 2 handoff before editing.
- Confirmed source order: jurisdiction CTA and local profiles link precede job routing; job routing precedes the detailed six-step workflow.
- Confirmed all job-route targets exist: HNA, Compare, Opportunity Finder, Preservation, Market Analysis, Deal Calculator, Land Value, Data Trust Center.
- Confirmed out-of-scope deploy files were not touched: `robots.txt`, sitemap files, `CNAME`, and `test/pages-availability-check.js`.

## Rendered QA
- Local server: `http://127.0.0.1:8090/index.html`
- Desktop screenshot: `/tmp/coho-home-phase2-3-desktop.png`
- Mobile screenshot: `/tmp/coho-home-phase2-3-mobile.png`
- Chrome/Playwright metrics: no console/page errors; 4 route cards rendered; CTA → routes → workflow visual order true on desktop and mobile; mobile CTA fits viewport after wrap fix.

## Tests
- `npm run test:homepage-job-routing` PASS
- `npm run test:navigation-paths` PASS
- `npm run validate` PASS
- `npm run test:inline-heading-typography` PASS
- `npm run test:phantom-css-vars` PASS
- `npm run test:public-build` PASS (rerun with local sandbox escalation for `dist.lock` write)

## Known Limitations
- Screenshots were captured locally and paths are listed above; CLI upload/attachment to the PR is not available in this environment without committing binary screenshots, which would broaden the PR beyond the homepage scope.
- This PR keeps the existing `select-jurisdiction.html` CTA rather than adding an inline jurisdiction-search widget; that matches the deliberately limited Phase 2.3 scope while still promoting jurisdiction-first entry and local profiles.