### PR TITLE
Fix check_dola_vintage.py: compare against SDO's current file, not a deprecated one

### DIFF
--- a/scripts/hna/check_dola_vintage.py
+++ b/scripts/hna/check_dola_vintage.py
@@ -3,22 +3,35 @@
 check_dola_vintage.py
 =====================
 Compare the county populations embedded in our projections
-(data/hna/projections/<fips>.json, derived from SDO's
-components-change-county.csv) against SDO's official published county
-forecast (forecast1yrcounty.csv, same co-publicdata bucket).
+(data/hna/projections/<fips>.json) against SDO's components-change-county.csv
+-- the same file our own projection pipeline sources from, and the file
+SDO actively republishes (it appears on their public data page; the
+previously-used forecast1yrcounty.csv does not and looks abandoned as of
+2026-07-09).
 
-Why: consultant HNAs often cite older, hotter SDO vintages (e.g. Root
-Policy's Feb 2025 La Plata report used a pre-revision series with 2030
-pop 61,656 vs the current vintage-2023 forecast of 59,471). This check
-proves our trajectory tracks the CURRENT official forecast, so divergence
-from consultant reports is a vintage story, not a pipeline bug.
+Why this check still has value even though it compares the repo against
+its own direct input: it's a regression guard against the *build process*
+silently drifting from what SDO currently publishes (e.g. projections/*.json
+going stale after an SDO update, or a future refactor breaking the read/write
+of population_dola). It is deliberately NOT a check of our projection
+*methodology* against an independent second source -- SDO does not appear
+to publish an independent long-range county forecast separate from this
+file, so there isn't one to compare against.
 
-Baseline established 2026-07-04: median diff −1.4% at 2030 across all
-64 counties; 12 counties beyond ±5%, almost all small-population
-(bookends: Broomfield −11.7%, San Juan +15.4%); every large county is
-within ±5%. Diffs beyond ±5% print as warnings; the script fails
-(nonzero exit) only when data cannot be fetched/parsed or fewer than
-60 counties match.
+History: this script originally compared against forecast1yrcounty.csv
+(SDO vintage 2023, prepared October 2024) and, on 2026-07-04, reported a
+median diff of -1.4% with 12 counties beyond +/-5% (bookends: Broomfield
+-11.7%, San Juan +15.4%). Investigation on 2026-07-09 (see repo issue
+#1115) found forecast1yrcounty.csv no longer appears on SDO's current
+public data page (https://demography.dola.colorado.gov/assets/html/sdodata.html)
+and is likely a deprecated/orphaned file. Re-run against
+components-change-county.csv (SDO vintage 2024, prepared March 2025 --
+their currently-published county components-of-change product, which is
+also what data/hna/projections/*.json is itself built from) showed all
+64 counties matching exactly (0.0% diff, 0 warnings) -- the prior 12
+"warnings" were entirely an artifact of comparing against a stale
+benchmark, not real trajectory divergence. docs/audits/SDO-OUTLIERS-2026-07-08.md
+documents the (now superseded) prior analysis for historical reference.
 
 Usage:
     python3 scripts/hna/check_dola_vintage.py            # compares at 2030
@@ -38,7 +51,7 @@ import sys
 import urllib.request
 
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-FORECAST_URL = 'https://storage.googleapis.com/co-publicdata/forecast1yrcounty.csv'
+FORECAST_URL = 'https://storage.googleapis.com/co-publicdata/components-change-county.csv'
 WARN_PCT = 5.0
 MIN_MATCHED = 60
 
@@ -51,54 +64,46 @@ def fetch_forecast() -> list[list[str]]:
 
 
 def parse_forecast(rows: list[list[str]]) -> tuple[str, dict[str, dict[int, float]]]:
-    """Return (vintage_line, {county_name_lower: {year: population}}).
+    """Return (vintage_line, {county_fips_no_leading_zeros: {year: estimate}}).
 
-    Layout quirks (verified against the Oct 2024 file): banner title row,
-    then a 'Vintage ...' row, then junk, then a header row whose first cell
-    is 'Counties' followed by years 2000–2050; county rows follow with
-    comma-formatted numbers; names have no ' County' suffix.
+    Layout (verified against the March 2025 file): banner 'Vintage ...' row,
+    then a header row (id,idtxt,countyfips,year,estimate,change,births,
+    deaths,netmig,datatype); county rows have countyfips WITHOUT the state
+    prefix and WITHOUT leading zeros (e.g. '14' for Broomfield/08014, '111'
+    for San Juan/08111). Matching by FIPS instead of county name avoids the
+    ' County' suffix / naming mismatches a name-based join is prone to.
     """
     vintage = ''
-    for r in rows[:5]:
+    for r in rows[:3]:
         joined = ' '.join(c for c in r if c).strip()
         if 'vintage' in joined.lower():
             vintage = joined
             break
 
     header_idx = None
-    for i, r in enumerate(rows):
+    for i, r in enumerate(rows[:5]):
         cells = [c.strip() for c in r]
-        if cells and cells[0].lower().startswith('count') and '2030' in cells:
+        if cells and cells[0] == 'id' and 'countyfips' in cells:
             header_idx = i
             break
     if header_idx is None:
-        raise ValueError('could not locate year header row (first cell "Counties")')
+        raise ValueError('could not locate header row (expected "id,idtxt,countyfips,...")')
 
-    years: dict[int, int] = {}
-    for col, cell in enumerate(rows[header_idx]):
-        cell = cell.strip()
-        if cell.isdigit() and 1990 < int(cell) < 2100:
-            years[int(cell)] = col
-
+    reader = csv.DictReader(','.join(r) for r in rows[header_idx:])
     out: dict[str, dict[int, float]] = {}
-    for r in rows[header_idx + 1:]:
-        if not r or not r[0].strip():
+    for r in reader:
+        cf = r.get('countyfips')
+        yr = r.get('year')
+        est = r.get('estimate')
+        dt = r.get('datatype')
+        if not cf or not yr or not est or dt not in ('Estimate', 'Projection'):
             continue
-        name = r[0].strip()
-        low = name.lower()
-        if low.startswith(('total', 'colorado', 'state', 'source', 'note', 'table')):
+        try:
+            year = int(yr)
+            pop = float(est)
+        except ValueError:
             continue
-        series: dict[int, float] = {}
-        for year, col in years.items():
-            if col < len(r):
-                raw = r[col].replace(',', '').strip()
-                if raw:
-                    try:
-                        series[year] = float(raw)
-                    except ValueError:
-                        pass
-        if series:
-            out[low] = series
+        out.setdefault(cf, {})[year] = pop
     return vintage, out
 
 
@@ -135,13 +140,14 @@ def main() -> int:
         return 1
 
     repo = repo_projections()
-    print(f'SDO official forecast: {vintage or "(vintage line not found)"}')
-    print(f'Comparing repo projections vs official forecast at {args.year}\n')
+    print(f'SDO components-of-change file: {vintage or "(vintage line not found)"}')
+    print(f'Comparing repo projections vs official data at {args.year}\n')
 
     diffs = []
     unmatched = []
     for fips, (name, series) in sorted(repo.items(), key=lambda kv: kv[1][0]):
-        sdo_series = official.get(name.lower())
+        county_only = str(int(fips[-3:]))  # strip '08' state prefix + leading zeros
+        sdo_series = official.get(county_only)
         if sdo_series is None or args.year not in sdo_series or args.year not in series:
             unmatched.append(name)
             continue


### PR DESCRIPTION
## Summary

Closes #1115. Fixes `scripts/hna/check_dola_vintage.py` (`npm run check:dola-vintage`) to compare the repo's county projections against SDO's currently-published data instead of a file that appears to have been abandoned.

## What was wrong

The script fetched `forecast1yrcounty.csv` and treated it as "SDO's official forecast." That file:
- Is labeled "Vintage 2023, Prepared October 2024"
- **Does not appear anywhere on SDO's current public data download page** (`https://demography.dola.colorado.gov/assets/html/sdodata.html`) — confirmed by fetching that page directly and listing every linked file
- Still responds when fetched directly, so it looked "live," but nothing indicates SDO still updates it

Meanwhile, the repo's own projections (`data/hna/projections/*.json`) are built from a *different* SDO file — `components-change-county.csv` — which SDO does actively republish (currently "Vintage 2024, Prepared March 2025," five months newer) and which **is** listed on their current data page.

## Evidence this was the actual cause, not a coincidence

Pulled both raw files directly and compared the two largest prior "warnings":

| County | Year | Repo | `forecast1yrcounty.csv` (old) | `components-change-county.csv` (current) |
|---|---|---:|---:|---:|
| Broomfield | 2030 | 85,261 | 96,506 (-11.7%) | **85,261 (exact match)** |
| San Juan | 2030 | 862 | 747 (+15.4%) | **862 (exact match)** |

Then re-ran the full 64-county comparison against the current file: **every single county matches exactly (0.0% diff)**. The prior "12 counties beyond ±5%" (documented in `docs/audits/SDO-OUTLIERS-2026-07-08.md`) were entirely an artifact of the stale comparison file — there is no real trajectory divergence in the repo's projections.

## Changes

- `FORECAST_URL` now points at `components-change-county.csv`.
- Rewrote `parse_forecast()` for that file's actual column layout (`id,idtxt,countyfips,year,estimate,change,births,deaths,netmig,datatype`), filtering to `Estimate`/`Projection` rows.
- Switched county matching from name-string comparison to FIPS-based (more robust — avoids "County" suffix / naming mismatches).
- Updated the module docstring with the full history/rationale so a future reader isn't confused about why the comparison source changed, and to be upfront that this is now a build-regression guard (repo vs. its own direct input) rather than an independent-source cross-check, since SDO doesn't appear to publish a truly separate long-range forecast anymore.

## Known limitation

`docs/audits/SDO-OUTLIERS-2026-07-08.md` (merged in #1112) is now factually superseded — it analyzes 12 "divergences" that don't hold up against the current SDO file. Left as-is here (docs-only, out of scope for a script fix) but flagged in the new docstring; worth a follow-up correcting or retiring that doc. Tracking issues #1114 (Broomfield) and #1102 already reference this PR.

## Tests
- `npm run check:dola-vintage` — 64/64 counties matched, 0 warnings (was 12 warnings before)
- `python3 scripts/hna/check_dola_vintage.py --year 2040` — also 64/64 matched, 0 warnings
- `npm run validate` — PASS
- Confirmed nothing else in the repo (tests, CI workflows) depends on this script's prior output format — it's a standalone diagnostic, not wired into any gate.