### PR TITLE
fix(hna): reject seventh combined member before announcement

### DIFF
--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -309,19 +309,20 @@
     const member = _memberFromCurrentSelect();
     if (!member) {
       window.HNARenderers.setBanner('Combined areas can include only places, CDPs, or counties. Select County or Incorporated Place (+ CDP) first.', 'warn');
-      return;
+      return false;
     }
     const key = member.geoType + ':' + member.geoid;
     const list = window.HNAState.state.combinedMembers || [];
-    if (list.some(m => (m.geoType + ':' + m.geoid) === key)) return;
+    if (list.some(m => (m.geoType + ':' + m.geoid) === key)) return false;
     if (list.length >= 6) {
       window.HNARenderers.setBanner('Combined areas support up to 6 members.', 'warn');
-      return;
+      return false;
     }
     list.push(member);
     window.HNAState.state.combinedMembers = list;
     _renderCombinedChips();
     if (typeof window.__announceUpdate === 'function') window.__announceUpdate('Combined member added: ' + _labelForMember(member));
+    return true;
   }
 
 
@@ -3549,7 +3550,8 @@
       update();
     });
     window.HNAState.els.btnAddCombinedGeo?.addEventListener('click', () => {
-      _addCurrentCombinedMember();
+      const added = _addCurrentCombinedMember();
+      if (!added) return;
       if (window.HNAState.els.combineGeosToggle) window.HNAState.els.combineGeosToggle.checked = true;
       _syncCombinedPanel();
       update();

--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -313,8 +313,13 @@
     }
     const key = member.geoType + ':' + member.geoid;
     const list = window.HNAState.state.combinedMembers || [];
-    if (!list.some(m => (m.geoType + ':' + m.geoid) === key)) list.push(member);
-    window.HNAState.state.combinedMembers = list.slice(0, 6);
+    if (list.some(m => (m.geoType + ':' + m.geoid) === key)) return;
+    if (list.length >= 6) {
+      window.HNARenderers.setBanner('Combined areas support up to 6 members.', 'warn');
+      return;
+    }
+    list.push(member);
+    window.HNAState.state.combinedMembers = list;
     _renderCombinedChips();
     if (typeof window.__announceUpdate === 'function') window.__announceUpdate('Combined member added: ' + _labelForMember(member));
   }

--- a/test/combined-geo.test.js
+++ b/test/combined-geo.test.js
@@ -271,6 +271,30 @@ test('Mode B UI is mounted by controller without requiring template HTML edits',
   assert(src.includes('buildPairedCountyView'), 'controller calls combined paired-view helper');
 });
 
+test('combined member cap is checked before mutation and success announcement', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-controller.js'), 'utf8');
+  const fnStart = src.indexOf('function _addCurrentCombinedMember()');
+  assert.ok(fnStart >= 0, 'controller exposes _addCurrentCombinedMember helper');
+  const fnEnd = src.indexOf('\n  }\n\n\n  function _ensurePairedCountyView', fnStart);
+  assert.ok(fnEnd > fnStart, 'test can isolate _addCurrentCombinedMember body');
+  const body = src.slice(fnStart, fnEnd);
+  const duplicateIdx = body.indexOf("if (list.some(m => (m.geoType + ':' + m.geoid) === key)) return;");
+  const capIdx = body.indexOf('if (list.length >= 6)');
+  const pushIdx = body.indexOf('list.push(member)');
+  const assignIdx = body.indexOf('window.HNAState.state.combinedMembers = list;');
+  const announceIdx = body.indexOf("window.__announceUpdate('Combined member added: ' + _labelForMember(member))");
+  assert.ok(duplicateIdx >= 0, 'duplicates are rejected before mutation');
+  assert.ok(capIdx >= 0, 'member cap guard exists');
+  assert.ok(pushIdx >= 0, 'member push remains present');
+  assert.ok(assignIdx >= 0, 'member list assignment remains present');
+  assert.ok(announceIdx >= 0, 'success announcement remains present');
+  assert.ok(duplicateIdx < pushIdx, 'duplicate guard runs before push');
+  assert.ok(capIdx < pushIdx, 'cap guard runs before push');
+  assert.ok(capIdx < announceIdx, 'cap guard runs before success announcement');
+  assert.ok(body.includes("window.HNARenderers.setBanner('Combined areas support up to 6 members.', 'warn')"), 'cap warning is shown');
+  assert.ok(!body.includes('list.slice(0, 6)'), '7th member is no longer pushed then truncated');
+});
+
 test('combined AMI-gap rendering gates on availability flag', () => {
   const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-renderers.js'), 'utf8');
   assert(src.includes('result.availability && result.availability.amiGap && result.availability.amiGap.available'), 'renderCombinedAssessment reads availability.amiGap.available');

--- a/test/combined-geo.test.js
+++ b/test/combined-geo.test.js
@@ -278,21 +278,43 @@ test('combined member cap is checked before mutation and success announcement', 
   const fnEnd = src.indexOf('\n  }\n\n\n  function _ensurePairedCountyView', fnStart);
   assert.ok(fnEnd > fnStart, 'test can isolate _addCurrentCombinedMember body');
   const body = src.slice(fnStart, fnEnd);
-  const duplicateIdx = body.indexOf("if (list.some(m => (m.geoType + ':' + m.geoid) === key)) return;");
+  const duplicateIdx = body.indexOf("if (list.some(m => (m.geoType + ':' + m.geoid) === key)) return false;");
   const capIdx = body.indexOf('if (list.length >= 6)');
   const pushIdx = body.indexOf('list.push(member)');
   const assignIdx = body.indexOf('window.HNAState.state.combinedMembers = list;');
   const announceIdx = body.indexOf("window.__announceUpdate('Combined member added: ' + _labelForMember(member))");
+  const successReturnIdx = body.indexOf('return true;');
   assert.ok(duplicateIdx >= 0, 'duplicates are rejected before mutation');
   assert.ok(capIdx >= 0, 'member cap guard exists');
   assert.ok(pushIdx >= 0, 'member push remains present');
   assert.ok(assignIdx >= 0, 'member list assignment remains present');
   assert.ok(announceIdx >= 0, 'success announcement remains present');
+  assert.ok(successReturnIdx > announceIdx, 'successful add reports true after announcement');
   assert.ok(duplicateIdx < pushIdx, 'duplicate guard runs before push');
   assert.ok(capIdx < pushIdx, 'cap guard runs before push');
   assert.ok(capIdx < announceIdx, 'cap guard runs before success announcement');
   assert.ok(body.includes("window.HNARenderers.setBanner('Combined areas support up to 6 members.', 'warn')"), 'cap warning is shown');
+  assert.ok(body.includes("if (!member) {\n      window.HNARenderers.setBanner('Combined areas can include only places, CDPs, or counties. Select County or Incorporated Place (+ CDP) first.', 'warn');\n      return false;\n    }"), 'invalid selections reject without re-rendering');
+  assert.ok(body.includes("if (list.some(m => (m.geoType + ':' + m.geoid) === key)) return false;"), 'duplicates reject without re-rendering');
+  assert.ok(body.includes("if (list.length >= 6) {\n      window.HNARenderers.setBanner('Combined areas support up to 6 members.', 'warn');\n      return false;\n    }"), 'cap rejects without re-rendering');
   assert.ok(!body.includes('list.slice(0, 6)'), '7th member is no longer pushed then truncated');
+});
+
+test('combined add button preserves rejection warning by skipping update on false', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-controller.js'), 'utf8');
+  const handlerStart = src.indexOf("window.HNAState.els.btnAddCombinedGeo?.addEventListener('click', () => {");
+  assert.ok(handlerStart >= 0, 'add-combined button handler exists');
+  const handlerEnd = src.indexOf('\n    });', handlerStart);
+  assert.ok(handlerEnd > handlerStart, 'test can isolate add-combined button handler');
+  const body = src.slice(handlerStart, handlerEnd);
+  const addIdx = body.indexOf('const added = _addCurrentCombinedMember();');
+  const guardIdx = body.indexOf('if (!added) return;');
+  const syncIdx = body.indexOf('_syncCombinedPanel();');
+  const updateIdx = body.indexOf('update();');
+  assert.ok(addIdx >= 0, 'handler captures add result');
+  assert.ok(guardIdx > addIdx, 'handler exits after rejected add');
+  assert.ok(syncIdx > guardIdx, 'sync only runs after a successful add');
+  assert.ok(updateIdx > guardIdx, 'update only runs after a successful add');
 });
 
 test('combined AMI-gap rendering gates on availability flag', () => {


### PR DESCRIPTION
## Summary
- Fixes #1092 from `docs/audits/CODEX-HANDOFF-COMBINED-JURISDICTIONS-2026-07-09.md`.
- Rejects duplicate combined members before mutation.
- Rejects the 7th combined member before `list.push(...)` and before the success aria-live announcement.
- Shows a warning banner for the 6-member cap instead of announcing a false success.

## Verification
- Re-checked `_addCurrentCombinedMember()` on current `main`: it pushed first, sliced to 6, then announced success unconditionally.
- Added a focused regression in `test/combined-geo.test.js` asserting the duplicate/cap guards run before mutation and before `__announceUpdate`, and that `list.slice(0, 6)` is gone from this helper.

## Tests
- `node test/combined-geo.test.js` -> PASS, 19/19
- `npm run validate` -> PASS

## Manual QA Note
- Browser manual walkthrough still recommended by external QA: add 7 members, confirm the 7th shows the cap warning and the chip list never exceeds 6.

Do not merge until external QA completes.