### PR TITLE
fix(hna): consolidate employment charts

### DIFF
--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -1346,10 +1346,10 @@
           <div class="chart-card span-6" style="margin:0">
             <h2>Top Industries by Employment</h2>
             <p style="color:var(--muted);font-size:.88rem">
-              Top NAICS 2-digit sectors from LEHD WAC workplace jobs; QCEW covered-employment wages remain in the wage trend card below.
+              Top NAICS 2-digit sectors from LEHD WAC workplace jobs (CNS fields).
             </p>
             <div id="industryChartContainer" class="chart-container">
-              <div class="chart-box" data-source="LEHD WAC by NAICS; BLS QCEW wage context" data-source-url="https://lehd.ces.census.gov/data/lodes/LODES8/" data-vintage="LODES 2023 · QCEW 2024 wage trend" data-source-type="transformed"><canvas id="chartIndustry" role="img" aria-label="Top industries by employment count chart"></canvas></div>
+              <div class="chart-box" data-source="LEHD WAC by NAICS" data-source-url="https://lehd.ces.census.gov/data/lodes/LODES8/" data-vintage="LODES 2023" data-source-type="transformed"><canvas id="chartIndustry" role="img" aria-label="Top industries by employment count chart"></canvas></div>
             </div>
           </div>
         </div>
@@ -1414,10 +1414,10 @@
             </div>
           </div>
           <div id="wageTrendContainer" class="chart-card span-6" style="margin:0">
-            <h2>Wage Trend</h2>
-            <p style="color:var(--muted);font-size:.88rem">Average wages over time (BLS QCEW).</p>
+            <h2>Wage-Band Job Trend</h2>
+            <p style="color:var(--muted);font-size:.88rem">Jobs by LEHD WAC wage band over time (CE01–CE03).</p>
             <div class="chart-container">
-              <div class="chart-box" data-source="BLS QCEW (Quarterly Census of Employment and Wages)" data-source-url="https://www.bls.gov/cew/" data-vintage="QCEW 2024" data-source-type="raw"><canvas id="chartWageTrend" role="img" aria-label="Average wage trend over time chart"></canvas></div>
+              <div class="chart-box" data-source="LEHD WAC wage bands" data-source-url="https://lehd.ces.census.gov/data/lodes/LODES8/" data-vintage="LODES 2023" data-source-type="transformed"><canvas id="chartWageTrend" role="img" aria-label="LEHD wage-band job trend over time chart"></canvas></div>
             </div>
           </div>
         </div>

--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -1345,9 +1345,11 @@
           </div>
           <div class="chart-card span-6" style="margin:0">
             <h2>Top Industries by Employment</h2>
-            <p style="color:var(--muted);font-size:.88rem">Top NAICS 2-digit sectors (LEHD WAC CNS fields).</p>
+            <p style="color:var(--muted);font-size:.88rem">
+              Top NAICS 2-digit sectors from LEHD WAC workplace jobs; QCEW covered-employment wages remain in the wage trend card below.
+            </p>
             <div id="industryChartContainer" class="chart-container">
-              <div class="chart-box" data-source="LEHD WAC by NAICS" data-source-url="https://lehd.ces.census.gov/data/lodes/LODES8/" data-vintage="LODES 2023" data-source-type="transformed"><canvas id="chartIndustry" role="img" aria-label="Top industries by employment count chart"></canvas></div>
+              <div class="chart-box" data-source="LEHD WAC by NAICS; BLS QCEW wage context" data-source-url="https://lehd.ces.census.gov/data/lodes/LODES8/" data-vintage="LODES 2023 · QCEW 2024 wage trend" data-source-type="transformed"><canvas id="chartIndustry" role="img" aria-label="Top industries by employment count chart"></canvas></div>
             </div>
           </div>
         </div>
@@ -1417,18 +1419,6 @@
             <div class="chart-container">
               <div class="chart-box" data-source="BLS QCEW (Quarterly Census of Employment and Wages)" data-source-url="https://www.bls.gov/cew/" data-vintage="QCEW 2024" data-source-type="raw"><canvas id="chartWageTrend" role="img" aria-label="Average wage trend over time chart"></canvas></div>
             </div>
-          </div>
-          <div id="industryAnalysisContainer" class="chart-card span-6" style="margin:0">
-            <h2>Industry Analysis</h2>
-            <p style="color:var(--muted);font-size:.88rem">Employment share by NAICS sector.</p>
-            <div class="chart-container">
-              <div class="chart-box" data-source="BLS QCEW Industry Share by NAICS" data-source-url="https://www.bls.gov/cew/" data-vintage="QCEW 2024" data-source-type="raw"><canvas id="chartIndustryAnalysis" role="img" aria-label="Industry employment share by NAICS sector chart"></canvas></div>
-            </div>
-          </div>
-          <div id="wageGapsContainer" class="chart-card span-6" style="margin:0">
-            <h2>Wage Gaps</h2>
-            <p style="color:var(--muted);font-size:.88rem">High / medium / low wage job distribution (LEHD CE01–CE03).</p>
-            <div class="chart-container chart-container--bar" data-source="LEHD LODES Wage Bands (CE01–CE03)" data-source-url="https://lehd.ces.census.gov/data/lodes/LODES8/" data-vintage="LODES 2023" data-source-type="raw"></div>
           </div>
         </div>
       </section>

--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -3181,8 +3181,6 @@
     window.HNARenderers.renderEconomicIndicators(econGeoid);
     window.HNARenderers.renderEmploymentTrend(econGeoid);
     window.HNARenderers.renderWageTrend(econGeoid);
-    window.HNARenderers.renderIndustryAnalysis(econGeoid);
-    window.HNARenderers.renderWageGaps(econGeoid, profile);
 
     // ── County-scope disclosures ────────────────────────────────────
     // LEHD, DOLA SYA, and BLS QCEW are county-only datasets. When the
@@ -3851,9 +3849,7 @@
   window.__HNA_PROJECTION_SCENARIOS     = window.HNAUtils.PROJECTION_SCENARIOS;
   window.__HNA_renderEmploymentTrend   = window.HNARenderers.renderEmploymentTrend;
   window.__HNA_renderWageTrend         = window.HNARenderers.renderWageTrend;
-  window.__HNA_renderIndustryAnalysis  = window.HNARenderers.renderIndustryAnalysis;
   window.__HNA_renderEconomicIndicators = window.HNARenderers.renderEconomicIndicators;
-  window.__HNA_renderWageGaps          = window.HNARenderers.renderWageGaps;
   window.__HNA_renderFmrPanel          = window.HNARenderers.renderFmrPanel;
   window.__HNA_renderChasAffordabilityGap = window.HNARenderers.renderChasAffordabilityGap;
 

--- a/js/hna/hna-dev-context.js
+++ b/js/hna/hna-dev-context.js
@@ -294,18 +294,6 @@
       project: 'Pro formas are typically stress-tested against the worst 5-yr wage trend in this dataset. When unit rents stay viable under flat wages for 5 years, the project survives a recession.',
     },
 
-    'Industry Analysis': {
-      why: 'Industry concentration shows economic resilience — diverse economies recover from shocks; single-industry towns don\'t. 15-year LIHTC compliance favors diverse economies.',
-      demand: 'Single-industry towns (mining, military, university) have wildly variable affordable-housing demand depending on local employer fortunes. Diverse economies have stable, predictable demand.',
-      project: 'Diverse economies suit 9% family / workforce projects with multi-AMI mixes. Single-industry towns suit targeted niches (senior, supportive, or employer-aligned workforce). Project type typically matches economic structure.',
-    },
-
-    'Wage Gaps': {
-      why: 'Wage inequality reveals "service worker / professional" splits that are invisible in median stats. It shows the depth of workforce-housing crisis.',
-      demand: 'Large wage gaps at the local level mean dual demand: deep-affordability for service workers (30-50% AMI) AND workforce middle for healthcare / education (60-80% AMI). Both are needed.',
-      project: 'Mixed-AMI projects (for example, 25% at 30% AMI, 35% at 50% AMI, and 40% at 60% AMI) can reflect documented wage gaps and show how the proposed affordability mix relates to the local economy under CHFA\'s QAP framework.',
-    },
-
     /* ── Affordable Housing Compliance (HB 22-1093 / Prop 123) ── */
     'HB 22-1093': {
       why: 'HB 22-1093 + Prop 123 are Colorado\'s state-level housing-action requirements. Compliance status determines eligibility for Prop 123 fast-track funding and state-level credit allocations.',

--- a/js/hna/hna-dev-context.js
+++ b/js/hna/hna-dev-context.js
@@ -275,7 +275,7 @@
       project: 'The ratio reads well in CHFA narratives: "A full-time worker earning X must spend Y% of pre-tax income on the median 2BR rent." This is the language that scores in "Community Need" + "Local Support" sections (because it persuades local elected officials).',
     },
 
-    /* ── Economic indicators / employment trend / wage trend / industry analysis ── */
+    /* ── Economic indicators / employment trend / wage-band job trend ── */
     'Economic Indicators': {
       why: 'Macroeconomic context (unemployment, labor-force participation, prime-age employment) shows whether the local economy is expanding or contracting — which shapes 15-year lease-up risk.',
       demand: 'Tight labor market + rising wages + low unemployment = strong rental demand at all AMI bands. Loosening labor market = workforce-housing demand stays high as workers downsize from market-rate to subsidized units.',
@@ -288,10 +288,10 @@
       project: 'Employment trends feed CHFA "market growth" + "lease-up confidence" narratives. Positive trends support 9% LIHTC family / workforce; negative trends suit senior / preservation niches.',
     },
 
-    'Wage Trend': {
-      why: 'Wage growth (or stagnation) shows whether AMI thresholds will rise (lifting unit rents) or stagnate (locking a project at its initial pricing). Critical for 15-year compliance economics.',
-      demand: 'Wage trend BELOW rent growth = expanding affordability gap = permanent and growing demand. Wage trend ABOVE rent growth = closing gap, projects may become less competitive over time.',
-      project: 'Pro formas are typically stress-tested against the worst 5-yr wage trend in this dataset. When unit rents stay viable under flat wages for 5 years, the project survives a recession.',
+    'Wage-Band Job Trend': {
+      why: 'The wage-band job trend shows whether local workplace jobs are shifting toward low-, medium-, or high-wage bands over time. It is a LEHD WAC job-count series, not an average-wage series.',
+      demand: 'Growth in low- and medium-wage job counts strengthens the case for workforce homes affordable to workers below typical market rents.',
+      project: 'AMI mix can be cross-checked against the local job distribution over time. When job growth concentrates in lower wage bands, deeper affordability is easier to justify in local-support and market narratives.',
     },
 
     /* ── Affordable Housing Compliance (HB 22-1093 / Prop 123) ── */

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -6025,50 +6025,6 @@
     });
   }
 
-  function renderIndustryAnalysis(geoid) {
-    var canvas = document.getElementById('chartIndustryAnalysis');
-    if (!canvas) return;
-    var lehd = _lehdFor(geoid);
-    var industries = lehd && U().parseIndustries
-      ? U().parseIndustries(lehd, 8)
-      : [];
-    if (!industries.length) {
-      _placeholderInBox(canvas, 'Industry analysis data not yet cached for this geography.');
-      return;
-    }
-    var t = chartTheme();
-    var fmtNum = U().fmtNum;
-    // Compute share-of-total for the share-axis label. Falls back to
-    // raw count when the pct field is absent (state-aggregate files
-    // already populate pct; per-county files don't always).
-    var total = industries.reduce(function (s, i) { return s + (i.count || 0); }, 0);
-    makeChart(canvas.getContext('2d'), {
-      type: 'bar',
-      data: {
-        labels: industries.map(function (i) { return i.label; }),
-        datasets: [{
-          data: industries.map(function (i) { return i.count; }),
-          backgroundColor: t.c2,
-        }],
-      },
-      options: {
-        indexAxis: 'y',
-        responsive: true, maintainAspectRatio: false,
-        plugins: {
-          legend: { display: false },
-          tooltip: { callbacks: { label: function (c) {
-            var pct = total > 0 ? ' (' + ((c.parsed.x / total) * 100).toFixed(1) + '%)' : '';
-            return fmtNum(c.parsed.x) + ' jobs' + pct;
-          } } },
-        },
-        scales: {
-          x: { ticks: { color: t.muted, callback: function (v) { return fmtNum(v); } }, grid: { color: t.border } },
-          y: { ticks: { color: t.muted }, grid: { color: t.border } },
-        },
-      },
-    });
-  }
-
   function renderEconomicIndicators(geoid) {
     // Cards container — the HTML has #econIndicatorCards (lower section)
     // and the legacy #economicIndicatorsCards is unused. Prefer the
@@ -6151,74 +6107,6 @@
         '<div class="mc-sub">'   + c.src              + '</div>' +
       '</div>';
     }).join('');
-  }
-
-  function renderWageGaps(geoid, profile) {
-    // Find the empty .chart-container--bar div the HTML reserves
-    // and inject a canvas for the wage-gap bar chart. The container
-    // is empty by design (HTML doesn't ship a canvas — the renderer
-    // owns the chart instance lifecycle).
-    var wrap = document.getElementById('wageGapsContainer');
-    if (!wrap) return;
-    var box = wrap.querySelector('.chart-container');
-    if (!box) return;
-
-    var lehd = _lehdFor(geoid);
-    var dist = lehd && U().calculateWageDistribution
-      ? U().calculateWageDistribution(lehd)
-      : null;
-    if (!dist || !dist.total) {
-      box.innerHTML = '<p style="margin:0;padding:1rem;color:var(--muted);font-size:.85rem;text-align:center">'
-        + 'Wage gap data not yet cached for this geography.</p>';
-      return;
-    }
-
-    // Ensure a canvas exists inside the box (idempotent on re-render).
-    var canvasId = 'chartWageGaps';
-    var canvas = document.getElementById(canvasId);
-    if (!canvas) {
-      box.innerHTML = '';
-      canvas = document.createElement('canvas');
-      canvas.id = canvasId;
-      canvas.setAttribute('role', 'img');
-      canvas.setAttribute('aria-label', 'Wage gap distribution: high vs medium vs low');
-      box.appendChild(canvas);
-    }
-
-    var t = chartTheme();
-    var fmtNum = U().fmtNum;
-    var lowPct    = (dist.low    / dist.total) * 100;
-    var mediumPct = (dist.medium / dist.total) * 100;
-    var highPct   = (dist.high   / dist.total) * 100;
-
-    makeChart(canvas.getContext('2d'), {
-      type: 'bar',
-      data: {
-        labels: ['Low (≤$15k/yr)', 'Medium ($15–40k)', 'High ($40k+)'],
-        datasets: [{
-          data: [lowPct, mediumPct, highPct],
-          backgroundColor: [t.c5, t.c3, t.c1],
-        }],
-      },
-      options: {
-        responsive: true, maintainAspectRatio: false,
-        plugins: {
-          legend: { display: false },
-          tooltip: { callbacks: { label: function (c) {
-            var counts = [dist.low, dist.medium, dist.high][c.dataIndex];
-            return c.parsed.y.toFixed(1) + '% (' + fmtNum(counts) + ' jobs)';
-          } } },
-        },
-        scales: {
-          x: { ticks: { color: t.muted }, grid: { color: t.border } },
-          y: {
-            beginAtZero: true,
-            ticks: { color: t.muted, callback: function (v) { return v + '%'; } },
-            grid: { color: t.border },
-          },
-        },
-      },
-    });
   }
 
   // ---------------------------------------------------------------------------
@@ -7998,7 +7886,6 @@
     'chartIndustry',
     'chartEmploymentTrend',
     'chartWageTrend',
-    'chartIndustryAnalysis',
     'chartProp123Growth',
     'chartProp123Historical',
     'chartBedroomNeed',
@@ -8364,9 +8251,7 @@
     renderLaborMarketSection,
     renderEmploymentTrend,
     renderWageTrend,
-    renderIndustryAnalysis,
     renderEconomicIndicators,
-    renderWageGaps,
     renderWageAffordability,  // F198 — income needed to afford rent + buy + LIHTC, vs LEHD wage tiers
     // F199 + F200 — Decade trends (county-level)
     renderDecadeAffordTrend,

--- a/scripts/audit/chart-population-audit.mjs
+++ b/scripts/audit/chart-population-audit.mjs
@@ -61,8 +61,6 @@ const EXPECTED = [
   { fixture: 'hna-adams',  url: '/housing-needs-assessment.html?geoType=county&geoid=08001&auto=1', chart: 'chartIndustry',         note: 'LEHD top industries' },
   { fixture: 'hna-adams',  url: '/housing-needs-assessment.html?geoType=county&geoid=08001&auto=1', chart: 'chartEmploymentTrend',  note: 'LEHD annualEmployment' },
   { fixture: 'hna-adams',  url: '/housing-needs-assessment.html?geoType=county&geoid=08001&auto=1', chart: 'chartWageTrend',        note: 'LEHD annualWages' },
-  { fixture: 'hna-adams',  url: '/housing-needs-assessment.html?geoType=county&geoid=08001&auto=1', chart: 'chartIndustryAnalysis', note: 'LEHD industry share' },
-  { fixture: 'hna-adams',  url: '/housing-needs-assessment.html?geoType=county&geoid=08001&auto=1', chart: 'chartWageGaps',         note: 'wage gap percent bars' },
   // ── Place selection (Paonia 0857300): place-apportioned LEHD ──
   { fixture: 'hna-paonia', url: '/housing-needs-assessment.html?geoType=place&geoid=0857300&auto=1', chart: 'chartLehd',         note: 'commute flows (apportioned from Delta)' },
   { fixture: 'hna-paonia', url: '/housing-needs-assessment.html?geoType=place&geoid=0857300&auto=1', chart: 'chartWage',         note: 'wage tiers (apportioned)' },

--- a/test/hna-functionality-check.js
+++ b/test/hna-functionality-check.js
@@ -134,6 +134,15 @@ test('HTML: site scripts are loaded', () => {
     assert(html.includes('js/housing-needs-assessment.js') || html.includes('js/hna/hna-controller.js'), 'hna controller is loaded');
 });
 
+test('HTML: HNA employment cards are consolidated', () => {
+    assert(html.includes('id="chartIndustry"'), 'consolidated Top Industries chart remains present');
+    assert(html.includes('LEHD WAC by NAICS; BLS QCEW wage context'), 'consolidated industry card discloses LEHD/QCEW source context');
+    assert(html.includes('id="chartWage"'), 'single wage distribution chart remains present');
+    assert(!html.includes('id="chartIndustryAnalysis"'), 'duplicate Industry Analysis chart is absent');
+    assert(!html.includes('id="wageGapsContainer"'), 'duplicate Wage Gaps card is absent');
+    assert(!html.includes('id="chartWageGaps"'), 'duplicate Wage Gaps chart canvas is absent');
+});
+
 // ---------------------------------------------------------------------------
 // JS: diagnostic banner on ACS failure
 // ---------------------------------------------------------------------------

--- a/test/hna-functionality-check.js
+++ b/test/hna-functionality-check.js
@@ -136,8 +136,19 @@ test('HTML: site scripts are loaded', () => {
 
 test('HTML: HNA employment cards are consolidated', () => {
     assert(html.includes('id="chartIndustry"'), 'consolidated Top Industries chart remains present');
-    assert(html.includes('LEHD WAC by NAICS; BLS QCEW wage context'), 'consolidated industry card discloses LEHD/QCEW source context');
+    const industryBlockMatch = html.match(/<div id="industryChartContainer"[\s\S]*?<\/div>\s*<\/div>/);
+    assert(industryBlockMatch, 'Top Industries card block exists for source-label guard');
+    const industryBlock = industryBlockMatch ? industryBlockMatch[0] : '';
+    assert(industryBlock.includes('LEHD WAC by NAICS'), 'consolidated industry card discloses LEHD WAC source context');
+    assert(!/QCEW/.test(industryBlock), 'Top Industries card must not claim QCEW involvement');
     assert(html.includes('id="chartWage"'), 'single wage distribution chart remains present');
+    const wageTrendBlockMatch = html.match(/<div id="wageTrendContainer"[\s\S]*?<\/div>\s*<\/div>/);
+    assert(wageTrendBlockMatch, 'Wage-Band Job Trend card block exists for source-label guard');
+    const wageTrendBlock = wageTrendBlockMatch ? wageTrendBlockMatch[0] : '';
+    assert(wageTrendBlock.includes('id="chartWageTrend"'), 'Wage-Band Job Trend chart remains present');
+    assert(wageTrendBlock.includes('LEHD WAC wage bands'), 'Wage-Band Job Trend card discloses LEHD WAC wage bands');
+    assert(wageTrendBlock.includes('LODES 2023'), 'Wage-Band Job Trend card discloses LODES 2023 vintage');
+    assert(!/QCEW/.test(wageTrendBlock), 'Wage-Band Job Trend card must not claim QCEW source/vintage');
     assert(!html.includes('id="chartIndustryAnalysis"'), 'duplicate Industry Analysis chart is absent');
     assert(!html.includes('id="wageGapsContainer"'), 'duplicate Wage Gaps card is absent');
     assert(!html.includes('id="chartWageGaps"'), 'duplicate Wage Gaps chart canvas is absent');

--- a/test/hna-labor-market-renderers.test.js
+++ b/test/hna-labor-market-renderers.test.js
@@ -4,15 +4,14 @@
  *
  * Regression for 2026-05-16 deep-dive batch 2. The Labor Market section
  * (chartWage, chartIndustry, jobMetrics) and Economic Indicators panel
- * (chartEmploymentTrend, chartWageTrend, chartIndustryAnalysis,
- * Wage Gaps, econIndicatorCards) were either:
+ * (chartEmploymentTrend, chartWageTrend, econIndicatorCards) were either:
  *   - stubs that found their canvas and returned, or
  *   - the existing trend renderer read from `state.lehdData`, a slot
  *     that was never populated (data lives in `__HNA_LEHD_CACHE` and
  *     is keyed by geoid).
  *
  * What this test asserts (source-grep):
- *   - Each of the 6 renderers is no longer a stub — it consumes lehd
+ *   - Each active renderer is no longer a stub — it consumes lehd
  *     data and renders a chart or placeholder.
  *   - renderEmploymentTrend reads `__HNA_LEHD_CACHE` (the cache the
  *     controller actually populates), not `state.lehdData`.
@@ -20,8 +19,9 @@
  *     `{year: count}` dict shape that lives in the cache files
  *     (previous code did `.map(d => d.year)` on a dict — would render
  *     `["0","1","2",…]` if it didn't return early).
- *   - renderWageGaps injects a canvas into wageGapsContainer because
- *     the HTML container ships empty (no canvas).
+ *   - The removed duplicate Industry Analysis and Wage Gaps renderers
+ *     stay removed so the HNA page has one industry card and one wage
+ *     distribution card.
  *
  * Run: node test/hna-labor-market-renderers.test.js
  */
@@ -56,9 +56,7 @@ console.log('\n[test] renderers are no longer stubs');
 ['renderLaborMarketSection',
  'renderEmploymentTrend',
  'renderWageTrend',
- 'renderIndustryAnalysis',
- 'renderEconomicIndicators',
- 'renderWageGaps'].forEach(function (name) {
+ 'renderEconomicIndicators'].forEach(function (name) {
   const body = fnBody(name);
   assert(body != null && /makeChart|innerHTML|appendChild|metric/.test(body),
     name + '() does real work (makeChart / DOM write)');
@@ -81,14 +79,15 @@ const wageBody = fnBody('renderWageTrend') || '';
 assert(/Object\.keys\(aw\)/.test(wageBody) || /Object\.keys\([^)]*annualWages/.test(wageBody),
   'renderWageTrend treats annualWages as a {year: {low,medium,high}} dict');
 
-console.log('\n[test] renderWageGaps injects a canvas into the empty container');
-const wgBody = fnBody('renderWageGaps') || '';
-assert(/wageGapsContainer/.test(wgBody),
-  'renderWageGaps looks up #wageGapsContainer');
-assert(/createElement\(['"]canvas/.test(wgBody),
-  'renderWageGaps creates a <canvas> element');
-assert(/chartWageGaps/.test(wgBody),
-  'the injected canvas has id="chartWageGaps"');
+console.log('\n[test] duplicate employment cards stay removed');
+assert(fnBody('renderIndustryAnalysis') === null,
+  'renderIndustryAnalysis was removed with the duplicate Industry Analysis card');
+assert(fnBody('renderWageGaps') === null,
+  'renderWageGaps was removed with the duplicate Wage Gaps card');
+assert(!/chartIndustryAnalysis/.test(src),
+  'chartIndustryAnalysis is not referenced by active renderers');
+assert(!/chartWageGaps|wageGapsContainer/.test(src),
+  'duplicate Wage Gaps chart/container is not referenced by active renderers');
 
 console.log('\n=========================================');
 console.log('Results: ' + passed + ' passed, ' + failed + ' failed');

--- a/test/integration/economic-indicators.test.js
+++ b/test/integration/economic-indicators.test.js
@@ -172,13 +172,6 @@ test('HNA modules define renderWageTrend', () => {
   assert(hnaSrc.includes('yAxisID'),                  'dual-axis chart uses yAxisID');
 });
 
-test('HNA modules define renderIndustryAnalysis', () => {
-  assert(hnaSrc.includes('function renderIndustryAnalysis'), 'renderIndustryAnalysis function defined');
-  assert(hnaSrc.includes('chartIndustryAnalysis'),           'creates chartIndustryAnalysis canvas');
-  assert(hnaSrc.includes('LEHD WAC CNS sectors'),            'uses LEHD WAC sector data source');
-  assert(hnaSrc.includes("' jobs' + pct"),                   'tooltip reports industry job count and share');
-});
-
 test('HNA modules define renderEconomicIndicators', () => {
   assert(hnaSrc.includes('function renderEconomicIndicators'), 'renderEconomicIndicators function defined');
   assert(hnaSrc.includes('economicIndicatorsContainer'),        'uses economicIndicatorsContainer element');
@@ -188,27 +181,23 @@ test('HNA modules define renderEconomicIndicators', () => {
   assert(hnaSrc.includes('Top Industry'),                       '4-card dashboard includes Top Industry card');
 });
 
-test('HNA modules define renderWageGaps', () => {
-  assert(hnaSrc.includes('function renderWageGaps'), 'renderWageGaps function defined');
-  assert(hnaSrc.includes('wageGapsContainer'),        'uses wageGapsContainer element');
-  assert(hnaSrc.includes('chartWageGaps'),            'creates chartWageGaps canvas');
-  assert(hnaSrc.includes('Wage gap distribution'),    'sets accessible wage-gap chart label');
+test('HNA modules do not retain duplicate employment renderers', () => {
+  assert(!hnaSrc.includes('function renderIndustryAnalysis'), 'duplicate renderIndustryAnalysis function removed');
+  assert(!hnaSrc.includes('chartIndustryAnalysis'),           'duplicate chartIndustryAnalysis canvas removed');
+  assert(!hnaSrc.includes('function renderWageGaps'),         'duplicate renderWageGaps function removed');
+  assert(!hnaSrc.includes('chartWageGaps'),                   'duplicate chartWageGaps canvas removed');
 });
 
 test('Economic indicator functions are exposed on window', () => {
   assert(hnaSrc.includes('window.__HNA_renderEmploymentTrend'),    '__HNA_renderEmploymentTrend exposed');
   assert(hnaSrc.includes('window.__HNA_renderWageTrend'),          '__HNA_renderWageTrend exposed');
-  assert(hnaSrc.includes('window.__HNA_renderIndustryAnalysis'),   '__HNA_renderIndustryAnalysis exposed');
   assert(hnaSrc.includes('window.__HNA_renderEconomicIndicators'), '__HNA_renderEconomicIndicators exposed');
-  assert(hnaSrc.includes('window.__HNA_renderWageGaps'),           '__HNA_renderWageGaps exposed');
 });
 
 test('Economic indicator functions are called in the update() flow', () => {
   assert(hnaSrc.includes('renderEconomicIndicators('), 'renderEconomicIndicators called in update');
   assert(hnaSrc.includes('renderEmploymentTrend('),    'renderEmploymentTrend called in update');
   assert(hnaSrc.includes('renderWageTrend('),          'renderWageTrend called in update');
-  assert(hnaSrc.includes('renderIndustryAnalysis('),   'renderIndustryAnalysis called in update');
-  assert(hnaSrc.includes('renderWageGaps('),           'renderWageGaps called in update');
 });
 
 test('LEHD cache is populated before economic indicator rendering', () => {


### PR DESCRIPTION
## Summary
- Consolidates HNA employment visuals so the page keeps one Wage Distribution card and one Top Industries card.
- Removes the duplicate/misleading lower-section `Industry Analysis` card and the literal duplicate `Wage Gaps` card, including their renderer calls, public debug exports, dev-context entries, and chart-audit fixtures.
- Relabels the surviving employment cards so Top Industries discloses LEHD WAC NAICS provenance and the lower trend card is labeled as a LEHD WAC wage-band job trend using LODES 2023; no QCEW card remains in this PR.

## Root Cause
The lower Economic Indicators section had two overlapping cards:
- `chartIndustryAnalysis` was presented as BLS QCEW industry share, but the renderer consumed the same LEHD industry cache used by `chartIndustry`.
- `wageGapsContainer` / `chartWageGaps` redrew the same LEHD CE01-CE03 wage distribution already shown by `chartWage`.
- The surviving `chartWageTrend` card was also mislabeled as average wages / BLS QCEW even though it renders LEHD WAC wage-band job counts over time.

## Non-vacuousness / QA Evidence
- Static guard now asserts `chartIndustry` and `chartWage` remain present while `chartIndustryAnalysis`, `wageGapsContainer`, and `chartWageGaps` are absent.
- Static guard extracts the actual Top Industries and Wage-Band Job Trend card blocks, asserts they exist, pins their LEHD WAC / LODES labels, and asserts neither block contains `QCEW`.
- Renderer regression tests assert `renderIndustryAnalysis` and `renderWageGaps` stay removed and that active LEHD renderers still do real work.
- Browser smoke on local HNA:
  - Adams County: `chartIndustry`, `chartWage`, `chartWageTrend` present; removed duplicate charts absent; console errors `[]`.
  - Paonia (town): `chartIndustry`, `chartWage`, `chartWageTrend` present; removed duplicate charts absent; console errors `[]`.
- Chart population audit: `20/20 charts pass` after removing the deleted chart IDs from the fixture list.

## Tests
- `npm run test:hna`
- `node test/hna-labor-market-renderers.test.js`
- `node test/integration/economic-indicators.test.js`
- `npm run validate`
- `npm run test:ci`
- `npm run audit:charts`

Closes #1199.

Do not merge until external QA completes.
