### PR TITLE
fix(hna): anchor scenario growth bands to base year

### DIFF
--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -1176,7 +1176,8 @@
           Cohort-component forward projections under three growth scenarios, aligned with
           <a href="https://dlg.colorado.gov/news-article/final-housing-needs-assessment-methodology-and-displacement-risk-assessment-guidance" target="_blank" rel="noopener" style="color:var(--accent)" aria-label="DLG final HNA methodology and displacement risk assessment guidance (opens in new tab)">DLG HNA methodology</a>.
           Adjust scenario assumptions and switch views to compare population, household formation,
-          and housing demand by affordability tier.
+          and housing demand by affordability tier. Sensitivity bands share the observed base year
+          and scale only the projected growth increment.
         </p>
 
         <!-- Scenario selector row -->
@@ -1232,7 +1233,7 @@
           <div class="hna-grid" style="margin-top:0">
             <div class="chart-card span-8" style="margin:0">
               <h3 style="margin:0 0 4px;">Population projection by scenario</h3>
-              <p style="font-size:.82rem;color:var(--muted);margin:0 0 8px">Baseline, low, and high growth trajectories from DOLA SYA data.</p>
+              <p style="font-size:.82rem;color:var(--muted);margin:0 0 8px">Baseline plus growth-increment sensitivity bands from DOLA SYA data.</p>
               <div class="chart-box tall" data-source="DOLA SYA + Cohort-Component Scenarios" data-source-url="https://demography.dola.colorado.gov/assets/html/sdodata.html" data-vintage="DOLA 2024" data-source-type="modeled"><canvas id="chartScenarioComparison" role="img" aria-label="Scenario comparison chart"></canvas></div>
             </div>
             <div class="chart-card span-4" style="margin:0">

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -3592,6 +3592,17 @@
     });
   }
 
+  function _scenarioGrowthSensitivitySeries(baseline, growthFactor) {
+    const series = Array.isArray(baseline) ? baseline : [];
+    const p0 = series.find(v => v != null && Number.isFinite(Number(v)));
+    if (p0 == null || !Number.isFinite(Number(growthFactor))) return series.map(() => null);
+    const base = Number(p0);
+    return series.map((p) => {
+      const value = Number(p);
+      return Number.isFinite(value) ? base + (growthFactor * (value - base)) : null;
+    });
+  }
+
   /**
    * _renderScenarioSection — render scenario comparison charts.
    * @param {object} proj        - Projection data object
@@ -3623,17 +3634,17 @@
           tension: 0.25,
         };
       });
-      // Fallback when proj.scenarios is missing: synthesise three lines
-      // from popSel (DOLA forecast) + popSelTrend-style ±15% sensitivity.
+      // Fallback when proj.scenarios is missing: synthesise three lines from
+      // popSel (DOLA forecast) and scale only the projected growth increment.
       // This makes the chart render for ALL geographies, not just those
       // with explicit scenario series in the projection JSON.
       if (!datasets.some(d => d.data && d.data.length)) {
         const baseline = popSel || proj.population_dola || [];
         datasets.length = 0;
         datasets.push(
-          { label: 'Baseline (DOLA)',  data: baseline,                           borderColor: t.c1, borderWidth: 2, pointRadius: 0, tension: 0.25 },
-          { label: 'Low growth (-15%)', data: baseline.map(p => p ? p * 0.85 : null), borderColor: t.c5, borderWidth: 2, borderDash: [4,4], pointRadius: 0, tension: 0.25 },
-          { label: 'High growth (+15%)',data: baseline.map(p => p ? p * 1.15 : null), borderColor: t.c6, borderWidth: 2, borderDash: [4,4], pointRadius: 0, tension: 0.25 }
+          { label: 'Baseline (DOLA)', data: baseline, borderColor: t.c1, borderWidth: 2, pointRadius: 0, tension: 0.25 },
+          { label: 'Growth −15%', data: _scenarioGrowthSensitivitySeries(baseline, 0.85), borderColor: t.c5, borderWidth: 2, borderDash: [4,4], pointRadius: 0, tension: 0.25 },
+          { label: 'Growth +15%', data: _scenarioGrowthSensitivitySeries(baseline, 1.15), borderColor: t.c6, borderWidth: 2, borderDash: [4,4], pointRadius: 0, tension: 0.25 }
         );
       }
       makeChart(compCanvas.getContext('2d'), {
@@ -3663,10 +3674,10 @@
       let series = popSel;
       if (proj.scenarios && proj.scenarios[scenarioSel]) {
         series = proj.scenarios[scenarioSel].map(d => d.population || d.pop || 0);
-      } else if (scenarioSel === 'low') {
-        series = popSel.map(p => p ? p * 0.85 : null);
-      } else if (scenarioSel === 'high') {
-        series = popSel.map(p => p ? p * 1.15 : null);
+      } else if (scenarioSel === 'low_growth') {
+        series = _scenarioGrowthSensitivitySeries(popSel, 0.85);
+      } else if (scenarioSel === 'high_growth') {
+        series = _scenarioGrowthSensitivitySeries(popSel, 1.15);
       }
       makeChart(detailCanvas.getContext('2d'), {
         type: 'line',
@@ -8368,6 +8379,7 @@
     renderFastTrackCalculatorSection,
     renderHistoricalSection,
     renderComplianceTable,
+    _scenarioGrowthSensitivitySeries,
     // BLS / CHAS / FMR
     renderBlsLabourMarket,
     renderGapCoverageStats,

--- a/test/hna-functionality-check.js
+++ b/test/hna-functionality-check.js
@@ -883,6 +883,25 @@ test('JS: reset button uses correct per-scenario migration defaults', () => {
     assert(js.includes('migration: 1000'), 'high_growth scenario uses 1000/yr migration default');
 });
 
+test('JS: scenario fallback sensitivity scales growth from the shared observed base year', () => {
+    const rendererSrc = fs.readFileSync(path.join(ROOT, 'js', 'hna', 'hna-renderers.js'), 'utf8');
+    const helperMatch = rendererSrc.match(/function _scenarioGrowthSensitivitySeries[\s\S]*?\n  \}\n\n  \/\*\*/);
+    assert(Boolean(helperMatch), '_scenarioGrowthSensitivitySeries helper exists');
+    if (!helperMatch) return;
+    const helperSrc = helperMatch[0].replace(/\n\n  \/\*\*$/, '');
+    const helper = new Function(`${helperSrc}; return _scenarioGrowthSensitivitySeries;`)();
+    const baseline = [13900, 14500, 15400];
+    const low = helper(baseline, 0.85);
+    const high = helper(baseline, 1.15);
+    assert(low[0] === baseline[0] && high[0] === baseline[0], 'low/high scenario series share the observed base-year value');
+    assert(low[2] === 13900 + 0.85 * (15400 - 13900), 'low scenario scales only cumulative growth at horizon');
+    assert(high[2] === 13900 + 1.15 * (15400 - 13900), 'high scenario scales only cumulative growth at horizon');
+    assert(low[2] !== baseline[2] * 0.85 && high[2] !== baseline[2] * 1.15, 'old level-scaling shortcut is not used');
+    assert(js.includes("label: 'Growth −15%'"), 'low fallback dataset is labeled Growth −15%');
+    assert(js.includes("label: 'Growth +15%'"), 'high fallback dataset is labeled Growth +15%');
+    assert(html.includes('scale only the projected growth increment'), 'scenario copy explains growth-increment sensitivity');
+});
+
 test('JS: __announceUpdate called on projection view toggle for WCAG 4.1.3', () => {
     assert(
         js.includes("__announceUpdate(`Scenario view changed to:") ||


### PR DESCRIPTION
## Summary
- Closes #1196.
- Fixes the HNA scenario fallback math so `Growth −15%` and `Growth +15%` share the observed base-year population with the baseline, then scale only the projected growth increment.
- Applies the same anchored fallback helper to the selected-scenario detail chart for `low_growth` and `high_growth`.
- Updates scenario copy so the UI describes growth-increment sensitivity rather than population-level scaling.
- Do not merge until external QA completes.

## What Changed
- `js/hna/hna-renderers.js`: adds `_scenarioGrowthSensitivitySeries(baseline, growthFactor)` using `p0 + factor * (p[t] - p0)`.
- `js/hna/hna-renderers.js`: replaces the old fallback `baseline.map(p => p * 0.85)` / `* 1.15` shortcut with anchored growth bands.
- `js/hna/hna-renderers.js`: fixes selected-detail fallback keys from stale `low` / `high` to actual `low_growth` / `high_growth`.
- `housing-needs-assessment.html`: updates the scenario description/subtitle to say sensitivity bands share the observed base year and scale only the projected growth increment.
- `test/hna-functionality-check.js`: executes the actual helper and asserts shared base-year values, final-index anchored formula values, labels, and copy.

## Evidence
- Non-vacuous regression fixture: baseline `[13900, 14500, 15400]` now yields:
  - low final = `13900 + 0.85 * (15400 - 13900)` = `15175`
  - high final = `13900 + 1.15 * (15400 - 13900)` = `15625`
  - both low/high index 0 = `13900`
  - test also asserts those are not `15400 * 0.85` or `15400 * 1.15`.
- Browser QA, local HNA page:
  - Garfield County: labels `Baseline (DOLA) | Growth −15% | Growth +15%`; base-year values `5956729 / 5956729 / 5956729`; final low/high matched anchored formula; 0 console errors.
  - Pitkin County: labels `Baseline (DOLA) | Growth −15% | Growth +15%`; base-year values `5956729 / 5956729 / 5956729`; final low/high matched anchored formula; 0 console errors.
- Note: browser chart data remained on the initial statewide projection series after county selection, which appears to be pre-existing scenario-tool refresh behavior outside #1196. This PR intentionally fixes only the fallback math/labels/copy described in #1196.

## Tests
- `npm run test:hna` ✅
- `npm run test:ci` ✅

## Non-Vacuousness Proof
- Temporarily restoring level-scaling (`p * 0.85` / `p * 1.15`) would fail the new `test:hna` assertions because the low/high base-year values would diverge from baseline and the horizon values would not match the anchored formula.
