### PR TITLE
chore(test): C-04 triage — annotate source-grep tests with dispositions (#1120)

### DIFF
--- a/test/hna-functionality-check.js
+++ b/test/hna-functionality-check.js
@@ -401,6 +401,9 @@ test('HTML: CSV and JSON download buttons are present', () => {
     assert(html.includes('id="btnJson"'), 'btnJson button is present in HTML');
 });
 
+// C-04 (#1120) triage: cross-file HTML-id <-> JS-reference contract grep.
+// This is the legitimate use of source-grep (a DOM contract has no better
+// static home); keep as-is. No retirement planned.
 test('JS: CSV and JSON export buttons are wired in init()', () => {
     assert(js.includes('btnCsv'),                'btnCsv is referenced in HNA modules');
     assert(js.includes('btnJson'),               'btnJson is referenced in HNA modules');

--- a/test/integration/compliance-dashboard.test.js
+++ b/test/integration/compliance-dashboard.test.js
@@ -149,6 +149,10 @@ test('js/prop123-historical-tracker.js: file exists with required exports', () =
   assert(src.includes('window.Prop123Tracker'),            'window.Prop123Tracker exposed');
 });
 
+// C-04 (#1120) triage: this block is SOURCE-GREP (IIFE shape + function-name
+// presence), kept as a static contract guard only. Retirement criteria: same
+// as test/prop123-historical.test.js — migrate to require()-based behavior
+// tests once the tracker/HNA modules gain Node-safe dual-context exports.
 test('js/prop123-historical-tracker.js: uses IIFE pattern consistent with codebase', () => {
   const src = fs.readFileSync(TRACKER, 'utf8');
   assert(src.includes('(function'),              'contains IIFE pattern');

--- a/test/prop123-historical.test.js
+++ b/test/prop123-historical.test.js
@@ -168,6 +168,14 @@ function generateComplianceReport(rows) {
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
+//
+// C-04 (#1120) triage: the assertions below are SOURCE-GREP static contract
+// checks (module defines its API surface and exposes window.Prop123Tracker),
+// not behavior tests — a broken implementation with the right names still
+// passes. Kept deliberately as existence guards. Retirement criteria: when
+// prop123-historical-tracker.js gains a Node-safe dual-context export
+// (pattern: js/deal-calculator-math.js / js/market-analysis-scoring.js),
+// replace these with require()-based behavior tests of the real functions.
 
 test('js/prop123-historical-tracker.js source file exists', () => {
   const p = path.join(ROOT, 'js', 'prop123-historical-tracker.js');

--- a/test/tigerweb-timeout.test.js
+++ b/test/tigerweb-timeout.test.js
@@ -52,6 +52,16 @@ const fetchHelperSrc = fs.readFileSync(FETCH_HELPER_PATH, 'utf8');
 const hnaControllerSrc = fs.readFileSync(HNA_CONTROLLER_PATH, 'utf8');
 
 // ── Tests ───────────────────────────────────────────────────────────────────
+//
+// C-04 (#1120) triage: these are the most brittle source-grep tests in the
+// repo — they pattern-match implementation details (AbortController spelling,
+// backoff arithmetic, a regex chain for the maxRetries default) to guard the
+// specific TIGERweb-timeout incident fix. Known-brittle placeholder, kept
+// because the incident regression it guards is real. Retirement criteria:
+// port fetchWithTimeout behavior coverage into the require()-based harness
+// used by test/fetch-helper-resolve.js (mock fetch, assert real timeout/retry
+// behavior), then delete every grep below except the two window-wiring
+// contract checks.
 
 test('fetch-helper.js defines fetchWithTimeout', () => {
   assert(fetchHelperSrc.includes('function fetchWithTimeout('), 'fetchWithTimeout is defined');


### PR DESCRIPTION
## Summary
- Closes #1120 by doing exactly what its suggested action asks: per-file disposition for each of the four cited source-grep sites, as annotation comments (no test behavior changes).
- Dispositions: two kept as static API-surface contracts with a concrete retirement path (the dual-context export pattern now established by `js/deal-calculator-math.js` / `js/market-analysis-scoring.js` makes future migration to `require()`-based behavior tests cheap); `tigerweb-timeout.test.js` flagged as the known-brittle placeholder it is, with specific retirement criteria; `hna-functionality-check.js`'s HTML↔JS id contract kept permanently (that's the legitimate use of source-grep).
- Transparency note: recent PRs (#1161, #1165, #1170, #1172) added new source-grep tests — all are in the "static contract guard" category the audit's carve-out endorses (label strings, default agreement, ceiling anti-drift, note wiring), not behavior stand-ins.

## Verification
- All four annotated suites pass unchanged: `test:hna` (full), `tigerweb-timeout`, `prop123-historical`, `compliance-dashboard` — comment-only diff, `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)