### PR TITLE
docs(pma): document Land/Supply vacancy-threshold divergence (#1149)

### DIFF
--- a/docs/PMA_SCORING.md
+++ b/docs/PMA_SCORING.md
@@ -86,9 +86,34 @@ Where `AMI` = Colorado statewide Area Median Income. See [HUD Income Limits](htt
 Measures housing supply tightness via vacancy rate.
 Very low vacancy signals unmet demand.
 
+**Two code paths implement this dimension with different vacancy ceilings** (#1149):
+
+**Current default path** — `scoreMarketTightness()` (`js/market-analysis-scoring.js`,
+delegated from `js/market-analysis.js`). Runs in every deployment without
+Bridge/MLS credentials, which is all of them today
+(`BRIDGE_BROWSER_TOKEN` is empty by default in `js/config.js`):
+
 ```
 landScore = max(0, min(100, (1 − vacancy_rate / 0.12) × 100))
 ```
+
+Suppressed/missing vacancy defaults to 0.05 (neutral ≈ 58), never max-tight.
+
+**Dormant Bridge-gated path** — `scoreLandSupplyWithBridge()` →
+`scoreLandSupply()` (`js/market-analysis/site-selection-score.js`). Preferred
+automatically whenever `BridgeMarketSummary.isAvailable()` is true, i.e. once
+real Bridge/MLS access is configured. Uses a **0.10** ceiling, chosen
+independently in that module ("10% is where lease-up risk begins to
+materially threaten LIHTC underwriting"), and blends in Bridge land-cost
+context (60% ACS vacancy / 40% land cost). Suppressed vacancy propagates
+`unavailable` (weight redistributes) instead of defaulting.
+
+Neither threshold has been formally reconciled — that is a deliberate open
+owner decision, not an oversight. Do not silently change either number; see
+the follow-up issue referenced from #1149. Until then, be aware that
+enabling Bridge/MLS access will switch this dimension from the 0.12 to the
+0.10 ceiling (and from neutral-default to weight-redistribution on
+suppressed vacancy) without any other code change.
 
 ### 5. Workforce (15%)
 

--- a/js/market-analysis.js
+++ b/js/market-analysis.js
@@ -876,6 +876,17 @@
     // null-propagation refactor — unwrap defensively. If the Bridge path
     // reports unavailable (ACS missing), fall back to the local
     // scoreMarketTightness which accepts a defaulted vacancy_rate.
+    //
+    // NOTE (#1149): the two paths below use DIFFERENT vacancy ceilings.
+    // This Bridge-gated path (scoreLandSupplyWithBridge → scoreLandSupply in
+    // js/market-analysis/site-selection-score.js) normalizes against a 0.10
+    // ceiling; the fallback scoreMarketTightness uses the 0.12 documented in
+    // docs/PMA_SCORING.md. Currently dormant in every default deployment —
+    // BridgeMarketSummary.isAvailable() is false until BRIDGE_BROWSER_TOKEN
+    // is configured (js/config.js) — so the 0.12 path always runs today.
+    // Flag to whoever enables real Bridge/MLS access: this divergence needs
+    // an owner decision before the 0.10 path silently takes over. See the
+    // follow-up issue referenced in #1149 for the reconciliation decision.
     var _landResult = (SSS.scoreLandSupplyWithBridge && _bridgeLandCtx)
       ? SSS.scoreLandSupplyWithBridge(acs, _bridgeLandCtx)
       : null;


### PR DESCRIPTION
## Summary
- Closes #1149 (item 5 of the #1154 handoff; implemented by Claude since Codex is out of credit)
- **Stopgap only, exactly as specced**: documents the 0.10 vs 0.12 divergence without reconciling it — the reconciliation is an owner methodology call, now filed as follow-up issue #1163 (the handoff's required step 3)
- `docs/PMA_SCORING.md` § Land/Supply now describes both code paths, both ceilings, both suppressed-vacancy behaviors, which one fires when, and the fact that configuring `BRIDGE_BROWSER_TOKEN` silently switches the dimension from 0.12 to 0.10 with no other code change
- `NOTE (#1149)` comment added at the preference point in `js/market-analysis.js` (line numbers had drifted since the handoff was written — the block is now at ~875, verified against current main) so whoever enables Bridge/MLS access hits the flag
- No behavior change: comment + docs only

## Verification
- Re-verified the underlying facts against current main before writing: `scoreLandSupply()` normalizes against 0.10 (`js/market-analysis/site-selection-score.js:622`), `scoreMarketTightness()` against 0.12 (now in `js/market-analysis-scoring.js` post-#1156), `BRIDGE_BROWSER_TOKEN` empty default (`js/config.js`), preference logic in `computePma()`
- `js/market-analysis.js` parses clean after the comment; `npm run test:pma-scoring` 86/86 (includes source-grep assertions on this file); `git diff --check` clean
- Docs section states both paths neutrally without asserting either threshold is "correct," per the handoff's explicit instruction
- Follow-up issue #1163 filed and cross-references #1149 + the handoff doc (QA gate requirement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)