### PR TITLE
fix(hna): add county home values to ownership screen

### DIFF
--- a/data/hna/home-value-cascade.json
+++ b/data/hna/home-value-cascade.json
@@ -1,9 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-27T03:57:02.823Z",
-    "schema": "median_home_value = { value, source, as_of, confidence }",
+    "generated_at": "2026-07-14T14:00:27.653Z",
+    "schema": "median_home_value = { value, source, as_of, confidence }; counties are display-only affordability inputs and are ignored by rank/score models",
     "sources": {
       "zhvi_city_csv": "https://files.zillowstatic.com/research/public_csvs/zhvi/City_zhvi_uc_sfrcondo_tier_0.33_0.67_sm_sa_month.csv",
+      "zhvi_county_csv": null,
       "acs_raw": "ACS DP04_0089E, 2020-2024 5-year"
     },
     "latest_zhvi_month": "2026-05-31",
@@ -11,8 +12,14 @@
     "counts": {
       "zhvi": 264,
       "acs_raw": 218,
-      "total": 482
-    }
+      "total": 482,
+      "counties": {
+        "acs_raw": 64,
+        "missing": 0,
+        "total": 64
+      }
+    },
+    "build_note": "Local Zillow city ZHVI CSV absent; preserved committed place rows and rebuilt county rows from committed ACS summary caches."
   },
   "places": {
     "0800320": {
@@ -3434,6 +3441,456 @@
       "confidence": "high",
       "zillow_region_id": "29333",
       "acs_raw_value": 165500
+    }
+  },
+  "counties": {
+    "08001": {
+      "value": 519500,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08003": {
+      "value": 239100,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08005": {
+      "value": 589300,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08007": {
+      "value": 478100,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08009": {
+      "value": 122900,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08011": {
+      "value": 146900,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08013": {
+      "value": 783000,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08014": {
+      "value": 686200,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08015": {
+      "value": 665700,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08017": {
+      "value": 187500,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08019": {
+      "value": 608500,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08021": {
+      "value": 193400,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08023": {
+      "value": 184700,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08025": {
+      "value": 116200,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08027": {
+      "value": 392100,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08029": {
+      "value": 343200,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08031": {
+      "value": 636400,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08033": {
+      "value": 247600,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08035": {
+      "value": 742700,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08037": {
+      "value": 839500,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08039": {
+      "value": 709800,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08041": {
+      "value": 486000,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08043": {
+      "value": 324000,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08045": {
+      "value": 527800,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08047": {
+      "value": 573900,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08049": {
+      "value": 601500,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08051": {
+      "value": 621800,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08053": {
+      "value": 437900,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08055": {
+      "value": 247800,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08057": {
+      "value": 239600,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08059": {
+      "value": 668600,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08061": {
+      "value": 161500,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08063": {
+      "value": 239500,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08065": {
+      "value": 466100,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08067": {
+      "value": 591500,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08069": {
+      "value": 610000,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08071": {
+      "value": 237600,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08073": {
+      "value": 246500,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08075": {
+      "value": 245300,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08077": {
+      "value": 410200,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08079": {
+      "value": 430500,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08081": {
+      "value": 289500,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08083": {
+      "value": 331400,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08085": {
+      "value": 388400,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08087": {
+      "value": 338600,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08089": {
+      "value": 168900,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08091": {
+      "value": 739800,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08093": {
+      "value": 532100,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08095": {
+      "value": 258200,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08097": {
+      "value": 1139100,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08099": {
+      "value": 160600,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08101": {
+      "value": 301800,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08103": {
+      "value": 274400,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08105": {
+      "value": 239500,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08107": {
+      "value": 854700,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08109": {
+      "value": 212600,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08111": {
+      "value": 432500,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08113": {
+      "value": 720700,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08115": {
+      "value": 149000,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08117": {
+      "value": 939900,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08119": {
+      "value": 479900,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08121": {
+      "value": 226200,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08123": {
+      "value": 496100,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
+    },
+    "08125": {
+      "value": 211700,
+      "source": "acs_raw",
+      "as_of": "ACS 2020-2024 5-year",
+      "confidence": "low",
+      "geography_level": "county"
     }
   },
   "review_flags": {

--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -3237,11 +3237,11 @@
     if (window.ChasTierShares && typeof window.ChasTierShares.init === 'function') {
       try { await window.ChasTierShares.init(); } catch (_) { /* soft-fail */ }
     }
-    // Affordable Ownership Need only uses the home-value cascade for
-    // place/CDP selections. Start it early but do not block the core CHAS
-    // and AMI-gap panels on this optional ownership-only input.
+    // Affordable Ownership Need uses the home-value cascade for place/CDP and
+    // county selections. Start it early but do not block the core CHAS and
+    // AMI-gap panels on this optional ownership-only input.
     let ownershipHomeValueCascadePromise = null;
-    if ((geoType === 'place' || geoType === 'cdp') && !window.HNAState.state.homeValueCascade) {
+    if ((geoType === 'place' || geoType === 'cdp' || geoType === 'county') && !window.HNAState.state.homeValueCascade) {
       ownershipHomeValueCascadePromise = loadJson('data/hna/home-value-cascade.json')
         .then((data) => { window.HNAState.state.homeValueCascade = data; return data; })
         .catch(() => { window.HNAState.state.homeValueCascade = null; return null; });

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -4720,6 +4720,10 @@
   }
 
   function _ownHomeValueForSelection(profile, geoType, geoid, homeValueData) {
+    if (geoType === 'county' && homeValueData && homeValueData.counties) {
+      var countyRec = homeValueData.counties[String(geoid)];
+      if (countyRec) return Object.assign({ geography_level: 'county' }, countyRec);
+    }
     if ((geoType === 'place' || geoType === 'cdp') && homeValueData && homeValueData.places) {
       var flagged = _ownReviewFlagSet(homeValueData.review_flags);
       var canonical = _ownCanonicalGeoid(geoid);

--- a/scripts/hna/build_home_value_cascade.mjs
+++ b/scripts/hna/build_home_value_cascade.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /**
- * Build current-market median home value display fields for HNA places.
+ * Build current-market median home value display fields for HNA places and
+ * county HNA ownership-affordability screens.
  *
  * Tier 1: Zillow city ZHVI, matched once into a GEOID -> RegionID crosswalk.
  * Tier 2: raw ACS DP04_0089E, labeled as a stale floor when no ZHVI row exists.
@@ -111,12 +112,42 @@ async function loadZhviRows() {
   return { byKey, latestAsOf: month.key, coRows };
 }
 
+function buildCountyAcsRows(registry) {
+  const counties = {};
+  let acsCount = 0;
+  let missingCount = 0;
+
+  for (const county of (registry.geographies || []).filter((geo) => geo.type === 'county').sort((a, b) => a.geoid.localeCompare(b.geoid))) {
+    const summaryPath = path.join(SUMMARY_DIR, `${county.geoid}.json`);
+    const summary = fs.existsSync(summaryPath) ? readJson(summaryPath) : null;
+    const profile = summary && summary.acsProfile || {};
+    const acsValue = Number(profile.DP04_0089E);
+    const hasValue = Number.isFinite(acsValue) && acsValue > 0;
+    counties[county.geoid] = {
+      value: hasValue ? acsValue : null,
+      source: 'acs_raw',
+      as_of: 'ACS 2020-2024 5-year',
+      confidence: hasValue ? 'low' : 'missing',
+      geography_level: 'county',
+    };
+    if (hasValue) acsCount += 1;
+    else missingCount += 1;
+  }
+
+  return { counties, acsCount, missingCount };
+}
+
 async function main() {
   const centroids = readJson(CENTROIDS).byGeoid || {};
   const placeCounties = readJson(PLACE_COUNTIES).places || {};
   const registry = readJson(REGISTRY);
   const countyNames = countyNamesByFips(registry);
-  const { byKey, latestAsOf, coRows } = await loadZhviRows();
+  const hasCityZhvi = fs.existsSync(ZHVI_CSV);
+  const existing = fs.existsSync(OUT) ? readJson(OUT) : {};
+  const zhviRows = hasCityZhvi ? await loadZhviRows() : null;
+  const byKey = zhviRows ? zhviRows.byKey : new Map();
+  const latestAsOf = zhviRows ? zhviRows.latestAsOf : (existing.meta && existing.meta.latest_zhvi_month) || null;
+  const coRows = zhviRows ? zhviRows.coRows : (existing.meta && existing.meta.colorado_zhvi_rows) || 0;
 
   const places = {};
   const crosswalk = {};
@@ -124,7 +155,17 @@ async function main() {
   let zhviCount = 0;
   let acsCount = 0;
 
-  for (const [geoid, place] of Object.entries(centroids).sort(([a], [b]) => a.localeCompare(b))) {
+  if (!hasCityZhvi && existing.places) {
+    Object.assign(places, existing.places);
+    const counts = existing.meta && existing.meta.counts || {};
+    zhviCount = Number(counts.zhvi) || Object.values(places).filter((row) => row && row.source === 'zhvi').length;
+    acsCount = Number(counts.acs_raw) || (Object.keys(places).length - zhviCount);
+    if (existing.review_flags && Array.isArray(existing.review_flags.zhvi_over_acs_ratio_gt_3)) {
+      review.push(...existing.review_flags.zhvi_over_acs_ratio_gt_3);
+    }
+  }
+
+  for (const [geoid, place] of hasCityZhvi ? Object.entries(centroids).sort(([a], [b]) => a.localeCompare(b)) : []) {
     const countyFips = placeCounties[geoid];
     const countyName = countyNames[countyFips];
     const summaryPath = path.join(SUMMARY_DIR, `${geoid}.json`);
@@ -178,33 +219,51 @@ async function main() {
     places[geoid] = display;
   }
 
+  const countyRows = buildCountyAcsRows(registry);
+
   fs.writeFileSync(OUT, JSON.stringify({
     meta: {
       generated_at: new Date().toISOString(),
-      schema: 'median_home_value = { value, source, as_of, confidence }',
+      schema: 'median_home_value = { value, source, as_of, confidence }; counties are display-only affordability inputs and are ignored by rank/score models',
       sources: {
         zhvi_city_csv: 'https://files.zillowstatic.com/research/public_csvs/zhvi/City_zhvi_uc_sfrcondo_tier_0.33_0.67_sm_sa_month.csv',
+        zhvi_county_csv: null,
         acs_raw: 'ACS DP04_0089E, 2020-2024 5-year',
       },
       latest_zhvi_month: latestAsOf,
       colorado_zhvi_rows: coRows,
-      counts: { zhvi: zhviCount, acs_raw: acsCount, total: zhviCount + acsCount },
+      counts: {
+        zhvi: zhviCount,
+        acs_raw: acsCount,
+        total: zhviCount + acsCount,
+        counties: {
+          acs_raw: countyRows.acsCount,
+          missing: countyRows.missingCount,
+          total: Object.keys(countyRows.counties).length,
+        },
+      },
+      build_note: hasCityZhvi
+        ? 'Place rows rebuilt from local Zillow city ZHVI CSV.'
+        : 'Local Zillow city ZHVI CSV absent; preserved committed place rows and rebuilt county rows from committed ACS summary caches.',
     },
     places,
+    counties: countyRows.counties,
     review_flags: {
       zhvi_over_acs_ratio_gt_3: review,
     },
   }, null, 2) + '\n');
 
-  fs.writeFileSync(CROSSWALK_OUT, JSON.stringify({
-    meta: {
-      generated_at: new Date().toISOString(),
-      source: 'Derived from Census GEOID place names + containing county matched to Zillow city RegionID + CountyName.',
-      latest_zhvi_month: latestAsOf,
-      count: Object.keys(crosswalk).length,
-    },
-    places: crosswalk,
-  }, null, 2) + '\n');
+  if (hasCityZhvi) {
+    fs.writeFileSync(CROSSWALK_OUT, JSON.stringify({
+      meta: {
+        generated_at: new Date().toISOString(),
+        source: 'Derived from Census GEOID place names + containing county matched to Zillow city RegionID + CountyName.',
+        latest_zhvi_month: latestAsOf,
+        count: Object.keys(crosswalk).length,
+      },
+      places: crosswalk,
+    }, null, 2) + '\n');
+  }
 
   console.log(`home-value cascade: ${zhviCount} ZHVI, ${acsCount} ACS raw, ${review.length} review flags`);
 }

--- a/test/hna-home-value-cascade.test.js
+++ b/test/hna-home-value-cascade.test.js
@@ -12,6 +12,8 @@ const affordabilityPanel = fs.readFileSync(path.join(ROOT, 'js/affordability-met
 const hnaUtils = fs.readFileSync(path.join(ROOT, 'js/hna/hna-utils.js'), 'utf8');
 const hnaNarratives = fs.readFileSync(path.join(ROOT, 'js/hna/hna-narratives.js'), 'utf8');
 const hnaRenderers = fs.readFileSync(path.join(ROOT, 'js/hna/hna-renderers.js'), 'utf8');
+const hnaController = fs.readFileSync(path.join(ROOT, 'js/hna/hna-controller.js'), 'utf8');
+const ownershipNeed = fs.readFileSync(path.join(ROOT, 'js/hna/hna-ownership-need.js'), 'utf8');
 
 assert(fruitaHomeValue, 'Fruita summary should be stamped with median_home_value');
 assert.equal(fruitaHomeValue.source, 'zhvi', 'Fruita should use Zillow ZHVI as the display home value');
@@ -22,6 +24,17 @@ assert.deepStrictEqual(fruitaHomeValue, cascade.places['0828745'], 'Fruita summa
 const flags = cascade.review_flags && cascade.review_flags.zhvi_over_acs_ratio_gt_3 || [];
 assert(flags.some((row) => row.geoid === '0803620' && row.ratio > 3), 'Aspen should be flagged as ZHVI/ACS > 3x');
 assert.equal(cascade.meta.counts.total, 482, 'home-value cascade should cover all Colorado places in the public HNA set');
+assert.equal(cascade.meta.counts.counties.total, 64, 'home-value cascade should cover all Colorado counties');
+assert.equal(cascade.meta.counts.counties.acs_raw, 64, 'county home values should be populated from committed ACS summaries when no county ZHVI CSV exists');
+
+for (const geoid of ['08097', '08045']) {
+  const row = cascade.counties && cascade.counties[geoid];
+  const profile = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/hna/summary', `${geoid}.json`), 'utf8')).acsProfile;
+  assert(row, `${geoid}: county cascade row should exist`);
+  assert.equal(row.geography_level, 'county', `${geoid}: county cascade row should be labeled county`);
+  assert.equal(row.source, 'acs_raw', `${geoid}: county cascade row should use ACS fallback in this repo state`);
+  assert.equal(row.value, profile.DP04_0089E, `${geoid}: county cascade should match summary DP04_0089E`);
+}
 
 const adjustedSummaries = fs.readdirSync(path.join(ROOT, 'data/hna/summary'))
   .filter((file) => file.endsWith('.json'))
@@ -43,6 +56,31 @@ assert(/function renderAffordChart[\s\S]*homeValueInfo\(profile\)/.test(hnaRende
 assert(/function renderWageAffordability[\s\S]*homeValueInfo\(profile\)/.test(hnaRenderers), 'Wage affordability panel should use the home-value cascade helper');
 assert(!/function renderAffordChart[\s\S]{0,900}safeNum\(profile\.DP04_0089E\) \|\| 0/.test(hnaRenderers), 'Affordability chart should not fall back to raw DP04 directly');
 assert(!/function renderWageAffordability[\s\S]{0,900}profile && profile\.DP04_0089E/.test(hnaRenderers), 'Wage affordability panel should not read raw DP04 directly');
+assert(/geoType === 'place' \|\| geoType === 'cdp' \|\| geoType === 'county'/.test(hnaController), 'Controller should lazy-load home-value cascade for county ownership views');
+assert(/geoType === 'county'[\s\S]{0,220}homeValueData\.counties/.test(hnaRenderers), 'Ownership renderer should read county cascade rows before profile fallback');
+assert(/Object\.assign\(\{ geography_level: 'county' \}, countyRec\)/.test(hnaRenderers), 'Ownership renderer should mark county home-value rows as county inputs');
+
+const ownershipCtx = { window: {} };
+vm.createContext(ownershipCtx);
+vm.runInContext(ownershipNeed, ownershipCtx, { filename: 'js/hna/hna-ownership-need.js' });
+const countyChas = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/hna/chas_affordability_gap.json'), 'utf8')).counties;
+const countyAmiGapRows = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/co_ami_gap_by_county.json'), 'utf8')).counties;
+function countyAmiGap(geoid) {
+  return countyAmiGapRows.find((row) => row.fips === geoid);
+}
+for (const [geoid, label] of [['08097', 'Pitkin County'], ['08045', 'Garfield County']]) {
+  const result = ownershipCtx.window.HNAOwnershipNeed.computeOwnershipNeed({
+    geographyId: geoid,
+    geographyName: label,
+    geoLevel: 'county',
+    countyChasEntry: countyChas[geoid],
+    amiGapEntry: countyAmiGap(geoid),
+    homeValueEntry: cascade.counties[geoid],
+  });
+  assert(result.affordabilityTest, `${label}: county ownership computation should render an affordability classification`);
+  assert(['priced-out', 'stretch'].includes(result.affordabilityTest.classification), `${label}: resort-area county value should classify as priced-out or stretch`);
+  assert.equal(result.affordabilityTest.medianHomeValue, cascade.counties[geoid].value, `${label}: computation should use the county cascade value`);
+}
 
 const context = {
   window: {},


### PR DESCRIPTION
## Summary
- Closes #1187.
- Adds a display-only `counties` block to `data/hna/home-value-cascade.json` with all 64 Colorado counties sourced from committed county summary `DP04_0089E` values.
- Preserves committed place rows when the gitignored Zillow city CSV is absent, so this PR does not alter Aspen/Lamar/place behavior.
- Extends Affordable Ownership Need to read county cascade rows and updates the controller lazy-load gate so county selections actually load `home-value-cascade.json`.
- Do not merge until external QA completes.

## Independent Verification
- Checked `data/zillow/`: only `median_list_price_metro.csv`, `zhvi_metro.csv`, and `zori_metro.csv` exist; no county-level ZHVI CSV is available, so counties use ACS fallback only with no new external fetch.
- Builder county rows: `scripts/hna/build_home_value_cascade.mjs:115` reads county summary caches and writes `geography_level: county`; `scripts/hna/build_home_value_cascade.mjs:145` preserves existing place rows when the local city ZHVI CSV is absent; `scripts/hna/build_home_value_cascade.mjs:222` writes the county block.
- Renderer path: `js/hna/hna-renderers.js:4722` checks `homeValueData.counties[geoid]` before profile fallback.
- Controller path: `js/hna/hna-controller.js:3244` now lazy-loads the cascade for `county` selections.
- Test coverage: `test/hna-home-value-cascade.test.js:27` asserts 64 county rows; `test/hna-home-value-cascade.test.js:59` guards the controller load path; `test/hna-home-value-cascade.test.js:71` computes Pitkin/Garfield ownership classifications from county cascade rows.

## Evidence
- `npm run build:home-values`: `home-value cascade: 264 ZHVI, 218 ACS raw, 6 review flags` and county counts `{ acs_raw: 64, missing: 0, total: 64 }`.
- Place behavior unchanged: JSON comparison vs `origin/main:data/hna/home-value-cascade.json` showed `places same: true`; Aspen `0803620` and Lamar `0843110` rows were byte-equivalent.
- Pitkin County `08097`: `$1,139,100`, source `acs_raw`, modeled as `priced-out`.
- Garfield County `08045`: `$527,800`, source `acs_raw`, modeled as `priced-out`.
- Live browser smoke via local server and UI county selection: Pitkin and Garfield rendered county cascade rows, modeled classifications, and 0 console errors after routing localhost external asset fallbacks to local files.

## Tests
- `npm run test:hna-home-values` ✅
- `npm run test:ci` ✅

## Non-Vacuousness Proof
- The new test asserts 64 county cascade rows and recomputes Pitkin/Garfield affordability using `cascade.counties[geoid]`. Removing the `counties` block or removing `county` from the controller lazy-load condition makes `npm run test:hna-home-values` fail.
