### PR TITLE
feat(pma): add seasonal vacancy count to market data pipeline

### DIFF
--- a/scripts/market/build_public_market_data.py
+++ b/scripts/market/build_public_market_data.py
@@ -594,6 +594,7 @@ ACS_VARIABLES = [
     "B25004_001E",  # total vacant
     "B25004_002E",  # vacant — for rent (#1163: rental-vacancy numerator)
     "B25004_003E",  # vacant — rented, not occupied (#1163: HVS denominator term)
+    "B25004_006E",  # vacant — seasonal, recreational, or occasional use (#1171)
     "B25064_001E",  # median gross rent
     "B19013_001E",  # median HH income
     "B25070_007E",  # 30-34.9% income on rent
@@ -685,6 +686,7 @@ def build_acs_metrics(centroids: dict) -> dict:
         # tight market" for tracts with no rental stock at all.
         vacant_for_rent     = safe_int(row[idx.get("B25004_002E", -1)])
         rented_not_occupied = safe_int(row[idx.get("B25004_003E", -1)])
+        vacant_seasonal     = safe_int(row[idx.get("B25004_006E", -1)])
         rental_universe     = renter_hh + vacant_for_rent + rented_not_occupied
         rental_vacancy_rate = round(vacant_for_rent / rental_universe, 4) \
                               if rental_universe > 0 else None
@@ -759,6 +761,7 @@ def build_acs_metrics(centroids: dict) -> dict:
             # counts instead of averaging tract rates.
             "vacant_for_rent":      vacant_for_rent,
             "rented_not_occupied":  rented_not_occupied,
+            "vacant_seasonal":      vacant_seasonal,
             "rental_vacancy_rate":  rental_vacancy_rate,
             # E — demographics breadth
             "median_age":           median_age,
@@ -791,6 +794,7 @@ def _acs_meta() -> dict:
             "vacancy_rate":      "Derived: vacant / (total_hh + vacant) — TOTAL vacancy, includes seasonal/recreational units",
             "vacant_for_rent":   "B25004_002E — Vacant housing units: for rent",
             "rented_not_occupied": "B25004_003E — Vacant housing units: rented, not occupied",
+            "vacant_seasonal":   "B25004_006E — Vacant housing units: for seasonal, recreational, or occasional use",
             "rental_vacancy_rate": "Derived (#1163, HVS convention): vacant_for_rent / (renter_hh + vacant_for_rent + rented_not_occupied); null when that universe is 0",
         },
         "note": "Rebuild via scripts/market/build_public_market_data.py",

--- a/test/pma-scoring.test.js
+++ b/test/pma-scoring.test.js
@@ -542,6 +542,18 @@ test('build_public_market_data.py: _bbox function exists', () => {
   assert(src.includes('"bbox"'), 'bbox key written to tract record');
 });
 
+test('build_public_market_data.py: emits additive vacant_seasonal field', () => {
+  const src = fs.readFileSync(
+    path.resolve(__dirname, '..', 'scripts', 'market', 'build_public_market_data.py'), 'utf8');
+  assert(src.includes('"B25004_006E"'), 'ACS variable B25004_006E is fetched');
+  assert(src.includes('vacant_seasonal     = safe_int(row[idx.get("B25004_006E", -1)])'),
+    'vacant_seasonal is parsed with safe_int');
+  assert(src.includes('"vacant_seasonal":      vacant_seasonal'),
+    'vacant_seasonal is emitted on each tract');
+  assert(src.includes('"vacant_seasonal":   "B25004_006E'),
+    'vacant_seasonal is documented in meta.fields');
+});
+
 test('generate_tract_centroids.py: compute_bbox function exists', () => {
   const src = fs.readFileSync(
     path.resolve(__dirname, '..', 'scripts', 'generate_tract_centroids.py'), 'utf8');


### PR DESCRIPTION
## Summary
- Add ACS B25004_006E to the market-data ACS fetch list, verified against the official 2023 ACS variables endpoint on 2026-07-14.
- Emit additive per-tract vacant_seasonal counts using the same safe_int convention as the rental-vacancy fields.
- Document vacant_seasonal in the acs_tract_metrics_co.json meta.fields block and add a guard test proving the builder fetches, parses, emits, and documents it.

Do not merge until external QA completes. Claude should QA before owner merge.

## Anti-fabrication / source verification
- Official Census endpoint checked: https://api.census.gov/data/2023/acs/acs5/variables/B25004_006E.json
- Returned label: Estimate!!Total:!!For seasonal, recreational, or occasional use
- No STR license counts or scoring changes are included in this PR; those belong to PR B per the handoff.

## Gates run
- npm run test:pma-scoring: 121 passed, 0 failed
- npm run validate:data: passed critical data checks; existing soft-funding freshness warning remains (lastUpdated 2026-04-07, 98 days old, SLA 90)
- node scripts/audit/data-sentinels-check.mjs: 5 ok, 0 below floor, 0 missing
- npm run validate: passed

## Regeneration note
The handoff's full tract-file sanity gates require a CENSUS_API_KEY-backed market_data_build.yml workflow_dispatch. A local in-memory full-tract run without the secret reached Census but returned the expected Missing Key HTML for the wildcard tract request, so I did not use that as evidence and did not hand-edit generated JSON.

After this pipeline PR is QAed/merged, run the market_data_build.yml workflow to open the chore/market-data-rebuild-* artifact PR and verify:
- vacant_seasonal <= vacant for every tract
- Summit County vacant_seasonal / vacant is in the expected seasonal-dominated range
- Denver aggregate remains well under 0.3
- legacy fields remain byte-identical except for the additive vacant_seasonal schema

## Scope
PR A only: pipeline schema addition. No PMA scoring discount, no STR calibration benchmark, no PMA_SCORING.md methodology change yet.