### PR TITLE
fix(hna): resolve combined URL member types from config

### DIFF
--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -264,6 +264,26 @@
     return { geoType: subtype || gt, geoid: window.HNAState.els.geoSelect.value };
   }
 
+  function _combinedMemberFromUrlGeoid(geoid) {
+    const id = String(geoid || '');
+    const cfg = window.__HNA_GEO_CONFIG || {};
+    const hasGeoid = (items) => Array.isArray(items) && items.some(item => String(item && item.geoid) === id);
+    const featuredByType = (type) => (cfg.featured || window.HNAUtils.FEATURED || []).filter(item => item && item.type === type);
+    if (hasGeoid(cfg.counties) || hasGeoid(featuredByType('county'))) {
+      return { geoType: 'county', geoid: id };
+    }
+    if (hasGeoid(cfg.cdps) || hasGeoid(featuredByType('cdp'))) {
+      return { geoType: 'cdp', geoid: id };
+    }
+    if (hasGeoid(cfg.places) || hasGeoid(featuredByType('place'))) {
+      return { geoType: 'place', geoid: id };
+    }
+    return {
+      geoType: id.length === 5 ? 'county' : 'place',
+      geoid: id,
+    };
+  }
+
   function _regionFromCurrentSelect() {
     const opt = _selectedOption();
     if (!opt) return null;
@@ -3420,10 +3440,7 @@
     } else if (urlGeos) {
       restoredGeoType = 'place';
       const parts = urlGeos.split(/[\s+,]+/).filter(Boolean);
-      window.HNAState.state.combinedMembers = parts.map(g => ({
-        geoType: String(g).length === 5 ? 'county' : 'place',
-        geoid: g,
-      })).slice(0, 6);
+      window.HNAState.state.combinedMembers = parts.map(_combinedMemberFromUrlGeoid).slice(0, 6);
       if (window.HNAState.els.combineGeosToggle) window.HNAState.els.combineGeosToggle.checked = true;
     }
     if (!restoredGeoType && urlAutoFlag && urlGeoType && urlGeoid) {

--- a/test/combined-geo.test.js
+++ b/test/combined-geo.test.js
@@ -480,6 +480,27 @@ test('combined add button preserves rejection warning by skipping update on fals
   assert.ok(updateIdx > guardIdx, 'update only runs after a successful add');
 });
 
+test('combined geos URL restore resolves member type from geo config before length fallback', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-controller.js'), 'utf8');
+  const helperStart = src.indexOf('function _combinedMemberFromUrlGeoid(geoid)');
+  assert.ok(helperStart >= 0, 'URL combined-member resolver exists');
+  const helperEnd = src.indexOf('\n\n  function _addCurrentCombinedMember', helperStart);
+  assert.ok(helperEnd > helperStart, 'test can isolate URL combined-member resolver');
+  const helperBody = src.slice(helperStart, helperEnd);
+  const countyIdx = helperBody.indexOf("hasGeoid(cfg.counties)");
+  const cdpIdx = helperBody.indexOf("hasGeoid(cfg.cdps)");
+  const placeIdx = helperBody.indexOf("hasGeoid(cfg.places)");
+  const fallbackIdx = helperBody.indexOf("geoType: id.length === 5 ? 'county' : 'place'");
+  assert.ok(countyIdx >= 0, 'resolver checks configured counties');
+  assert.ok(cdpIdx >= 0, 'resolver checks configured CDPs');
+  assert.ok(placeIdx >= 0, 'resolver checks configured places');
+  assert.ok(countyIdx < fallbackIdx, 'county lookup runs before length fallback');
+  assert.ok(cdpIdx < fallbackIdx, 'CDP lookup runs before length fallback');
+  assert.ok(placeIdx < fallbackIdx, 'place lookup runs before length fallback');
+  assert.ok(src.includes('window.HNAState.state.combinedMembers = parts.map(_combinedMemberFromUrlGeoid).slice(0, 6);'), '?geos restore uses resolver helper');
+  assert.ok(!src.includes("parts.map(g => ({\n        geoType: String(g).length === 5 ? 'county' : 'place',"), '?geos restore no longer uses inline length-only inference');
+});
+
 test('combined AMI-gap rendering gates on availability flag', () => {
   const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-renderers.js'), 'utf8');
   assert(src.includes('result.availability && result.availability.amiGap && result.availability.amiGap.available'), 'renderCombinedAssessment reads availability.amiGap.available');


### PR DESCRIPTION
## Summary
- Handles #1093 cleanup item 5 from docs/audits/CODEX-HANDOFF-COMBINED-JURISDICTIONS-2026-07-09.md.
- Adds a `_combinedMemberFromUrlGeoid()` helper for `?geos=` restore.
- Resolves combined member type from initialized geo config (`counties`, `cdps`, `places`, plus featured fallback) before using the old length fallback.
- Replaces the inline length-only `?geos=` inference with the resolver helper.

## Verification
- Re-read the handoff item on current main after #1135 merged.
- Confirmed the restore branch ran after geo-config and county-list initialization, so config membership is available at the call site.
- Confirmed the previous `?geos=` path was still `String(g).length === 5 ? county : place`.
- Scoped this PR to #1093 sub-item 5 only; sub-item 6 is intentionally not bundled.

## Tests
- node test/combined-geo.test.js — 26 passed, 0 failed
- npm run validate — passed
- npm run test:hna — 730 passed, 0 failed

## QA notes
- External QA can load an HNA URL with `?geos=` containing county and place/CDP GEOIDs and confirm combined chips restore with the expected member types.
- Unknown IDs still fall back to the existing length heuristic, preserving legacy behavior when a GEOID is absent from config.