### PR TITLE
fix(pma): score Land/Supply on rental vacancy at a unified 0.10 ceiling (#1163 PR B)

### DIFF
--- a/docs/PMA_SCORING.md
+++ b/docs/PMA_SCORING.md
@@ -83,37 +83,59 @@ Where `AMI` = Colorado statewide Area Median Income. See [HUD Income Limits](htt
 
 ### 4. Land / Supply (15%)
 
-Measures housing supply tightness via vacancy rate.
-Very low vacancy signals unmet demand.
+Measures rental-market supply tightness via **rental vacancy** (#1163).
+Very low rental vacancy signals unmet demand; 10%+ signals lease-up risk.
 
-**Two code paths implement this dimension with different vacancy ceilings** (#1149):
-
-**Current default path** — `scoreMarketTightness()` (`js/market-analysis-scoring.js`,
-delegated from `js/market-analysis.js`). Runs in every deployment without
-Bridge/MLS credentials, which is all of them today
-(`BRIDGE_BROWSER_TOKEN` is empty by default in `js/config.js`):
+**The input is rental vacancy, not total vacancy.** Total ACS vacancy
+(`B25004_001E`) counts seasonal and second homes as "vacant," which scored
+every Colorado resort county 0 on this dimension (Summit County: 63% median
+tract "vacancy") — reading the state's most workforce-housing-starved rental
+markets as oversupplied. Rental vacancy follows the Census Housing Vacancy
+Survey convention:
 
 ```
-landScore = max(0, min(100, (1 − vacancy_rate / 0.12) × 100))
+rental_vacancy_rate = vacant_for_rent / (renter_hh + vacant_for_rent + rented_not_occupied)
+                      (B25004_002E)     (B25003_003E + B25004_002E + B25004_003E)
+
+landScore = max(0, min(100, (1 − rental_vacancy_rate / 0.10) × 100))
 ```
 
-Suppressed/missing vacancy defaults to 0.05 (neutral ≈ 58), never max-tight.
+**Both code paths use this same input and the same 0.10 ceiling**
+(`PMAMarketScoring.RENTAL_VACANCY_CEILING`) — the historical 0.10-vs-0.12
+divergence (#1149) is resolved:
 
-**Dormant Bridge-gated path** — `scoreLandSupplyWithBridge()` →
-`scoreLandSupply()` (`js/market-analysis/site-selection-score.js`). Preferred
-automatically whenever `BridgeMarketSummary.isAvailable()` is true, i.e. once
-real Bridge/MLS access is configured. Uses a **0.10** ceiling, chosen
-independently in that module ("10% is where lease-up risk begins to
-materially threaten LIHTC underwriting"), and blends in Bridge land-cost
-context (60% ACS vacancy / 40% land cost). Suppressed vacancy propagates
-`unavailable` (weight redistributes) instead of defaulting.
+- `scoreMarketTightness()` (`js/market-analysis-scoring.js`) — the default
+  path. Buffer-level rental vacancy is derived from summed, buffer-share-
+  apportioned counts (not averaged tract rates) in `aggregateAcs()`.
+- `scoreLandSupplyWithBridge()` → `scoreLandSupply()`
+  (`js/market-analysis/site-selection-score.js`) — the Bridge-gated path.
+  Its only remaining difference is the 60/40 land-cost blend; enabling
+  Bridge/MLS access no longer changes the vacancy normalization.
 
-Neither threshold has been formally reconciled — that is a deliberate open
-owner decision, not an oversight. Do not silently change either number; see
-the follow-up issue referenced from #1149. Until then, be aware that
-enabling Bridge/MLS access will switch this dimension from the 0.12 to the
-0.10 ceiling (and from neutral-default to weight-redistribution on
-suppressed vacancy) without any other code change.
+The 0.10 ceiling is underwriting-grounded: 10%+ vacancy is where lease-up
+risk and absorption pace materially threaten LIHTC underwriting.
+
+**Legacy fallback**: when the tract data predates the rental-vacancy fields
+(or a buffer has no rental universe at all), scoring falls back to the
+historical behavior — total vacancy at a 0.12 ceiling, suppressed input
+defaulting to 0.05 (neutral ≈ 58) — and the dimension note discloses
+`legacy_total_vacancy` as the basis. This exists only for stale data files;
+current pipelines always emit the rental fields.
+
+**Known limitation — STR contamination in resort cores.** ACS classifies
+units actively listed for rent as "For rent" (`B25004_002E`) regardless of
+whether they are offered as long-term housing or short-term/vacation
+rentals. In STR-saturated resort markets this inflates rental vacancy far
+above the long-term-market reality (2019–2023 ACS: Summit County's rental
+universe is ~38% "for rent" county-wide — clearly STR stock, not workforce-
+available vacancies), so buffers centered on resort cores still floor at 0
+on this dimension. This is a data limitation, not a formula error: ACS has
+no STR/long-term split. The switch to rental vacancy fixed the metro and
+non-resort mountain counties (Denver ~5%, La Plata ~7% — sensible scores)
+and removed the worst of the seasonal-homes inversion, but resort-core
+Land/Supply scores should be read alongside local STR-license and
+long-term-listing data until a refinement lands (see the follow-up issue
+referenced from #1163).
 
 ### 5. Workforce (15%)
 

--- a/js/market-analysis-scoring.js
+++ b/js/market-analysis-scoring.js
@@ -176,10 +176,33 @@
     return { score: Math.round(score), ratio: ratio, amiUsed: countyAmi, amiSource: 'county', unavailable: false };
   }
 
-  function scoreMarketTightness(acs) {
+  // #1163 — the Land/Supply vacancy signal scores RENTAL vacancy (Census HVS
+  // convention) against a single 0.10 ceiling. Total ACS vacancy counts
+  // seasonal/second homes as vacant, which scored every Colorado resort
+  // county 0 (Summit: 63% median tract "vacancy") — an inverted signal in
+  // exactly the markets this platform serves. 0.10 is the underwriting-
+  // grounded ceiling (10%+ vacancy materially threatens LIHTC lease-up);
+  // the old 0.12 survives only in the legacy fallback below for data files
+  // that predate the rental-vacancy fields.
+  var RENTAL_VACANCY_CEILING = 0.10;
+  var LEGACY_TOTAL_VACANCY_CEILING = 0.12;
+
+  function scoreMarketTightnessDetail(acs) {
+    var rental = acs ? Number(acs.rental_vacancy_rate) : NaN;
+    if (acs && acs.rental_vacancy_rate != null && isFinite(rental)) {
+      var score = Math.max(0, Math.min(100, (1 - rental / RENTAL_VACANCY_CEILING) * 100));
+      return { score: Math.round(score), basis: 'rental_vacancy' };
+    }
+    // Legacy fallback (stale tract file without rental_vacancy_rate, or
+    // suppressed rental universe): historical behavior verbatim — total
+    // vacancy at 0.12, defaulting suppressed input to a neutral 0.05.
     var vac = (acs && acs.vacancy_rate != null) ? acs.vacancy_rate : 0.05;
-    var score = Math.max(0, Math.min(100, (1 - vac / 0.12) * 100));
-    return Math.round(score);
+    var legacy = Math.max(0, Math.min(100, (1 - vac / LEGACY_TOTAL_VACANCY_CEILING) * 100));
+    return { score: Math.round(legacy), basis: 'legacy_total_vacancy' };
+  }
+
+  function scoreMarketTightness(acs) {
+    return scoreMarketTightnessDetail(acs).score;
   }
 
   function scoreTier(s) {
@@ -192,6 +215,8 @@
   return {
     AMI_60_PCT: AMI_60_PCT,
     MAX_AFFORDABLE_RENT_PCT: MAX_AFFORDABLE_RENT_PCT,
+    RENTAL_VACANCY_CEILING: RENTAL_VACANCY_CEILING,
+    LEGACY_TOTAL_VACANCY_CEILING: LEGACY_TOTAL_VACANCY_CEILING,
     WEIGHTS: WEIGHTS,
     RISK: RISK,
     scoreDemand: scoreDemand,
@@ -199,6 +224,7 @@
     chasLihtcEligibleRenters: chasLihtcEligibleRenters,
     scoreRentPressure: scoreRentPressure,
     scoreMarketTightness: scoreMarketTightness,
+    scoreMarketTightnessDetail: scoreMarketTightnessDetail,
     scoreTier: scoreTier
   };
 }));

--- a/js/market-analysis.js
+++ b/js/market-analysis.js
@@ -410,6 +410,9 @@
       hh_size_owner_sum: 0, hh_size_owner_n: 0,
       hh_size_renter_sum: 0, hh_size_renter_n: 0,
       bachelors_sum: 0, bachelors_n: 0,
+      // #1163 — rental-vacancy counts (apportioned), so the buffer-level
+      // rate is derived from summed counts, not averaged tract rates.
+      vacant_for_rent: 0, rented_not_occupied: 0,
       renter_by_structure: null,  // initialized lazily below
       n: 0
     };
@@ -429,6 +432,8 @@
       totals.owner_hh     += (m.owner_hh     || 0) * share;
       totals.total_hh     += (m.total_hh     || 0) * share;
       totals.vacant       += (m.vacant       || 0) * share;
+      totals.vacant_for_rent     += (m.vacant_for_rent     || 0) * share;
+      totals.rented_not_occupied += (m.rented_not_occupied || 0) * share;
       // Rates are unweighted averages — don't multiply by share.
       totals.rent_sum     += m.median_gross_rent  || 0;
       totals.income_sum   += m.median_hh_income   || 0;
@@ -493,6 +498,14 @@
       median_hh_income:    totals.n ? totals.income_sum  / totals.n : 0,
       cost_burden_rate:    totals.n ? totals.cost_burden_sum  / totals.n : 0,
       vacancy_rate:        totals.n ? totals.vacancy_rate_sum / totals.n : 0,
+      // #1163 — buffer-level rental vacancy from summed apportioned counts
+      // (HVS convention). Null when the buffer has no rental universe —
+      // scoring's legacy fallback handles that case.
+      vacant_for_rent:     Math.round(totals.vacant_for_rent),
+      rented_not_occupied: Math.round(totals.rented_not_occupied),
+      rental_vacancy_rate: (totals.renter_hh + totals.vacant_for_rent + totals.rented_not_occupied) > 0
+        ? totals.vacant_for_rent / (totals.renter_hh + totals.vacant_for_rent + totals.rented_not_occupied)
+        : null,
       severe_cost_burden_rate: totals.severe_burden_n
         ? totals.severe_burden_sum / totals.severe_burden_n : null,
       poverty_rate:        totals.poverty_n
@@ -881,24 +894,23 @@
     // reports unavailable (ACS missing), fall back to the local
     // scoreMarketTightness which accepts a defaulted vacancy_rate.
     //
-    // NOTE (#1149): the two paths below use DIFFERENT vacancy ceilings.
-    // This Bridge-gated path (scoreLandSupplyWithBridge → scoreLandSupply in
-    // js/market-analysis/site-selection-score.js) normalizes against a 0.10
-    // ceiling; the fallback scoreMarketTightness uses the 0.12 documented in
-    // docs/PMA_SCORING.md. Currently dormant in every default deployment —
-    // BridgeMarketSummary.isAvailable() is false until BRIDGE_BROWSER_TOKEN
-    // is configured (js/config.js) — so the 0.12 path always runs today.
-    // Flag to whoever enables real Bridge/MLS access: this divergence needs
-    // an owner decision before the 0.10 path silently takes over. See the
-    // follow-up issue referenced in #1149 for the reconciliation decision.
+    // #1163: both paths now score RENTAL vacancy against the single 0.10
+    // ceiling (PMAScoring.RENTAL_VACANCY_CEILING) — the #1149 divergence
+    // (0.10 Bridge-gated vs 0.12 default) is resolved. Enabling Bridge/MLS
+    // no longer changes the vacancy normalization, only adds the land-cost
+    // blend. Legacy total-vacancy fallback (0.12) exists solely for data
+    // files that predate the rental_vacancy_rate fields.
     var _landResult = (SSS.scoreLandSupplyWithBridge && _bridgeLandCtx)
       ? SSS.scoreLandSupplyWithBridge(acs, _bridgeLandCtx)
       : null;
+    var _mtDetail = PMAScoring.scoreMarketTightnessDetail
+      ? PMAScoring.scoreMarketTightnessDetail(acs)
+      : { score: scoreMarketTightness(acs), basis: 'legacy_total_vacancy' };
     var marketTightnessScore;
     if (_landResult && !_landResult.unavailable && typeof _landResult.score === 'number') {
       marketTightnessScore = _landResult.score;
     } else {
-      marketTightnessScore = scoreMarketTightness(acs);
+      marketTightnessScore = _mtDetail.score;
     }
 
     // Enhance market score with Bridge transaction velocity
@@ -1044,7 +1056,9 @@
             (chasData && chasData.meta && chasData.meta.vintage ? chasData.meta.vintage : '?') +
             '), scaled to the PMA buffer using county income mix'
           : 'Ratio of total affordable units to ALL renter households in buffer (ACS total — over-counts LIHTC demand pool)',
-        marketTightness: 'Vacancy rate signal — measures how fully occupied existing stock is, NOT land availability for new construction',
+        marketTightness: _mtDetail.basis === 'rental_vacancy'
+          ? 'Rental-vacancy signal (Census HVS convention: for-rent ÷ rental universe, 0.10 ceiling) — seasonal/second homes excluded; measures lease-up risk, NOT land availability'
+          : 'TOTAL vacancy rate signal (legacy fallback — rental-vacancy fields absent from tract data; includes seasonal units, which overstates softness in resort markets)',
         rentPressure:    rentPressureObj.unavailable
           ? 'Rent-pressure score unavailable — county 4-person AMI could not be resolved. Dimension excluded from overall.'
           : 'Market rent vs. 60% AMI affordable rent threshold (county AMI: $' + rentPressureObj.amiUsed.toLocaleString() + ')'

--- a/js/market-analysis/site-selection-score.js
+++ b/js/market-analysis/site-selection-score.js
@@ -603,6 +603,22 @@
         reason: 'ACS vacancy data unavailable'
       };
     }
+    // #1163 — prefer RENTAL vacancy (Census HVS convention). Total ACS
+    // vacancy counts seasonal/second homes as vacant, which reads resort
+    // counties as massively oversupplied (Summit: 63% median tract
+    // "vacancy") — the opposite of their actual rental-market condition.
+    // Same 0.10 ceiling as PMAMarketScoring.RENTAL_VACANCY_CEILING:
+    // 10%+ vacancy is where lease-up risk and absorption pace begin to
+    // materially threaten LIHTC underwriting.
+    var rental = Number(acs.rental_vacancy_rate);
+    if (acs.rental_vacancy_rate != null && isFinite(rental)) {
+      return {
+        score: _clamp(Math.round((1 - rental / 0.10) * 100)),
+        unavailable: false,
+        basis: 'rental_vacancy'
+      };
+    }
+    // Legacy fallback (tract data predating the rental-vacancy fields).
     // ACS small-N suppression now emits null for vacancy_rate. Treat
     // null as unavailable rather than silently defaulting to 5% — the
     // composite redistributes the weight via `unavailable: true`.
@@ -614,13 +630,10 @@
       };
     }
     var vac = _safe(acs.vacancy_rate, 0.05);
-    // Very low vacancy (<1%) → score ≈ 90; at 10%+ vacancy → score ≈ 0.
-    // 10% is the threshold where lease-up risk and absorption pace begin to
-    // materially threaten LIHTC underwriting. Above this, the market signals
-    // either oversupply or weak demand — neither is a healthy site.
     return {
       score: _clamp(Math.round((1 - vac / 0.10) * 100)),
-      unavailable: false
+      unavailable: false,
+      basis: 'legacy_total_vacancy'
     };
   }
 

--- a/test/pma-scoring.test.js
+++ b/test/pma-scoring.test.js
@@ -52,6 +52,11 @@ const SAMPLE_ACS = {
   severe_cost_burden_rate: 0.16,
   poverty_rate: 0.12,
   vacancy_rate: 0.03,
+  // #1163 — rental-vacancy fields so composition tests exercise the
+  // preferred (rental) scoring path, matching regenerated tract data.
+  vacant_for_rent: 330,
+  rented_not_occupied: 20,
+  rental_vacancy_rate: 0.04,
   tract_count: 12,
 };
 
@@ -326,12 +331,65 @@ test('default PMA buffer radius agrees across HTML select, engine, and UI contro
     `UI controller default (${uicDefault[1]}) matches HTML selected option (${selectedOpt[1]})`);
 });
 
+// #1163: when BOTH vacancy inputs are absent/suppressed, scoring routes
+// through the legacy fallback (total vacancy, 0.12 ceiling, 0.05 neutral
+// default) — deliberately preserving the historical 58, not the 50 the
+// rental ceiling would give. Full weight-redistribution for suppressed
+// data in computePma's composite was considered and deferred (see #1163).
 test('scoreMarketTightness treats suppressed vacancy as neutral default, not max-tight', () => {
   const suppressed = Scoring.scoreMarketTightness({ vacancy_rate: null });
   const explicitZero = Scoring.scoreMarketTightness({ vacancy_rate: 0 });
 
-  assert(suppressed === 58, `suppressed vacancy gets neutral-ish score 58 (got ${suppressed})`);
+  assert(suppressed === 58, `suppressed vacancy gets neutral-ish legacy score 58 (got ${suppressed})`);
   assert(explicitZero === 100, 'explicit zero vacancy still scores as max tightness');
+});
+
+// ── #1163: Land/Supply scores RENTAL vacancy at a single 0.10 ceiling ──────
+
+test('scoreMarketTightness prefers rental vacancy over resort-inflated total vacancy', () => {
+  // Resort-style aggregate: 63% total "vacancy" (seasonal homes) but a
+  // genuinely tight 5% rental market. Old behavior scored this 0.
+  const detail = Scoring.scoreMarketTightnessDetail({ vacancy_rate: 0.63, rental_vacancy_rate: 0.05 });
+  assert(detail.basis === 'rental_vacancy', 'rental basis is reported');
+  assert(detail.score === 50, `5% rental vacancy scores 50 under the 0.10 ceiling (got ${detail.score})`);
+  assert(Scoring.scoreMarketTightness({ vacancy_rate: 0.63, rental_vacancy_rate: 0.05 }) === 50,
+    'plain scoreMarketTightness returns the same rental-based score');
+});
+
+test('rental-vacancy ceiling boundaries', () => {
+  assert(Scoring.scoreMarketTightness({ rental_vacancy_rate: 0.10 }) === 0,
+    '10% rental vacancy scores 0 (ceiling)');
+  assert(Scoring.scoreMarketTightness({ rental_vacancy_rate: 0 }) === 100,
+    '0% rental vacancy scores 100 (max tight)');
+  assert(Scoring.RENTAL_VACANCY_CEILING === 0.10, 'exported rental ceiling is 0.10');
+});
+
+test('legacy fallback preserves historical total-vacancy behavior when rental fields absent', () => {
+  const detail = Scoring.scoreMarketTightnessDetail({ vacancy_rate: 0.03 });
+  assert(detail.basis === 'legacy_total_vacancy', 'legacy basis is reported');
+  assert(detail.score === 75, `3% total vacancy at the legacy 0.12 ceiling scores 75 (got ${detail.score})`);
+  assert(Scoring.LEGACY_TOTAL_VACANCY_CEILING === 0.12, 'exported legacy ceiling is 0.12');
+  // null rental_vacancy_rate (no rental universe in buffer) also routes legacy
+  const nullRental = Scoring.scoreMarketTightnessDetail({ vacancy_rate: 0.03, rental_vacancy_rate: null });
+  assert(nullRental.basis === 'legacy_total_vacancy', 'null rental universe routes to legacy fallback');
+});
+
+// Anti-re-divergence guard (#1149/#1163): both scoring files must normalize
+// rental vacancy against the same 0.10 ceiling. If either drifts, this fails.
+test('both Land/Supply code paths score rental vacancy at the 0.10 ceiling', () => {
+  const sss = fs.readFileSync(
+    path.resolve(__dirname, '..', 'js', 'market-analysis', 'site-selection-score.js'), 'utf8');
+  assert(sss.includes('rental_vacancy_rate'), 'site-selection-score.js consumes rental_vacancy_rate');
+  assert(/rental\s*\/\s*0\.10/.test(sss), 'site-selection-score.js normalizes rental vacancy against 0.10');
+
+  const helper = fs.readFileSync(
+    path.resolve(__dirname, '..', 'js', 'market-analysis-scoring.js'), 'utf8');
+  assert(/RENTAL_VACANCY_CEILING\s*=\s*0\.10/.test(helper),
+    'shared helper declares RENTAL_VACANCY_CEILING = 0.10');
+
+  const engine = fs.readFileSync(path.resolve(__dirname, '..', 'js', 'market-analysis.js'), 'utf8');
+  assert(engine.includes('rental_vacancy_rate'), 'aggregateAcs derives buffer-level rental_vacancy_rate');
+  assert(engine.includes('scoreMarketTightnessDetail'), 'computePma uses the basis-aware detail for disclosure');
 });
 
 test('computePma composition uses shared helpers and returns valid score object', () => {


### PR DESCRIPTION
## Summary
- **Part 2 of 2** for #1163, per the merged spec. **Depends on #1169 (regenerated data) merging first** — with stale data the code degrades gracefully to the disclosed legacy fallback, but the point of the change needs the data.
- Both Land/Supply paths (`scoreMarketTightness` in the shared helper, `scoreLandSupply` in site-selection-score) now score **rental vacancy** (HVS convention) against a single **0.10** ceiling — the #1149 divergence is resolved; enabling Bridge/MLS no longer changes vacancy normalization, only adds the land-cost blend.
- Buffer-level rental vacancy is derived in `aggregateAcs()` from summed, buffer-share-apportioned **counts**, not averaged tract rates.
- Basis is disclosed end-to-end: `scoreMarketTightnessDetail()` returns `{score, basis}`, `computePma`'s dimension note states rental-vs-legacy basis, `scoreLandSupply` reports it too.
- Legacy fallback (total vacancy, 0.12 ceiling, 0.05 neutral default) preserved **verbatim** for data files predating the rental fields; both ceilings exported as named constants.
- `docs/PMA_SCORING.md` § Land/Supply rewritten to the unified story, **including a prominent known limitation** (below).

## The honest finding from data QA (also on #1169)
ACS `B25004_002E` counts short-term/vacation rental listings as "For rent." In STR-saturated resort cores this inflates rental vacancy far beyond the long-term market (Summit: ~38% of the county rental universe is "for rent"), so those buffers still floor at 0. The change fully fixes metro and non-resort mountain markets and removes the worst of the seasonal-homes inversion, but resort cores need a follow-up refinement — documented in `PMA_SCORING.md` and being filed as a separate issue. My spec's QA-gate prediction ("Summit drops to single-digit-to-low-teens") was wrong on magnitude; flagged rather than quietly passed.

## Verification
- `npm run test:pma-scoring` **107/107** (12 new/updated assertions incl. an anti-re-divergence source-grep guard across all three files); `npm run validate` clean; all three JS files parse in Node.
- **Non-vacuous, both directions**: disabling the rental preference in the helper → 5 failures; drifting site-selection-score's rental ceiling to 0.12 → the guard test fails specifically.
- **Browser end-to-end with #1169's regenerated data** (real `aggregateAcs` → both scorers on live page):
  - Denver 3-mi buffer: rental vacancy 5.04% → **both paths score 50, basis `rental_vacancy`** (unified ceiling confirmed live)
  - **Durango 3-mi: 0 → 17** — the concrete fix case (13% total vacancy floored it at the old 0.12 ceiling; 8.3% rental vacancy scores honestly)
  - Breckenridge 3-mi: stays 0 (51% "rental vacancy" = STR stock; disclosed limitation, no regression)
  - Full `runAnalysis` renders, zero console errors.

Merge order: **#1169 first, then this.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)