### PR TITLE
fix(pma): align default buffer radius to 3 mi across engine, UI, and HTML (#1160)

### DIFF
--- a/js/market-analysis.js
+++ b/js/market-analysis.js
@@ -58,7 +58,11 @@
   var todMarkers   = null;   // L.layerGroup for highlighted transit stops in ½-mile
   var isochroneRingsLayer = null;  // L.featureGroup of walking + biking rings
   var siteLatLng   = null;
-  var bufferMiles  = 5;
+  // Must match the `selected` option of #pmaBufferSelect in
+  // market-analysis.html and _bufferMiles in js/pma-ui-controller.js —
+  // guarded by a three-way agreement test in test/pma-scoring.test.js
+  // (#1160). bindBufferSelect() re-syncs from the live select at init.
+  var bufferMiles  = 3;
 
   // Walking + biking ring radii (miles). The ½-mile walking ring is the
   // canonical CHFA TOD-scoring ring drawn separately as `todCircle` — skipped
@@ -1478,7 +1482,7 @@
     if (!tbody || !_pmaLastSite) return;
     var radiusSel = document.getElementById('pmaNearbyRadius');
     var outer = radiusSel ? Math.max(1, parseFloat(radiusSel.value) || 25) : 25;
-    var inner = (_pmaLastSite.bufferMiles || 5);
+    var inner = (_pmaLastSite.bufferMiles || 3);
     var lat = _pmaLastSite.lat, lon = _pmaLastSite.lon;
     if (!Number.isFinite(lat) || !Number.isFinite(lon) || !lihtcFeatures) {
       tbody.innerHTML = '<tr><td colspan="6" style="padding:8px;color:var(--muted)">No LIHTC features loaded.</td></tr>';
@@ -3681,8 +3685,12 @@
   function bindBufferSelect() {
     var sel = el('pmaBufferSelect');
     if (!sel) return;
+    // #1160: sync module state to whatever the HTML marks as selected, so
+    // programmatic runAnalysis() calls (no change event) use the same
+    // default the UI displays.
+    bufferMiles = parseInt(sel.value, 10) || bufferMiles;
     sel.addEventListener('change', function () {
-      bufferMiles = parseInt(sel.value, 10) || 5;
+      bufferMiles = parseInt(sel.value, 10) || 3;
       if (siteLatLng) {
         placeSiteMarker(siteLatLng.lat, siteLatLng.lon);
         runAnalysis(siteLatLng.lat, siteLatLng.lon);
@@ -3794,7 +3802,7 @@
    */
   function _buildPmaReportData() {
     var r = lastResult || {};
-    var bufferM = r.bufferMiles || bufferMiles || 5;
+    var bufferM = r.bufferMiles || bufferMiles || 3;
     var acs = r.acs || {};
     var dims = r.dimensions || {};
     var dimAvail = r.dimensionDataAvailable || {};
@@ -4447,7 +4455,7 @@
       }
       if (!_allFlowArcs || !_allFlowArcs.features) return;
 
-      var bufMi = site.bufferMiles || 5;
+      var bufMi = site.bufferMiles || 3;
       // Expand filter radius to catch arcs that start/end near the site
       var filterRadius = Math.max(bufMi * 2, 15);
 
@@ -4589,7 +4597,7 @@
     // guidance + standard market studies expect. Buffer is still selectable
     // for sites where LODES data is sparse.
     method      = method      || 'hybrid';
-    bufferMiles = bufferMiles || 5;
+    bufferMiles = bufferMiles || 3;
 
     if (method === 'buffer') {
       var commMod = window.PMACommuting;

--- a/test/pma-scoring.test.js
+++ b/test/pma-scoring.test.js
@@ -298,6 +298,34 @@ test('scoreRentPressure requires county AMI instead of statewide fallback', () =
   assert(typeof present.score === 'number', 'county AMI score is numeric');
 });
 
+// #1160: three sources declare the default PMA buffer radius — the HTML
+// select's `selected` option, market-analysis.js's module-level fallback,
+// and pma-ui-controller.js's _bufferMiles. They silently disagreed (5 vs 3)
+// until #1160; this guards against re-drift. bindBufferSelect() also
+// re-syncs the module var from the live select at init, but these static
+// defaults are what programmatic callers hit before/without DOM.
+test('default PMA buffer radius agrees across HTML select, engine, and UI controller (#1160)', () => {
+  const html = fs.readFileSync(path.resolve(__dirname, '..', 'market-analysis.html'), 'utf8');
+  const selStart = html.indexOf('id="pmaBufferSelect"');
+  const selEnd = html.indexOf('</select>', selStart);
+  assert(selStart !== -1 && selEnd > selStart, 'pmaBufferSelect found in market-analysis.html');
+  const selectedOpt = html.slice(selStart, selEnd).match(/<option value="(\d+)"\s+selected/);
+  assert(selectedOpt, 'pmaBufferSelect has a selected default option');
+
+  const engine = fs.readFileSync(path.resolve(__dirname, '..', 'js', 'market-analysis.js'), 'utf8');
+  const engineDefault = engine.match(/var bufferMiles\s*=\s*(\d+)\s*;/);
+  assert(engineDefault, 'module-level bufferMiles default found in market-analysis.js');
+
+  const uic = fs.readFileSync(path.resolve(__dirname, '..', 'js', 'pma-ui-controller.js'), 'utf8');
+  const uicDefault = uic.match(/var _bufferMiles\s*=\s*(\d+)\s*;/);
+  assert(uicDefault, '_bufferMiles default found in pma-ui-controller.js');
+
+  assert(engineDefault[1] === selectedOpt[1],
+    `engine default (${engineDefault[1]}) matches HTML selected option (${selectedOpt[1]})`);
+  assert(uicDefault[1] === selectedOpt[1],
+    `UI controller default (${uicDefault[1]}) matches HTML selected option (${selectedOpt[1]})`);
+});
+
 test('scoreMarketTightness treats suppressed vacancy as neutral default, not max-tight', () => {
   const suppressed = Scoring.scoreMarketTightness({ vacancy_rate: null });
   const explicitZero = Scoring.scoreMarketTightness({ vacancy_rate: 0 });


### PR DESCRIPTION
## Summary
- Closes #1160 (flagged by Codex in PR #1159's notes; implemented by Claude)
- `js/market-analysis.js` module default `bufferMiles` 5 → 3, matching the HTML select's `selected` option and `pma-ui-controller.js`'s `_bufferMiles`
- `bindBufferSelect()` now syncs the module var from the live select at init — the HTML is the single source of truth even if static defaults drift
- All `|| 5` fallbacks on the same quantity aligned to 3 (restore path, polygon generator, permalink/export paths — grep confirms zero `|| 5` remain in the file)
- Three-way agreement guard test added to `test/pma-scoring.test.js` (already in `test:ci`): parses the selected option value from the HTML and the two JS defaults, asserts all three agree

## Verification
- 92/92 `test:pma-scoring` pass; guard proven **non-vacuous** (setting the engine default back to 5 fails exactly the new test)
- `js/market-analysis.js` parses clean; `git diff --check` clean
- **Live browser, fresh load, select untouched**: programmatic `PMAEngine.runAnalysis()` produced an 87-tract buffer = the 3-mile ground truth at the Denver test point (independently computed from `tract_centroids_co.json`: 3 mi = 87 tracts, 5 mi = 165). Pre-fix, the same call would have used 5 mi/165 tracts while the UI displayed 3. Zero console errors.
- Note: the original issue misattributed its evidence (87 tracts is the 3-mile count, not 5 — corrected in an issue comment); the underlying mismatch was real regardless, as the module-default logic shows directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)