### PR TITLE
fix(pma): contain mobile overflow

### DIFF
--- a/css/navigation.css
+++ b/css/navigation.css
@@ -307,8 +307,47 @@ html.dark-mode .footer-col a:hover { color: #e4f0fc; }
 /* ── Responsive: mobile breakpoint ────────────────────────────────────── */
 
 @media (max-width: 768px) {
+  .nav-wrap {
+    gap: 8px;
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+
+  .brand {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .brand a,
+  .brand small {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .jurisdiction-pill-wrap {
+    flex: 0 1 auto;
+    min-width: 0;
+  }
+
+  .jurisdiction-pill {
+    max-width: 8rem;
+  }
+
+  .nav-search {
+    flex: 0 0 44px;
+    width: 44px;
+    height: 44px;
+    justify-content: center;
+  }
+
+  .nav-search-btn {
+    width: 44px;
+    height: 44px;
+  }
+
   .mobile-menu-btn {
     display: flex;
+    flex: 0 0 44px;
   }
 
   nav.site-nav {
@@ -317,6 +356,12 @@ html.dark-mode .footer-col a:hover { color: #e4f0fc; }
 
   .footer-wrap {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 420px) {
+  .brand small {
+    display: none;
   }
 }
 

--- a/css/pages/market-analysis.css
+++ b/css/pages/market-analysis.css
@@ -64,6 +64,36 @@
   #pmaSiteCoords {
     margin-left: 0 !important;
   }
+
+  .pma-card .info-tooltip[open] {
+    display: block;
+    margin: 0.4rem 0 0;
+    max-width: 100%;
+  }
+
+  .pma-card .info-tooltip-body {
+    max-width: 100%;
+    overflow-wrap: anywhere;
+  }
+
+  #dc-soft-funding-ref {
+    max-width: 100%;
+    overflow-x: clip;
+  }
+
+  #dc-soft-funding-ref-list {
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
+
+  #dc-soft-funding-ref-list > div {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  #dc-soft-funding-ref-list a {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
 }
 
 /* ── Controls bar (buffer selector) ── */


### PR DESCRIPTION
## Summary
- Contain the mobile header row so the injected jurisdiction pill/search/hamburger controls do not push beyond the viewport.
- Keep expanded PMA info tooltips and the embedded soft-funding reference panel inside the mobile card width.
- Resolves the remaining Phase 3 rendered evidence follow-up: PMA mobile document overflow.

## Evidence
- Before: `npm run audit:core-rendered-smoke` reported PMA mobile `Document overflows mobile viewport by 31px`.
- After: `REPORT_DIR=/tmp/coho-core-rendered-smoke-final AUDIT_BASE_URL=http://127.0.0.1:3000 npm run audit:core-rendered-smoke` passed all 6 flows x 2 viewports.

## Validation
- `npm run validate`
- `npm run lint:css`
- `REPORT_DIR=/tmp/coho-core-rendered-smoke-final AUDIT_BASE_URL=http://127.0.0.1:3000 npm run audit:core-rendered-smoke`

## Note
- PR/issue #1008 is already merged and covers HNA home-value cascade stamps; this PR addresses the current rendered-audit PMA mobile overflow follow-up.
