### PR TITLE
refactor(hna): table-drive combined stat text

### DIFF
--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -7802,6 +7802,12 @@
     if (el) el.textContent = value == null || value === '' ? '—' : String(value);
   }
 
+  function _combinedSetTextMap(values) {
+    Object.keys(values || {}).forEach(function (id) {
+      _combinedSetText(id, values[id]);
+    });
+  }
+
   function _combinedUnavailable(id, message) {
     var el = document.getElementById(id);
     if (el) el.textContent = message || 'Not available for combined areas — view members individually.';
@@ -7886,10 +7892,23 @@
     var total = renter + owner;
     var renterShare = total ? renter / total : 0;
     var renterCbShare = renter ? Number(summary.renter_cb30_count || 0) / renter : 0;
-    _combinedSetText('statPop', 'Not available');
-    _combinedSetText('statPopSrc', 'Combined areas do not have a direct ACS population profile in v1.');
-    _combinedSetText('statMhi', 'Not available');
-    _combinedSetText('statMhiSrc', 'Not available for combined areas — view members individually.');
+    var unavailable = 'Not available for combined areas — view members individually.';
+    _combinedSetTextMap({
+      statPop: 'Not available',
+      statPopSrc: 'Combined areas do not have a direct ACS population profile in v1.',
+      statMhi: 'Not available',
+      statMhiSrc: unavailable,
+      statRent: 'Not available',
+      statRentSrc: unavailable,
+      statIncomeNeed: 'Not available',
+      statIncomeNeedNote: 'AMI limits are county-level; multi-county combos list counties separately.',
+      statCommute: 'Not available',
+      statCommuteSrc: unavailable,
+      statBaseUnits: 'Not available',
+      statBaseUnitsSrc: unavailable,
+      statUnitsNeed: 'Not available',
+      statNetMig: 'Not available',
+    });
     var homeValueMetric = result.medianMetrics && result.medianMetrics.homeValue;
     if (homeValueMetric && homeValueMetric.available) {
       var homeRange = homeValueMetric.min && homeValueMetric.max
@@ -7902,16 +7921,10 @@
       _combinedSetText('statHomeValue', 'Not available');
       _combinedSetText('statHomeValueSrc', 'Not available — no member home-value inputs available.');
     }
-    _combinedSetText('statRent', 'Not available');
-    _combinedSetText('statRentSrc', 'Not available for combined areas — view members individually.');
     _combinedSetText('statTenure', _ownFmtPct(renterShare) + ' renters / ' + _ownFmtPct(1 - renterShare) + ' owners');
     _combinedSetText('statTenureSrc', 'Combined CHAS households · DERIVED');
     _combinedSetText('statRentBurden', _ownFmtPct(renterCbShare));
     _combinedSetText('statRentBurdenSrc', 'Combined CHAS renter cost burden · DERIVED');
-    _combinedSetText('statIncomeNeed', 'Not available');
-    _combinedSetText('statIncomeNeedNote', 'AMI limits are county-level; multi-county combos list counties separately.');
-    _combinedSetText('statCommute', 'Not available');
-    _combinedSetText('statCommuteSrc', 'Not available for combined areas — view members individually.');
 
     var amiGapAvailable = !!(result.availability && result.availability.amiGap && result.availability.amiGap.available);
     var amiGapMessage = 'Not available — one or more members missing AMI-gap data';
@@ -7935,17 +7948,12 @@
       _combinedSetText('hnaGapConfidence', amiGapMessage);
     }
 
-    var unavailable = 'Not available for combined areas — view members individually.';
     _combinedClearNonCanvasPanels(unavailable, result);
     _combinedUnavailable('lehdNote', unavailable);
     _combinedUnavailable('seniorNote', unavailable);
     _combinedUnavailable('scenarioNeedSummary', unavailable);
     _combinedUnavailable('localResources', 'Local resources are listed by individual jurisdiction; view members individually.');
     _combinedUnavailable('lihtcMapStatus', 'LIHTC map remains county/statewide scoped for combined areas.');
-    _combinedSetText('statBaseUnits', 'Not available');
-    _combinedSetText('statBaseUnitsSrc', unavailable);
-    _combinedSetText('statUnitsNeed', 'Not available');
-    _combinedSetText('statNetMig', 'Not available');
     document.querySelectorAll('canvas[id^="chart"]').forEach(function (canvas) {
       _combinedMarkChartUnavailable(canvas.id, unavailable);
     });

--- a/test/combined-geo.test.js
+++ b/test/combined-geo.test.js
@@ -20,7 +20,12 @@ const Combined = loadBrowserModule('js/hna/combined-geo.js', 'HNACombinedGeo');
 const Ownership = loadBrowserModule('js/hna/hna-ownership-need.js', 'HNAOwnershipNeed');
 
 function loadRenderersDom() {
-  const dom = new JSDOM('<!doctype html><div id="hnaBanner"></div><div id="geoContextPill"></div><div id="execNarrative"></div><div id="statHomeValue"></div><div id="statHomeValueSrc"></div>');
+  const dom = new JSDOM('<!doctype html>' +
+    '<div id="hnaBanner"></div><div id="geoContextPill"></div><div id="execNarrative"></div>' +
+    '<div id="statPop"></div><div id="statPopSrc"></div><div id="statMhi"></div><div id="statMhiSrc"></div>' +
+    '<div id="statHomeValue"></div><div id="statHomeValueSrc"></div><div id="statRent"></div><div id="statRentSrc"></div>' +
+    '<div id="statIncomeNeed"></div><div id="statIncomeNeedNote"></div><div id="statCommute"></div><div id="statCommuteSrc"></div>' +
+    '<div id="statBaseUnits"></div><div id="statBaseUnitsSrc"></div><div id="statUnitsNeed"></div><div id="statNetMig"></div>');
   const sandbox = {
     window: dom.window,
     document: dom.window.document,
@@ -393,6 +398,8 @@ test('combined home-value renderer uses computed metric instead of static placeh
   });
   assert(loadBody.includes('homeValues: homeValueCascade && homeValueCascade.places'), 'combined datasets unwrap home-value cascade places');
   assert.equal((loadBody.match(/await loadJson/g) || []).length, 0, 'combined loader does not fetch datasets sequentially');
+  assert(renderers.includes('function _combinedSetTextMap(values)'), 'combined renderer has table-driven stat text helper');
+  assert(renderers.includes('_combinedSetTextMap({'), 'combined renderer uses table-driven stat text assignment');
   assert(renderers.includes('var homeValueMetric = result.medianMetrics && result.medianMetrics.homeValue;'), 'renderer reads combined home-value metric');
   assert(renderers.includes("_combinedSetText('statHomeValue', homeRange + ' · avg ' + homeAvg);"), 'renderer displays range and weighted average');
   assert(renderers.includes("_combinedSetText('statHomeValue', 'Not available');"), 'renderer has unavailable fallback');
@@ -417,8 +424,16 @@ test('combined home-value renderer paints range and average into stat card', () 
       },
     },
   });
+  assert.equal(dom.window.document.getElementById('statPop').textContent, 'Not available');
+  assert.equal(dom.window.document.getElementById('statPopSrc').textContent, 'Combined areas do not have a direct ACS population profile in v1.');
+  assert.equal(dom.window.document.getElementById('statMhi').textContent, 'Not available');
+  assert.equal(dom.window.document.getElementById('statMhiSrc').textContent, 'Not available for combined areas — view members individually.');
   assert.equal(dom.window.document.getElementById('statHomeValue').textContent, '$300,000 - $600,000 · avg $450,000');
   assert.equal(dom.window.document.getElementById('statHomeValueSrc').textContent, 'Fixture home-value caveat.');
+  assert.equal(dom.window.document.getElementById('statRent').textContent, 'Not available');
+  assert.equal(dom.window.document.getElementById('statRentSrc').textContent, 'Not available for combined areas — view members individually.');
+  assert.equal(dom.window.document.getElementById('statIncomeNeedNote').textContent, 'AMI limits are county-level; multi-county combos list counties separately.');
+  assert.equal(dom.window.document.getElementById('statBaseUnitsSrc').textContent, 'Not available for combined areas — view members individually.');
 });
 
 test('combined add button preserves rejection warning by skipping update on false', () => {


### PR DESCRIPTION
## Summary
- Handles #1093 cleanup item 3 from docs/audits/CODEX-HANDOFF-COMBINED-JURISDICTIONS-2026-07-09.md.
- Adds a small _combinedSetTextMap helper for combined-mode stat/source text assignments.
- Replaces repeated one-off static stat/source blanking calls with a table-driven map while preserving the same rendered strings.
- Expands the JSDOM renderer test to assert representative combined-mode stat text remains unchanged.

## Verification
- Re-read the handoff item on current main after #1133 merged.
- Confirmed result.availability is not a one-to-one DOM panel map, so I did not force a broad availability-driven rewrite.
- Scoped this PR to the safe static stat/source text subset only; dynamic AMI-gap, home-value, tenure, burden, ownership, and chart behavior are unchanged.
- #1093 sub-items 4-6 are intentionally not bundled.

## Tests
- node test/combined-geo.test.js — 25 passed, 0 failed
- npm run validate — passed
- npm run test:hna — 730 passed, 0 failed

## QA notes
- Expected rendered output is unchanged.
- External QA can build a combined area and compare the snapshot stat/source text for population, MHI, rent, income need, commute, base units, units need, and net migration against the previous combined-mode wording.