### PR TITLE
Document shared metric source convention

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -55,6 +55,17 @@ The repo runs four layers of data quality checks. Each catches a different
 class of bug. New ingest pipelines should add at least one assertion in
 every applicable layer.
 
+### Shared metric source convention
+
+When the same metric appears in more than one place on a page, or across
+multiple pages, every render path should read from one shared source object or
+helper instead of recomputing the value locally. The HNA median-home-value
+display is the reference pattern: `HNAUtils.homeValueInfo()` centralizes the
+value, source label, confidence, and suppression flags so the headline stat,
+narrative text, ownership module, and combined-area views cannot drift apart.
+If a future metric needs multiple presentations, create the equivalent shared
+helper/source first, then make each UI surface consume that object.
+
 ### Layer 1 — Schema (`scripts/validate-schemas.js`)
 
 Asserts file existence + JSON parseability + presence of expected keys


### PR DESCRIPTION
## Summary
- Adds the #1099 shared metric source convention to docs/CONTRIBUTING.md under QA/QC layers.
- Documents that repeated metrics should read from one shared source object/helper, using HNAUtils.homeValueInfo as the reference pattern.
- Does not add generalized lint/scanning tooling, per the handoff decision.

Closes #1099.

## QA / Evidence
- Re-verified HNAUtils.homeValueInfo exists in js/hna/hna-utils.js and centralizes home-value display/source/confidence/suppression fields.
- npm run validate

## Tests
- No code tests required; docs-only change.