### PR TITLE
Add regional comparison HNA mode

### DIFF
--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -309,7 +309,17 @@
             Combine jurisdictions
           </label>
           <div id="combinedGeosPanel" hidden style="grid-column:1 / -1;border:1px solid var(--border);border-radius:6px;padding:.55rem;background:var(--card);">
-            <div id="combinedGeosHint" style="font-size:.78rem;color:var(--muted);margin-bottom:.45rem;">Select 2–6 non-overlapping jurisdictions. Use the selected geography dropdown, then add each member.</div>
+            <div id="combinedGeosHint" style="font-size:.78rem;color:var(--muted);margin-bottom:.45rem;">Select 2–6 jurisdictions. Use the selected geography dropdown, then add each member.</div>
+            <div role="radiogroup" aria-label="Combined jurisdiction mode" style="display:flex;align-items:center;gap:.7rem;flex-wrap:wrap;margin-bottom:.5rem;font-size:.82rem;color:var(--muted);">
+              <label style="display:inline-flex;align-items:center;gap:.3rem;font-weight:700;">
+                <input type="radio" name="combinedGeoMode" value="blended" checked>
+                Blended total
+              </label>
+              <label style="display:inline-flex;align-items:center;gap:.3rem;font-weight:700;">
+                <input type="radio" name="combinedGeoMode" value="regional">
+                Side-by-side comparison
+              </label>
+            </div>
             <div style="display:flex;align-items:center;gap:.45rem;flex-wrap:wrap;">
               <button id="btnAddCombinedGeo" type="button">Add selected</button>
               <button id="btnClearCombinedGeos" type="button">Clear</button>

--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -325,6 +325,15 @@
     _renderCombinedChips();
   }
 
+  function _combinedMode() {
+    const checked = document.querySelector('input[name="combinedGeoMode"]:checked');
+    return checked && checked.value === 'regional' ? 'regional' : 'blended';
+  }
+
+  function _isMultiJurisdictionSelection(selection) {
+    return !!(selection && (selection.geoType === 'combined' || selection.geoType === 'regional-comparison'));
+  }
+
   function _addCurrentCombinedMember() {
     const member = _memberFromCurrentSelect();
     if (!member) {
@@ -484,9 +493,59 @@
         url.searchParams.set('geos', validation.members.map(function (m) { return m.geoid; }).join('+'));
         url.searchParams.delete('region');
       }
+      url.searchParams.delete('combinedMode');
       window.history.replaceState(null, '', url.toString());
     } catch (_) {}
     if (typeof window.__announceUpdate === 'function') window.__announceUpdate('Combined area loaded: ' + result.label);
+    window.HNARenderers.hideChartLoading();
+  }
+
+  async function updateRegionalComparison(region) {
+    window.HNARenderers.showAllChartsLoading();
+    window.HNARenderers.clearStats();
+    const members = region ? (region.members || []) : (window.HNAState.state.combinedMembers || []);
+    const label = region ? region.label : members.map(_labelForMember).join(' + ');
+    if (!members.length) {
+      window.HNARenderers.setBanner('Select 2 to 6 jurisdictions for side-by-side comparison.', 'warn');
+      window.HNARenderers.hideChartLoading();
+      return;
+    }
+    const digests = await Promise.all(members.map(async function (member) {
+      const digest = await loadJson('data/hna/jurisdiction-metrics-digest/' + member.geoid + '.json');
+      return {
+        member,
+        label: _labelForMember(member),
+        digest,
+      };
+    }));
+    _clearCombinedMapOverlays();
+    window.HNARenderers.renderBoundary({ type: 'FeatureCollection', features: [] }, 'combined');
+    window.HNARenderers.renderRegionalComparison({
+      label: label || 'Regional comparison',
+      members: digests,
+      cap: 6,
+    });
+    window.HNAState.state.current = {
+      geoType: 'regional-comparison',
+      geoid: region ? ('region:' + region.id) : 'regional-comparison',
+      label: label || 'Regional comparison',
+      members: digests.map(function (row) { return row.member; }),
+      regionalComparison: digests,
+    };
+    window.HNAState.state.lastGeoLabel = label || 'Regional comparison';
+    try {
+      const url = new URL(window.location.href);
+      if (region) {
+        url.searchParams.set('region', region.id);
+        url.searchParams.delete('geos');
+      } else {
+        url.searchParams.set('geos', members.map(function (m) { return m.geoid; }).join('+'));
+        url.searchParams.delete('region');
+      }
+      url.searchParams.set('combinedMode', 'regional');
+      window.history.replaceState(null, '', url.toString());
+    } catch (_) {}
+    if (typeof window.__announceUpdate === 'function') window.__announceUpdate('Regional comparison loaded: ' + (label || 'selected jurisdictions'));
     window.HNARenderers.hideChartLoading();
   }
 
@@ -734,7 +793,7 @@
     // Update "LIHTC projects in area" panel whenever the map view changes
     function updateLihtcInfoPanel() {
       var cur = window.HNAState.state.current || {};
-      if (cur.geoType === 'combined') return;
+      if (_isMultiJurisdictionSelection(cur)) return;
       window.HNARenderers.updateLihtcInfoPanel();
     }
     window.HNAState.map.on('moveend', updateLihtcInfoPanel);
@@ -2234,7 +2293,7 @@
 
   async function applyAssumptions(proj, selection){
     if (!proj) return;
-    if (selection && selection.geoType === 'combined') {
+    if (_isMultiJurisdictionSelection(selection)) {
       var unavailable = 'Not available for combined areas — view members individually.';
       if (window.HNAState.els.statBaseUnits) window.HNAState.els.statBaseUnits.textContent = 'Not available';
       if (window.HNAState.els.statBaseUnitsSrc) window.HNAState.els.statBaseUnitsSrc.textContent = unavailable;
@@ -2265,7 +2324,7 @@
 
     // If selection is a place/CDP, scale projections from containing county.
     // State-level: projections are loaded directly for '08', no scaling needed.
-    if (selection && selection.geoType !== 'county' && selection.geoType !== 'state' && selection.geoType !== 'combined'){
+    if (selection && selection.geoType !== 'county' && selection.geoType !== 'state' && !_isMultiJurisdictionSelection(selection)){
       const placePopNow = window.HNAUtils.safeNum(selection.profile?.DP05_0001E);
       const placeHhNow = window.HNAUtils.safeNum(selection.profile?.DP02_0001E);
       const placeUnitsNow = window.HNAUtils.safeNum(selection.profile?.DP04_0001E);
@@ -2338,7 +2397,7 @@
     }
 
     let placeProjectionRec = null;
-    if (selection && selection.geoType !== 'county' && selection.geoType !== 'state' && selection.geoType !== 'combined' && selection.geoid){
+    if (selection && selection.geoType !== 'county' && selection.geoType !== 'state' && !_isMultiJurisdictionSelection(selection) && selection.geoid){
       try {
         const placeDoc = await loadPlaceProjectionsDoc();
         placeProjectionRec = placeDoc?.places?.[selection.geoid] || null;
@@ -2364,14 +2423,14 @@
         const permitText = sh.permit == null ? 'permit share unavailable' : `permit share ${(sh.permit * 100).toFixed(1)}%`;
         projectionMethodNote = ` Place-level projection uses a 50/50 blend of ACS household share (${((sh.household || 0) * 100).toFixed(1)}%) and ${permitText} from Census BPS ${sh.permit_window || '2020-2024'}.`;
       }
-    } else if (selection && selection.geoType !== 'county' && selection.geoType !== 'state' && selection.geoType !== 'combined') {
+    } else if (selection && selection.geoType !== 'county' && selection.geoType !== 'state' && !_isMultiJurisdictionSelection(selection)) {
       projectionMethodNote = ' Need is scaled from the containing county DOLA projection.';
     }
 
     // Net migration scaled for places/CDPs (share of county base).
     // State-level projections are loaded directly for '08' — no scaling needed.
     let net20 = window.HNAUtils.safeNum(proj?.net_migration_20y);
-    if (selection && selection.geoType !== 'county' && selection.geoType !== 'state' && selection.geoType !== 'combined' && baseCountyPop && basePop){
+    if (selection && selection.geoType !== 'county' && selection.geoType !== 'state' && !_isMultiJurisdictionSelection(selection) && baseCountyPop && basePop){
       const d = window.HNAState.state.derived?.geos?.[selection.geoid]?.derived || null;
       const placeShare = placeProjectionRec?.shares?.blended;
       const share0 = placeShare != null
@@ -2744,17 +2803,19 @@
     const selectedRegion = _regionFromCurrentSelect();
     const combineOn = !!(window.HNAState.els.combineGeosToggle && window.HNAState.els.combineGeosToggle.checked);
     if (selectedRegion) {
-      await updateCombined(selectedRegion);
+      if (_combinedMode() === 'regional') await updateRegionalComparison(selectedRegion);
+      else await updateCombined(selectedRegion);
       return;
     }
     if (combineOn) {
       if ((window.HNAState.state.combinedMembers || []).length < 2) {
         window.HNARenderers.clearStats();
-        window.HNARenderers.setBanner('Select 2 to 6 non-overlapping jurisdictions, then refresh the combined screening area.', 'warn');
+        window.HNARenderers.setBanner('Select 2 to 6 jurisdictions, then refresh the combined screening area.', 'warn');
         window.HNARenderers.hideChartLoading();
         return;
       }
-      await updateCombined(null);
+      if (_combinedMode() === 'regional') await updateRegionalComparison(null);
+      else await updateCombined(null);
       return;
     }
     if (window.HNARenderers.clearCombinedUnavailable) window.HNARenderers.clearCombinedUnavailable();
@@ -2763,6 +2824,7 @@
       if (url.searchParams.has('region') || url.searchParams.has('geos')) {
         url.searchParams.delete('region');
         url.searchParams.delete('geos');
+        url.searchParams.delete('combinedMode');
         window.history.replaceState(null, '', url.toString());
       }
     } catch (_) {}
@@ -3431,6 +3493,7 @@
     const urlGeoid   = urlParams.get('geoid') || urlParams.get('fips');
     const urlRegion  = urlParams.get('region');
     const urlGeos    = urlParams.get('geos');
+    const urlCombinedMode = urlParams.get('combinedMode');
     /* F165 — Infer geoType from GEOID length when the param wasn't passed.
        Previously a bare `?geoid=0853395` was ignored because urlGeoType was
        null, and the page silently fell back to state-level Colorado data
@@ -3528,6 +3591,10 @@
       window.HNAState.els.geoSelect.value = restoredGeoId;
     }
     _syncCombinedPanel();
+    if (urlCombinedMode === 'regional') {
+      const regionalMode = document.querySelector('input[name="combinedGeoMode"][value="regional"]');
+      if (regionalMode) regionalMode.checked = true;
+    }
 
     // For county type, ensure a county is selected (first in list when no match)
     if (window.HNAState.els.geoType.value === 'county' && !window.HNAState.els.geoSelect.value){
@@ -3610,6 +3677,11 @@
       _renderCombinedChips();
       update();
     });
+    document.querySelectorAll('input[name="combinedGeoMode"]').forEach((radio) => {
+      radio.addEventListener('change', () => {
+        if (window.HNAState.els.combineGeosToggle && window.HNAState.els.combineGeosToggle.checked) update();
+      });
+    });
     window.HNAState.els.btnPdf?.addEventListener('click', exportPdf);
     window.HNAState.els.btnCsv?.addEventListener('click', ()=>{
       if (window.__HNA_exportCsv){ window.__HNA_exportCsv(); }
@@ -3663,7 +3735,7 @@
 
     // Sync checklist state to compliance-dashboard.html on unload
     window.addEventListener('beforeunload', () => {
-      if (window.ComplianceChecklist && window.HNAState.state.current && window.HNAState.state.current.geoType !== 'combined') {
+      if (window.ComplianceChecklist && window.HNAState.state.current && !_isMultiJurisdictionSelection(window.HNAState.state.current)) {
         window.ComplianceChecklist.broadcastChecklistChange({
           geoType: window.HNAState.state.current.geoType,
           geoid:   window.HNAState.state.current.geoid,

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -8183,6 +8183,105 @@
     setBanner('Combined screening area loaded. Panels that cannot be safely aggregated are marked unavailable.', 'info');
   }
 
+  var REGIONAL_COMPARISON_ROWS = [
+    { section: 'Affordability', label: 'Cost burdened households', key: 'pct_cost_burdened', format: 'pct' },
+    { section: 'Affordability', label: '≤30% AMI households', key: 'pct_ami_lte30', format: 'pct' },
+    { section: 'Affordability', label: '31–50% AMI households', key: 'pct_ami_31to50', format: 'pct' },
+    { section: 'Affordability', label: '51–80% AMI households', key: 'pct_ami_51to80', format: 'pct' },
+    { section: 'Affordability', label: '>80% AMI households', key: 'pct_ami_gt80', format: 'pct' },
+    { section: 'Housing Stock', label: 'Renter share', key: 'pct_renters', format: 'pct' },
+    { section: 'Housing Stock', label: 'Overcrowding', key: 'overcrowding_rate', format: 'pct' },
+    { section: 'Housing Stock', label: 'Housing built before 1970', key: 'pct_housing_built_pre1970', format: 'pct' },
+    { section: 'Housing Stock', label: 'Median home value', key: 'median_home_value', format: 'money' },
+    { section: 'Demographics', label: 'No high school degree, age 25+', key: 'pct_no_hs_degree_25plus', format: 'pct' },
+    { section: 'Demographics', label: 'Single-parent households', key: 'pct_single_parent_households', format: 'pct' },
+    { section: 'Demographics', label: 'Age 65+', key: 'pct_age_65_plus', format: 'pct' },
+  ];
+
+  function _regionalFmt(value, format) {
+    var n = Number(value);
+    if (!Number.isFinite(n)) return '—';
+    if (format === 'money') return _ownFmtMoney(n);
+    if (format === 'int') return _ownFmtNum(n);
+    return _ownFmtPct(n / 100);
+  }
+
+  function renderRegionalComparison(result) {
+    var members = result && result.members || [];
+    if (!members.length) {
+      setBanner('Regional comparison unavailable — no member digests loaded.', 'warn');
+      return;
+    }
+    var label = result.label || 'Regional comparison';
+    _combinedSetText('geoContextPill', 'Regional comparison: ' + members.map(function (m) { return m.label || (m.member && m.member.geoid); }).join(' + '));
+    var caption = label + ' compares ' + members.length + ' jurisdictions side by side. Values are read from each jurisdiction metric digest; no households, rates, or medians are blended.';
+    var grouped = {};
+    REGIONAL_COMPARISON_ROWS.forEach(function (row) {
+      if (!grouped[row.section]) grouped[row.section] = [];
+      grouped[row.section].push(row);
+    });
+    var html = '<div class="regional-comparison-table-wrap" style="overflow-x:auto;margin-top:.65rem;">' +
+      '<table class="regional-comparison-table table" style="min-width:680px;width:100%;border-collapse:collapse;font-size:.86rem;">' +
+      '<caption style="text-align:left;color:var(--muted);font-size:.82rem;margin-bottom:.4rem;">Side-by-side view only; not an aggregate.</caption>' +
+      '<thead><tr><th scope="col" style="text-align:left;">Metric</th>' +
+      members.map(function (m) { return '<th scope="col" style="text-align:right;">' + escHtml(m.label || (m.member && m.member.geoid) || 'Jurisdiction') + '</th>'; }).join('') +
+      '</tr></thead><tbody>';
+    Object.keys(grouped).forEach(function (section) {
+      html += '<tr><th scope="rowgroup" colspan="' + (members.length + 1) + '" style="text-align:left;color:var(--text);background:var(--bg2);">' + escHtml(section) + '</th></tr>';
+      grouped[section].forEach(function (row) {
+        html += '<tr><th scope="row" style="text-align:left;font-weight:700;">' + escHtml(row.label) + '</th>' +
+          members.map(function (m) {
+            var metric = m.digest && m.digest.metrics && m.digest.metrics[row.key];
+            return '<td style="text-align:right;">' + escHtml(_regionalFmt(metric && metric.value, row.format)) + '</td>';
+          }).join('') + '</tr>';
+      });
+    });
+    html += '</tbody></table></div>' +
+      '<p style="margin:.55rem 0 0;color:var(--muted);font-size:.82rem;">Shared picker cap remains 6 members for now; the product question is whether regional comparison should later allow more columns.</p>';
+    var exec = document.getElementById('execNarrative');
+    if (exec) {
+      exec.classList.add('hna-narrative-mount');
+      exec.innerHTML = '<p style="margin:0;">' + escHtml(caption) + '</p>' + html;
+    }
+    _combinedSetTextMap({
+      statPop: 'Side-by-side',
+      statPopSrc: 'Regional comparison uses each member digest, not a blended ACS profile.',
+      statMhi: 'See table',
+      statMhiSrc: 'Digest-backed member metrics.',
+      statHomeValue: 'See table',
+      statHomeValueSrc: 'Member median home values are not averaged.',
+      statRent: 'See table',
+      statRentSrc: 'Member digest values only.',
+      statTenure: 'See table',
+      statTenureSrc: 'Member renter-share digest values.',
+      statRentBurden: 'See table',
+      statRentBurdenSrc: 'Member cost-burden digest values.',
+      statIncomeNeed: 'See table',
+      statIncomeNeedNote: 'AMI-tier shares come from member CHAS/digest records.',
+      statCommute: 'Not available',
+      statCommuteSrc: 'Regional side-by-side mode does not aggregate commute flows.',
+      statBaseUnits: 'Not available',
+      statBaseUnitsSrc: 'Regional side-by-side mode does not project blended units.',
+      statUnitsNeed: 'Not available',
+      statNetMig: 'Not available',
+    });
+    updateDecisionStrip({
+      need: { value: 'Compare', read: 'Digest rows', href: '#execNarrative' },
+      affordability: { value: 'Side-by-side', read: 'No blending', href: '#execNarrative' },
+      production: { value: 'Not available', read: 'View members', href: '#statUnitsNeed', tone: 'unavailable' },
+    });
+    _combinedClearNonCanvasPanels('Not available for regional side-by-side comparison — view members individually.', null);
+    _combinedUnavailable('lehdNote', 'Regional side-by-side mode does not aggregate commute or LEHD flows.');
+    _combinedUnavailable('seniorNote', 'Age 65+ is shown in the comparison table.');
+    _combinedUnavailable('scenarioNeedSummary', 'Scenario projections are not blended in regional side-by-side mode.');
+    _combinedUnavailable('localResources', 'Local resources are listed by individual jurisdiction; view members individually.');
+    _combinedUnavailable('lihtcMapStatus', 'LIHTC map remains county/statewide scoped for regional comparisons.');
+    COMBINED_UNAVAILABLE_CHART_IDS.concat(['chartChasGap']).forEach(function (id) {
+      _combinedMarkChartUnavailable(id, 'Regional side-by-side mode uses the comparison table above; view members individually for charts.');
+    });
+    setBanner('Regional comparison loaded. Values are side-by-side member digest metrics; no aggregation is applied.', 'info');
+  }
+
   window.HNARenderers = {
     // Chart / UI utilities
     chartTheme,
@@ -8242,6 +8341,7 @@
     renderAffordableOwnershipNeed,
     tryRenderAffordableOwnershipNeedFromState,
     renderCombinedAssessment,
+    renderRegionalComparison,
     clearCombinedUnavailable,
     // Labor market
     renderLaborMarketSection,

--- a/test/combined-geo.test.js
+++ b/test/combined-geo.test.js
@@ -486,6 +486,60 @@ test('combined home-value renderer paints range and average into stat card', () 
   assert.ok(dom.window.document.getElementById('chartMode').parentElement.textContent.includes('Not available for combined areas'), 'single-geography chart gets unavailable note');
 });
 
+test('regional comparison renderer paints distinct digest values side by side', () => {
+  const dom = loadRenderersDom();
+  dom.window.HNARenderers.renderRegionalComparison({
+    label: 'Fixture regional comparison',
+    members: [
+      {
+        label: 'Garfield County',
+        member: { geoType: 'county', geoid: '08045' },
+        digest: { metrics: {
+          pct_cost_burdened: { value: 34.8 },
+          pct_ami_lte30: { value: 10.9 },
+          pct_ami_31to50: { value: 9.2 },
+          pct_ami_51to80: { value: 19.1 },
+          pct_ami_gt80: { value: 60.8 },
+          pct_renters: { value: 30.4 },
+          overcrowding_rate: { value: 2.0 },
+          pct_housing_built_pre1970: { value: 14.1 },
+          median_home_value: { value: 589000 },
+          pct_no_hs_degree_25plus: { value: 10.6 },
+          pct_single_parent_households: { value: 5.9 },
+          pct_age_65_plus: { value: 14.8 },
+        } },
+      },
+      {
+        label: 'Aspen',
+        member: { geoType: 'place', geoid: '0803620' },
+        digest: { metrics: {
+          pct_cost_burdened: { value: 67.6 },
+          pct_ami_lte30: { value: 10.1 },
+          pct_ami_31to50: { value: 10.5 },
+          pct_ami_51to80: { value: 18.6 },
+          pct_ami_gt80: { value: 60.8 },
+          pct_renters: { value: 42.9 },
+          overcrowding_rate: { value: 1.1 },
+          pct_housing_built_pre1970: { value: 18.2 },
+          median_home_value: { value: 2500000 },
+          pct_no_hs_degree_25plus: { value: 1.2 },
+          pct_single_parent_households: { value: 4.1 },
+          pct_age_65_plus: { value: 17.4 },
+        } },
+      },
+    ],
+  });
+  const html = dom.window.document.getElementById('execNarrative').innerHTML;
+  assert.ok(html.includes('Garfield County'), 'renders first jurisdiction header');
+  assert.ok(html.includes('Aspen'), 'renders second jurisdiction header');
+  assert.ok(html.includes('34.8%'), 'renders Garfield cost burden');
+  assert.ok(html.includes('67.6%'), 'renders Aspen cost burden');
+  assert.ok(html.includes('$589,000'), 'renders Garfield home value');
+  assert.ok(html.includes('$2,500,000'), 'renders Aspen home value');
+  assert.ok(html.includes('Side-by-side view only'), 'discloses non-aggregate mode');
+  assert.equal(dom.window.document.getElementById('geoContextPill').textContent, 'Regional comparison: Garfield County + Aspen');
+});
+
 test('HNA executive decision strip mirrors detailed renderer values', () => {
   const dom = loadRenderersDom();
   const doc = dom.window.document;
@@ -632,6 +686,20 @@ test('combine toggle off resyncs current jurisdiction to WorkflowState', () => {
   assert.ok(updateIdx > syncIdx, 'update runs after WorkflowState is resynced');
 });
 
+test('regional comparison mode reuses combined picker but fetches member digests instead of aggregating', () => {
+  const controller = fs.readFileSync(path.join(ROOT, 'js/hna/hna-controller.js'), 'utf8');
+  const html = fs.readFileSync(path.join(ROOT, 'housing-needs-assessment.html'), 'utf8');
+  assert.ok(html.includes('name="combinedGeoMode" value="blended" checked'), 'blended mode radio is present and default');
+  assert.ok(html.includes('name="combinedGeoMode" value="regional"'), 'regional mode radio is present');
+  assert.ok(controller.includes('function _combinedMode()'), 'controller reads combined mode');
+  assert.ok(controller.includes("if (_combinedMode() === 'regional') await updateRegionalComparison(null);"), 'combined update branches to regional mode');
+  assert.ok(controller.includes('else await updateCombined(null);'), 'blended update path remains intact');
+  assert.ok(controller.includes("loadJson('data/hna/jurisdiction-metrics-digest/' + member.geoid + '.json')"), 'regional mode fetches member digest files');
+  assert.ok(controller.includes('window.HNARenderers.renderRegionalComparison({'), 'regional mode calls dedicated renderer');
+  assert.ok(controller.includes("url.searchParams.set('combinedMode', 'regional')"), 'regional mode persists URL mode');
+  assert.ok(controller.includes("selection.geoType === 'regional-comparison'"), 'regional mode is guarded as a multi-jurisdiction selection');
+});
+
 test('combined AMI-gap rendering gates on availability flag', () => {
   const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-renderers.js'), 'utf8');
   assert(src.includes('result.availability && result.availability.amiGap && result.availability.amiGap.available'), 'renderCombinedAssessment reads availability.amiGap.available');
@@ -667,9 +735,11 @@ test('ownership need labels combined areas as combined CHAS', () => {
 
 test('combined geoType is guarded at projection, map, and checklist call sites', () => {
   const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-controller.js'), 'utf8');
-  assert(src.includes("selection && selection.geoType === 'combined'"), 'applyAssumptions exits for combined selections');
-  assert(src.includes("if (cur.geoType === 'combined') return;"), 'moveend LIHTC refresh is gated for combined selections');
-  assert(src.includes("window.HNAState.state.current.geoType !== 'combined'"), 'beforeunload checklist broadcast skips combined selections');
+  assert(src.includes('function _isMultiJurisdictionSelection(selection)'), 'multi-jurisdiction guard helper exists');
+  assert(src.includes("selection.geoType === 'combined' || selection.geoType === 'regional-comparison'"), 'guard covers blended and regional modes');
+  assert(src.includes('if (_isMultiJurisdictionSelection(cur)) return;'), 'moveend LIHTC refresh is gated for multi-jurisdiction selections');
+  assert(src.includes('if (_isMultiJurisdictionSelection(selection))'), 'applyAssumptions exits for multi-jurisdiction selections');
+  assert(src.includes('!_isMultiJurisdictionSelection(window.HNAState.state.current)'), 'beforeunload checklist broadcast skips multi-jurisdiction selections');
 });
 
 test('preset config members resolve against registry and validate', () => {


### PR DESCRIPTION
## Summary
- Adds a Blended total vs Side-by-side comparison mode selector to the existing combined-jurisdiction HNA picker.
- Implements digest-backed regional comparison rendering so selected jurisdictions display distinct side-by-side affordability, stock, and demographic metrics with no aggregation.
- Preserves the existing blended combined path, keeps the shared 6-member picker cap, and guards regional-comparison selections from single-geography projection/map/checklist flows.

## Handoff Notes
- This is Phase 2 from docs/audits/CODEX-HANDOFF-REGIONAL-COMPARISON-2026-07-10.md.
- The regional mode reads data/hna/jurisdiction-metrics-digest/<geoid>.json for each selected member rather than reusing the combined aggregation engine.
- Cap decision: kept the existing shared 6-member cap for now to avoid layout and workflow drift. The UI includes a note that allowing more regional columns remains a product question.
- Do not merge before external QA.

## Validation
- npm run test:combined-geo
- npm run test:hna
- npm run validate

## Suggested QA Walkthrough
- In housing-needs-assessment.html, enable Combine jurisdictions, add a mix of counties and places, select Side-by-side comparison, and confirm the table shows distinct jurisdiction columns and no aggregate claim.
- Switch back to Blended total and confirm the existing combined-area behavior still renders through the aggregation path.
- Reload with combinedMode=regional and geos=... in the URL and confirm mode restoration.