### PR TITLE
fix(hygiene): widen duplicate-artifact gitignore, add local scan script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,11 @@ dist/
 private/
 
 # IDE save-as / duplicate artifacts (macOS Finder + some editors create
-# "filename 2.ext" when re-saving). These have been polluting the tree.
-*\ 2.*
-*\ 2/
+# "filename 2.ext" when re-saving; iCloud sync conflicts create "filename 3.ext",
+# "filename 4.ext", etc. on subsequent conflicts — the original "*\ 2.*"-only
+# pattern missed those higher suffixes, see #1107). These have been polluting
+# the tree.
+*\ [0-9].*
+*\ [0-9]/
 data/hna/lodes-raw/
 out/~$*

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "audit:core-rendered-smoke": "node scripts/audit/core-rendered-smoke.mjs",
     "audit:charts": "node scripts/audit/chart-population-audit.mjs",
     "audit:public-artifact": "node scripts/audit/public-artifact-guard.mjs dist",
+    "audit:duplicate-artifacts": "node scripts/audit/duplicate-artifact-scan.mjs",
     "audit:opportunity-finder": "node scripts/audit/verify-opportunity-finder.mjs",
     "audit:repo-links": "node scripts/audit/repo-link-audit.mjs",
     "audit:repo-links:probe": "node scripts/audit/repo-link-audit.mjs --probe",

--- a/scripts/audit/duplicate-artifact-scan.mjs
+++ b/scripts/audit/duplicate-artifact-scan.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * scripts/audit/duplicate-artifact-scan.mjs — F(#1107)
+ *
+ * Why this exists
+ * ----------------
+ * When this repo lives under an iCloud-synced folder, sync conflicts create
+ * "filename 2.ext", "filename 3.ext", etc. duplicates on disk (macOS Finder
+ * save-as conflicts do the same for " 2." only). They're gitignored (see
+ * "*\ [0-9].*" in .gitignore) so they can't be committed, but they still
+ * distort local `find`/`ls`/glob-based counts and repo sweeps for whoever's
+ * running them — 460 such files were found at audit time (2026-07-09), up
+ * from 228 a day earlier.
+ *
+ * This is local-dev-only by design: CI clones a fresh checkout from git, so
+ * these files never exist there. Warn-only, always exits 0 — never auto-
+ * deletes, since a " 2."/" 3." file may represent a real unresolved sync
+ * conflict a developer needs to look at before choosing which copy to keep.
+ *
+ * Usage:
+ *   node scripts/audit/duplicate-artifact-scan.mjs
+ *
+ * Hooked into `npm run audit:duplicate-artifacts` (not part of test:ci —
+ * see rationale above).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..');
+
+const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', '_site', '.venv', '_tobedeleted', '_audit']);
+const DUPLICATE_RE = / [0-9]+\.[a-zA-Z0-9]+$/;
+
+function walk(dir, out = []) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, out);
+    } else if (DUPLICATE_RE.test(entry.name)) {
+      out.push(path.relative(ROOT, full));
+    }
+  }
+  return out;
+}
+
+const duplicates = walk(ROOT).sort();
+
+if (duplicates.length === 0) {
+  console.log('duplicate-artifact-scan: clean — no "name N.ext" duplicate files found.');
+  process.exit(0);
+}
+
+console.log(`duplicate-artifact-scan: found ${duplicates.length} "name N.ext" duplicate file(s) in the working tree.`);
+console.log('These are gitignored and cannot be committed, but they can distort local find/ls/glob-based counts.');
+console.log('If this is an iCloud (or similar) sync-conflict folder, review and resolve the conflicts by hand — this script never deletes files.\n');
+for (const f of duplicates.slice(0, 20)) {
+  console.log(`  ${f}`);
+}
+if (duplicates.length > 20) {
+  console.log(`  ...and ${duplicates.length - 20} more`);
+}
+process.exit(0);


### PR DESCRIPTION
## Summary
- Closes #1107. Re-verifying this finding turned up a live gap beyond the issue's original scope: the existing `.gitignore` pattern only matched `" 2.ext"` duplicates (macOS Finder save-as conflicts). A second iCloud sync conflict on the same file produces `" 3.ext"`, `" 4.ext"`, etc. — and those were **not** covered, sitting untracked-but-not-ignored in the real working tree.
- Confirmed: `git status --short` in the actual (non-worktree) repo showed 87 untracked `" 3.json"` files before this fix — one `git add -A` away from shipping duplicate data into the public repo.
- Widens the pattern to `*\ [0-9].*` / `*\ [0-9]/` (any digit suffix). Confirmed no legitimately-tracked filename matches this shape first (`git ls-files | grep -E ' [0-9]\.[a-zA-Z0-9]+$'` → empty).
- Adds `npm run audit:duplicate-artifacts`, a warn-only local script that reports duplicate counts. **Not** wired into `test:ci` / CI — CI clones a fresh checkout from git and never has these files, so a CI gate would be a permanent no-op; this is genuinely a local-dev-only concern. Never deletes anything (per the issue's explicit guidance — a duplicate may be an unresolved sync conflict the developer needs to look at).

## Verification
- Planted a fake `data/hna/fake 2.json`, confirmed the scan script detects it (`found 1 ... duplicate file(s)`), removed it, confirmed clean output again.
- Planted a fake `data/hna/fake 3.json`, confirmed `git check-ignore -v` now matches it against the new pattern (`.gitignore:60:*\ [0-9].*`), removed it.
- `npm run validate` — PASS (52 HTML files).
- `npm run audit:duplicate-artifacts` — PASS, clean output on this fresh checkout.