### PR TITLE
feat(pma): auto-flag STR-distorted Land/Supply buffers (#1171 option 4)

### DIFF
--- a/docs/PMA_SCORING.md
+++ b/docs/PMA_SCORING.md
@@ -134,8 +134,21 @@ no STR/long-term split. The switch to rental vacancy fixed the metro and
 non-resort mountain counties (Denver ~5%, La Plata ~7% — sensible scores)
 and removed the worst of the seasonal-homes inversion, but resort-core
 Land/Supply scores should be read alongside local STR-license and
-long-term-listing data until a refinement lands (see the follow-up issue
-referenced from #1163).
+long-term-listing data until a refinement lands (see #1171).
+
+Buffers meeting **both** of the following are automatically flagged
+"STR-DISTORTED" in the dimension note (`PMAMarketScoring.isStrDistorted`,
+disclosure only — the score itself is unchanged):
+
+- `rental_vacancy_rate ≥ 0.08` (score ≤ 20 — materially depressed), and
+- total `vacancy_rate ≥ 0.25` (seasonal-dominated market, the STR tell).
+
+Calibrated against 2019–2023 county aggregates: flags Summit, Eagle,
+Pitkin, Gunnison, San Miguel, and Archuleta buffers; does not flag
+Denver/Boulder (low on both), La Plata (score not floored), tight-but-
+seasonal towns like Leadville (rental vacancy near 0 — score not
+depressed), or a genuinely soft non-seasonal market (high rental, low
+total vacancy — real oversupply, not STR).
 
 ### 5. Workforce (15%)
 

--- a/js/market-analysis-scoring.js
+++ b/js/market-analysis-scoring.js
@@ -205,6 +205,32 @@
     return scoreMarketTightnessDetail(acs).score;
   }
 
+  // #1171 — STR-distortion disclosure. ACS B25004_002E counts short-term/
+  // vacation rental listings as "for rent", so in STR-saturated resort
+  // cores rental vacancy reads far above the long-term market (Summit:
+  // ~38% of the county rental universe). Flag a buffer as STR-distorted
+  // when BOTH hold:
+  //   - rental vacancy >= 0.08 (score <= 20 — materially depressed), AND
+  //   - total vacancy >= 0.25 (seasonal-dominated market, the STR tell).
+  // Calibrated against 2019-2023 county aggregates: flags Summit, Eagle,
+  // Pitkin, Gunnison, San Miguel, Archuleta; does NOT flag Denver/Boulder
+  // (low both), La Plata (score 27, mixed), Lake/Leadville (rental tight —
+  // score not depressed), or a hypothetical soft metro (high rental, low
+  // total — genuine oversupply, not STR). Disclosure only; the score is
+  // unchanged. Real refinement options tracked in #1171.
+  var STR_FLAG_RENTAL_VACANCY_MIN = 0.08;
+  var STR_FLAG_TOTAL_VACANCY_MIN = 0.25;
+
+  function isStrDistorted(acs) {
+    if (!acs) return false;
+    var rental = Number(acs.rental_vacancy_rate);
+    var total = Number(acs.vacancy_rate);
+    return acs.rental_vacancy_rate != null && isFinite(rental) &&
+           acs.vacancy_rate != null && isFinite(total) &&
+           rental >= STR_FLAG_RENTAL_VACANCY_MIN &&
+           total >= STR_FLAG_TOTAL_VACANCY_MIN;
+  }
+
   function scoreTier(s) {
     if (s >= 80) return { label: 'Strong', color: 'var(--good)' };
     if (s >= 60) return { label: 'Moderate', color: 'var(--accent)' };
@@ -225,6 +251,9 @@
     scoreRentPressure: scoreRentPressure,
     scoreMarketTightness: scoreMarketTightness,
     scoreMarketTightnessDetail: scoreMarketTightnessDetail,
+    STR_FLAG_RENTAL_VACANCY_MIN: STR_FLAG_RENTAL_VACANCY_MIN,
+    STR_FLAG_TOTAL_VACANCY_MIN: STR_FLAG_TOTAL_VACANCY_MIN,
+    isStrDistorted: isStrDistorted,
     scoreTier: scoreTier
   };
 }));

--- a/js/market-analysis.js
+++ b/js/market-analysis.js
@@ -1056,9 +1056,12 @@
             (chasData && chasData.meta && chasData.meta.vintage ? chasData.meta.vintage : '?') +
             '), scaled to the PMA buffer using county income mix'
           : 'Ratio of total affordable units to ALL renter households in buffer (ACS total — over-counts LIHTC demand pool)',
-        marketTightness: _mtDetail.basis === 'rental_vacancy'
+        marketTightness: (_mtDetail.basis === 'rental_vacancy'
           ? 'Rental-vacancy signal (Census HVS convention: for-rent ÷ rental universe, 0.10 ceiling) — seasonal/second homes excluded; measures lease-up risk, NOT land availability'
-          : 'TOTAL vacancy rate signal (legacy fallback — rental-vacancy fields absent from tract data; includes seasonal units, which overstates softness in resort markets)',
+          : 'TOTAL vacancy rate signal (legacy fallback — rental-vacancy fields absent from tract data; includes seasonal units, which overstates softness in resort markets)')
+          + (PMAScoring.isStrDistorted && PMAScoring.isStrDistorted(acs)
+            ? ' ⚠ STR-DISTORTED: ACS counts short-term/vacation rental listings as "for rent" — in this seasonal-dominated market the score likely understates long-term rental tightness. Verify against local STR-license and long-term listing data (#1171).'
+            : ''),
         rentPressure:    rentPressureObj.unavailable
           ? 'Rent-pressure score unavailable — county 4-person AMI could not be resolved. Dimension excluded from overall.'
           : 'Market rent vs. 60% AMI affordable rent threshold (county AMI: $' + rentPressureObj.amiUsed.toLocaleString() + ')'

--- a/test/pma-scoring.test.js
+++ b/test/pma-scoring.test.js
@@ -374,6 +374,32 @@ test('legacy fallback preserves historical total-vacancy behavior when rental fi
   assert(nullRental.basis === 'legacy_total_vacancy', 'null rental universe routes to legacy fallback');
 });
 
+// #1171 — STR-distortion disclosure predicate. Flags only when the score is
+// materially depressed (rental >= 0.08) AND the market is seasonal-dominated
+// (total >= 0.25). Disclosure-only: the score itself is unchanged.
+test('isStrDistorted flags STR-saturated resort buffers and nothing else', () => {
+  assert(Scoring.isStrDistorted({ rental_vacancy_rate: 0.51, vacancy_rate: 0.69 }) === true,
+    'Breckenridge-style buffer (51% rental / 69% total) is flagged');
+  assert(Scoring.isStrDistorted({ rental_vacancy_rate: 0.11, vacancy_rate: 0.32 }) === true,
+    'Pitkin-style buffer (11% / 32%) is flagged');
+  assert(Scoring.isStrDistorted({ rental_vacancy_rate: 0.05, vacancy_rate: 0.077 }) === false,
+    'Denver-style buffer (5% / 7.7%) is not flagged');
+  assert(Scoring.isStrDistorted({ rental_vacancy_rate: 0.16, vacancy_rate: 0.10 }) === false,
+    'genuinely soft non-seasonal market (16% rental / 10% total) is NOT flagged — real oversupply');
+  assert(Scoring.isStrDistorted({ rental_vacancy_rate: 0.0, vacancy_rate: 0.27 }) === false,
+    'tight-but-seasonal town (0% rental / 27% total) is not flagged — score not depressed');
+  assert(Scoring.isStrDistorted({ vacancy_rate: 0.40 }) === false,
+    'missing rental field never flags (legacy data)');
+  assert(Scoring.isStrDistorted(null) === false, 'null acs never flags');
+  // score is unchanged by the flag — disclosure only
+  assert(Scoring.scoreMarketTightness({ rental_vacancy_rate: 0.51, vacancy_rate: 0.69 }) === 0,
+    'flagged buffer still scores on the same formula');
+  // the dimension note wiring exists in computePma
+  const engine = fs.readFileSync(path.resolve(__dirname, '..', 'js', 'market-analysis.js'), 'utf8');
+  assert(engine.includes('isStrDistorted'), 'computePma consults isStrDistorted for the dimension note');
+  assert(engine.includes('STR-DISTORTED'), 'dimension note carries the STR-DISTORTED warning text');
+});
+
 // Anti-re-divergence guard (#1149/#1163): both scoring files must normalize
 // rental vacancy against the same 0.10 ceiling. If either drifts, this fails.
 test('both Land/Supply code paths score rental vacancy at the 0.10 ceiling', () => {


### PR DESCRIPTION
## Summary
- Implements the recommended zero-methodology-risk first step from #1171: an automatic **STR-DISTORTED** warning in the `marketTightness` dimension note. The score is untouched — this is disclosure, matching the staged approach used for #1149→#1163.
- Flag predicate (`PMAMarketScoring.isStrDistorted`, exported, named constants): `rental_vacancy_rate ≥ 0.08` (score ≤ 20, materially depressed) **AND** total `vacancy_rate ≥ 0.25` (seasonal-dominated — the STR tell).
- Both conditions are required so the flag stays silent for genuinely soft non-seasonal markets (high rental / low total = real oversupply) and for tight-but-seasonal towns (score not depressed).
- Documented in `docs/PMA_SCORING.md`'s known-limitation section with the calibration table. #1171 stays open for the real refinement (owner methodology call).

## Verification
- Calibrated against 2019–2023 county count-aggregates: flags Summit, Eagle, Pitkin, Gunnison, San Miguel, Archuleta; clean on Denver, Boulder, El Paso, Larimer, La Plata, Lake.
- **Live browser** (real `aggregateAcs` on regenerated data): Breckenridge 3-mi (51.4%/68.9%) → flagged; Aspen 3-mi (12.8%/31.3%) → flagged; Denver (5.0%/7.7%) → clean; Durango (8.3%/13%) → scores 17, correctly unflagged. Zero console errors.
- `npm run test:pma-scoring` **117/117**, including a 7-case predicate matrix, a score-unchanged assertion, and note-wiring source assertions. **Non-vacuous**: forcing the predicate to `false` fails exactly the 2 flag-positive assertions; restore → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)