### PR TITLE
fix(homepage): reconcile renter cost burden copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         <span class="home-opening__eyebrow">Colorado Housing Tax Credit Educational Guide</span>
         <h1 id="home-heading">Housing with dignity starts with clear data, thoughtful planning, and better decisions about the places people call home.</h1>
         <p class="home-opening__lead">
-          Across Colorado, about 45% of renters now spend more than 30% of every paycheck
+          Across Colorado, roughly half of renters now spend more than 30% of every paycheck
           on rent, and the state is short roughly a quarter&#8209;million homes for the
           residents who need them most. This site draws together the public sources
           anyone can read &mdash; ACS, HUD CHAS, CHFA, and DOLA &mdash; so residents,

--- a/test/homepage-job-routing.test.js
+++ b/test/homepage-job-routing.test.js
@@ -59,4 +59,16 @@ assert(
 assert(!index.includes('every stat is sourced'), 'homepage must not overclaim that every stat is sourced');
 assert(!index.includes('docs/demo-mode-audit.csv'), 'homepage trust claim must not point public readers to the old demo-mode audit');
 
+const leadMatch = index.match(/<p class="home-opening__lead">([\s\S]*?)<\/p>/);
+assert(leadMatch, 'homepage hero lead copy must exist');
+const heroLead = leadMatch[1].replace(/\s+/g, ' ').trim();
+assert(
+  heroLead.includes('roughly half of renters now spend more than 30%'),
+  'homepage hero should use durable renter cost-burden copy aligned with the live snapshot card'
+);
+assert(
+  !/\b\d+(?:\.\d+)?% of renters\b/.test(heroLead),
+  'homepage hero must not hard-code a renter cost-burden percentage that can drift from #snapCostBurden'
+);
+
 console.log('Homepage job routing (Phase 2.3): PASS');


### PR DESCRIPTION
## Summary
- Replaces the homepage hero's stale hard-coded renter cost-burden percentage with durable copy: "roughly half of renters".
- Extends the existing homepage source-grep guard so the hero lead cannot reintroduce a hard-coded renter cost-burden percentage that drifts from #snapCostBurden.

## Non-vacuousness proof
- Recomputed the snapshot card's current source (`data/market/acs_tract_metrics_co.json`) using the same tract renter-household weighting as `js/index.js`: 1,447 tracts, 781,889 renter-household weight, current value 49.9%.
- Guard test now extracts `.home-opening__lead`, asserts the durable phrase is present, and rejects `N% of renters` copy in the hero lead.

## Tests
- `npm run test:homepage-job-routing`
- `npm run test:ci`

Closes #1198.

Do not merge until external QA completes.
