### PR TITLE
fix(hna): sync workflow after combine off

### DIFF
--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -3584,6 +3584,7 @@
     window.HNAState.els.combineGeosToggle?.addEventListener('change', () => {
       _syncCombinedPanel();
       if (window.HNAState.els.combineGeosToggle.checked) _addCurrentCombinedMember();
+      else _syncJurisdictionToWorkflowState();
       update();
     });
     window.HNAState.els.btnAddCombinedGeo?.addEventListener('click', () => {

--- a/test/combined-geo.test.js
+++ b/test/combined-geo.test.js
@@ -501,6 +501,23 @@ test('combined geos URL restore resolves member type from geo config before leng
   assert.ok(!src.includes("parts.map(g => ({\n        geoType: String(g).length === 5 ? 'county' : 'place',"), '?geos restore no longer uses inline length-only inference');
 });
 
+test('combine toggle off resyncs current jurisdiction to WorkflowState', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-controller.js'), 'utf8');
+  const handlerStart = src.indexOf("window.HNAState.els.combineGeosToggle?.addEventListener('change', () => {");
+  assert.ok(handlerStart >= 0, 'combine toggle handler exists');
+  const handlerEnd = src.indexOf('\n    });', handlerStart);
+  assert.ok(handlerEnd > handlerStart, 'test can isolate combine toggle handler');
+  const body = src.slice(handlerStart, handlerEnd);
+  const panelIdx = body.indexOf('_syncCombinedPanel();');
+  const addIdx = body.indexOf('if (window.HNAState.els.combineGeosToggle.checked) _addCurrentCombinedMember();');
+  const syncIdx = body.indexOf('else _syncJurisdictionToWorkflowState();');
+  const updateIdx = body.indexOf('update();');
+  assert.ok(panelIdx >= 0, 'panel sync still runs on toggle change');
+  assert.ok(addIdx > panelIdx, 'turning combine on still adds current member after panel sync');
+  assert.ok(syncIdx > addIdx, 'turning combine off syncs WorkflowState instead of adding a member');
+  assert.ok(updateIdx > syncIdx, 'update runs after WorkflowState is resynced');
+});
+
 test('combined AMI-gap rendering gates on availability flag', () => {
   const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-renderers.js'), 'utf8');
   assert(src.includes('result.availability && result.availability.amiGap && result.availability.amiGap.available'), 'renderCombinedAssessment reads availability.amiGap.available');


### PR DESCRIPTION
## Summary
- Handles #1093 cleanup item 6 from docs/audits/CODEX-HANDOFF-COMBINED-JURISDICTIONS-2026-07-09.md.
- When the combined-geography toggle changes from on to off, calls `_syncJurisdictionToWorkflowState()` after `_syncCombinedPanel()` and before `update()`.
- Keeps the existing toggle-on behavior unchanged: panel sync, add current member, then update.
- Adds regression coverage for the toggle handler call order.

## Verification
- Re-read the handoff item on current main after #1136 merged.
- Confirmed `_syncJurisdictionToWorkflowState()` already exits while combine mode is checked, so the fix belongs in the unchecked/off branch.
- Confirmed the existing geoType and geoSelect change listeners already sync WorkflowState; only the combine toggle off path was missing it.
- This completes #1093 sub-item 6; no other sub-items are bundled.

## Tests
- node test/combined-geo.test.js — 27 passed, 0 failed
- npm run validate — passed
- npm run test:hna — 730 passed, 0 failed

## QA notes
- External QA should select a single jurisdiction, turn combine on, then turn combine off and confirm WorkflowState / Select Jurisdiction reflects the current single-geography selection again.