### PR TITLE
fix(hygiene): polish duplicate artifact guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,10 +54,13 @@ private/
 
 # IDE save-as / duplicate artifacts (macOS Finder + some editors create
 # "filename 2.ext" when re-saving; iCloud sync conflicts create "filename 3.ext",
-# "filename 4.ext", etc. on subsequent conflicts — the original "*\ 2.*"-only
-# pattern missed those higher suffixes, see #1107). These have been polluting
-# the tree.
+# "filename 4.ext", etc. on subsequent conflicts. Keep common one-, two-, and
+# three-digit suffix patterns aligned with scripts/audit/duplicate-artifact-scan.mjs.
 *\ [0-9].*
+*\ [0-9][0-9].*
+*\ [0-9][0-9][0-9].*
 *\ [0-9]/
+*\ [0-9][0-9]/
+*\ [0-9][0-9][0-9]/
 data/hna/lodes-raw/
 out/~$*

--- a/scripts/audit/duplicate-artifact-scan.mjs
+++ b/scripts/audit/duplicate-artifact-scan.mjs
@@ -6,8 +6,8 @@
  * ----------------
  * When this repo lives under an iCloud-synced folder, sync conflicts create
  * "filename 2.ext", "filename 3.ext", etc. duplicates on disk (macOS Finder
- * save-as conflicts do the same for " 2." only). They're gitignored (see
- * "*\ [0-9].*" in .gitignore) so they can't be committed, but they still
+ * save-as conflicts do the same for " 2." only). Common one-, two-, and
+ * three-digit suffixes are gitignored, so they can't be committed, but they still
  * distort local `find`/`ls`/glob-based counts and repo sweeps for whoever's
  * running them — 460 such files were found at audit time (2026-07-09), up
  * from 228 a day earlier.
@@ -30,7 +30,18 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..', '..');
 
-const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', '_site', '.venv', '_tobedeleted', '_audit']);
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  '.claude',
+  '.agents',
+  '.codex',
+  'dist',
+  '_site',
+  '.venv',
+  '_tobedeleted',
+  '_audit',
+]);
 const DUPLICATE_RE = / [0-9]+\.[a-zA-Z0-9]+$/;
 
 function walk(dir, out = []) {


### PR DESCRIPTION
## Summary
- Aligns duplicate-artifact ignore rules with the scanner for common multi-digit suffixes (`name 10.ext`, `name 100.ext`).
- Skips local Codex/Claude session folders in the warn-only duplicate scan so nested worktrees do not dominate the output.
- Leaves the scan warn-only and non-deleting.

## Evidence
- `git check-ignore -v "data/example 3.json"` -> ignored by one-digit pattern.
- `git check-ignore -v "data/example 10.json"` -> ignored by two-digit pattern.
- `git check-ignore -v "data/example 100.json"` -> ignored by three-digit pattern.
- `npm run audit:duplicate-artifacts` passed; local warning output dropped from 551 nested/session-heavy hits to 4 top-level working-tree duplicates.
- `npm run validate` passed.

## Notes
- Follow-up to merged PR #1122.
- No public artifact, product behavior, or data changes.
- Do not merge until external QA completes.