### PR TITLE
fix: scale PMA CHAS denominator to buffer

### DIFF
--- a/js/market-analysis-scoring.js
+++ b/js/market-analysis-scoring.js
@@ -79,6 +79,92 @@
     };
   }
 
+  /**
+   * Estimate LIHTC-eligible renter households (<=80% AMI) inside a PMA buffer.
+   *
+   * CHAS income tiers are county-wide, while the PMA buffer is tract-scoped.
+   * For each county touched by the buffer, scale that county's CHAS tiers by
+   * buffer renter HH / county CHAS renter HH. This keeps the income-qualified
+   * denominator narrowed to <=80% AMI without accidentally using a whole
+   * county's renter pool for a small urban buffer.
+   *
+   * @param {Object<string,Object>} chasCounties - chasData.counties
+   * @param {Array<Object>} bufTracts - buffer tracts with geoid/_bufferShare
+   * @param {Object<string,Object>} acsIdx - tract metrics keyed by geoid
+   * @returns {{
+   *   value: number|null,
+   *   tier_breakdown: Object|null,
+   *   source: 'chas'|'unavailable',
+   *   counties: Array<{fips:string, share:number, lihtc_eligible:number}>
+   * }}
+   */
+  function chasLihtcEligibleRenters(chasCounties, bufTracts, acsIdx) {
+    if (!chasCounties || !bufTracts || !bufTracts.length || !acsIdx) {
+      return { value: null, tier_breakdown: null, source: 'unavailable', counties: [] };
+    }
+
+    var rentersByCounty = {};
+    bufTracts.forEach(function (tract) {
+      var gid = String(tract && tract.geoid || '');
+      if (gid.length < 5) return;
+      var metrics = acsIdx[gid];
+      var renterHh = metrics && metrics.renter_hh;
+      if (typeof renterHh !== 'number' || renterHh <= 0) return;
+      var share = (typeof tract._bufferShare === 'number') ? tract._bufferShare : 1;
+      if (share <= 0) return;
+      var fips = gid.slice(0, 5);
+      rentersByCounty[fips] = (rentersByCounty[fips] || 0) + renterHh * share;
+    });
+
+    var lihtcEligible = 0;
+    var breakdown = { lte30: 0, '31to50': 0, '51to80': 0 };
+    var perCounty = [];
+
+    Object.keys(rentersByCounty).forEach(function (fips) {
+      var rec = chasCounties[fips];
+      var pop = rec && rec.renter_hh_by_ami;
+      if (!pop) return;
+
+      var chasCountyTotalRenters = 0;
+      ['lte30', '31to50', '51to80', '81to100', '100plus'].forEach(function (tier) {
+        var total = pop[tier] && pop[tier].total;
+        if (typeof total === 'number' && total > 0) chasCountyTotalRenters += total;
+      });
+      if (chasCountyTotalRenters <= 0) return;
+
+      // County CHAS is the only income-tier source currently available, so
+      // assume the PMA buffer's income mix matches the county's income mix.
+      var countyScale = Math.min(1, rentersByCounty[fips] / chasCountyTotalRenters);
+      if (countyScale <= 0) return;
+
+      var countyLihtc = 0;
+      ['lte30', '31to50', '51to80'].forEach(function (tier) {
+        var total = pop[tier] && pop[tier].total;
+        if (typeof total !== 'number' || total <= 0) return;
+        var apportioned = total * countyScale;
+        countyLihtc += apportioned;
+        breakdown[tier] += apportioned;
+      });
+
+      if (countyLihtc <= 0) return;
+      lihtcEligible += countyLihtc;
+      perCounty.push({ fips: fips, share: countyScale, lihtc_eligible: Math.round(countyLihtc) });
+    });
+
+    if (lihtcEligible <= 0) {
+      return { value: null, tier_breakdown: null, source: 'unavailable', counties: [] };
+    }
+
+    Object.keys(breakdown).forEach(function (k) { breakdown[k] = Math.round(breakdown[k]); });
+
+    return {
+      value: Math.round(lihtcEligible),
+      tier_breakdown: breakdown,
+      source: 'chas',
+      counties: perCounty.sort(function (a, b) { return b.share - a.share; })
+    };
+  }
+
   function scoreRentPressure(acs, countyAmi) {
     acs = acs || {};
     if (!countyAmi || countyAmi <= 0) {
@@ -110,6 +196,7 @@
     RISK: RISK,
     scoreDemand: scoreDemand,
     scoreCaptureRisk: scoreCaptureRisk,
+    chasLihtcEligibleRenters: chasLihtcEligibleRenters,
     scoreRentPressure: scoreRentPressure,
     scoreMarketTightness: scoreMarketTightness,
     scoreTier: scoreTier

--- a/js/market-analysis.js
+++ b/js/market-analysis.js
@@ -600,8 +600,8 @@
   }
 
   /**
-   * D — Compute LIHTC-eligible renter HH count from CHAS, weighted across
-   * the buffer's tracts by county.
+   * D — Compute LIHTC-eligible renter HH count from CHAS, scaled to the
+   * buffer's tract-level renter footprint by county.
    *
    * CHFA market study standard: capture-rate denominator should be renter
    * households at or below the project's max target AMI (typically 80% for
@@ -618,68 +618,8 @@
    *   counties: Array<{fips:string, share:number, lihtc_eligible:number}>
    * }}
    */
-  function _chasLihtcEligibleRenters(bufTracts) {
-    if (!chasData || !chasData.counties || !bufTracts || !bufTracts.length) {
-      return { value: null, tier_breakdown: null, source: 'unavailable', counties: [] };
-    }
-    // Sum tract-share by county FIPS so multi-county buffers get a weighted blend.
-    var shareByCounty = {};
-    var totalShare = 0;
-    bufTracts.forEach(function (t) {
-      var gid = String(t.geoid || '');
-      if (gid.length < 5) return;
-      var fips = gid.slice(0, 5);
-      var share = (typeof t._bufferShare === 'number') ? t._bufferShare : 1;
-      shareByCounty[fips] = (shareByCounty[fips] || 0) + share;
-      totalShare += share;
-    });
-    if (totalShare <= 0) return { value: null, tier_breakdown: null, source: 'unavailable', counties: [] };
-
-    var lihtcEligible = 0;
-    var breakdown = { lte30: 0, '31to50': 0, '51to80': 0 };
-    var perCounty = [];
-    Object.keys(shareByCounty).forEach(function (fips) {
-      var rec = chasData.counties[fips];
-      if (!rec || !rec.renter_hh_by_ami) return;
-      // Weight: county's share of the buffer (e.g., 2 tracts at .5 share in one
-      // county = 1.0 share; another county with 0.5 share = 0.5 share). Use the
-      // share as a fraction of the totalShare to apportion the county-wide
-      // count to the buffer footprint.
-      var pop = rec.renter_hh_by_ami;
-      var w = shareByCounty[fips] / totalShare;
-      var countyLihtc = 0;
-      ['lte30', '31to50', '51to80'].forEach(function (tier) {
-        var t = pop[tier] && pop[tier].total;
-        if (typeof t === 'number') {
-          // CHAS gives county TOTAL renter HH at that tier. The buffer
-          // covers only `share/totalTracts` of the county geographically;
-          // but the per-tract _bufferShare already approximates that. Use
-          // w as the within-buffer weighting and scale the county tier
-          // total by w * (buffer share within county / county area share).
-          //
-          // Simpler approach: just sum (county tier total * w). This
-          // assumes the income distribution is uniform across the county,
-          // which is reasonable at the buffer-scale.
-          var apportioned = t * w;
-          countyLihtc += apportioned;
-          breakdown[tier] += apportioned;
-        }
-      });
-      lihtcEligible += countyLihtc;
-      perCounty.push({ fips: fips, share: w, lihtc_eligible: Math.round(countyLihtc) });
-    });
-
-    if (lihtcEligible <= 0) return { value: null, tier_breakdown: null, source: 'unavailable', counties: [] };
-
-    // Round to integers for cleaner downstream math.
-    Object.keys(breakdown).forEach(function (k) { breakdown[k] = Math.round(breakdown[k]); });
-
-    return {
-      value: Math.round(lihtcEligible),
-      tier_breakdown: breakdown,
-      source: 'chas',
-      counties: perCounty.sort(function (a, b) { return b.share - a.share; })
-    };
+  function _chasLihtcEligibleRenters(bufTracts, acsIdx) {
+    return PMAScoring.chasLihtcEligibleRenters(chasData && chasData.counties, bufTracts, acsIdx);
   }
 
   function scoreCaptureRisk(acs, existingUnits, proposedUnits, chasEligible) {
@@ -916,14 +856,14 @@
     };
   }
 
-  function computePma(acs, existingLihtcUnits, proposedUnits, lat, lon, bufTracts, countyAmi, nearbyLihtcFeatures) {
+  function computePma(acs, existingLihtcUnits, proposedUnits, lat, lon, bufTracts, countyAmi, nearbyLihtcFeatures, acsIdx) {
     proposedUnits = proposedUnits || 0;
 
     var demandScore        = scoreDemand(acs);
     // D — Pre-compute LIHTC-eligible renter HH from CHAS (≤80% AMI tiers) so
     // capture-rate uses the income-qualified denominator CHFA expects, not
     // raw ACS renter_hh.
-    var chasEligible       = _chasLihtcEligibleRenters(bufTracts);
+    var chasEligible       = _chasLihtcEligibleRenters(bufTracts, acsIdx);
     var captureObj         = scoreCaptureRisk(acs, existingLihtcUnits, proposedUnits, chasEligible);
     var rentPressureObj    = scoreRentPressure(acs, countyAmi);
     var lihtcRecency       = _computeLihtcRecency(nearbyLihtcFeatures);
@@ -1086,7 +1026,8 @@
       dimensionNotes: {
         captureRisk:     captureObj.denominatorSource === 'chas_lihtc_eligible'
           ? 'Ratio of total affordable units to LIHTC-eligible renter HH (≤80% AMI from CHAS ' +
-            (chasData && chasData.meta && chasData.meta.vintage ? chasData.meta.vintage : '?') + ')'
+            (chasData && chasData.meta && chasData.meta.vintage ? chasData.meta.vintage : '?') +
+            '), scaled to the PMA buffer using county income mix'
           : 'Ratio of total affordable units to ALL renter households in buffer (ACS total — over-counts LIHTC demand pool)',
         marketTightness: 'Vacancy rate signal — measures how fully occupied existing stock is, NOT land availability for new construction',
         rentPressure:    rentPressureObj.unavailable
@@ -2202,7 +2143,7 @@
       _pmaCountyFips = _bestCf;
     }
     var _pmaCountyAmi = _getCountyAmi(_pmaCountyFips);
-    var pma          = computePma(acs, lihtcUnits, 0, lat, lon, bufTracts, _pmaCountyAmi, nearbyLihtc);
+    var pma          = computePma(acs, lihtcUnits, 0, lat, lon, bufTracts, _pmaCountyAmi, nearbyLihtc, acsIdx);
 
     // Heuristic confidence score
     var CONF = window.PMAConfidence;

--- a/test/pma-scoring.test.js
+++ b/test/pma-scoring.test.js
@@ -90,6 +90,7 @@ test('market-analysis.js source file exists and delegates to shared scoring help
   const content = fs.readFileSync(srcPath, 'utf8');
   assert(content.includes('PMAMarketScoring'), 'market-analysis.js reads window.PMAMarketScoring');
   assert(content.includes('PMAScoring.scoreCaptureRisk'), 'scoreCaptureRisk delegates to shared helper');
+  assert(content.includes('PMAScoring.chasLihtcEligibleRenters'), 'CHAS LIHTC denominator delegates to shared helper');
   assert(content.includes('PMAScoring.scoreRentPressure'), 'scoreRentPressure delegates to shared helper');
   assert(content.includes('PMAScoring.scoreMarketTightness'), 'scoreMarketTightness delegates to shared helper');
   assert(content.includes('lihtcLoadError'), 'source contains lihtcLoadError flag');
@@ -114,12 +115,119 @@ test('shared scoring helper exports real scoring functions', () => {
   [
     'scoreDemand',
     'scoreCaptureRisk',
+    'chasLihtcEligibleRenters',
     'scoreRentPressure',
     'scoreMarketTightness',
     'scoreTier',
   ].forEach((name) => {
     assert(typeof Scoring[name] === 'function', `${name} is exported`);
   });
+});
+
+function chasCounty(tiers) {
+  return {
+    renter_hh_by_ami: {
+      lte30: { total: tiers.lte30 },
+      '31to50': { total: tiers['31to50'] },
+      '51to80': { total: tiers['51to80'] },
+      '81to100': { total: tiers['81to100'] },
+      '100plus': { total: tiers['100plus'] },
+    },
+  };
+}
+
+test('chasLihtcEligibleRenters scales one-county CHAS tiers to buffer renters', () => {
+  const result = Scoring.chasLihtcEligibleRenters({
+    '08031': chasCounty({
+      lte30: 2500,
+      '31to50': 2500,
+      '51to80': 2500,
+      '81to100': 1250,
+      '100plus': 1250,
+    }),
+  }, [
+    { geoid: '08031000100', _bufferShare: 0.5 },
+    { geoid: '08031000200', _bufferShare: 0.5 },
+  ], {
+    '08031000100': { renter_hh: 1000 },
+    '08031000200': { renter_hh: 1000 },
+  });
+
+  assert(result.source === 'chas', 'scaled CHAS result is available');
+  assert(result.value === 750, 'one-county buffer uses 750 eligible renters, not full county 7,500');
+  assert(result.tier_breakdown.lte30 === 250, 'lte30 tier scales to 250');
+  assert(result.tier_breakdown['31to50'] === 250, '31to50 tier scales to 250');
+  assert(result.tier_breakdown['51to80'] === 250, '51to80 tier scales to 250');
+  assertClose(result.counties[0].share, 0.10, 1e-12, 'county scale is buffer renters / CHAS county renters');
+});
+
+test('chasLihtcEligibleRenters caps county scale at one', () => {
+  const result = Scoring.chasLihtcEligibleRenters({
+    '08001': chasCounty({
+      lte30: 100,
+      '31to50': 200,
+      '51to80': 300,
+      '81to100': 200,
+      '100plus': 200,
+    }),
+  }, [
+    { geoid: '08001000100', _bufferShare: 1 },
+  ], {
+    '08001000100': { renter_hh: 1500 },
+  });
+
+  assert(result.value === 600, 'scale cap returns full <=80% pool, never inflated');
+  assert(result.counties[0].share === 1, 'county scale is capped at 1');
+});
+
+test('chasLihtcEligibleRenters sums independently scaled multi-county pools', () => {
+  const result = Scoring.chasLihtcEligibleRenters({
+    '08001': chasCounty({
+      lte30: 1000,
+      '31to50': 1000,
+      '51to80': 1000,
+      '81to100': 1000,
+      '100plus': 1000,
+    }),
+    '08005': chasCounty({
+      lte30: 2000,
+      '31to50': 1000,
+      '51to80': 500,
+      '81to100': 1000,
+      '100plus': 500,
+    }),
+  }, [
+    { geoid: '08001000100', _bufferShare: 1 },
+    { geoid: '08005000100', _bufferShare: 0.5 },
+  ], {
+    '08001000100': { renter_hh: 500 },
+    '08005000100': { renter_hh: 1000 },
+  });
+
+  assert(result.value === 650,
+    'multi-county total is sum of county A 300 and county B 350, not a cross-county blend');
+  assert(result.tier_breakdown.lte30 === 300, 'lte30 sums scaled county contributions');
+  assert(result.tier_breakdown['31to50'] === 200, '31to50 sums scaled county contributions');
+  assert(result.tier_breakdown['51to80'] === 150, '51to80 sums scaled county contributions');
+});
+
+test('chasLihtcEligibleRenters unavailable result lets capture risk fall back to ACS', () => {
+  const chasResult = Scoring.chasLihtcEligibleRenters({
+    '08031': chasCounty({
+      lte30: 2500,
+      '31to50': 2500,
+      '51to80': 2500,
+      '81to100': 1250,
+      '100plus': 1250,
+    }),
+  }, [
+    { geoid: '08031000100', _bufferShare: 1 },
+  ], {});
+  const capture = Scoring.scoreCaptureRisk({ renter_hh: 8000 }, 100, 100, chasResult);
+
+  assert(chasResult.source === 'unavailable', 'missing ACS tract metrics make CHAS denominator unavailable');
+  assert(capture.denominatorSource === 'acs_total_renter_hh', 'capture risk falls back to ACS renter households');
+  assert(capture.qualRenters === 8000, 'ACS fallback denominator is preserved');
 });
 
 test('scoreCaptureRisk prefers CHAS LIHTC-eligible renter households as denominator', () => {
@@ -143,6 +251,33 @@ test('scoreCaptureRisk prefers CHAS LIHTC-eligible renter households as denomina
     `smaller CHAS denominator increases capture risk (${chas.score} < ${acsOnly.score})`);
   assert(chas.chasBreakdown && chas.chasBreakdown.lte30 === 250,
     'CHAS tier breakdown is carried through');
+});
+
+test('buffer-scaled CHAS denominator lowers or preserves capture score versus old county-wide denominator', () => {
+  const scaled = Scoring.chasLihtcEligibleRenters({
+    '08031': chasCounty({
+      lte30: 2500,
+      '31to50': 2500,
+      '51to80': 2500,
+      '81to100': 1250,
+      '100plus': 1250,
+    }),
+  }, [
+    { geoid: '08031000100', _bufferShare: 1 },
+  ], {
+    '08031000100': { renter_hh: 1000 },
+  });
+  const oldCountyWide = {
+    value: 7500,
+    tier_breakdown: { lte30: 2500, '31to50': 2500, '51to80': 2500 },
+  };
+  const fixed = Scoring.scoreCaptureRisk({ renter_hh: 8000 }, 100, 100, scaled);
+  const old = Scoring.scoreCaptureRisk({ renter_hh: 8000 }, 100, 100, oldCountyWide);
+
+  assert(fixed.qualRenters < old.qualRenters,
+    `scaled denominator is smaller than old county-wide denominator (${fixed.qualRenters} < ${old.qualRenters})`);
+  assert(fixed.score <= old.score,
+    `smaller denominator lowers or preserves capture score (${fixed.score} <= ${old.score})`);
 });
 
 test('scoreCaptureRisk falls back to denominator 1 when ACS renter households are missing', () => {


### PR DESCRIPTION
## Summary

Fixes #1157 by scaling county-level CHAS LIHTC-eligible renter tiers to the PMA buffer footprint before feeding the capture-rate denominator.

- Adds PMAMarketScoring.chasLihtcEligibleRenters(chasCounties, bufTracts, acsIdx) as the shared pure helper.
- Replaces old cross-county w normalization with per-county min(1, buffer renter HH / CHAS county renter HH) scaling.
- Threads acsIdx into computePma() so the live page can use buffer-scoped tract renter counts.
- Updates the CHAS disclosure to describe county-income-mix buffer scaling.

Do not merge until external QA completes.

## Root Cause

The CHAS path used county-wide renter AMI tier totals and normalized only between counties. A buffer entirely inside Denver County got w = 1, so the denominator used Denver County full 90,813 <=80% AMI renter households instead of a buffer-scaled pool. That understated capture risk in dense counties.

## Tests / Evidence

- npm run test:pma-scoring green: 86 passed, 0 failed.
- Non-vacuous proof: temporarily set countyScale = 1; PMA scoring suite failed 10 assertions, including the fixture returning full county 7,500 instead of expected 750; restored formula and suite returned green.
- npm run test:ci green after installing worktree deps: full repository gate completed.
- git diff --check clean.
- Browser smoke via local market-analysis.html and window.PMAEngine.runAnalysis(): no console/page errors; 3-mile Denver-area run rendered capture tile 59.1%, score 45; denominator source chas_lihtc_eligible; CHAS denominator value 40,070, below Denver 90,813 county-wide <=80% AMI pool; disclosure note includes scaled to the PMA buffer using county income mix.

## Notes

I noticed during smoke that the HTML marks the 3-mile buffer option as selected while the module-level bufferMiles default initializes to 5 until the select change handler runs. I did not change that here because it is outside #1157; the smoke explicitly selected 3 miles before running.