### PR TITLE
docs(audit): Codex handoff — tenure-aware place-CHAS anchoring (#1186) + county home values (#1187)

### DIFF
--- a/docs/audits/CODEX-HANDOFF-TENURE-ANCHOR-COUNTY-HOMEVALUES-2026-07.md
+++ b/docs/audits/CODEX-HANDOFF-TENURE-ANCHOR-COUNTY-HOMEVALUES-2026-07.md
@@ -61,14 +61,17 @@ targets.
    `test:ranking-scenarios` fails if you regenerate the index without them).
    Commit all regenerated artifacts in the same PR.
 6. **Basalt / cross-county (F2)**: Basalt (`0804935`) is 74% Eagle County
-   (`cross-county-places.json`, `primary_county: "08037"`) and is ABSENT from
-   `data/hna/derived/place_county_lookup.json` (verified — the flat map has no
-   `0804935` key). Trace how the HNA controller resolves Basalt's
-   `contextCounty` today (cross-county handling exists — find it before
-   changing anything). Required outcome: the ownership panel's county-context
-   inputs (AMI fallback, county CHAS fallback) for cross-county places use
-   `primary_county`. If tracing shows this already works, document the
-   evidence in the PR instead of changing code.
+   (`cross-county-places.json`, `primary_county: "08037"`). CORRECTION from
+   review: `data/hna/derived/place_county_lookup.json` ALREADY maps Basalt
+   correctly — the mapping is nested under the file's `places` key
+   (`places["0804935"] = "08037"`); an earlier flat-key read misreported it
+   as absent. So the data layer is likely fine — this sub-item is
+   **trace-and-document, not repair**: confirm the HNA controller's
+   `contextCounty` for Basalt resolves to `08037` end-to-end (including the
+   ownership panel's AMI fallback and county-CHAS fallback), and put the
+   trace evidence in the PR. Only change code if the trace shows a consumer
+   bypassing the lookup/cross-county handling. Do not "fix" the lookup file
+   itself — it is correct.
 
 **Tests** (extend `test/hna-ownership-need.test.js` or a new file wired into
 the explicit `test:ci` chain — new test files do NOT auto-run):
@@ -114,6 +117,16 @@ market-attainable/stretch/priced-out.
    `js/hna/hna-renderers.js` to look up counties. Keep the display-only
    convention: the rank/score model must continue ignoring these fields
    (stated in the builder's header — preserve that contract).
+3. **Controller load path (added from review — without this the renderer
+   change is dead code on county views)**: `js/hna/hna-controller.js`
+   lazy-loads `home-value-cascade.json` ONLY for place/CDP selections
+   (`if (geoType === 'place' || geoType === 'cdp')` guarding
+   `ownershipHomeValueCascadePromise`, ~line 3244 — recheck, lines drift).
+   Extend that gate so county selections also load the cascade (or drop
+   the gate and lazy-load for any ownership-panel render); otherwise
+   Pitkin/Garfield keep falling back to the profile's raw `DP04_0089E`
+   and never exercise the new county block. The QA gate below assumes
+   this works.
 3. The renderer/test conventions from `test/hna-home-values.test.js` apply —
    extend it for the county block and wire any new npm script into `test:ci`.
 

--- a/docs/audits/CODEX-HANDOFF-TENURE-ANCHOR-COUNTY-HOMEVALUES-2026-07.md
+++ b/docs/audits/CODEX-HANDOFF-TENURE-ANCHOR-COUNTY-HOMEVALUES-2026-07.md
@@ -1,0 +1,135 @@
+# Codex Handoff: tenure-aware place-CHAS anchoring (#1186) + county home values (#1187)
+
+**For: Codex.** Two items, one PR each, in this order — item 1 is the gate for
+the ownership roadmap's next phase (#1167 Tier 1); item 2 is small and
+independent. Both originate from the EPS Phase II benchmark
+(`docs/audits/OWNERSHIP-BENCHMARK-EPS-PHASE2-2026-07.md`, findings F1/F2/F4).
+
+**QA**: Claude re-verifies each PR against its gate before the owner merges.
+Mark PRs "Do not merge until external QA completes."
+
+---
+
+## 1. Tenure-aware ACS anchoring for place-CHAS (#1186)
+
+**What's wrong (root-caused, verified)**: `data/hna/place-chas.json` is built
+by tract apportionment, so a small town inherits its host tracts' tenure mix —
+owner-heavy rural surroundings — instead of the town's own. Parachute:
+place-chas reads 149.1 renter / 368.1 owner households (28.8% renter), while
+the place's own summary cache (`data/hna/summary/0857400.json`) carries direct
+ACS place-level tenure `DP04_0046E = 262` owner / `DP04_0047E = 255` renter
+(49.3% renter) — matching the EPS report's 49% exactly, in both 2019 and 2024
+vintages (structural, not vintage). Also affected: Snowmass Village (27.3%
+place-chas vs 39% ACS), Basalt (24.8 vs 41), Rifle (22.7 vs 34). This biases
+`renterShare`, `ownershipFit`, and `rentalPressure` inputs in
+`js/hna/hna-ownership-need.js` for exactly the towns the ownership roadmap
+targets.
+
+**The fix — extend the existing acs_anchor mechanism to be tenure-aware**:
+
+1. Read the current anchor implementation in `scripts/hna/build_place_chas.py`
+   (it currently caps TOTAL household counts to ACS occupied; see the
+   `acs_anchor` flags in the output and the 2026-06 "place-chas HH counts
+   capped at ACS occupied" convention). Understand it before changing it.
+2. After apportionment, rescale **per tenure**: `renter_scale =
+   DP04_0047E / apportioned_total_renter_hh` and `owner_scale =
+   DP04_0046E / apportioned_total_owner_hh`, from the place's own summary
+   cache. Apply each scale uniformly across that tenure's AMI bands and
+   cost-burden counts — this preserves the within-tenure AMI distribution and
+   burden RATES (the apportionment's genuinely useful signal) while fixing the
+   tenure LEVELS and mix. Recompute `summary.*` fields from the rescaled bands.
+3. Fallbacks, explicitly handled and flagged in the record: summary cache
+   missing, or DP04 tenure fields null/zero → keep current behavior for that
+   place and set a flag (e.g. `tenure_anchor: "unavailable"`); tiny places
+   where DP04 tenure has margin-of-error zeros → same. Never divide by zero;
+   never rescale a tenure whose apportioned total is 0.
+4. Record metadata per place (e.g. `tenure_anchor: {applied: true,
+   renter_scale: …, owner_scale: …, source: "DP04_0046E/0047E place-level"}`)
+   and bump the file-level meta. `js/hna/hna-ownership-need.js`'s
+   `dataQuality()` already reads `acs_anchor` — decide (and document in the PR)
+   whether `tenure_anchor` should also demote quality; recommendation: no
+   demotion when applied cleanly (it makes data BETTER), demote to Medium when
+   `unavailable`.
+5. **Regeneration order + coupling (this chain has burned CI before — see
+   `docs/audits/` incident notes)**: summary caches are INPUTS here (do not
+   regenerate them); regenerate in this order: `place-chas.json` (this fix) →
+   place pages (`scripts/hna/build_place_pages.py`; `test:place-pages-fresh`
+   FAILS CI on drift) → jurisdiction digests
+   (`npm run build:jurisdiction-metrics-digest`) → ranking index
+   (`scripts/hna/build_ranking_index.py` consumes place-chas owner-burden
+   fields) → ranking scenarios (pinned to the index's `generatedAt`;
+   `test:ranking-scenarios` fails if you regenerate the index without them).
+   Commit all regenerated artifacts in the same PR.
+6. **Basalt / cross-county (F2)**: Basalt (`0804935`) is 74% Eagle County
+   (`cross-county-places.json`, `primary_county: "08037"`) and is ABSENT from
+   `data/hna/derived/place_county_lookup.json` (verified — the flat map has no
+   `0804935` key). Trace how the HNA controller resolves Basalt's
+   `contextCounty` today (cross-county handling exists — find it before
+   changing anything). Required outcome: the ownership panel's county-context
+   inputs (AMI fallback, county CHAS fallback) for cross-county places use
+   `primary_county`. If tracing shows this already works, document the
+   evidence in the PR instead of changing code.
+
+**Tests** (extend `test/hna-ownership-need.test.js` or a new file wired into
+the explicit `test:ci` chain — new test files do NOT auto-run):
+- Data-level guard: for every place in `place-chas.json` where
+  `tenure_anchor.applied`, `summary.total_renter_hh / (renter+owner)` matches
+  the place's `DP04_0047PE / 100` within ±1pt. Non-vacuous proof: temporarily
+  zero one town's `renter_scale` application and show the guard fails.
+- Fixture spot-checks with the EPS/ACS anchors: Parachute renter share ≈ 49.3%
+  (±1), Snowmass ≈ 39 (±2), Rifle ≈ 34 (±2), Basalt ≈ 41 (±2, using its
+  blended two-county ACS place record).
+- Within-tenure rates preserved: pick one town, assert renter
+  `pct_cost_burdened_30` per band is unchanged from the pre-fix value (rates
+  must survive rescaling; only levels move).
+
+**QA gate**: full `test:ci` green locally (including place-pages-fresh and
+ranking-scenarios); the four benchmark towns' renter shares close to the EPS
+anchors as above; a county view and a non-affected large place (e.g. Aspen,
+Glenwood Springs) show materially unchanged numbers (their apportionment was
+already sound — large deltas there mean the rescale is misapplied); zero
+console errors on the HNA ownership panel for Parachute
+(`?geoid=0857400&geoType=place&auto=1`) and Basalt.
+
+---
+
+## 2. County home values for the affordability test (#1187)
+
+**What's wrong**: `affordabilityTest` in `js/hna/hna-ownership-need.js`
+returns null for county selections because `data/hna/home-value-cascade.json`
+(built by `scripts/hna/build_home_value_cascade.mjs`) covers places only — so
+the county HNA view (the default landing) never shows
+market-attainable/stretch/priced-out.
+
+**Implementation**:
+1. Check whether a county-level ZHVI CSV exists under `data/zillow/` (the
+   place build uses the city file). If yes, mirror the existing tier-1
+   (ZHVI) → tier-2 (ACS floor) cascade for the 64 counties. If no, ship
+   counties on ACS DP04_0089E (median home value) from the county summary
+   caches (`data/hna/summary/<fips>.json`), labeled exactly the way the place
+   tier-2 fallback labels its "stale floor" — do NOT add a new external fetch
+   for this item.
+2. Extend the cascade file's schema additively (e.g. a `counties` block
+   parallel to places) and update `_ownHomeValueForSelection()` in
+   `js/hna/hna-renderers.js` to look up counties. Keep the display-only
+   convention: the rank/score model must continue ignoring these fields
+   (stated in the builder's header — preserve that contract).
+3. The renderer/test conventions from `test/hna-home-values.test.js` apply —
+   extend it for the county block and wire any new npm script into `test:ci`.
+
+**QA gate**: Pitkin and Garfield county views render an affordability
+classification (both should classify priced-out or stretch given resort-area
+values — sanity-check against the EPS narrative); place behavior byte-
+unchanged for a sample (Aspen, Lamar); `npm run test:hna-home-values` and full
+`test:ci` green; non-vacuous proof on the new county lookup (remove the
+counties block → county test fails).
+
+---
+
+## Deliverables per PR
+1. What changed, which issue it closes, evidence for every claim you relied
+   on (line numbers drift — recheck), and for item 1: before/after renter
+   shares for the four benchmark towns plus one unaffected control.
+2. Non-vacuousness proofs as specified.
+3. For item 1: explicit confirmation of the regeneration order used and that
+   ranking scenarios were rebuilt with the index.


### PR DESCRIPTION
## Summary
- Hands off the two implementation items from the EPS Phase II ownership benchmark (merged in #1185): the tenure-mix fix that gates #1167 Tier 1, and the small county home-value gap.
- **Item 1 (#1186)**: extend the place-CHAS `acs_anchor` mechanism to be tenure-aware — rescale renter/owner levels per place to the direct ACS DP04 tenure counts already in the summary caches, preserving within-tenure AMI/burden rates. Verified target values in hand: Parachute's cache reads 49.3% renter (DP04_0047E=255 / 0046E=262), matching EPS's 49% exactly, vs place-chas's biased 28.8%. Includes the full regeneration coupling chain (place-chas → place pages → digests → ranking index → scenarios), fallback semantics, benchmark-anchored tests with tolerances, and an unaffected-control gate (Aspen/GWS must NOT move materially).
- Also covers F2: Basalt's cross-county context (74% Eagle; verified absent from place_county_lookup) — trace-first instruction, change only if tracing shows the wrong county in use.
- **Item 2 (#1187)**: county block for the home-value cascade (ZHVI county tier if a CSV exists locally, else ACS DP04_0089E floor — no new external fetches), renderer lookup extension, display-only contract preserved.

## Verification behind the spec
- Parachute/Basalt root causes verified this session (DP04 fields read from the live cache; cross-county file checked; all four towns confirmed `acs_anchor: true` with full coverage).
- Regeneration order mirrors the documented coupling incidents (place-pages-fresh CI gate, ranking-scenarios generatedAt pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)