### PR TITLE
fix(pma): rename absorption-risk label to Competitive Supply Share (#1148)

### DIFF
--- a/docs/PMA_SCORING.md
+++ b/docs/PMA_SCORING.md
@@ -167,6 +167,32 @@ the "Total proposed units" field.
 
 ---
 
+## Competitive Supply Share (absorption risk)
+
+**Not a capture rate.** Capture rate (above) divides units by a *demand pool*
+(income-qualified renter households). Competitive Supply Share divides supply
+by supply — the proposed project's share of the competitive inventory it will
+lease up against. The two move in opposite directions for the same market
+signal (more existing LIHTC supply raises capture rate but lowers supply
+share), so they must never share a label. Implemented by
+`calculateAbsorptionRisk()` in `js/pma-competitive-set.js`:
+
+```
+competitiveSupplyShare = proposedUnits / (totalCompetitiveUnits + proposedUnits)
+```
+
+Thresholds (`SATURATION_LIMIT = 0.10`):
+- **Low**: share < 5%
+- **Moderate**: 5% ≤ share < 10%
+- **High**: share ≥ 10%
+
+Rendered in the "Absorption Risk — Competitive Supply Share" card on the
+Market Analysis page. The result object's internal field name remains
+`captureRate` for backwards compatibility; only the user-facing label
+changed (#1148).
+
+---
+
 ## Explainability
 
 Each dimension score is displayed as a bar (0–100) in the UI alongside the

--- a/js/pma-competitive-set.js
+++ b/js/pma-competitive-set.js
@@ -21,7 +21,7 @@
   var EARTH_RADIUS_MI   = 3958.8;
   var DEFAULT_RADIUS    = 5;         // miles
   var SUBSIDY_EXPIRY_RISK_YEARS = 5;         // properties expiring within this many years are "at risk"
-  var SATURATION_LIMIT  = 0.10;      // >10 % capture rate = high absorption risk
+  var SATURATION_LIMIT  = 0.10;      // >10 % competitive supply share = high absorption risk
   var CURRENT_YEAR      = new Date().getFullYear();
 
   /* ── Internal state ───────────────────────────────────────────────── */

--- a/js/pma-ui-controller.js
+++ b/js/pma-ui-controller.js
@@ -520,10 +520,13 @@
       }
     }
 
-    // Absorption / capture risk — was previously computed by the PMA
-    // runner (results.absorptionRisk) but never rendered. Surfacing it
-    // here so a banker can see whether the proposed unit count vs the
-    // existing competitive set raises a saturation flag.
+    // Absorption risk (competitive supply share) — was previously computed
+    // by the PMA runner (results.absorptionRisk) but never rendered.
+    // Surfacing it here so a banker can see whether the proposed unit count
+    // vs the existing competitive set raises a saturation flag. Deliberately
+    // NOT labeled "capture rate": that term is reserved for the demand-pool
+    // metric (units ÷ income-qualified renter HH) in the stat tile — this is
+    // a supply-÷-supply ratio with a different threshold (see #1148).
     var absorption = scoreRun.absorptionRisk || null;
     var absWrap = $id('pmaAbsorptionRiskWrap');
     var absBody = $id('pmaAbsorptionRiskBody');
@@ -541,17 +544,17 @@
         var propUnits = absorption.proposedUnits || 0;
         absBody.innerHTML =
           '<div><strong style="color:' + riskColor + ';">' + _esc(riskLabel) + '</strong> ' +
-            '— capture rate: <strong>' + captureRatePct + '%</strong> ' +
+            '— competitive supply share: <strong>' + captureRatePct + '%</strong> ' +
             '(' + propUnits + ' proposed / ' + (compUnits + propUnits) + ' total).' +
           '</div>' +
           '<div style="font-size:.92em;color:var(--muted,#888);margin-top:.25rem;">' +
             'Based on ' + compCount + ' nearby competitive ' +
             (compCount === 1 ? 'property' : 'properties') + ' totaling ' + compUnits + ' units. ' +
             (risk === 'high'
-               ? 'High capture rate suggests the proposed deal may struggle to lease at proforma absorption rates.'
+               ? 'High competitive supply share suggests the proposed deal may struggle to lease at proforma absorption rates.'
             : risk === 'moderate'
-               ? 'Moderate capture — verify lease-up assumptions vs comparable lease-up timelines.'
-            :  'Low capture — proposed unit count is well-absorbed by the local market.') +
+               ? 'Moderate supply share — verify lease-up assumptions vs comparable lease-up timelines.'
+            :  'Low supply share — proposed unit count is well-absorbed by the local market.') +
           '</div>';
         absWrap.hidden = false;
       } else {

--- a/market-analysis.html
+++ b/market-analysis.html
@@ -973,7 +973,7 @@
           </div>
           <!-- Absorption risk card — proposed units vs total competitive set -->
           <div id="pmaAbsorptionRiskWrap" hidden style="margin-top:.75rem;padding:.5rem .65rem;border-left:3px solid var(--border,#333);border-radius:0 4px 4px 0;background:var(--bg2,#1a1a1a);font-size:.78em;">
-            <p style="font-weight:600;margin:0 0 .35rem;">Absorption / Capture Risk</p>
+            <p style="font-weight:600;margin:0 0 .35rem;">Absorption Risk — Competitive Supply Share</p>
             <div id="pmaAbsorptionRiskBody" style="line-height:1.55;"></div>
           </div>
           <!-- Opportunity / incentive badges -->

--- a/test/pma-competitive-set.test.js
+++ b/test/pma-competitive-set.test.js
@@ -297,6 +297,40 @@ group('5. calculateAbsorptionRisk', () => {
     assert.equal(r.captureRate, 0.08);
     assert.equal(r.risk, 'moderate');
   });
+
+  // Label guard for #1148: calculateAbsorptionRisk()'s output is a
+  // supply-÷-supply ratio and must be rendered as "competitive supply
+  // share", never "capture rate" — that term is reserved for the
+  // demand-pool metric (units ÷ income-qualified renter HH) documented in
+  // docs/PMA_SCORING.md. Scope the greps to the absorption block only:
+  // "capture rate" legitimately appears elsewhere in both files for the
+  // real metric.
+  test('absorption-risk UI surfaces use "competitive supply share", not "capture rate"', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+
+    const ui = fs.readFileSync(
+      path.resolve(__dirname, '..', 'js', 'pma-ui-controller.js'), 'utf8');
+    const uiStart = ui.indexOf('scoreRun.absorptionRisk');
+    const uiEnd = ui.indexOf('pmaIncentiveBadges', uiStart);
+    assert.ok(uiStart !== -1 && uiEnd > uiStart, 'absorption render block found in pma-ui-controller.js');
+    const uiBlock = ui.slice(uiStart, uiEnd);
+    assert.ok(!/capture rate/i.test(uiBlock),
+      'absorption block must not label its value "capture rate"');
+    assert.ok(/competitive supply share/i.test(uiBlock),
+      'absorption block labels its value "competitive supply share"');
+
+    const html = fs.readFileSync(
+      path.resolve(__dirname, '..', 'market-analysis.html'), 'utf8');
+    const cardStart = html.indexOf('pmaAbsorptionRiskWrap');
+    const cardEnd = html.indexOf('pmaAbsorptionRiskBody', cardStart);
+    assert.ok(cardStart !== -1 && cardEnd > cardStart, 'absorption card found in market-analysis.html');
+    const cardBlock = html.slice(cardStart, cardEnd);
+    assert.ok(!/capture/i.test(cardBlock),
+      'absorption card heading must not say "capture"');
+    assert.ok(/Competitive Supply Share/.test(cardBlock),
+      'absorption card heading uses "Competitive Supply Share"');
+  });
 });
 
 /* ── Summary ───────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Closes #1148 (item 4 of `docs/audits/CODEX-HANDOFF-DEAL-CALC-PMA-FIXES-2026-07.md`; implemented by Claude since Codex is out of credit)
- Label chosen: **"Competitive Supply Share"** — it literally describes the formula (the proposed project's share of competitive inventory), while "Market Saturation" reads as a market-wide condition and invites confusion with the existing vacancy/tightness metrics
- `calculateAbsorptionRisk()`'s output is no longer labeled "capture rate" anywhere user-facing: card heading (`market-analysis.html`), narrative label, and all three risk-tier sentences (`js/pma-ui-controller.js`) now use supply-share language
- "Capture Rate" remains only on the demand-pool stat tile (`#pmaCaptureRate`), matching CHFA convention and `docs/PMA_SCORING.md`
- New `docs/PMA_SCORING.md` section documents the formula exactly as implemented (`proposedUnits / (totalCompetitiveUnits + proposedUnits)`), the `SATURATION_LIMIT = 0.10` tiers (low < 5%, moderate 5–10%, high ≥ 10%), and why the two metrics must never share a label
- Internal `captureRate` field name in `js/pma-competitive-set.js` intentionally unchanged (per handoff: internal name, renaming optional); its constant comment updated for consistency

## Verification
- Grepped all user-facing surfaces for renderings of `absorptionRisk`: only `pma-ui-controller.js` (narrative) and `market-analysis.html` (card heading) render it; `pma-analysis-runner.js` only computes. The "capture-rate simulator" (`pma-ui-controller.js:619`) is the real demand-pool metric and is untouched.
- `npm run test:pma-competitive-set` → 25/25 pass. New label-guard test proven **non-vacuous**: temporarily restoring the old "capture rate" label fails exactly that test; restoring passes.
- `npm run validate` → 53/53 HTML files pass. `npm run test:pma-scoring` → 86/86. `git diff --check` clean.
- Live browser: drove the real render path (`PMADataCache.saveLastResult` → `PMAUIController.restoreLastRun()` → `_renderJustification`) with a moderate-band fixture — card renders "Absorption Risk — Competitive Supply Share" / "Moderate — competitive supply share: 8.0% (100 proposed / 1300 total)" with the reworded tier sentence, zero console errors. Confirmed the real demand-pool tile still reads "Capture rate (existing)" on the same page — the two metrics are now distinctly labeled side by side.
- Label-guard test is scoped to the absorption block only, so the legitimate "capture rate" usages elsewhere in both files can't false-positive it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)