### PR TITLE
feat(pma): apply STR seasonal vacancy discount

### DIFF
--- a/data/benchmarks/str-license-counts.json
+++ b/data/benchmarks/str-license-counts.json
@@ -1,0 +1,55 @@
+{
+  "meta": {
+    "generated": "2026-07-14",
+    "purpose": "Warn-only calibration benchmark for the PMA STR seasonal-share discount (#1171).",
+    "method_note": "Licensed STR counts are not ACS vacant-for-rent units. They use different universes and dates; compare only for order-of-magnitude calibration. License counts are advisory only and are never scoring inputs.",
+    "source_rules": "Each row was queried from an official municipal/county ArcGIS or open-data endpoint on 2026-07-14. Absent jurisdictions are preferable to unverifiable or remembered counts."
+  },
+  "entries": [
+    {
+      "jurisdiction": "Denver",
+      "geoid": "0820000",
+      "geography_level": "place",
+      "licensed_str_units": 2386,
+      "as_of": "2026-07-14",
+      "source_url": "https://services1.arcgis.com/zdB7qR0BtYrg0Xpl/arcgis/rest/services/ODC_short_term_rental_licenses_active_or_pending_renewal/FeatureServer/67/query?where=1%3D1&returnCountOnly=true&f=json",
+      "source_note": "City and County of Denver table 'Short Term Rental-Licenses Active or Pending Renewal'; query returned count 2386."
+    },
+    {
+      "jurisdiction": "Manitou Springs",
+      "geoid": "0848445",
+      "geography_level": "place",
+      "licensed_str_units": 51,
+      "as_of": "2026-07-14",
+      "source_url": "https://services6.arcgis.com/JvLU4FaQtqrjGWfU/arcgis/rest/services/Short_Term_Rental_and_Hotel_Motel_August_2025/FeatureServer/0/query?where=1%3D1&returnCountOnly=true&f=json",
+      "source_note": "City of Manitou Springs service 'Short Term Rentals' / 'Active Short Term Rentals'; query returned count 51."
+    },
+    {
+      "jurisdiction": "Lyons",
+      "geoid": "0847070",
+      "geography_level": "place",
+      "licensed_str_units": 16,
+      "as_of": "2026-07-14",
+      "source_url": "https://services1.arcgis.com/upSnbuH7dAfu37yT/arcgis/rest/services/Licensesed_Short_Term_Rental/FeatureServer/0/query?where=1%3D1&returnCountOnly=true&f=json",
+      "source_note": "Town of Lyons service 'Licensed Short Term Rentals'; query returned count 16."
+    },
+    {
+      "jurisdiction": "Lake County",
+      "geoid": "08065",
+      "geography_level": "county",
+      "licensed_str_units": 132,
+      "as_of": "2026-07-14",
+      "source_url": "https://services1.arcgis.com/38PTfoP8IjlBsxZN/arcgis/rest/services/STR_Compliance/FeatureServer/0/query?where=1%3D1&returnCountOnly=true&f=json",
+      "source_note": "Lake County, Colorado GIS service 'Compliant STR 2024'; query returned count 132."
+    },
+    {
+      "jurisdiction": "Clear Creek County",
+      "geoid": "08019",
+      "geography_level": "county",
+      "licensed_str_units": 154,
+      "as_of": "2026-07-14",
+      "source_url": "https://services1.arcgis.com/faTiISwEuJk1lvB1/arcgis/rest/services/GovBuilt_STR_License_Parcels_(GIS_Friendly)/FeatureServer/0/query?where=licenseStatus%3D%27Active%27&outFields=licenseNumber&returnDistinctValues=true&returnGeometry=false&f=json",
+      "source_note": "Clear Creek County STR license parcel service; distinct active licenseNumber query returned 154 features."
+    }
+  ]
+}

--- a/data/benchmarks/str-license-counts.json
+++ b/data/benchmarks/str-license-counts.json
@@ -48,7 +48,7 @@
       "geography_level": "county",
       "licensed_str_units": 154,
       "as_of": "2026-07-14",
-      "source_url": "https://services1.arcgis.com/faTiISwEuJk1lvB1/arcgis/rest/services/GovBuilt_STR_License_Parcels_(GIS_Friendly)/FeatureServer/0/query?where=licenseStatus%3D%27Active%27&outFields=licenseNumber&returnDistinctValues=true&returnGeometry=false&f=json",
+      "source_url": "https://services1.arcgis.com/faTiISwEuJk1lvB1/arcgis/rest/services/GovBuilt_STR_License_Parcels_%28GIS_Friendly%29/FeatureServer/0/query?where=licenseStatus%3D%27Active%27&outFields=licenseNumber&returnDistinctValues=true&returnGeometry=false&f=json",
       "source_note": "Clear Creek County STR license parcel service; distinct active licenseNumber query returned 154 features."
     }
   ]

--- a/docs/PMA_SCORING.md
+++ b/docs/PMA_SCORING.md
@@ -144,6 +144,9 @@ does not identify short-term rentals directly. The seasonal-share discount
 mitigates the worst resort-core inversion, but it can under- or over-discount
 where seasonal housing and STR licenses diverge. Read adjusted resort-market
 scores alongside local STR-license and long-term-listing data.
+For example, a year-round-marketed Breckenridge STR can be counted as ACS
+"for rent" without also being counted as "seasonal," so residual STR
+contamination can remain after the seasonal-share discount.
 
 Buffers meeting **both** of the following are automatically flagged
 "STR-DISTORTED" in the dimension note (`PMAMarketScoring.isStrDistorted`,

--- a/docs/PMA_SCORING.md
+++ b/docs/PMA_SCORING.md
@@ -83,7 +83,8 @@ Where `AMI` = Colorado statewide Area Median Income. See [HUD Income Limits](htt
 
 ### 4. Land / Supply (15%)
 
-Measures rental-market supply tightness via **rental vacancy** (#1163).
+Measures rental-market supply tightness via **STR-adjusted rental vacancy**
+(#1163/#1171).
 Very low rental vacancy signals unmet demand; 10%+ signals lease-up risk.
 
 **The input is rental vacancy, not total vacancy.** Total ACS vacancy
@@ -91,22 +92,36 @@ Very low rental vacancy signals unmet demand; 10%+ signals lease-up risk.
 every Colorado resort county 0 on this dimension (Summit County: 63% median
 tract "vacancy") — reading the state's most workforce-housing-starved rental
 markets as oversupplied. Rental vacancy follows the Census Housing Vacancy
-Survey convention:
+Survey convention, then applies a seasonal-share discount as a proxy for the
+share of "for rent" units that are short-term/vacation product unavailable to
+the long-term rental market:
 
 ```
-rental_vacancy_rate = vacant_for_rent / (renter_hh + vacant_for_rent + rented_not_occupied)
-                      (B25004_002E)     (B25003_003E + B25004_002E + B25004_003E)
+seasonal_share       = Σ vacant_seasonal / Σ vacant
+                      (B25004_006E)       (B25004_001E)
+                      # 0 when Σ vacant = 0
 
-landScore = max(0, min(100, (1 − rental_vacancy_rate / 0.10) × 100))
+adj_vacant_for_rent  = Σ vacant_for_rent × (1 − seasonal_share)
+
+str_adjusted_rental_vacancy_rate =
+    adj_vacant_for_rent / (Σ renter_hh + adj_vacant_for_rent + Σ rented_not_occupied)
+
+landScore = max(0, min(100, (1 − str_adjusted_rental_vacancy_rate / 0.10) × 100))
 ```
 
-**Both code paths use this same input and the same 0.10 ceiling**
+The seasonal discount is a proxy, not a direct STR inventory count: Colorado
+has no statewide STR registry, and local license counts are patchy and use a
+different universe than ACS "for rent at survey time." License counts are used
+only in a warn-only calibration benchmark (`npm run
+audit:str-discount-calibration`) and are never scoring inputs.
+
+**Both code paths use this same preferred input and the same 0.10 ceiling**
 (`PMAMarketScoring.RENTAL_VACANCY_CEILING`) — the historical 0.10-vs-0.12
-divergence (#1149) is resolved:
+divergence (#1149) remains resolved:
 
 - `scoreMarketTightness()` (`js/market-analysis-scoring.js`) — the default
-  path. Buffer-level rental vacancy is derived from summed, buffer-share-
-  apportioned counts (not averaged tract rates) in `aggregateAcs()`.
+  path. Buffer-level adjusted rental vacancy is derived from summed, buffer-
+  share-apportioned counts (not averaged tract rates) in `aggregateAcs()`.
 - `scoreLandSupplyWithBridge()` → `scoreLandSupply()`
   (`js/market-analysis/site-selection-score.js`) — the Bridge-gated path.
   Its only remaining difference is the 60/40 land-cost blend; enabling
@@ -115,40 +130,32 @@ divergence (#1149) is resolved:
 The 0.10 ceiling is underwriting-grounded: 10%+ vacancy is where lease-up
 risk and absorption pace materially threaten LIHTC underwriting.
 
-**Legacy fallback**: when the tract data predates the rental-vacancy fields
-(or a buffer has no rental universe at all), scoring falls back to the
-historical behavior — total vacancy at a 0.12 ceiling, suppressed input
-defaulting to 0.05 (neutral ≈ 58) — and the dimension note discloses
-`legacy_total_vacancy` as the basis. This exists only for stale data files;
-current pipelines always emit the rental fields.
+**Fallbacks**:
 
-**Known limitation — STR contamination in resort cores.** ACS classifies
-units actively listed for rent as "For rent" (`B25004_002E`) regardless of
-whether they are offered as long-term housing or short-term/vacation
-rentals. In STR-saturated resort markets this inflates rental vacancy far
-above the long-term-market reality (2019–2023 ACS: Summit County's rental
-universe is ~38% "for rent" county-wide — clearly STR stock, not workforce-
-available vacancies), so buffers centered on resort cores still floor at 0
-on this dimension. This is a data limitation, not a formula error: ACS has
-no STR/long-term split. The switch to rental vacancy fixed the metro and
-non-resort mountain counties (Denver ~5%, La Plata ~7% — sensible scores)
-and removed the worst of the seasonal-homes inversion, but resort-core
-Land/Supply scores should be read alongside local STR-license and
-long-term-listing data until a refinement lands (see #1171).
+- When tract data predates the `vacant_seasonal` field, scoring uses raw
+  `rental_vacancy_rate` (`rental_vacancy` basis) at the same 0.10 ceiling.
+- When tract data predates all rental-vacancy fields (or a buffer has no rental
+  universe at all), scoring falls back to the historical behavior — total
+  vacancy at a 0.12 ceiling, suppressed input defaulting to 0.05 (neutral ≈ 58)
+  — and the dimension note discloses `legacy_total_vacancy` as the basis.
+
+**Known limitation — residual STR contamination in resort cores.** ACS still
+does not identify short-term rentals directly. The seasonal-share discount
+mitigates the worst resort-core inversion, but it can under- or over-discount
+where seasonal housing and STR licenses diverge. Read adjusted resort-market
+scores alongside local STR-license and long-term-listing data.
 
 Buffers meeting **both** of the following are automatically flagged
 "STR-DISTORTED" in the dimension note (`PMAMarketScoring.isStrDistorted`,
-disclosure only — the score itself is unchanged):
+disclosure only):
 
-- `rental_vacancy_rate ≥ 0.08` (score ≤ 20 — materially depressed), and
+- `str_adjusted_rental_vacancy_rate ≥ 0.08` when present, otherwise raw
+  `rental_vacancy_rate ≥ 0.08` for stale data (score ≤ 20 — materially
+  depressed), and
 - total `vacancy_rate ≥ 0.25` (seasonal-dominated market, the STR tell).
 
-Calibrated against 2019–2023 county aggregates: flags Summit, Eagle,
-Pitkin, Gunnison, San Miguel, and Archuleta buffers; does not flag
-Denver/Boulder (low on both), La Plata (score not floored), tight-but-
-seasonal towns like Leadville (rental vacancy near 0 — score not
-depressed), or a genuinely soft non-seasonal market (high rental, low
-total vacancy — real oversupply, not STR).
+Residual flags mean the proxy-adjusted rate is still high in a seasonal-
+dominated market; they do not change the score.
 
 ### 5. Workforce (15%)
 

--- a/js/market-analysis-scoring.js
+++ b/js/market-analysis-scoring.js
@@ -176,18 +176,20 @@
     return { score: Math.round(score), ratio: ratio, amiUsed: countyAmi, amiSource: 'county', unavailable: false };
   }
 
-  // #1163 — the Land/Supply vacancy signal scores RENTAL vacancy (Census HVS
-  // convention) against a single 0.10 ceiling. Total ACS vacancy counts
-  // seasonal/second homes as vacant, which scored every Colorado resort
-  // county 0 (Summit: 63% median tract "vacancy") — an inverted signal in
-  // exactly the markets this platform serves. 0.10 is the underwriting-
-  // grounded ceiling (10%+ vacancy materially threatens LIHTC lease-up);
-  // the old 0.12 survives only in the legacy fallback below for data files
-  // that predate the rental-vacancy fields.
+  // #1163/#1171 — the Land/Supply vacancy signal scores RENTAL vacancy
+  // (Census HVS convention) against a single 0.10 ceiling. Current tract data
+  // applies a seasonal-share discount to vacant-for-rent as an STR proxy before
+  // scoring; raw rental vacancy and legacy total vacancy remain fallbacks for
+  // stale data files.
   var RENTAL_VACANCY_CEILING = 0.10;
   var LEGACY_TOTAL_VACANCY_CEILING = 0.12;
 
   function scoreMarketTightnessDetail(acs) {
+    var strAdjusted = acs ? Number(acs.str_adjusted_rental_vacancy_rate) : NaN;
+    if (acs && acs.str_adjusted_rental_vacancy_rate != null && isFinite(strAdjusted)) {
+      var adjustedScore = Math.max(0, Math.min(100, (1 - strAdjusted / RENTAL_VACANCY_CEILING) * 100));
+      return { score: Math.round(adjustedScore), basis: 'rental_vacancy_str_adjusted' };
+    }
     var rental = acs ? Number(acs.rental_vacancy_rate) : NaN;
     if (acs && acs.rental_vacancy_rate != null && isFinite(rental)) {
       var score = Math.max(0, Math.min(100, (1 - rental / RENTAL_VACANCY_CEILING) * 100));
@@ -205,27 +207,22 @@
     return scoreMarketTightnessDetail(acs).score;
   }
 
-  // #1171 — STR-distortion disclosure. ACS B25004_002E counts short-term/
-  // vacation rental listings as "for rent", so in STR-saturated resort
-  // cores rental vacancy reads far above the long-term market (Summit:
-  // ~38% of the county rental universe). Flag a buffer as STR-distorted
-  // when BOTH hold:
-  //   - rental vacancy >= 0.08 (score <= 20 — materially depressed), AND
-  //   - total vacancy >= 0.25 (seasonal-dominated market, the STR tell).
-  // Calibrated against 2019-2023 county aggregates: flags Summit, Eagle,
-  // Pitkin, Gunnison, San Miguel, Archuleta; does NOT flag Denver/Boulder
-  // (low both), La Plata (score 27, mixed), Lake/Leadville (rental tight —
-  // score not depressed), or a hypothetical soft metro (high rental, low
-  // total — genuine oversupply, not STR). Disclosure only; the score is
-  // unchanged. Real refinement options tracked in #1171.
+  // #1171 — residual STR-distortion disclosure. Prefer the STR-adjusted
+  // vacancy rate when present; raw rental vacancy is the stale-data fallback.
+  // Most resort-core buffers should stop flagging after the seasonal-share
+  // proxy discount. Residual flags mean the adjusted rate is still materially
+  // depressed in a seasonal-dominated market and should be verified locally.
   var STR_FLAG_RENTAL_VACANCY_MIN = 0.08;
   var STR_FLAG_TOTAL_VACANCY_MIN = 0.25;
 
   function isStrDistorted(acs) {
     if (!acs) return false;
-    var rental = Number(acs.rental_vacancy_rate);
+    var basis = acs.str_adjusted_rental_vacancy_rate != null
+      ? acs.str_adjusted_rental_vacancy_rate
+      : acs.rental_vacancy_rate;
+    var rental = Number(basis);
     var total = Number(acs.vacancy_rate);
-    return acs.rental_vacancy_rate != null && isFinite(rental) &&
+    return basis != null && isFinite(rental) &&
            acs.vacancy_rate != null && isFinite(total) &&
            rental >= STR_FLAG_RENTAL_VACANCY_MIN &&
            total >= STR_FLAG_TOTAL_VACANCY_MIN;

--- a/js/market-analysis.js
+++ b/js/market-analysis.js
@@ -412,7 +412,7 @@
       bachelors_sum: 0, bachelors_n: 0,
       // #1163 — rental-vacancy counts (apportioned), so the buffer-level
       // rate is derived from summed counts, not averaged tract rates.
-      vacant_for_rent: 0, rented_not_occupied: 0,
+      vacant_for_rent: 0, rented_not_occupied: 0, vacant_seasonal: 0,
       renter_by_structure: null,  // initialized lazily below
       n: 0
     };
@@ -434,6 +434,7 @@
       totals.vacant       += (m.vacant       || 0) * share;
       totals.vacant_for_rent     += (m.vacant_for_rent     || 0) * share;
       totals.rented_not_occupied += (m.rented_not_occupied || 0) * share;
+      totals.vacant_seasonal     += (m.vacant_seasonal     || 0) * share;
       // Rates are unweighted averages — don't multiply by share.
       totals.rent_sum     += m.median_gross_rent  || 0;
       totals.income_sum   += m.median_hh_income   || 0;
@@ -488,6 +489,11 @@
       STRUCT_KEYS.forEach(function (k) { rbs[k] = Math.round(rbs[k]); });
     }
 
+    var rentalUniverse = totals.renter_hh + totals.vacant_for_rent + totals.rented_not_occupied;
+    var seasonalShare = totals.vacant > 0 ? Math.min(1, Math.max(0, totals.vacant_seasonal / totals.vacant)) : 0;
+    var strAdjustedVacantForRent = totals.vacant_for_rent * (1 - seasonalShare);
+    var strAdjustedRentalUniverse = totals.renter_hh + strAdjustedVacantForRent + totals.rented_not_occupied;
+
     return {
       // F80: round the apportioned floats back to whole counts for display.
       pop:              Math.round(totals.pop),
@@ -503,8 +509,14 @@
       // scoring's legacy fallback handles that case.
       vacant_for_rent:     Math.round(totals.vacant_for_rent),
       rented_not_occupied: Math.round(totals.rented_not_occupied),
-      rental_vacancy_rate: (totals.renter_hh + totals.vacant_for_rent + totals.rented_not_occupied) > 0
-        ? totals.vacant_for_rent / (totals.renter_hh + totals.vacant_for_rent + totals.rented_not_occupied)
+      vacant_seasonal:     Math.round(totals.vacant_seasonal),
+      seasonal_vacancy_share: seasonalShare,
+      str_adjusted_vacant_for_rent: Math.round(strAdjustedVacantForRent),
+      rental_vacancy_rate: rentalUniverse > 0
+        ? totals.vacant_for_rent / rentalUniverse
+        : null,
+      str_adjusted_rental_vacancy_rate: strAdjustedRentalUniverse > 0
+        ? strAdjustedVacantForRent / strAdjustedRentalUniverse
         : null,
       severe_cost_burden_rate: totals.severe_burden_n
         ? totals.severe_burden_sum / totals.severe_burden_n : null,
@@ -894,12 +906,12 @@
     // reports unavailable (ACS missing), fall back to the local
     // scoreMarketTightness which accepts a defaulted vacancy_rate.
     //
-    // #1163: both paths now score RENTAL vacancy against the single 0.10
-    // ceiling (PMAScoring.RENTAL_VACANCY_CEILING) — the #1149 divergence
-    // (0.10 Bridge-gated vs 0.12 default) is resolved. Enabling Bridge/MLS
+    // #1163/#1171: both paths score rental vacancy against the single 0.10
+    // ceiling (PMAScoring.RENTAL_VACANCY_CEILING), preferring the STR proxy
+    // rate when the tract data includes vacant_seasonal. Enabling Bridge/MLS
     // no longer changes the vacancy normalization, only adds the land-cost
-    // blend. Legacy total-vacancy fallback (0.12) exists solely for data
-    // files that predate the rental_vacancy_rate fields.
+    // blend. Raw rental vacancy and legacy total vacancy remain fallbacks for
+    // stale tract files.
     var _landResult = (SSS.scoreLandSupplyWithBridge && _bridgeLandCtx)
       ? SSS.scoreLandSupplyWithBridge(acs, _bridgeLandCtx)
       : null;
@@ -1056,11 +1068,13 @@
             (chasData && chasData.meta && chasData.meta.vintage ? chasData.meta.vintage : '?') +
             '), scaled to the PMA buffer using county income mix'
           : 'Ratio of total affordable units to ALL renter households in buffer (ACS total — over-counts LIHTC demand pool)',
-        marketTightness: (_mtDetail.basis === 'rental_vacancy'
-          ? 'Rental-vacancy signal (Census HVS convention: for-rent ÷ rental universe, 0.10 ceiling) — seasonal/second homes excluded; measures lease-up risk, NOT land availability'
-          : 'TOTAL vacancy rate signal (legacy fallback — rental-vacancy fields absent from tract data; includes seasonal units, which overstates softness in resort markets)')
+        marketTightness: (_mtDetail.basis === 'rental_vacancy_str_adjusted'
+          ? 'STR-adjusted rental-vacancy signal (Census HVS convention with seasonal-share discount applied as an STR proxy — verify against local STR-license data; 0.10 ceiling) — measures lease-up risk, NOT land availability'
+          : (_mtDetail.basis === 'rental_vacancy'
+            ? 'Rental-vacancy signal (Census HVS convention: for-rent ÷ rental universe, 0.10 ceiling; raw fallback because seasonal-vacancy field is absent) — measures lease-up risk, NOT land availability'
+            : 'TOTAL vacancy rate signal (legacy fallback — rental-vacancy fields absent from tract data; includes seasonal units, which overstates softness in resort markets)'))
           + (PMAScoring.isStrDistorted && PMAScoring.isStrDistorted(acs)
-            ? ' ⚠ STR-DISTORTED: ACS counts short-term/vacation rental listings as "for rent" — in this seasonal-dominated market the score likely understates long-term rental tightness. Verify against local STR-license and long-term listing data (#1171).'
+            ? ' ⚠ STR-DISTORTED: residual ACS short-term/vacation rental contamination may remain after the seasonal-share proxy discount. Verify against local STR-license and long-term listing data (#1171).'
             : ''),
         rentPressure:    rentPressureObj.unavailable
           ? 'Rent-pressure score unavailable — county 4-person AMI could not be resolved. Dimension excluded from overall.'

--- a/js/market-analysis/site-selection-score.js
+++ b/js/market-analysis/site-selection-score.js
@@ -603,13 +603,19 @@
         reason: 'ACS vacancy data unavailable'
       };
     }
-    // #1163 — prefer RENTAL vacancy (Census HVS convention). Total ACS
-    // vacancy counts seasonal/second homes as vacant, which reads resort
-    // counties as massively oversupplied (Summit: 63% median tract
-    // "vacancy") — the opposite of their actual rental-market condition.
-    // Same 0.10 ceiling as PMAMarketScoring.RENTAL_VACANCY_CEILING:
+    // #1163/#1171 — prefer the STR-adjusted rental vacancy proxy when present,
+    // then raw RENTAL vacancy (Census HVS convention), then legacy total
+    // vacancy. Same 0.10 ceiling as PMAMarketScoring.RENTAL_VACANCY_CEILING:
     // 10%+ vacancy is where lease-up risk and absorption pace begin to
     // materially threaten LIHTC underwriting.
+    var adjusted = Number(acs.str_adjusted_rental_vacancy_rate);
+    if (acs.str_adjusted_rental_vacancy_rate != null && isFinite(adjusted)) {
+      return {
+        score: _clamp(Math.round((1 - adjusted / 0.10) * 100)),
+        unavailable: false,
+        basis: 'rental_vacancy_str_adjusted'
+      };
+    }
     var rental = Number(acs.rental_vacancy_rate);
     if (acs.rental_vacancy_rate != null && isFinite(rental)) {
       return {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "audit:public-artifact": "node scripts/audit/public-artifact-guard.mjs dist",
     "audit:duplicate-artifacts": "node scripts/audit/duplicate-artifact-scan.mjs",
     "audit:benchmark-freshness": "node scripts/audit/benchmark-freshness-check.mjs",
+    "audit:str-discount-calibration": "node scripts/audit/str-discount-calibration.mjs",
     "audit:opportunity-finder": "node scripts/audit/verify-opportunity-finder.mjs",
     "audit:repo-links": "node scripts/audit/repo-link-audit.mjs",
     "audit:repo-links:probe": "node scripts/audit/repo-link-audit.mjs --probe",

--- a/scripts/audit/str-discount-calibration.mjs
+++ b/scripts/audit/str-discount-calibration.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/*
+ * Warn-only calibration for the PMA STR seasonal-share discount (#1171).
+ *
+ * Licensed STR counts are not ACS vacant-for-rent units: they differ by
+ * universe, date, and collection method. This script compares only the order
+ * of magnitude of units removed by the seasonal-share proxy. It never fails
+ * the build and must not be wired into test:ci.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..');
+
+function readJson(rel) {
+  return JSON.parse(fs.readFileSync(path.join(ROOT, rel), 'utf8'));
+}
+
+function fmt(n, digits = 1) {
+  return Number.isFinite(n) ? n.toFixed(digits) : 'n/a';
+}
+
+function loadAcsIndex() {
+  const data = readJson('data/market/acs_tract_metrics_co.json');
+  const idx = new Map();
+  for (const tract of data.tracts || []) {
+    idx.set(String(tract.geoid), tract);
+  }
+  return idx;
+}
+
+function countyRows(acsIdx, countyGeoid) {
+  const rows = [];
+  for (const [geoid, tract] of acsIdx.entries()) {
+    if (geoid.startsWith(countyGeoid)) rows.push({ tract, share: 1 });
+  }
+  return rows;
+}
+
+function placeRows(acsIdx, memberships, placeGeoid) {
+  const place = memberships.places && memberships.places[placeGeoid];
+  if (!place || !Array.isArray(place.tracts)) return [];
+  return place.tracts
+    .map((member) => ({
+      tract: acsIdx.get(String(member.tract_geoid)),
+      share: Number(member.share_of_tract_area)
+    }))
+    .filter((row) => row.tract && Number.isFinite(row.share) && row.share > 0);
+}
+
+function aggregate(rows) {
+  const totals = rows.reduce((acc, row) => {
+    const t = row.tract;
+    const share = row.share;
+    acc.vacant += (Number(t.vacant) || 0) * share;
+    acc.vacantSeasonal += (Number(t.vacant_seasonal) || 0) * share;
+    acc.vacantForRent += (Number(t.vacant_for_rent) || 0) * share;
+    acc.renterHh += (Number(t.renter_hh) || 0) * share;
+    acc.rentedNotOccupied += (Number(t.rented_not_occupied) || 0) * share;
+    return acc;
+  }, {
+    vacant: 0,
+    vacantSeasonal: 0,
+    vacantForRent: 0,
+    renterHh: 0,
+    rentedNotOccupied: 0
+  });
+
+  const seasonalShare = totals.vacant > 0
+    ? Math.min(1, Math.max(0, totals.vacantSeasonal / totals.vacant))
+    : 0;
+  const removedUnits = totals.vacantForRent * seasonalShare;
+  const rawUniverse = totals.renterHh + totals.vacantForRent + totals.rentedNotOccupied;
+  const adjustedForRent = totals.vacantForRent - removedUnits;
+  const adjustedUniverse = totals.renterHh + adjustedForRent + totals.rentedNotOccupied;
+
+  return {
+    ...totals,
+    seasonalShare,
+    removedUnits,
+    rawRentalVacancy: rawUniverse > 0 ? totals.vacantForRent / rawUniverse : null,
+    adjustedRentalVacancy: adjustedUniverse > 0 ? adjustedForRent / adjustedUniverse : null
+  };
+}
+
+function main() {
+  const benchmark = readJson('data/benchmarks/str-license-counts.json');
+  const acsIdx = loadAcsIndex();
+  const memberships = readJson('data/hna/place-tract-membership.json');
+  const entries = benchmark.entries || [];
+  const warnings = [];
+
+  console.log('STR seasonal-discount calibration (warn-only)');
+  console.log('Licensed STR counts != ACS vacant-for-rent units; compare order of magnitude only.');
+  console.log('');
+  console.log([
+    'jurisdiction'.padEnd(22),
+    'license'.padStart(8),
+    'removed'.padStart(9),
+    'ratio'.padStart(7),
+    'seasonal'.padStart(9),
+    'raw rv'.padStart(8),
+    'adj rv'.padStart(8),
+    'note'
+  ].join('  '));
+
+  for (const entry of entries) {
+    const rows = entry.geography_level === 'county'
+      ? countyRows(acsIdx, String(entry.geoid))
+      : placeRows(acsIdx, memberships, String(entry.geoid));
+    if (!rows.length) {
+      warnings.push(`${entry.jurisdiction}: no tract rows found for ${entry.geoid}`);
+      continue;
+    }
+
+    const result = aggregate(rows);
+    const licensed = Number(entry.licensed_str_units);
+    const ratio = licensed > 0 ? result.removedUnits / licensed : null;
+    let note = 'ok';
+    if (licensed > 0 && ratio > 1.5) {
+      note = 'warn: removed >1.5x licenses';
+      warnings.push(`${entry.jurisdiction}: removed ${fmt(result.removedUnits)} > 1.5x licensed ${licensed}`);
+    } else if (licensed > 0 && result.seasonalShare >= 0.25 && ratio < 0.1) {
+      note = 'warn: removed <0.1x licenses';
+      warnings.push(`${entry.jurisdiction}: seasonal-dominated but removed ${fmt(result.removedUnits)} < 0.1x licensed ${licensed}`);
+    }
+
+    console.log([
+      entry.jurisdiction.padEnd(22),
+      String(licensed).padStart(8),
+      fmt(result.removedUnits).padStart(9),
+      (ratio == null ? 'n/a' : fmt(ratio, 2)).padStart(7),
+      (fmt(result.seasonalShare * 100, 1) + '%').padStart(9),
+      (fmt((result.rawRentalVacancy || 0) * 100, 1) + '%').padStart(8),
+      (fmt((result.adjustedRentalVacancy || 0) * 100, 1) + '%').padStart(8),
+      note
+    ].join('  '));
+  }
+
+  if (warnings.length) {
+    console.warn('');
+    console.warn('Warnings:');
+    warnings.forEach((warning) => console.warn(`- ${warning}`));
+  }
+  console.log('');
+  console.log('Calibration complete: warn-only, exit 0.');
+}
+
+main();

--- a/test/pma-scoring.test.js
+++ b/test/pma-scoring.test.js
@@ -356,6 +356,49 @@ test('scoreMarketTightness prefers rental vacancy over resort-inflated total vac
     'plain scoreMarketTightness returns the same rental-based score');
 });
 
+test('scoreMarketTightness prefers STR-adjusted rental vacancy when present', () => {
+  const detail = Scoring.scoreMarketTightnessDetail({
+    vacancy_rate: 0.69,
+    rental_vacancy_rate: 0.51,
+    str_adjusted_rental_vacancy_rate: 0.075
+  });
+  assert(detail.basis === 'rental_vacancy_str_adjusted', 'STR-adjusted rental basis is reported');
+  assert(detail.score === 25, `7.5% adjusted rental vacancy scores 25 under the 0.10 ceiling (got ${detail.score})`);
+  assert(Scoring.scoreMarketTightness({
+    rental_vacancy_rate: 0.51,
+    str_adjusted_rental_vacancy_rate: 0.075
+  }) === 25, 'plain scoreMarketTightness uses the adjusted basis');
+});
+
+test('STR-adjusted vacancy formula fixtures match buffer-count method', () => {
+  function adjustedRate(renterHh, vacant, vacantForRent, rentedNotOccupied, vacantSeasonal) {
+    const seasonalShare = vacant > 0 ? Math.min(1, Math.max(0, vacantSeasonal / vacant)) : 0;
+    const adjustedForRent = vacantForRent * (1 - seasonalShare);
+    const universe = renterHh + adjustedForRent + rentedNotOccupied;
+    return universe > 0 ? adjustedForRent / universe : null;
+  }
+
+  const seasonalDominated = adjustedRate(3801, 19502, 2447, 182, 15847);
+  assertClose(seasonalDominated, 0.1033, 0.0002,
+    'Summit-style seasonal-dominated fixture discounts raw 38.1% rental vacancy to low-teens');
+  assert(Scoring.scoreMarketTightness({
+    rental_vacancy_rate: 2447 / (3801 + 2447 + 182),
+    str_adjusted_rental_vacancy_rate: seasonalDominated
+  }) === 0, 'low-teens adjusted rate still hits the 0.10 ceiling');
+
+  const zeroSeasonal = adjustedRate(900, 100, 50, 10, 0);
+  assertClose(zeroSeasonal, 50 / (900 + 50 + 10), 1e-12,
+    'zero-seasonal fixture leaves raw rental vacancy unchanged');
+  assert(Scoring.scoreMarketTightnessDetail({
+    rental_vacancy_rate: zeroSeasonal,
+    str_adjusted_rental_vacancy_rate: zeroSeasonal
+  }).basis === 'rental_vacancy_str_adjusted', 'zero-seasonal current data still reports adjusted basis');
+
+  const zeroVacant = adjustedRate(800, 0, 20, 5, 30);
+  assertClose(zeroVacant, 20 / (800 + 20 + 5), 1e-12,
+    'zero-vacant fixture clamps seasonal share to 0 instead of dividing by zero');
+});
+
 test('rental-vacancy ceiling boundaries', () => {
   assert(Scoring.scoreMarketTightness({ rental_vacancy_rate: 0.10 }) === 0,
     '10% rental vacancy scores 0 (ceiling)');
@@ -374,14 +417,23 @@ test('legacy fallback preserves historical total-vacancy behavior when rental fi
   assert(nullRental.basis === 'legacy_total_vacancy', 'null rental universe routes to legacy fallback');
 });
 
-// #1171 — STR-distortion disclosure predicate. Flags only when the score is
-// materially depressed (rental >= 0.08) AND the market is seasonal-dominated
-// (total >= 0.25). Disclosure-only: the score itself is unchanged.
-test('isStrDistorted flags STR-saturated resort buffers and nothing else', () => {
+// #1171 — STR-distortion disclosure predicate. After the seasonal-share
+// discount, flags only residual cases where the adjusted score is still
+// materially depressed (adjusted rental >= 0.08) AND the market is seasonal-
+// dominated (total >= 0.25). Raw rental vacancy remains the stale-data fallback.
+test('isStrDistorted evaluates adjusted rental vacancy when present', () => {
+  assert(Scoring.isStrDistorted({
+    rental_vacancy_rate: 0.51,
+    str_adjusted_rental_vacancy_rate: 0.06,
+    vacancy_rate: 0.69
+  }) === false, 'Breckenridge-style buffer stops flagging when adjusted rate drops below 8%');
+  assert(Scoring.isStrDistorted({
+    rental_vacancy_rate: 0.51,
+    str_adjusted_rental_vacancy_rate: 0.11,
+    vacancy_rate: 0.69
+  }) === true, 'residual high adjusted vacancy still flags');
   assert(Scoring.isStrDistorted({ rental_vacancy_rate: 0.51, vacancy_rate: 0.69 }) === true,
-    'Breckenridge-style buffer (51% rental / 69% total) is flagged');
-  assert(Scoring.isStrDistorted({ rental_vacancy_rate: 0.11, vacancy_rate: 0.32 }) === true,
-    'Pitkin-style buffer (11% / 32%) is flagged');
+    'stale data without adjusted rate falls back to raw rental vacancy');
   assert(Scoring.isStrDistorted({ rental_vacancy_rate: 0.05, vacancy_rate: 0.077 }) === false,
     'Denver-style buffer (5% / 7.7%) is not flagged');
   assert(Scoring.isStrDistorted({ rental_vacancy_rate: 0.16, vacancy_rate: 0.10 }) === false,
@@ -391,20 +443,25 @@ test('isStrDistorted flags STR-saturated resort buffers and nothing else', () =>
   assert(Scoring.isStrDistorted({ vacancy_rate: 0.40 }) === false,
     'missing rental field never flags (legacy data)');
   assert(Scoring.isStrDistorted(null) === false, 'null acs never flags');
-  // score is unchanged by the flag — disclosure only
-  assert(Scoring.scoreMarketTightness({ rental_vacancy_rate: 0.51, vacancy_rate: 0.69 }) === 0,
-    'flagged buffer still scores on the same formula');
+  assert(Scoring.scoreMarketTightness({
+    rental_vacancy_rate: 0.51,
+    str_adjusted_rental_vacancy_rate: 0.06,
+    vacancy_rate: 0.69
+  }) === 40, 'adjusted fixture moves score off 0');
   // the dimension note wiring exists in computePma
   const engine = fs.readFileSync(path.resolve(__dirname, '..', 'js', 'market-analysis.js'), 'utf8');
   assert(engine.includes('isStrDistorted'), 'computePma consults isStrDistorted for the dimension note');
-  assert(engine.includes('STR-DISTORTED'), 'dimension note carries the STR-DISTORTED warning text');
+  assert(engine.includes('seasonal-share discount applied as an STR proxy'),
+    'dimension note discloses the STR proxy basis');
 });
 
-// Anti-re-divergence guard (#1149/#1163): both scoring files must normalize
-// rental vacancy against the same 0.10 ceiling. If either drifts, this fails.
-test('both Land/Supply code paths score rental vacancy at the 0.10 ceiling', () => {
+// Anti-re-divergence guard (#1149/#1163/#1171): both scoring files must prefer
+// the STR-adjusted rental basis and normalize against the same 0.10 ceiling.
+test('both Land/Supply code paths prefer STR-adjusted rental vacancy at the 0.10 ceiling', () => {
   const sss = fs.readFileSync(
     path.resolve(__dirname, '..', 'js', 'market-analysis', 'site-selection-score.js'), 'utf8');
+  assert(sss.includes('str_adjusted_rental_vacancy_rate'), 'site-selection-score.js consumes adjusted rental vacancy');
+  assert(/adjusted\s*\/\s*0\.10/.test(sss), 'site-selection-score.js normalizes adjusted vacancy against 0.10');
   assert(sss.includes('rental_vacancy_rate'), 'site-selection-score.js consumes rental_vacancy_rate');
   assert(/rental\s*\/\s*0\.10/.test(sss), 'site-selection-score.js normalizes rental vacancy against 0.10');
 
@@ -415,6 +472,8 @@ test('both Land/Supply code paths score rental vacancy at the 0.10 ceiling', () 
 
   const engine = fs.readFileSync(path.resolve(__dirname, '..', 'js', 'market-analysis.js'), 'utf8');
   assert(engine.includes('rental_vacancy_rate'), 'aggregateAcs derives buffer-level rental_vacancy_rate');
+  assert(engine.includes('str_adjusted_rental_vacancy_rate'), 'aggregateAcs derives buffer-level adjusted rental vacancy');
+  assert(engine.includes('vacant_seasonal'), 'aggregateAcs sums vacant_seasonal counts');
   assert(engine.includes('scoreMarketTightnessDetail'), 'computePma uses the basis-aware detail for disclosure');
 });
 


### PR DESCRIPTION
## Summary
- Derive buffer-level str_adjusted_rental_vacancy_rate from apportioned ACS counts: seasonal_share = sum(vacant_seasonal) / sum(vacant), then discount vacant_for_rent by that share.
- Prefer the adjusted basis in both PMA Land/Supply scoring paths, preserving raw rental vacancy and legacy total-vacancy fallbacks.
- Update STR-DISTORTED to evaluate the adjusted rate when present and update PMA_SCORING.md to document the formula, proxy caveat, fallbacks, and residual warning behavior.
- Add a warn-only STR license calibration benchmark/checker. License counts are advisory only and not wired into test:ci.

Do not merge until external QA completes. Claude should QA before owner merge.

## Anti-fabrication / benchmark sources
All benchmark rows were fetched from official government ArcGIS/open-data endpoints on 2026-07-14. Included rows: Denver, Manitou Springs, Lyons, Lake County, Clear Creek County. I excluded a Clear Creek parcel-expanded raw count until querying distinct active licenseNumber produced a clean count.

## Calibration checker output
npm run audit:str-discount-calibration exits 0 and prints:
- Denver: 2,386 licenses; 1,161.1 removed; ratio 0.49; adjusted RV 4.3%; ok
- Manitou Springs: 51 licenses; 0.0 removed; warning (<0.1x licenses)
- Lyons: 16 licenses; 0.0 removed; warning (<0.1x licenses)
- Lake County: 132 licenses; 0.0 removed; warning (<0.1x licenses)
- Clear Creek County: 154 licenses; 68.7 removed; ratio 0.45; adjusted RV 3.5%; ok

Those warnings are intentional: they show places/counties with seasonal stock but no ACS for-rent units to discount, i.e. a real proxy limitation.

## Live browser smoke
Local Playwright against http://localhost:3000/market-analysis.html, zero console/page errors:
- Denver 3-mi: raw rental vacancy 5.55% -> adjusted 5.22%; Market Tightness 48; adjusted proxy note visible.
- Durango 3-mi: raw 8.02% -> adjusted 5.52%; Market Tightness 45; adjusted proxy note visible.
- Breckenridge 3-mi: raw 55.37% -> adjusted 20.85%; Market Tightness remains 0 and residual STR-DISTORTED warning is visible.

Important QA note: the handoff expected Breckenridge to move off 0. With the current rebuilt tract data (#1201) and the exact requested formula where discounted units leave numerator and denominator, Breckenridge improves directionally but remains above the 0.10 ceiling. I did not tune the formula away from the owner-approved spec to force that expected value.

## Gates run
- npm run validate: pass
- npm run test:pma-scoring: 134 passed, 0 failed
- npm run audit:str-discount-calibration: exits 0 with table/warnings above
- npm run test:ci: pass

## Non-vacuousness
- Unit fixtures prove adjusted basis is preferred over raw rental vacancy and legacy total vacancy.
- Fixture matrix covers seasonal-dominated, zero-seasonal, zero-vacant, missing adjusted field fallback, ceiling unchanged, and residual flag behavior.
- Anti-re-divergence guard asserts both scoring paths consume str_adjusted_rental_vacancy_rate and keep the 0.10 ceiling.
- Live browser smoke confirms the adjusted basis appears in rendered PMA result metadata and no console errors occur.

## Out of scope honored
- No license counts are used in scoring.
- No AirDNA/commercial data.
- No suppressed-vacancy weight redistribution work.