### PR TITLE
fix(css): remove dead .home-onboarding__num rules

### DIFF
--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -1136,18 +1136,16 @@ label { color: var(--muted); font-size: var(--small); font-weight: 600; display:
    which read as visually jarring even though contrast was AAA. We
    accept the lower contrast on those rare inline buttons and lean on
    the class-based overrides below for the canonical .btn.primary /
-   .btn-primary / .home-onboarding__num cases.
+   .btn-primary cases.
    ================================================================ */
 @media (prefers-color-scheme: dark) {
-  .btn.primary, .btn-primary,
-  .home-onboarding__num {
+  .btn.primary, .btn-primary {
     color: #0d1f35 !important;
   }
   .kicker { color: var(--accent) !important; }
 }
 html.dark-mode .btn.primary,
-html.dark-mode .btn-primary,
-html.dark-mode .home-onboarding__num { color: #0d1f35 !important; }
+html.dark-mode .btn-primary { color: #0d1f35 !important; }
 html.dark-mode .kicker { color: var(--accent) !important; }
 /* F155 — Explicit light-mode override for the same rules. The
    `@media (prefers-color-scheme: dark)` block above fires off the OS
@@ -1157,8 +1155,7 @@ html.dark-mode .kicker { color: var(--accent) !important; }
    (rgb(13,31,53) on rgb(9,110,101) = 2.71:1). Class-based selector beats
    the @media block via specificity, restoring white text in light mode. */
 html.light-mode .btn.primary,
-html.light-mode .btn-primary,
-html.light-mode .home-onboarding__num { color: var(--on-accent, #fff) !important; }
+html.light-mode .btn-primary { color: var(--on-accent, #fff) !important; }
 html.light-mode .kicker { color: var(--accent) !important; }
 
 /* ================================================================


### PR DESCRIPTION
## Summary
- Closes #1094. PR #1090 removed the `.home-onboarding` 6-step onboarding rail markup from `index.html` but left the corresponding `.home-onboarding__num` selector in three dark/light-mode contrast-override rules in `css/site-theme.css`.
- Confirmed via repo-wide grep (`grep -rn "home-onboarding" --include="*.html" --include="*.css" --include="*.js" .`) that nothing else references it.
- The rules were bundled together with the still-live `.btn.primary`/`.btn-primary` overrides — only the dead `.home-onboarding__num` selector is removed; the button rules are untouched.

## Verification
- `grep -n "home-onboarding" css/site-theme.css` → no matches.
- `npm run validate` — PASS (52 HTML files).
- `npm run lint:css` — PASS, no new warnings.
- Live browser check (light + dark mode) on `select-jurisdiction.html`'s `.btn.primary`/`.btn-primary` buttons confirms colors unchanged: light mode white-on-teal (`rgb(255,255,255)` on `rgb(9,110,101)`), dark mode navy-on-cyan (`rgb(13,31,53)` on `rgb(15,212,207)`) — matching pre-fix values exactly.