### PR TITLE
docs(audit): resolve household-level race/ethnicity metric (B25003H found)

### DIFF
--- a/docs/audits/SCOPING-HOUSEHOLD-RACE-B25006-2026-07.md
+++ b/docs/audits/SCOPING-HOUSEHOLD-RACE-B25006-2026-07.md
@@ -1,57 +1,87 @@
-# Scoping — Household-Level Race/Ethnicity Metric (B25006 and related tables, 2026-07)
+# Scoping — Household-Level Race/Ethnicity Metric (2026-07)
 
-**For**: whoever picks this up next (Codex or Claude) — this is a **research/scoping document, not an implementation handoff**. It exists to answer "how big is this, actually?" before anyone commits to building it. Do not implement from this doc directly; it should produce a real implementation handoff (or a decision to drop the idea) as its output.
+**Status: RESOLVED.** The blocking question this doc originally raised (does a household-level race+ethnicity cross-tab table exist?) is answered: **yes.** This doc now specs a real implementation, not an open research question. See revision history at the bottom for what changed and why.
+
+**For**: Codex (implementer) — pending owner approval of label/scope, same as Phase 1b.
+**QA**: Claude Code reviews the PR against the gate below before the owner merges.
 **Owner**: paulglasow
 **Repo**: `pggLLC/Housing-Analytics`
-**Triggered by**: Regional Comparison Phase 1b (`docs/audits/CODEX-HANDOFF-REGIONAL-COMPARISON-PHASE1B-RACE-ETHNICITY-2026-07.md`) specced a population-level BIPOC metric and explicitly deferred the EPS report's household-level "BIPOC Households" equivalent as out of scope, citing a new Census table fetch. This doc is that deferred question, actually investigated rather than left as a placeholder.
+**Triggered by**: Regional Comparison Phase 1b (`docs/audits/CODEX-HANDOFF-REGIONAL-COMPARISON-PHASE1B-RACE-ETHNICITY-2026-07.md`) deferred the EPS report's household-level "BIPOC Households" metric as needing further research. This doc is that research, now complete, with a verified formula that reproduces the EPS report's own published numbers exactly.
 
-## Bottom line up front
+## The metric, verified
 
-**This is not "add one more table fetch."** The mechanics of fetching a new B-series table are cheap — this repo already has a proven, working pattern for it. The hard part is that **no single Census table appears to cross-tabulate race AND Hispanic origin of the householder together**, which is exactly the information needed to compute a BIPOC household share without double-counting. Confirming whether such a table genuinely doesn't exist (vs. this investigation missing it) is real, unfinished work — not something to guess at. Recommendation at the bottom.
+**Formula**: `BIPOC households % = (Total occupied housing units − White-alone-Not-Hispanic-householder occupied units) / Total occupied housing units × 100`
 
-## What's already proven to work (the easy part)
+**Exact Census fields** (Detail Table B25003, "Tenure," and its race/ethnicity iteration `B25003H`):
+- Numerator: `B25003_001E − B25003H_001E`
+- Denominator: `B25003_001E`
 
-This repo already fetches three other B-series detail tables at both county and place level, via a working, tested pattern in `scripts/hna/build_hna_data.py` (~line 630-720): `B25024` (units in structure), `B25070` (GRAPI rent burden), `B25091` (SMOCAPI owner cost burden). The fetch mechanics — county vs. place geography params, year-fallback chain, Census API batching — are all solved problems here; a new B-series table is a small, mechanical addition to that existing function, not new infrastructure.
+`B25003H`'s universe, confirmed directly against the Census API, is literally "Occupied housing units with a householder who is White alone, not Hispanic or Latino" — the household-level equivalent of DP05's `DP05_0096E` used in the population-level metric (Phase 1b). Same complement methodology, different underlying tables, same reasoning for why it avoids double-counting (mutually-exclusive by Census's own table design, same as the population case).
 
-**One relevant caution already on record in this exact code**: the `B25091` fetch has a comment documenting a past mistake — an earlier pass assumed that table's layout without checking, got the bin boundaries wrong, and had to be corrected by verifying against `https://api.census.gov/data/{year}/acs/acs5/groups/B25091.json` directly. That's the standard this doc followed, and any implementation of this scoping's findings should follow too — verify against the live Census API, never assume a B-table's layout from memory or a prior ACS vintage.
+**This is not a proxy or an approximation — it's confirmed to exactly reproduce the EPS report's own published figures**, independently, on two geographies:
 
-## What I verified directly against the Census API (2024 5-year vintage)
+| Geography | B25003 total | B25003H (Not-Hispanic-White) | Computed BIPOC households % | EPS report's own Table 9 figure (2024) |
+|---|---:|---:|---:|---:|
+| Garfield County (`08045`) | 23,404 | 16,776 | **28.3%** | **28.3%** (exact match) |
+| Aspen (`0803620`) | 4,105 | 3,209 | **21.8%** | **21.8%** (exact match) |
 
-**`B25006` (Race of Householder, occupied housing units)** — confirmed structure, 9 estimate variables:
-| Code | Label |
-|---|---|
-| `B25006_001E` | Total |
-| `B25006_002E` | White alone |
-| `B25006_003E` | Black or African American alone |
-| `B25006_004E` | American Indian and Alaska Native alone |
-| `B25006_005E` | Asian alone |
-| `B25006_006E` | Native Hawaiian and Other Pacific Islander alone |
-| `B25006_007E` | Some other race alone |
-| `B25006_008E` | Two races excluding Some other race, and three or more races |
-| `B25006_009E` | Two or more races |
+Both fetched live from Census Reporter's B25003/B25003H tables, ACS 2024 5-year, and compared against the report's actual printed values (I read the PDF directly earlier in this work). This confirms `B25003`/`B25003H` is the right table pair and the complement formula is the right methodology — not just plausible, but numerically exact on two independent test cases.
 
-**Critical gap: `B25006` has no Hispanic/Latino ethnicity dimension at all.** It classifies households by householder *race* only. Unlike DP05's "HISPANIC OR LATINO AND RACE" section (which is what makes the population-level metric in Phase 1b clean — a single mutually-exclusive "Not Hispanic White alone" cell), there is no equivalent cell here. A household with a Hispanic White householder is indistinguishable from a non-Hispanic White householder in this table.
+## Why the original version of this doc got it wrong
 
-**Data availability spot-check**: fetched `B25006` for Silt, CO (a small town, ~1,300 households) via Census Reporter. Fully populated, all 9 categories sum exactly to the total (1,314). Four categories read zero (Black, AIAN, Asian, NHPI) — plausible for a town this size and racial composition (consistent with what this repo's own corrected DP05 population data shows for Silt), not obviously a suppression artifact. Small-place reliability looks workable, but should be re-checked for a few more places before committing to build on it.
+The first pass checked `B25006` (Race of Householder) and `B11001I` (Household Type, Hispanic-or-Latino iteration) and concluded no single table cross-tabbed race and ethnicity together. That conclusion was correct about those two tables, but incomplete — it didn't check Census's *tenure*-table race/ethnicity iterations (`B25003A` through `B25003I`), where the "H" iteration (White alone, Not Hispanic) is exactly the missing piece. Worth naming plainly: the first pass stopped one table short of the answer. Flagging this so the same gap doesn't recur — when checking whether a race/ethnicity iteration exists for a concept, check the full iteration set (`A` White alone, `B` Black alone, `C` AIAN alone, `D` Asian alone, `E` NHPI alone, `F` Some other race alone, `G` Two or more races, `H` White alone Not Hispanic, `I` Hispanic or Latino) before concluding one doesn't exist.
 
-**Candidate companion table for the missing ethnicity dimension: `B11001I`** — "Household Type (Including Living Alone) (Hispanic or Latino)," universe explicitly stated as "Households with a householder who is Hispanic or Latino." This looks like the right concept (total Hispanic-householder households), but I could not fully confirm `B11001I_001E` is the clean total variable in this pass — the API response was incomplete. **This needs direct confirmation before anyone relies on it**, same as every DP05/DP04 code this session got independently verified rather than assumed.
+## Implementation scope
 
-## Why two separate tables isn't enough on its own
+**Files to change:**
+1. `scripts/hna/build_hna_data.py` — add `B25003_001E` and `B25003H_001E` to the existing B-series fetch function (~line 630-720, same function that already fetches `B25024`/`B25070`/`B25091`). No new fetch infrastructure needed; this is two more variable codes in an existing, proven request.
+2. `scripts/hna/build_jurisdiction_metrics_digest.mjs` — add `pct_bipoc_households` to `regionalComparisonMetrics()` (~line 382-416), same pattern as every other metric in that function:
+   ```js
+   pct_bipoc_households: acsRegionalMetric(
+     pctFromCounts(sumNumbers([acs.B25003_001E]) - sumNumbers([acs.B25003H_001E]), acs.B25003_001E),
+     entry,
+     'acs-b25003',
+     'occupied_housing_units',
+     acs.B25003_001E,
+   ),
+   ```
+3. `js/hna/hna-renderers.js` — add a row to `REGIONAL_COMPARISON_ROWS` (Demographics section): `{ section: 'Demographics', label: 'BIPOC households', key: 'pct_bipoc_households', format: 'pct' }`. This label is accurate as-is — unlike Phase 1b's population-level metric, this one genuinely is a household statistic, so "BIPOC households" is the correct, non-misleading label here (the opposite framing caution from Phase 1b applies in reverse: don't accidentally call *this* one "population").
 
-Even with both `B25006` (race) and `B11001I` (Hispanic-or-Latino householder households) fetched, computing "BIPOC households" (matching the population-level definition's logic — total minus non-Hispanic-White-alone) needs **non-Hispanic-White-alone household count** as an input. Neither table gives that directly:
-- `B25006` gives White-alone households (Hispanic + non-Hispanic White combined).
-- `B11001I` gives Hispanic-householder households (all races combined).
-- Subtracting the overlap requires knowing how many White-alone households are *also* Hispanic-householder households — which isn't derivable from these two tables' marginal totals alone.
+**Generated artifacts**: regenerate `data/hna/jurisdiction-metrics-digest/*.json` via `build-hna-data.yml`, same as Phase 1/1b.
 
-The clean solution is a table that cross-tabulates *both* dimensions on the same households (the household-level equivalent of DP05's population cross-tab). I did not find one in this pass. It may exist under a table ID I haven't checked (Census publishes many race-iteration suffixes — A through I — across dozens of base tables; I only spot-checked household-type and housing-cost iterations), or it may genuinely not exist at the household level the way it does for population. **This is the open question the next pass needs to resolve before any implementation starts.**
+**Relationship to Phase 1b**: this and the population-level metric are both real, correct, and answer different questions — recommend shipping both as separate Demographics rows ("Population identifying as BIPOC" and "BIPOC households"), not choosing one over the other. They will read differently (household composition skews the household-level number relative to population share, as seen above: Garfield 28.3% households vs. ~38.5% population), and that gap is itself informative, not a discrepancy to resolve.
 
-## What "next pass" should actually do
+**Data availability**: `B25003`/`B25003H` are standard Detail Table tenure iterations, same publication tier as the already-fetched `B25024`/`B25070`/`B25091` — no reason to expect worse small-place coverage than those. Spot-check a small place (e.g. Silt, Parachute) during implementation as a final confirmation, same as every other new field this session got checked before shipping, but this is a formality at this point, not an open risk.
 
-1. Systematically search Census's table shell for a household-level cross-tab of race AND Hispanic origin of householder (check the `B25006` group's own metadata for a Hispanic-origin variant suffix; check whether ACS Subject Tables — `S` prefix — publish this differently than Detail Tables; check `B11001I_001E` directly once a Census API key is available).
-2. If found: this becomes a real implementation handoff — small addition to the existing B-series fetch pattern, one new digest metric, mirroring the population-level Phase 1b spec exactly.
-3. If not found: report that plainly. Options at that point are (a) accept an imperfect proxy — e.g. `1 − (White-alone households / total households)`, disclosed clearly as "not adjusted for Hispanic ethnicity, will understate BIPOC share for any Hispanic householder who selected White alone" — or (b) drop household-level entirely and treat the population-level metric (Phase 1b) as the permanent answer, with the gap documented rather than silently worked around.
-4. Either way, re-run the same small-place data-availability spot-check (§ above) across a handful of the state's smallest tracked places before committing — a table that's clean for Silt (1,300 households) may not hold up for a town with 200.
+## Tests Codex must add
 
-## Recommendation
+Same shape as Phase 1b's §4:
+1. Sane bounds: `0 <= pct_bipoc_households <= 100` for every geography.
+2. Recompute independently from raw `acsProfile` fields in the test (not just internal consistency with the digest's own formula).
+3. Fixture values: Garfield County **28.3%**, Aspen **21.8%** — cite this doc and the EPS report Table 9 as the independent source in the test comment.
+4. Label regression: confirm the row label says "households," distinguishing it from Phase 1b's population-level row (guards against the two getting mislabeled or swapped).
 
-Don't greenlight implementation yet. The next step is answering the cross-tab question in §"Why two separate tables isn't enough," which is a bounded, half-day-scale research task, not a build task. Once that's answered, the actual implementation (whichever path it points to) is small — comparable in size to Phase 1b, not a major undertaking. This doc's job was to stop that from being discovered mid-implementation; it's cheaper to find out now.
+## QA gate
+
+```
+npm run test:jurisdiction-metrics-digest
+npm run test:hna
+npm run validate
+```
+Rendered smoke: `housing-needs-assessment.html?geos=08045+0803620&combinedMode=regional`, confirm both the population-level row (Phase 1b, if merged) and this household-level row appear, with visibly different values, both labeled correctly.
+
+## Owner decision points
+
+1. Ship alongside Phase 1b (both rows) or standalone — recommend both, see "Relationship to Phase 1b" above.
+2. Exact label wording — "BIPOC households" is accurate and matches the EPS report's own term for the concept it measures (unlike Phase 1b, where reusing their label would have been misleading).
+3. Sequencing — this can implement independently of Phase 1b; they touch the same functions but different metrics/fields, no ordering dependency.
+
+## Final Codex implementation prompt (paste after owner approval)
+
+> Implement the household-level BIPOC metric from `docs/audits/SCOPING-HOUSEHOLD-RACE-B25006-2026-07.md`. Add `B25003_001E` and `B25003H_001E` to the existing B-series ACS fetch in `scripts/hna/build_hna_data.py`. Add `pct_bipoc_households` to `regionalComparisonMetrics()` in `scripts/hna/build_jurisdiction_metrics_digest.mjs` using the formula and pattern in this doc. Add the row to `REGIONAL_COMPARISON_ROWS` in `js/hna/hna-renderers.js` labeled "BIPOC households." Regenerate all jurisdiction-metrics-digest artifacts via `build-hna-data.yml`. Add the four tests in this doc's "Tests Codex must add" section, including the Garfield County (28.3%) and Aspen (21.8%) fixtures. Run `test:jurisdiction-metrics-digest`, `test:hna`, and `validate`, plus a live-browser rendered smoke check. Mark the PR "do not merge until external QA completes."
+
+---
+
+## Revision history
+
+**2026-07-10, second pass**: superseded the original conclusion. First pass checked `B25006` (race-only, confirmed no ethnicity dimension) and `B11001I` (Hispanic household-type, wrong table concept) and concluded no cross-tab existed. Checking `B25003`'s full race/ethnicity iteration set found `B25003H` (White alone, Not Hispanic householder) — confirmed against the live Census API and validated by exactly reproducing the EPS report's own published Garfield County (28.3%) and Aspen (21.8%) BIPOC-household figures. This is now a real, verified, low-risk implementation handoff, not an open research question.

--- a/docs/audits/SCOPING-HOUSEHOLD-RACE-B25006-2026-07.md
+++ b/docs/audits/SCOPING-HOUSEHOLD-RACE-B25006-2026-07.md
@@ -1,0 +1,57 @@
+# Scoping — Household-Level Race/Ethnicity Metric (B25006 and related tables, 2026-07)
+
+**For**: whoever picks this up next (Codex or Claude) — this is a **research/scoping document, not an implementation handoff**. It exists to answer "how big is this, actually?" before anyone commits to building it. Do not implement from this doc directly; it should produce a real implementation handoff (or a decision to drop the idea) as its output.
+**Owner**: paulglasow
+**Repo**: `pggLLC/Housing-Analytics`
+**Triggered by**: Regional Comparison Phase 1b (`docs/audits/CODEX-HANDOFF-REGIONAL-COMPARISON-PHASE1B-RACE-ETHNICITY-2026-07.md`) specced a population-level BIPOC metric and explicitly deferred the EPS report's household-level "BIPOC Households" equivalent as out of scope, citing a new Census table fetch. This doc is that deferred question, actually investigated rather than left as a placeholder.
+
+## Bottom line up front
+
+**This is not "add one more table fetch."** The mechanics of fetching a new B-series table are cheap — this repo already has a proven, working pattern for it. The hard part is that **no single Census table appears to cross-tabulate race AND Hispanic origin of the householder together**, which is exactly the information needed to compute a BIPOC household share without double-counting. Confirming whether such a table genuinely doesn't exist (vs. this investigation missing it) is real, unfinished work — not something to guess at. Recommendation at the bottom.
+
+## What's already proven to work (the easy part)
+
+This repo already fetches three other B-series detail tables at both county and place level, via a working, tested pattern in `scripts/hna/build_hna_data.py` (~line 630-720): `B25024` (units in structure), `B25070` (GRAPI rent burden), `B25091` (SMOCAPI owner cost burden). The fetch mechanics — county vs. place geography params, year-fallback chain, Census API batching — are all solved problems here; a new B-series table is a small, mechanical addition to that existing function, not new infrastructure.
+
+**One relevant caution already on record in this exact code**: the `B25091` fetch has a comment documenting a past mistake — an earlier pass assumed that table's layout without checking, got the bin boundaries wrong, and had to be corrected by verifying against `https://api.census.gov/data/{year}/acs/acs5/groups/B25091.json` directly. That's the standard this doc followed, and any implementation of this scoping's findings should follow too — verify against the live Census API, never assume a B-table's layout from memory or a prior ACS vintage.
+
+## What I verified directly against the Census API (2024 5-year vintage)
+
+**`B25006` (Race of Householder, occupied housing units)** — confirmed structure, 9 estimate variables:
+| Code | Label |
+|---|---|
+| `B25006_001E` | Total |
+| `B25006_002E` | White alone |
+| `B25006_003E` | Black or African American alone |
+| `B25006_004E` | American Indian and Alaska Native alone |
+| `B25006_005E` | Asian alone |
+| `B25006_006E` | Native Hawaiian and Other Pacific Islander alone |
+| `B25006_007E` | Some other race alone |
+| `B25006_008E` | Two races excluding Some other race, and three or more races |
+| `B25006_009E` | Two or more races |
+
+**Critical gap: `B25006` has no Hispanic/Latino ethnicity dimension at all.** It classifies households by householder *race* only. Unlike DP05's "HISPANIC OR LATINO AND RACE" section (which is what makes the population-level metric in Phase 1b clean — a single mutually-exclusive "Not Hispanic White alone" cell), there is no equivalent cell here. A household with a Hispanic White householder is indistinguishable from a non-Hispanic White householder in this table.
+
+**Data availability spot-check**: fetched `B25006` for Silt, CO (a small town, ~1,300 households) via Census Reporter. Fully populated, all 9 categories sum exactly to the total (1,314). Four categories read zero (Black, AIAN, Asian, NHPI) — plausible for a town this size and racial composition (consistent with what this repo's own corrected DP05 population data shows for Silt), not obviously a suppression artifact. Small-place reliability looks workable, but should be re-checked for a few more places before committing to build on it.
+
+**Candidate companion table for the missing ethnicity dimension: `B11001I`** — "Household Type (Including Living Alone) (Hispanic or Latino)," universe explicitly stated as "Households with a householder who is Hispanic or Latino." This looks like the right concept (total Hispanic-householder households), but I could not fully confirm `B11001I_001E` is the clean total variable in this pass — the API response was incomplete. **This needs direct confirmation before anyone relies on it**, same as every DP05/DP04 code this session got independently verified rather than assumed.
+
+## Why two separate tables isn't enough on its own
+
+Even with both `B25006` (race) and `B11001I` (Hispanic-or-Latino householder households) fetched, computing "BIPOC households" (matching the population-level definition's logic — total minus non-Hispanic-White-alone) needs **non-Hispanic-White-alone household count** as an input. Neither table gives that directly:
+- `B25006` gives White-alone households (Hispanic + non-Hispanic White combined).
+- `B11001I` gives Hispanic-householder households (all races combined).
+- Subtracting the overlap requires knowing how many White-alone households are *also* Hispanic-householder households — which isn't derivable from these two tables' marginal totals alone.
+
+The clean solution is a table that cross-tabulates *both* dimensions on the same households (the household-level equivalent of DP05's population cross-tab). I did not find one in this pass. It may exist under a table ID I haven't checked (Census publishes many race-iteration suffixes — A through I — across dozens of base tables; I only spot-checked household-type and housing-cost iterations), or it may genuinely not exist at the household level the way it does for population. **This is the open question the next pass needs to resolve before any implementation starts.**
+
+## What "next pass" should actually do
+
+1. Systematically search Census's table shell for a household-level cross-tab of race AND Hispanic origin of householder (check the `B25006` group's own metadata for a Hispanic-origin variant suffix; check whether ACS Subject Tables — `S` prefix — publish this differently than Detail Tables; check `B11001I_001E` directly once a Census API key is available).
+2. If found: this becomes a real implementation handoff — small addition to the existing B-series fetch pattern, one new digest metric, mirroring the population-level Phase 1b spec exactly.
+3. If not found: report that plainly. Options at that point are (a) accept an imperfect proxy — e.g. `1 − (White-alone households / total households)`, disclosed clearly as "not adjusted for Hispanic ethnicity, will understate BIPOC share for any Hispanic householder who selected White alone" — or (b) drop household-level entirely and treat the population-level metric (Phase 1b) as the permanent answer, with the gap documented rather than silently worked around.
+4. Either way, re-run the same small-place data-availability spot-check (§ above) across a handful of the state's smallest tracked places before committing — a table that's clean for Silt (1,300 households) may not hold up for a town with 200.
+
+## Recommendation
+
+Don't greenlight implementation yet. The next step is answering the cross-tab question in §"Why two separate tables isn't enough," which is a bounded, half-day-scale research task, not a build task. Once that's answered, the actual implementation (whichever path it points to) is small — comparable in size to Phase 1b, not a major undertaking. This doc's job was to stop that from being discovered mid-implementation; it's cheaper to find out now.

--- a/docs/audits/SCOPING-HOUSEHOLD-RACE-B25006-2026-07.md
+++ b/docs/audits/SCOPING-HOUSEHOLD-RACE-B25006-2026-07.md
@@ -33,33 +33,50 @@ The first pass checked `B25006` (Race of Householder) and `B11001I` (Household T
 
 ## Implementation scope
 
-**Files to change:**
-1. `scripts/hna/build_hna_data.py` — add `B25003_001E` and `B25003H_001E` to the existing B-series fetch function (~line 630-720, same function that already fetches `B25024`/`B25070`/`B25091`). No new fetch infrastructure needed; this is two more variable codes in an existing, proven request.
-2. `scripts/hna/build_jurisdiction_metrics_digest.mjs` — add `pct_bipoc_households` to `regionalComparisonMetrics()` (~line 382-416), same pattern as every other metric in that function:
+**Correction (post-QA, see revision history)**: the original version of this section was wrong about the fetch path, and also overstated an existing claim. Both are fixed below.
+
+**`B25024`/`B25070`/`B25091` are NOT actually populated for normal geographies today.** I said the fetch pattern for these was "proven, working" — that was true of the code as written, but misleading about what it actually does in practice. Verified directly: neither Garfield County's nor Aspen's current `acsProfile` cache contains `B25070_007E`, `B25024_002E`, or `B25003_001E` at all. The function holding those variables, `_fetch_acs5_b_series()` (`scripts/hna/build_hna_data.py:635`), is called from exactly one place (`fetch_acs_profile()`, line 979) — **only when the primary DP-profile fetch (batch A) fails entirely for a geography**. For the overwhelming majority of real geographies, including every one this session actually inspected, batch A succeeds, so this function never runs and none of its variables — old or newly added — land in the cached summary. Adding `B25003_001E`/`B25003H_001E` to this function's variable list would do nothing for Garfield, Aspen, or any other normally-fetched geography.
+
+**Correct implementation path — an always-run supplement, not the fallback:**
+1. `scripts/hna/build_hna_data.py`, inside `fetch_acs_profile()` — add a new, unconditional Detail Table fetch that runs for every geography regardless of whether batch A/B/C/D succeeded, modeled on the `supplements` loop (~line 990-995: `('C', vars_c, ...)`, `('D', vars_d, ...)`) but hitting the Detail Table endpoint instead of the Data Profile endpoint. `_fetch_batch()` (line 946) is hardcoded to `/acs/{series}/profile` — it cannot fetch `B25003`/`B25003H`, which live at `/acs/{series}` (no `/profile` suffix), the same endpoint shape already used inside `_fetch_acs5_b_series()` (see its `build_url`-equivalent construction there for the exact query-string pattern, including the manual colon-preserving encoding for `for=`/`in=`). Concretely: add a small helper (e.g. `_fetch_acs5_detail(year, batch_vars)`) that queries that endpoint with `['B25003_001E', 'B25003H_001E']`, call it unconditionally after the `supplements` loop, and merge its result into `merged` the same way batch C/D are merged (`merged.setdefault(k, v)` — don't overwrite if a key already exists from an earlier batch).
+2. Confirm after implementing: `data/hna/summary/08045.json` and `.../0803620.json` (Garfield, Aspen) actually contain `B25003_001E`/`B25003H_001E` post-regeneration. This is not a formality — it's the check that would have caught the original version of this doc's mistake before it shipped.
+3. `scripts/hna/build_jurisdiction_metrics_digest.mjs` — add `pct_bipoc_households` to `regionalComparisonMetrics()` (~line 382-416). **Use a dedicated helper with explicit null-checking on both raw fields before subtracting** — do not subtract two `sumNumbers()` calls directly (see the null-coercion bug this doc originally proposed, corrected below). Follow the exact shape of `housingBuiltPre1970Pct()` (~line 373-380), which already handles a similar multi-field computation safely:
+   ```js
+   function bipocHouseholdsPct(acs) {
+     const total = numberOrNull(acs.B25003_001E);
+     const nonHispanicWhite = numberOrNull(acs.B25003H_001E);
+     if (total == null || nonHispanicWhite == null) return null;
+     return pctFromCounts(total - nonHispanicWhite, total);
+   }
+   ```
+   then in `regionalComparisonMetrics()`:
    ```js
    pct_bipoc_households: acsRegionalMetric(
-     pctFromCounts(sumNumbers([acs.B25003_001E]) - sumNumbers([acs.B25003H_001E]), acs.B25003_001E),
+     bipocHouseholdsPct(acs),
      entry,
      'acs-b25003',
      'occupied_housing_units',
      acs.B25003_001E,
    ),
    ```
-3. `js/hna/hna-renderers.js` — add a row to `REGIONAL_COMPARISON_ROWS` (Demographics section): `{ section: 'Demographics', label: 'BIPOC households', key: 'pct_bipoc_households', format: 'pct' }`. This label is accurate as-is — unlike Phase 1b's population-level metric, this one genuinely is a household statistic, so "BIPOC households" is the correct, non-misleading label here (the opposite framing caution from Phase 1b applies in reverse: don't accidentally call *this* one "population").
+   **Why the original snippet was a real bug, not just a style nitpick**: `sumNumbers([acs.B25003_001E]) - sumNumbers([acs.B25003H_001E])` — `sumNumbers()` returns `null` (not `0`) when its input is missing (confirmed at `build_jurisdiction_metrics_digest.mjs:291-301`). If `B25003H_001E` were ever missing for a geography while `B25003_001E` succeeded, JavaScript would coerce `null` to `0` in the subtraction (`someTotal - null` evaluates to `someTotal`, not `NaN`), so the metric would silently compute `pctFromCounts(total, total)` — a false **100% BIPOC households** — instead of correctly returning unavailable. `pctFromCounts`'s own null-check operates on the already-computed (and by then already-corrupted) difference, so it can't catch this after the fact. The fields must be null-checked individually, before the subtraction, which is what the corrected helper above does.
+4. `js/hna/hna-renderers.js` — add a row to `REGIONAL_COMPARISON_ROWS` (Demographics section): `{ section: 'Demographics', label: 'BIPOC households', key: 'pct_bipoc_households', format: 'pct' }`. This label is accurate as-is — unlike Phase 1b's population-level metric, this one genuinely is a household statistic, so "BIPOC households" is the correct, non-misleading label here (the opposite framing caution from Phase 1b applies in reverse: don't accidentally call *this* one "population").
 
-**Generated artifacts**: regenerate `data/hna/jurisdiction-metrics-digest/*.json` via `build-hna-data.yml`, same as Phase 1/1b.
+**Generated artifacts**: regenerate `data/hna/jurisdiction-metrics-digest/*.json` via `build-hna-data.yml`, same as Phase 1/1b. This regeneration is load-bearing here in a way it wasn't for other metrics — until it runs (and the new always-run fetch actually executes, not the fallback), `data/hna/summary/*.json` has no `B25003_001E`/`B25003H_001E` for any geography, and the digest metric will be `null` everywhere.
 
 **Relationship to Phase 1b**: this and the population-level metric are both real, correct, and answer different questions — recommend shipping both as separate Demographics rows ("Population identifying as BIPOC" and "BIPOC households"), not choosing one over the other. They will read differently (household composition skews the household-level number relative to population share, as seen above: Garfield 28.3% households vs. ~38.5% population), and that gap is itself informative, not a discrepancy to resolve.
 
-**Data availability**: `B25003`/`B25003H` are standard Detail Table tenure iterations, same publication tier as the already-fetched `B25024`/`B25070`/`B25091` — no reason to expect worse small-place coverage than those. Spot-check a small place (e.g. Silt, Parachute) during implementation as a final confirmation, same as every other new field this session got checked before shipping, but this is a formality at this point, not an open risk.
+**Data availability**: `B25003`/`B25003H` are standard Detail Table tenure iterations, same publication tier as `B25024`/`B25070`/`B25091` — no reason to expect worse small-place coverage than those (which, per the correction above, is itself unverified for the normal-fetch path; don't cite those three as a reliability precedent without checking). Spot-check a small place (e.g. Silt, Parachute) after implementing to confirm the new supplement actually populates for a low-population geography, not just Garfield/Aspen.
 
 ## Tests Codex must add
 
-Same shape as Phase 1b's §4:
+Same shape as Phase 1b's §4, plus one new item specific to this metric's fetch-path fix and null-safety bug:
 1. Sane bounds: `0 <= pct_bipoc_households <= 100` for every geography.
 2. Recompute independently from raw `acsProfile` fields in the test (not just internal consistency with the digest's own formula).
 3. Fixture values: Garfield County **28.3%**, Aspen **21.8%** — cite this doc and the EPS report Table 9 as the independent source in the test comment.
 4. Label regression: confirm the row label says "households," distinguishing it from Phase 1b's population-level row (guards against the two getting mislabeled or swapped).
+5. **Fetch-path regression**: assert `B25003_001E`/`B25003H_001E` are present in a *normal* (non-fallback) geography's regenerated summary cache — e.g. Garfield County, which is known to succeed on batch A. This is the test that would have caught this doc's original mistake; don't skip it even though it feels redundant with #1/#3.
+6. **Null-safety regression**: unit-test `bipocHouseholdsPct()` (or equivalent) directly with a fixture where `B25003_001E` is present but `B25003H_001E` is `null`/missing, and assert the function returns `null` — not `100`. This is the regression guard for the coercion bug described in the Implementation scope section above.
 
 ## QA gate
 
@@ -68,6 +85,8 @@ npm run test:jurisdiction-metrics-digest
 npm run test:hna
 npm run validate
 ```
+Additional check specific to this metric (not needed for a metric that only touches already-fetched fields, but required here since this adds a new always-run fetch): after regenerating via `build-hna-data.yml`, directly inspect `data/hna/summary/08045.json` and confirm `acsProfile.B25003_001E` and `acsProfile.B25003H_001E` are present and numeric — don't rely on the digest output alone to infer the fetch worked, since a silently-`null` digest value and a genuinely-missing raw field look the same from the digest side.
+
 Rendered smoke: `housing-needs-assessment.html?geos=08045+0803620&combinedMode=regional`, confirm both the population-level row (Phase 1b, if merged) and this household-level row appear, with visibly different values, both labeled correctly.
 
 ## Owner decision points
@@ -78,10 +97,12 @@ Rendered smoke: `housing-needs-assessment.html?geos=08045+0803620&combinedMode=r
 
 ## Final Codex implementation prompt (paste after owner approval)
 
-> Implement the household-level BIPOC metric from `docs/audits/SCOPING-HOUSEHOLD-RACE-B25006-2026-07.md`. Add `B25003_001E` and `B25003H_001E` to the existing B-series ACS fetch in `scripts/hna/build_hna_data.py`. Add `pct_bipoc_households` to `regionalComparisonMetrics()` in `scripts/hna/build_jurisdiction_metrics_digest.mjs` using the formula and pattern in this doc. Add the row to `REGIONAL_COMPARISON_ROWS` in `js/hna/hna-renderers.js` labeled "BIPOC households." Regenerate all jurisdiction-metrics-digest artifacts via `build-hna-data.yml`. Add the four tests in this doc's "Tests Codex must add" section, including the Garfield County (28.3%) and Aspen (21.8%) fixtures. Run `test:jurisdiction-metrics-digest`, `test:hna`, and `validate`, plus a live-browser rendered smoke check. Mark the PR "do not merge until external QA completes."
+> Implement the household-level BIPOC metric from `docs/audits/SCOPING-HOUSEHOLD-RACE-B25006-2026-07.md`. **Read the "Implementation scope" section carefully — the fetch path is not what it looks like at first glance.** `B25003_001E`/`B25003H_001E` must be fetched via a new, unconditional (always-run) Detail Table supplement inside `fetch_acs_profile()` in `scripts/hna/build_hna_data.py`, modeled on the `supplements` loop pattern (batches C/D) but hitting the `/acs/{series}` Detail Table endpoint, not `/acs/{series}/profile`. Do **not** add these fields to `_fetch_acs5_b_series()` — that function only runs as a fallback when the primary profile fetch fails entirely, and would leave these fields absent for normal geographies like Garfield County and Aspen. After implementing, directly inspect a regenerated `data/hna/summary/08045.json` to confirm the fields actually landed there. Add `pct_bipoc_households` to `regionalComparisonMetrics()` in `scripts/hna/build_jurisdiction_metrics_digest.mjs` via a dedicated `bipocHouseholdsPct()` helper that null-checks `B25003_001E` and `B25003H_001E` individually *before* subtracting — do not subtract two `sumNumbers()` calls directly, since a missing `B25003H_001E` would silently coerce to a false 100% rather than correctly returning null. Add the row to `REGIONAL_COMPARISON_ROWS` in `js/hna/hna-renderers.js` labeled "BIPOC households." Regenerate all jurisdiction-metrics-digest artifacts via `build-hna-data.yml`. Add all six tests in this doc's "Tests Codex must add" section, including the fetch-path regression, the null-safety regression, and the Garfield County (28.3%) / Aspen (21.8%) fixtures. Run `test:jurisdiction-metrics-digest`, `test:hna`, and `validate`, plus a live-browser rendered smoke check. Mark the PR "do not merge until external QA completes."
 
 ---
 
 ## Revision history
 
 **2026-07-10, second pass**: superseded the original conclusion. First pass checked `B25006` (race-only, confirmed no ethnicity dimension) and `B11001I` (Hispanic household-type, wrong table concept) and concluded no cross-tab existed. Checking `B25003`'s full race/ethnicity iteration set found `B25003H` (White alone, Not Hispanic householder) — confirmed against the live Census API and validated by exactly reproducing the EPS report's own published Garfield County (28.3%) and Aspen (21.8%) BIPOC-household figures. This is now a real, verified, low-risk implementation handoff, not an open research question.
+
+**2026-07-10, third pass (post-Codex-QA)**: Codex's external QA on the resulting PR confirmed the B25003/B25003H table pair and fixture values are correct, but caught two real implementation-scope defects in the second pass's guidance, both fixed here: (1) the doc directed adding the new fields to `_fetch_acs5_b_series()`, which is fallback-only and never runs for normal geographies — confirmed directly that Garfield's and Aspen's current summary caches contain none of that function's variables, including the three (`B25024`/`B25070`/`B25091`) this doc previously cited as an already-proven pattern for normal geographies, which was itself an overstatement; corrected to specify a new always-run Detail Table supplement instead. (2) the proposed digest snippet subtracted two `sumNumbers()` calls directly, which silently coerces a missing `B25003H_001E` to a false 100% via JavaScript's `null` arithmetic rather than correctly returning unavailable; corrected to a dedicated helper with explicit per-field null-checking before the subtraction.


### PR DESCRIPTION
## Summary
- Docs-only, no code changes.
- **Update**: this PR's conclusion changed after opening. The first commit found no household-level race+ethnicity cross-tab table and recommended holding off. Checking one more table (`B25003`'s race/ethnicity iteration set) found the missing piece: `B25003H` — "Occupied housing units with a householder who is White alone, not Hispanic or Latino." This doc is now a verified, ready-to-approve implementation spec, not an open research question.

## What changed my mind
Computed BIPOC households % using `(B25003_001E - B25003H_001E) / B25003_001E` for two geographies and got an **exact match** to the EPS Regional HNA report's own published Table 9 figures both times:
- Garfield County: computed 28.3%, report 28.3%
- Aspen: computed 21.8%, report 21.8%

Not an approximation — this reproduces the consultant's own numbers exactly, confirming `B25003`/`B25003H` is the right table pair.

## What's in the doc now
- Exact formula and Census field codes.
- File-by-file implementation scope, including the corrected fetch path: add an always-run ACS Detail Table supplement inside `fetch_acs_profile()` and merge `B25003_001E`/`B25003H_001E` into summary caches; do **not** add these fields only to fallback `_fetch_acs5_b_series()`.
- Tests Codex must add, with verified fixture values.
- QA gate and a paste-ready Codex implementation prompt, gated on owner approval of label/sequencing.
- A short note on where the first pass went wrong (checked `B25006` and `B11001I`, stopped one table short of `B25003H`) so the same gap doesn't recur next time.

## Tests
No code changes; `npm run validate` passes.
