### PR TITLE
Document ownership benchmark prerequisite

### DIFF
--- a/docs/methodology/AFFORDABLE-OWNERSHIP-METHODOLOGY.md
+++ b/docs/methodology/AFFORDABLE-OWNERSHIP-METHODOLOGY.md
@@ -153,6 +153,12 @@ Each tiered component receives a score from 0 to 3 based on these cutpoints. Com
 - High: 1.75 to below 2.5
 - Very High: 2.5 or higher
 
+### EPS Phase II Benchmark Check
+
+The constants above were benchmarked against EPS "Regional Housing Needs Assessment -- Draft Phase II Report" (June 16, 2026, EPS #243156) before the ownership roadmap advanced beyond the initial screening layer. See `docs/audits/OWNERSHIP-BENCHMARK-EPS-PHASE2-2026-07.md`.
+
+The benchmark did not invalidate the constants: it supports keeping the current cutpoints and keeping the screening caveat. It also records the input-scope issues and follow-up sequence that should be checked before ownership tiers are surfaced more widely, especially small-town tenure mix, cross-county place context, CHAS vintage lag, and county home-value coverage.
+
 ## Recommendation Logic
 
 The recommendation follows this order:

--- a/test/hna-ownership-need.test.js
+++ b/test/hna-ownership-need.test.js
@@ -252,6 +252,31 @@ test('copy contains screening framing and avoids banned phrases', () => {
   ].forEach(phrase => assert.equal(src.includes(phrase), false, phrase + ' should be absent'));
 });
 
+test('EPS Phase II benchmark remains documented before ownership roadmap expansion', () => {
+  assert.deepStrictEqual(Array.from(Ownership.CONSTANTS.rentalPressure.renterCb30Share), [0.35, 0.42, 0.47]);
+  assert.deepStrictEqual(Array.from(Ownership.CONSTANTS.rentalPressure.renterCb50Share), [0.15, 0.21, 0.24]);
+  assert.deepStrictEqual(Array.from(Ownership.CONSTANTS.rentalPressure.renterShare), [0.24, 0.28, 0.32]);
+  assert.deepStrictEqual(Array.from(Ownership.CONSTANTS.ownershipPressure.ownerCb30Share), [0.19, 0.21, 0.25]);
+  assert.deepStrictEqual(Array.from(Ownership.CONSTANTS.ownershipPressure.ownerCb50Share), [0.08, 0.09, 0.10]);
+  assert.deepStrictEqual(Array.from(Ownership.CONSTANTS.ownershipPressure.moderateOwnerCbShare), [0.18, 0.29, 0.36]);
+  assert.deepStrictEqual(Array.from(Ownership.CONSTANTS.ownershipFit.moderateRenterHouseholds), [200, 500, 1400]);
+  assert.deepStrictEqual(Array.from(Ownership.CONSTANTS.ownershipFit.moderateRenterShare), [0.30, 0.33, 0.36]);
+
+  const benchmark = fs.readFileSync(path.join(ROOT, 'docs/audits/OWNERSHIP-BENCHMARK-EPS-PHASE2-2026-07.md'), 'utf8');
+  const methodology = fs.readFileSync(path.join(ROOT, 'docs/methodology/AFFORDABLE-OWNERSHIP-METHODOLOGY.md'), 'utf8');
+  assert.ok(benchmark.includes('EPS #243156'));
+  assert.match(benchmark, /June 16,\s+2026/);
+  assert.ok(benchmark.includes('The constants are NOT invalidated'));
+  assert.match(benchmark, /keep them,\s+keep the screening\s+caveat/);
+  assert.ok(benchmark.includes('Pitkin County'));
+  assert.ok(benchmark.includes('Garfield County'));
+  assert.ok(benchmark.includes('Parachute'));
+  assert.match(benchmark, /F1[\s\S]*tenure mix is biased by tract apportionment/);
+  assert.match(benchmark, /Before Tier 1 item 4[\s\S]*F1\/F2 tenure-mix fix/);
+  assert.ok(methodology.includes('OWNERSHIP-BENCHMARK-EPS-PHASE2-2026-07.md'));
+  assert.ok(methodology.includes('The benchmark did not invalidate the constants'));
+});
+
 test('renderer ownership lookups resolve phantom GEOIDs to canonical IDs', () => {
   const rendererSrc = fs.readFileSync(path.join(ROOT, 'js/hna/hna-renderers.js'), 'utf8');
   const aliases = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/hna/place-phantom-aliases.json'), 'utf8')).aliases;


### PR DESCRIPTION
## Summary
- Adds an EPS Phase II benchmark cross-link to the Affordable Ownership methodology so #1167's benchmark prerequisite is visible from the public methodology path.
- Adds a non-vacuous ownership-need guard that pins the benchmarked cutpoints and verifies the EPS benchmark source, verdict, jurisdiction coverage, and Tier 1 follow-up sequencing remain documented.

## Independent verification
- Confirmed the methodology note lands under Threshold Constants at docs/methodology/AFFORDABLE-OWNERSHIP-METHODOLOGY.md:156.
- Confirmed the guard test lands in test:hna-ownership-need at test/hna-ownership-need.test.js:255.
- Confirmed test:hna-ownership-need is already part of the explicit test:ci chain in package.json.

## Validation
- npm run test:hna-ownership-need
- npm run validate
- npm run test:ci

Refs #1167.

Do not merge until external QA completes.