### PR TITLE
fix(hna): reuse canonical combined alias resolver

### DIFF
--- a/js/hna/combined-geo.js
+++ b/js/hna/combined-geo.js
@@ -26,6 +26,9 @@
 
   function resolveAlias(geoid, datasets) {
     var key = String(geoid || '').padStart(7, '0');
+    if (window.PlaceChas && typeof window.PlaceChas.resolveAlias === 'function') {
+      try { return window.PlaceChas.resolveAlias(key); } catch (_e) {}
+    }
     return aliasMap(datasets)[key] || key;
   }
 

--- a/test/combined-geo.test.js
+++ b/test/combined-geo.test.js
@@ -8,9 +8,9 @@ const { JSDOM } = require('jsdom');
 
 const ROOT = path.resolve(__dirname, '..');
 
-function loadBrowserModule(rel, exportName) {
+function loadBrowserModule(rel, exportName, windowExtras) {
   const src = fs.readFileSync(path.join(ROOT, rel), 'utf8');
-  const sandbox = { window: {} };
+  const sandbox = { window: Object.assign({}, windowExtras || {}) };
   vm.createContext(sandbox);
   vm.runInContext(src, sandbox, { filename: rel });
   return sandbox.window[exportName];
@@ -221,6 +221,26 @@ test('phantom alias member resolves to canonical record', () => {
   assert.equal(out.valid, true);
   assert.equal(out.members[0].geoid, '0800001');
   assert.equal(out.pseudoChasRecord.memberNames[0], 'A');
+});
+
+test('combined alias resolution delegates to canonical PlaceChas helper when available', () => {
+  const calls = [];
+  const combined = loadBrowserModule('js/hna/combined-geo.js', 'HNACombinedGeo', {
+    PlaceChas: {
+      resolveAlias(geoid) {
+        calls.push(geoid);
+        return geoid === '0999999' ? '0800002' : geoid;
+      },
+    },
+  });
+  const out = combined.aggregate([
+    { geoType: 'place', geoid: '0999999' },
+    { geoType: 'place', geoid: '0800001' },
+  ], fixtureDatasets());
+  assert.deepEqual(calls, ['0999999', '0800001']);
+  assert.equal(out.valid, true);
+  assert.deepEqual(out.members.map(m => m.geoid), ['0800002', '0800001']);
+  assert.equal(out.pseudoChasRecord.summary.total_renter_hh, 1000);
 });
 
 test('availability map marks commuting unavailable and multi-county AMI limits listed', () => {


### PR DESCRIPTION
## Summary
- Handles #1093 cleanup item 1 from docs/audits/CODEX-HANDOFF-COMBINED-JURISDICTIONS-2026-07-09.md.
- Updates combined geography alias resolution to call window.PlaceChas.resolveAlias when available.
- Keeps the existing combined-geo dataset alias map as a fallback when PlaceChas is unavailable or throws.
- Adds regression coverage proving combined aggregation follows the canonical helper while preserving the existing fallback alias test.

## Verification
- Re-read the handoff item on current main after #1130 merged.
- Confirmed js/hna/combined-geo.js still had its own inline resolver and js/place-chas-lookup.js exposes the canonical PlaceChas.resolveAlias helper.
- Scoped this PR to #1093 sub-item 1 only; sub-items 2-6 are intentionally not bundled.

## Tests
- node test/combined-geo.test.js — 25 passed, 0 failed
- npm run validate — passed
- npm run test:hna — 730 passed, 0 failed

## QA notes
- External QA can spot-check a phantom alias combined member still resolves to its canonical place.
- No browser UI or data-shape changes expected beyond using the shared alias helper.