### PR TITLE
Add HNA executive decision strip

### DIFF
--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -19,6 +19,79 @@
   <link rel="stylesheet" href="css/pages.css">
   <link rel="stylesheet" href="css/responsive.css">
   <link rel="stylesheet" href="css/pages/housing-needs-assessment.css">
+  <style>
+    .hna-decision-strip {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      gap: .6rem;
+      margin: 0 var(--sp4) var(--sp3);
+    }
+    .hna-decision-strip[hidden] {
+      display: none;
+    }
+    .hna-decision-tile {
+      min-width: 0;
+      border: 1px solid var(--border);
+      border-left: 3px solid var(--accent);
+      border-radius: 6px;
+      background: color-mix(in oklab, var(--card) 92%, var(--bg2) 8%);
+      color: var(--text);
+      display: flex;
+      flex-direction: column;
+      gap: .16rem;
+      padding: .72rem .8rem;
+      text-decoration: none;
+    }
+    .hna-decision-tile:hover,
+    .hna-decision-tile:focus-visible {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 2px color-mix(in oklab, var(--accent) 18%, transparent);
+      outline: none;
+    }
+    .hna-decision-label {
+      color: var(--muted);
+      font-size: .72rem;
+      font-weight: 800;
+      line-height: 1.2;
+      text-transform: uppercase;
+    }
+    .hna-decision-tile strong {
+      font-size: clamp(1rem, 1.4vw, 1.18rem);
+      font-weight: 900;
+      line-height: 1.16;
+      overflow-wrap: anywhere;
+    }
+    .hna-decision-tile span:last-child {
+      color: var(--muted);
+      font-size: .8rem;
+      line-height: 1.25;
+      overflow-wrap: anywhere;
+    }
+    .hna-decision-tile[data-tone="high"],
+    .hna-decision-tile[data-tone="elevated"] {
+      border-left-color: var(--bad, #dc2626);
+    }
+    .hna-decision-tile[data-tone="moderate"] {
+      border-left-color: var(--warn, #d97706);
+    }
+    .hna-decision-tile[data-tone="low"],
+    .hna-decision-tile[data-tone="ready"] {
+      border-left-color: var(--good, #16a34a);
+    }
+    .hna-decision-tile[data-tone="unavailable"] {
+      border-left-color: var(--muted);
+    }
+    @media (max-width: 980px) {
+      .hna-decision-strip {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+    @media (max-width: 560px) {
+      .hna-decision-strip {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
   <!-- Leaflet (vendored locally — no CDN required) -->
   <link rel="stylesheet" href="js/vendor/leaflet.css" />
   <script src="js/path-resolver.js"></script>
@@ -251,6 +324,34 @@
           <button id="btnJson" type="button" title="Downloads the full report snapshot as a JSON file">Download JSON</button>
         </div>
       </div>
+    </section>
+
+    <section id="hnaDecisionStrip" class="hna-decision-strip" aria-label="Executive decision indicators" hidden>
+      <a class="hna-decision-tile" href="#hnaScorecardPanel" data-decision-key="need">
+        <span class="hna-decision-label">Need severity</span>
+        <strong id="decisionNeedValue">—</strong>
+        <span id="decisionNeedRead">Loading</span>
+      </a>
+      <a class="hna-decision-tile" href="#statRentBurden" data-decision-key="affordability">
+        <span class="hna-decision-label">Affordability pressure</span>
+        <strong id="decisionAffordabilityValue">—</strong>
+        <span id="decisionAffordabilityRead">Loading</span>
+      </a>
+      <a class="hna-decision-tile" href="#statUnitsNeed" data-decision-key="production">
+        <span class="hna-decision-label">Production gap</span>
+        <strong id="decisionProductionValue">—</strong>
+        <span id="decisionProductionRead">Loading</span>
+      </a>
+      <a class="hna-decision-tile" href="#affordable-ownership-need-section" data-decision-key="ownership">
+        <span class="hna-decision-label">Ownership feasibility</span>
+        <strong id="decisionOwnershipValue">—</strong>
+        <span id="decisionOwnershipRead">Loading</span>
+      </a>
+      <a class="hna-decision-tile" href="#hnaGapCoveragePanel" data-decision-key="confidence">
+        <span class="hna-decision-label">Data confidence</span>
+        <strong id="decisionConfidenceValue">—</strong>
+        <span id="decisionConfidenceRead">Loading</span>
+      </a>
     </section>
 
     <div id="pageContext"></div>

--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -2385,6 +2385,17 @@
     window.HNAState.els.statBaseUnitsSrc.textContent = baseYear ? `Total units to house current households at ${window.HNAUtils.fmtPct(targetVac*100)} target vacancy` : 'Current requirement';
     window.HNAState.els.statTargetVac.textContent = window.HNAUtils.fmtPct(targetVac * 100);
     window.HNAState.els.statUnitsNeed.textContent = incUnits !== null ? window.HNAUtils.fmtNum(Math.round(incUnits)) : '—';
+    if (window.HNARenderers.updateDecisionStrip) {
+      window.HNARenderers.updateDecisionStrip({
+        production: {
+          value: incUnits !== null ? window.HNAUtils.fmtNum(Math.round(incUnits)) : '—',
+          read: incUnits !== null && Number.isFinite(Number(incUnits))
+            ? (incUnits > 0 ? 'Gap remains' : (incUnits === 0 ? 'At target' : 'Surplus'))
+            : 'Unavailable',
+          href: '#statUnitsNeed',
+        },
+      });
+    }
     window.HNAState.els.statNetMig.textContent = net20 !== null ? window.HNAUtils.fmtNum(Math.round(net20)) : '—';
 
     const endYear = (i>=0 && years[i]) ? years[i] : (years.length ? years[years.length-1] : '');

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -40,6 +40,81 @@
     return /^https?:\/\//i.test(url) ? url : '#';
   }
 
+  const DECISION_STRIP_DEFAULTS = {
+    need: { value: '—', read: 'Loading', href: '#hnaScorecardPanel', tone: '' },
+    affordability: { value: '—', read: 'Loading', href: '#statRentBurden', tone: '' },
+    production: { value: '—', read: 'Loading', href: '#statUnitsNeed', tone: '' },
+    ownership: { value: '—', read: 'Loading', href: '#affordable-ownership-need-section', tone: '' },
+    confidence: { value: '—', read: 'Loading', href: '#hnaGapCoveragePanel', tone: '' },
+  };
+
+  function _decisionTone(read) {
+    const t = String(read || '').toLowerCase();
+    if (/unavailable|not available/.test(t)) return 'unavailable';
+    if (/high data|ready|available|lower|low/.test(t)) return 'ready';
+    if (/highest|high|acute|limited/.test(t)) return 'high';
+    if (/elevated|moderate|verify|medium|gap remains/.test(t)) return 'moderate';
+    return '';
+  }
+
+  function _decisionReadFromPct(pct) {
+    if (pct == null || !Number.isFinite(Number(pct))) return 'Unavailable';
+    const v = Number(pct);
+    if (v >= 50) return 'High';
+    if (v >= 35) return 'Elevated';
+    if (v >= 20) return 'Moderate';
+    return 'Lower';
+  }
+
+  function _decisionState() {
+    const state = S() && S().state;
+    if (!state) return null;
+    state.decisionStrip = state.decisionStrip || {};
+    Object.keys(DECISION_STRIP_DEFAULTS).forEach(function (key) {
+      state.decisionStrip[key] = state.decisionStrip[key] || Object.assign({}, DECISION_STRIP_DEFAULTS[key]);
+    });
+    return state.decisionStrip;
+  }
+
+  function _paintDecisionStrip() {
+    const strip = document.getElementById('hnaDecisionStrip');
+    if (!strip) return;
+    const state = _decisionState();
+    if (!state) return;
+    let hasValue = false;
+    Object.keys(DECISION_STRIP_DEFAULTS).forEach(function (key) {
+      const tile = strip.querySelector('[data-decision-key="' + key + '"]');
+      const data = Object.assign({}, DECISION_STRIP_DEFAULTS[key], state[key] || {});
+      if (!tile) return;
+      const valueEl = document.getElementById('decision' + key.charAt(0).toUpperCase() + key.slice(1) + 'Value');
+      const readEl = document.getElementById('decision' + key.charAt(0).toUpperCase() + key.slice(1) + 'Read');
+      if (valueEl) valueEl.textContent = data.value || '—';
+      if (readEl) readEl.textContent = data.read || 'Loading';
+      tile.setAttribute('href', data.href || DECISION_STRIP_DEFAULTS[key].href);
+      const tone = data.tone || _decisionTone(data.read);
+      if (tone) tile.setAttribute('data-tone', tone);
+      else tile.removeAttribute('data-tone');
+      if (data.value && data.value !== '—' && data.value !== 'Loading') hasValue = true;
+    });
+    strip.hidden = !hasValue;
+  }
+
+  function updateDecisionStrip(patch) {
+    const state = _decisionState();
+    if (!state || !patch) return;
+    Object.keys(patch).forEach(function (key) {
+      if (!DECISION_STRIP_DEFAULTS[key]) return;
+      state[key] = Object.assign({}, state[key] || DECISION_STRIP_DEFAULTS[key], patch[key] || {});
+    });
+    _paintDecisionStrip();
+  }
+
+  function clearDecisionStrip() {
+    const state = S() && S().state;
+    if (state) state.decisionStrip = null;
+    _paintDecisionStrip();
+  }
+
   // ---------------------------------------------------------------------------
   // Chart theme / core utilities
   // ---------------------------------------------------------------------------
@@ -287,6 +362,7 @@
     fields.forEach(id => {
       if (els[id]) els[id].textContent = '—';
     });
+    clearDecisionStrip();
   }
 
   // ---------------------------------------------------------------------------
@@ -383,6 +459,13 @@
     // Rent burden: % paying 30%+ of income on rent (DP04_0141PE + DP04_0142PE)
     const rb30 = U().rentBurden30Plus ? U().rentBurden30Plus(profile) : null;
     if (els.statRentBurden) els.statRentBurden.textContent = rb30 !== null ? fmtPct(rb30) : '—';
+    updateDecisionStrip({
+      affordability: {
+        value: rb30 !== null ? fmtPct(rb30) : '—',
+        read: _decisionReadFromPct(rb30),
+        href: '#statRentBurden',
+      },
+    });
 
     // Income needed to buy the median home at the 30%-rule front-end
     // ratio. computeIncomeNeeded takes a scalar home value and returns
@@ -3478,6 +3561,9 @@
     if (els.needNote) {
       els.needNote.textContent = 'County-level projections are not shown for state-level view. Select a county, place, or CDP.';
     }
+    updateDecisionStrip({
+      production: { value: 'Not available', read: 'Select local geography', href: '#statUnitsNeed', tone: 'unavailable' },
+    });
     return { ok: true };
   }
 
@@ -4656,10 +4742,18 @@
     if (!container) return;
     if (!window.HNAOwnershipNeed || typeof window.HNAOwnershipNeed.computeOwnershipNeed !== 'function') {
       container.innerHTML = '<p style="color:var(--muted);font-size:.88rem;font-style:italic">Ownership data unavailable for this geography.</p>';
+      updateDecisionStrip({
+        ownership: { value: 'Unavailable', read: 'Verify locally', href: '#affordable-ownership-need-section', tone: 'unavailable' },
+        confidence: { value: 'Unavailable', read: 'Ownership data missing', href: '#affordable-ownership-need-section', tone: 'unavailable' },
+      });
       return;
     }
     if (!result || result.dataQuality === 'Unavailable') {
       container.innerHTML = '<p style="color:var(--muted);font-size:.88rem;font-style:italic">Ownership data unavailable for this geography.</p>';
+      updateDecisionStrip({
+        ownership: { value: 'Unavailable', read: 'Verify locally', href: '#affordable-ownership-need-section', tone: 'unavailable' },
+        confidence: { value: 'Unavailable', read: 'Ownership data missing', href: '#affordable-ownership-need-section', tone: 'unavailable' },
+      });
       return;
     }
 
@@ -4729,6 +4823,19 @@
     var caveats = (result.caveats || []).map(function (c) {
       return '<li style="margin:.2rem 0;">' + escHtml(c) + '</li>';
     }).join('');
+
+    updateDecisionStrip({
+      ownership: {
+        value: result.tenureMixRecommendation || 'Verify locally',
+        read: result.dataQuality ? result.dataQuality + ' data' : 'Verify locally',
+        href: '#affordable-ownership-need-section',
+      },
+      confidence: {
+        value: result.dataQuality || 'Verify',
+        read: (result.caveats && result.caveats.length) ? 'Review caveats' : 'Ready to screen',
+        href: '#affordable-ownership-need-section',
+      },
+    });
 
     container.innerHTML =
       '<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(210px,1fr));gap:.8rem;margin:.75rem 0 1rem;">' + cardHtml + '</div>' +
@@ -7187,6 +7294,14 @@
     else if (composite >= 50) { compSev = 'var(--warn,#d97706)'; compLabel = 'Elevated';     }
     else if (composite >= 30) { compSev = 'var(--accent,#1d4ed8)'; compLabel = 'Moderate';   }
     else                       { compSev = 'var(--good,#16a34a)'; compLabel = 'Lower';       }
+    updateDecisionStrip({
+      need: {
+        value: composite + '/100',
+        read: compLabel,
+        href: '#hnaScorecardPanel',
+        tone: _decisionTone(compLabel),
+      },
+    });
 
     // Format helpers
     const pctStr = (v, digits) => v != null && Number.isFinite(v) ? (v * 100).toFixed(digits != null ? digits : 1) + '%' : '—';
@@ -7996,6 +8111,25 @@
     _combinedSetText('statTenureSrc', 'Combined CHAS households · DERIVED');
     _combinedSetText('statRentBurden', _ownFmtPct(renterCbShare));
     _combinedSetText('statRentBurdenSrc', 'Combined CHAS renter cost burden · DERIVED');
+    updateDecisionStrip({
+      need: {
+        value: 'Combined',
+        read: 'Member-level scorecards',
+        href: '#hnaScorecardPanel',
+        tone: 'unavailable',
+      },
+      affordability: {
+        value: _ownFmtPct(renterCbShare),
+        read: _decisionReadFromPct(renterCbShare * 100),
+        href: '#statRentBurden',
+      },
+      production: {
+        value: 'Not available',
+        read: 'View members',
+        href: '#statUnitsNeed',
+        tone: 'unavailable',
+      },
+    });
 
     var amiGapAvailable = !!(result.availability && result.availability.amiGap && result.availability.amiGap.available);
     var amiGapMessage = 'Not available — one or more members missing AMI-gap data';
@@ -8059,6 +8193,8 @@
     showAllChartsLoading,
     setBanner,
     clearStats,
+    updateDecisionStrip,
+    clearDecisionStrip,
     // Map
     renderBoundary,
     // Snapshot

--- a/test/combined-geo.test.js
+++ b/test/combined-geo.test.js
@@ -21,11 +21,20 @@ const Ownership = loadBrowserModule('js/hna/hna-ownership-need.js', 'HNAOwnershi
 
 function loadRenderersDom() {
   const dom = new JSDOM('<!doctype html>' +
+    '<section id="hnaDecisionStrip" hidden>' +
+    '<a data-decision-key="need" href="#hnaScorecardPanel"><strong id="decisionNeedValue">—</strong><span id="decisionNeedRead">Loading</span></a>' +
+    '<a data-decision-key="affordability" href="#statRentBurden"><strong id="decisionAffordabilityValue">—</strong><span id="decisionAffordabilityRead">Loading</span></a>' +
+    '<a data-decision-key="production" href="#statUnitsNeed"><strong id="decisionProductionValue">—</strong><span id="decisionProductionRead">Loading</span></a>' +
+    '<a data-decision-key="ownership" href="#affordable-ownership-need-section"><strong id="decisionOwnershipValue">—</strong><span id="decisionOwnershipRead">Loading</span></a>' +
+    '<a data-decision-key="confidence" href="#hnaGapCoveragePanel"><strong id="decisionConfidenceValue">—</strong><span id="decisionConfidenceRead">Loading</span></a>' +
+    '</section>' +
     '<div id="hnaBanner"></div><div id="geoContextPill"></div><div id="execNarrative"></div>' +
     '<div id="statPop"></div><div id="statPopSrc"></div><div id="statMhi"></div><div id="statMhiSrc"></div>' +
     '<div id="statHomeValue"></div><div id="statHomeValueSrc"></div><div id="statRent"></div><div id="statRentSrc"></div>' +
+    '<div id="statTenure"></div><div id="statTenureSrc"></div><div id="statRentBurden"></div>' +
     '<div id="statIncomeNeed"></div><div id="statIncomeNeedNote"></div><div id="statCommute"></div><div id="statCommuteSrc"></div>' +
     '<div id="statBaseUnits"></div><div id="statBaseUnitsSrc"></div><div id="statUnitsNeed"></div><div id="statNetMig"></div>' +
+    '<section id="hnaScorecardPanel"></section><section id="affordable-ownership-need-section"><div id="hnaAffordableOwnershipNeed"></div></section>' +
     '<div id="chasGapStatus"></div><div class="chart-box"><canvas id="chartChasGap"></canvas></div>' +
     '<div class="chart-box"><canvas id="chartMode"></canvas></div>');
   dom.window.HTMLCanvasElement.prototype.getContext = function () { return { canvas: this }; };
@@ -37,12 +46,26 @@ function loadRenderersDom() {
     getComputedStyle: dom.window.getComputedStyle.bind(dom.window),
   };
   sandbox.window.Chart = sandbox.Chart;
-  sandbox.window.HNAState = { els: { banner: dom.window.document.getElementById('hnaBanner') }, charts: {} };
+  sandbox.window.HNAState = { state: {}, els: { banner: dom.window.document.getElementById('hnaBanner') }, charts: {} };
+  [
+    'geoContextPill', 'statPop', 'statPopSrc', 'statMhi', 'statMhiSrc',
+    'statHomeValue', 'statHomeValueSrc', 'statRent', 'statRentSrc',
+    'statTenure', 'statRentBurden', 'statIncomeNeed', 'statIncomeNeedNote',
+    'statCommute', 'statCommuteSrc', 'statBaseUnits', 'statBaseUnitsSrc',
+    'statUnitsNeed', 'statNetMig',
+  ].forEach(id => { sandbox.window.HNAState.els[id] = dom.window.document.getElementById(id); });
   sandbox.window.HNAUtils = {
     fmtMoney(n) { return Number(n).toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }); },
     fmtNum(n) { return Number(n).toLocaleString('en-US', { maximumFractionDigits: 0 }); },
     fmtPct(n) { return Number(n).toFixed(1) + '%'; },
     safeNum(n) { const value = Number(n); return Number.isFinite(value) ? value : null; },
+    srcLink() { return 'fixture source'; },
+    homeValueSourceText() { return 'fixture home-value source'; },
+    rentBurden30Plus(profile) {
+      const severe = Number(profile.DP04_0142PE);
+      const moderate = Number(profile.DP04_0141PE);
+      return (Number.isFinite(severe) ? severe : 0) + (Number.isFinite(moderate) ? moderate : 0);
+    },
   };
   vm.createContext(sandbox);
   vm.runInContext(fs.readFileSync(path.join(ROOT, 'js/hna/hna-renderers.js'), 'utf8'), sandbox, { filename: 'js/hna/hna-renderers.js' });
@@ -461,6 +484,97 @@ test('combined home-value renderer paints range and average into stat card', () 
   assert.equal(dom.window.document.getElementById('chasGapStatus').textContent, 'Source: combined HUD CHAS 2018-2022 member records · DERIVED.');
   assert.equal(dom.window.document.getElementById('chartMode').style.display, 'none', 'single-geography commute chart is marked unavailable');
   assert.ok(dom.window.document.getElementById('chartMode').parentElement.textContent.includes('Not available for combined areas'), 'single-geography chart gets unavailable note');
+});
+
+test('HNA executive decision strip mirrors detailed renderer values', () => {
+  const dom = loadRenderersDom();
+  const doc = dom.window.document;
+  dom.window.HNAState.state.chasData = {
+    counties: {
+      '08009': {
+        name: 'Fixture County',
+        summary: {
+          total_renter_hh: 600,
+          total_owner_hh: 400,
+          pct_renter_cb30: 0.52,
+          pct_owner_cb30: 0.18,
+          pct_renter_cb50: 0.28,
+        },
+        renter_hh_by_ami: {
+          lte30: { total: 200 },
+          '31to50': { total: 160 },
+          '51to80': { total: 150 },
+          '81to100': { total: 90 },
+        },
+      },
+      '08011': {
+        name: 'Peer County',
+        summary: {
+          total_renter_hh: 500,
+          total_owner_hh: 500,
+          pct_renter_cb30: 0.22,
+          pct_owner_cb30: 0.1,
+          pct_renter_cb50: 0.12,
+        },
+        renter_hh_by_ami: {
+          lte30: { total: 80 },
+          '31to50': { total: 140 },
+          '51to80': { total: 160 },
+          '81to100': { total: 120 },
+        },
+      },
+    },
+  };
+  dom.window.HNAState.state.blsEconData = {
+    counties: {
+      'Fixture County': { affordability_index: 6.8 },
+      'Peer County': { affordability_index: 3.4 },
+    },
+  };
+  dom.window.HNARenderers.renderSnapshot({
+    _acsYear: 2024,
+    _acsSeries: 'ACS5',
+    _geoType: 'county',
+    _geoid: '08009',
+    DP05_0001E: 1000,
+    DP03_0062E: 75000,
+    DP04_0134E: 1500,
+    DP04_0047PE: 48,
+    DP04_0141PE: 25,
+    DP04_0142PE: 15,
+  }, null, 'Fixture County', null);
+  dom.window.HNARenderers.updateDecisionStrip({
+    production: { value: '125', read: 'Gap remains', href: '#statUnitsNeed' },
+  });
+  doc.getElementById('statUnitsNeed').textContent = '125';
+  dom.window.HNAOwnershipNeed = { computeOwnershipNeed() {} };
+  dom.window.HNARenderers.renderAffordableOwnershipNeed({
+    dataQuality: 'High',
+    tenureMixRecommendation: 'Rental plus shared-equity ownership',
+    recommendationDetail: 'Fixture recommendation detail.',
+    renterCostBurdened: 240,
+    severeRenterCostBurdened: 100,
+    ownerCostBurdened: 90,
+    severeOwnerCostBurdened: 40,
+    moderateIncomeRenterHouseholds: 75,
+    moderateIncomeOwnerCostBurdened: 25,
+    existingRentalGap: 125,
+    rentalPressure: { tier: 'High', inputs: { source: 'HUD CHAS', renterCostBurdenedShare: 0.4, severeRenterCostBurdenedShare: 0.17 } },
+    ownershipPressure: { tier: 'Moderate', inputs: { ownerCostBurdenedShare: 0.23, moderateIncomeOwnerCostBurdenedShare: 0.06 } },
+    ownershipFit: { tier: 'Moderate', inputs: { moderateIncomeRenterShare: 0.13 } },
+    affordabilityTest: { medianHomeValue: 350000, classification: 'constrained', source: 'fixture home values' },
+    caveats: [],
+  });
+  dom.window.HNARenderers.renderHnaScorecardPanel('08009');
+
+  assert.equal(doc.getElementById('hnaDecisionStrip').hidden, false, 'decision strip is visible after real renderers populate it');
+  assert.equal(doc.getElementById('decisionAffordabilityValue').textContent, doc.getElementById('statRentBurden').textContent, 'affordability tile mirrors rent-burden stat');
+  assert.equal(doc.getElementById('decisionProductionValue').textContent, doc.getElementById('statUnitsNeed').textContent, 'production tile mirrors unit-need stat');
+  assert.equal(doc.getElementById('decisionOwnershipValue').textContent, 'Rental plus shared-equity ownership', 'ownership tile mirrors ownership recommendation');
+  assert.equal(doc.getElementById('decisionConfidenceValue').textContent, 'High', 'confidence tile mirrors ownership data-quality field');
+  const needValue = doc.getElementById('decisionNeedValue').textContent;
+  assert.match(needValue, /^\d+\/100$/, 'need tile renders scorecard composite');
+  assert.ok(doc.getElementById('hnaScorecardPanel').textContent.includes(needValue.replace('/100', '')), 'scorecard panel contains same composite score');
 });
 
 test('combined add button preserves rejection warning by skipping update on false', () => {


### PR DESCRIPTION
## Summary
- Adds a compact executive decision strip near the top of the HNA page for need severity, affordability pressure, production gap, ownership feasibility, and data confidence.
- Wires the strip to existing render paths: scorecard composite, rent-burden stat, DOLA unit-need stat, Affordable Ownership Need recommendation, and ownership data-quality field.
- Keeps combined areas honest: affordability uses the combined CHAS result, while scorecard severity and production gap are marked member-level/not available because there is no clean existing combined source without new modeling.

Closes #1096.

## QA / Evidence
- node test/combined-geo.test.js
- npm run test:hna
- npm run validate

## Notes
- No new scoring formula was introduced. Qualitative reads are display bands around the values already rendered in the detailed page sections.
- Visual layout uses the page-local HNA style and responsive CSS: five columns on wide screens, two columns on tablet, one column on narrow mobile.