### PR TITLE
perf(hna): load combined datasets concurrently

### DIFF
--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -397,15 +397,34 @@
 
   async function _loadCombinedDatasets() {
     if (window.HNAState.state.combinedDatasets) return window.HNAState.state.combinedDatasets;
+    const [
+      placeChas,
+      countyChas,
+      amiGapPlace,
+      amiGapCounty,
+      placeCountyLookup,
+      crossCountyPlaces,
+      aliases,
+      homeValueCascade,
+    ] = await Promise.all([
+      loadJson('data/hna/place-chas.json'),
+      loadJson(window.HNAUtils.PATHS.chasCostBurden),
+      loadJson('data/co_ami_gap_by_place.json'),
+      loadJson(window.HNAUtils.PATHS.acsAmiGap),
+      loadJson('data/hna/derived/place_county_lookup.json'),
+      loadJson('data/hna/cross-county-places.json'),
+      loadJson('data/hna/place-phantom-aliases.json'),
+      loadJson('data/hna/home-value-cascade.json'),
+    ]);
     const datasets = {
-      placeChas: await loadJson('data/hna/place-chas.json'),
-      countyChas: await loadJson(window.HNAUtils.PATHS.chasCostBurden),
-      amiGapPlace: await loadJson('data/co_ami_gap_by_place.json'),
-      amiGapCounty: await loadJson(window.HNAUtils.PATHS.acsAmiGap),
-      placeCountyLookup: await loadJson('data/hna/derived/place_county_lookup.json'),
-      crossCountyPlaces: await loadJson('data/hna/cross-county-places.json'),
-      aliases: await loadJson('data/hna/place-phantom-aliases.json'),
-      homeValues: await loadJson('data/hna/home-value-cascade.json').then(function (d) { return d && d.places; }),
+      placeChas,
+      countyChas,
+      amiGapPlace,
+      amiGapCounty,
+      placeCountyLookup,
+      crossCountyPlaces,
+      aliases,
+      homeValues: homeValueCascade && homeValueCascade.places,
     };
     window.HNAState.state.combinedDatasets = datasets;
     return datasets;

--- a/test/combined-geo.test.js
+++ b/test/combined-geo.test.js
@@ -373,7 +373,26 @@ test('combined member cap is checked before mutation and success announcement', 
 test('combined home-value renderer uses computed metric instead of static placeholder', () => {
   const controller = fs.readFileSync(path.join(ROOT, 'js/hna/hna-controller.js'), 'utf8');
   const renderers = fs.readFileSync(path.join(ROOT, 'js/hna/hna-renderers.js'), 'utf8');
-  assert(controller.includes("homeValues: await loadJson('data/hna/home-value-cascade.json').then(function (d) { return d && d.places; })"), 'combined datasets unwrap home-value cascade places');
+  const loadStart = controller.indexOf('async function _loadCombinedDatasets()');
+  assert.ok(loadStart >= 0, 'combined dataset loader exists');
+  const loadEnd = controller.indexOf('\n  }\n\n  async function updateCombined', loadStart);
+  assert.ok(loadEnd > loadStart, 'test can isolate combined dataset loader body');
+  const loadBody = controller.slice(loadStart, loadEnd);
+  assert(loadBody.includes('] = await Promise.all(['), 'combined datasets are fetched concurrently');
+  [
+    "loadJson('data/hna/place-chas.json')",
+    'loadJson(window.HNAUtils.PATHS.chasCostBurden)',
+    "loadJson('data/co_ami_gap_by_place.json')",
+    'loadJson(window.HNAUtils.PATHS.acsAmiGap)',
+    "loadJson('data/hna/derived/place_county_lookup.json')",
+    "loadJson('data/hna/cross-county-places.json')",
+    "loadJson('data/hna/place-phantom-aliases.json')",
+    "loadJson('data/hna/home-value-cascade.json')",
+  ].forEach(expected => {
+    assert(loadBody.includes(expected), 'combined loader includes ' + expected);
+  });
+  assert(loadBody.includes('homeValues: homeValueCascade && homeValueCascade.places'), 'combined datasets unwrap home-value cascade places');
+  assert.equal((loadBody.match(/await loadJson/g) || []).length, 0, 'combined loader does not fetch datasets sequentially');
   assert(renderers.includes('var homeValueMetric = result.medianMetrics && result.medianMetrics.homeValue;'), 'renderer reads combined home-value metric');
   assert(renderers.includes("_combinedSetText('statHomeValue', homeRange + ' · avg ' + homeAvg);"), 'renderer displays range and weighted average');
   assert(renderers.includes("_combinedSetText('statHomeValue', 'Not available');"), 'renderer has unavailable fallback');


### PR DESCRIPTION
## Summary
- Handles #1093 cleanup item 2 from docs/audits/CODEX-HANDOFF-COMBINED-JURISDICTIONS-2026-07-09.md.
- Changes _loadCombinedDatasets() from eight sequential loadJson awaits to one Promise.all batch.
- Preserves the same loadJson call paths, no-store fetch behavior, HNAState combinedDatasets cache, and home-value cascade places unwrap.
- Updates the combined-geo regression contract to assert concurrent loading and all eight existing dataset sources.

## Verification
- Re-read the handoff item on current main after #1131 merged.
- Confirmed _loadCombinedDatasets() was still sequential and used loadJson for all eight data sources.
- Scoped this PR to #1093 sub-item 2 only; sub-items 3-6 are intentionally not bundled.

## Tests
- node test/combined-geo.test.js — 25 passed, 0 failed
- npm run validate — passed
- npm run test:hna — 730 passed, 0 failed

## QA notes
- Expected behavior is unchanged except faster combined-mode dataset startup because requests are fired concurrently.
- External QA can build a combined area and confirm the same combined metrics render as before.