### PR TITLE
Surface ownership need in regional comparison

### DIFF
--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -8091,6 +8091,11 @@
     { section: 'Affordability', label: '31–50% AMI households', key: 'pct_ami_31to50', format: 'pct' },
     { section: 'Affordability', label: '51–80% AMI households', key: 'pct_ami_51to80', format: 'pct' },
     { section: 'Affordability', label: '>80% AMI households', key: 'pct_ami_gt80', format: 'pct' },
+    { section: 'Ownership Need', label: 'Tenure strategy recommendation', key: 'ownership_need_recommendation', format: 'text' },
+    { section: 'Ownership Need', label: 'Rental pressure tier', key: 'ownership_need_rental_pressure_tier', format: 'text' },
+    { section: 'Ownership Need', label: 'Ownership pressure tier', key: 'ownership_need_ownership_pressure_tier', format: 'text' },
+    { section: 'Ownership Need', label: 'Ownership fit tier', key: 'ownership_need_ownership_fit_tier', format: 'text' },
+    { section: 'Ownership Need', label: 'Modeled affordability classification', key: 'ownership_need_affordability_classification', format: 'text' },
     { section: 'Housing Stock', label: 'Renter share', key: 'pct_renters', format: 'pct' },
     { section: 'Housing Stock', label: 'Overcrowding', key: 'overcrowding_rate', format: 'pct' },
     { section: 'Housing Stock', label: 'Housing built before 1970', key: 'pct_housing_built_pre1970', format: 'pct' },
@@ -8103,6 +8108,7 @@
   ];
 
   function _regionalFmt(value, format) {
+    if (format === 'text') return value == null || value === '' ? '—' : String(value);
     var n = Number(value);
     if (!Number.isFinite(n)) return '—';
     if (format === 'money') return _ownFmtMoney(n);

--- a/test/combined-geo.test.js
+++ b/test/combined-geo.test.js
@@ -500,6 +500,11 @@ test('regional comparison renderer paints distinct digest values side by side', 
           pct_ami_31to50: { value: 9.2 },
           pct_ami_51to80: { value: 19.1 },
           pct_ami_gt80: { value: 60.8 },
+          ownership_need_recommendation: { value: 'Ownership-supportive strategy' },
+          ownership_need_rental_pressure_tier: { value: 'Moderate' },
+          ownership_need_ownership_pressure_tier: { value: 'High' },
+          ownership_need_ownership_fit_tier: { value: 'Very High' },
+          ownership_need_affordability_classification: { value: 'priced-out' },
           pct_renters: { value: 30.4 },
           overcrowding_rate: { value: 2.0 },
           pct_housing_built_pre1970: { value: 14.1 },
@@ -518,6 +523,11 @@ test('regional comparison renderer paints distinct digest values side by side', 
           pct_ami_31to50: { value: 10.5 },
           pct_ami_51to80: { value: 18.6 },
           pct_ami_gt80: { value: 60.8 },
+          ownership_need_recommendation: { value: 'Rental + ownership mix' },
+          ownership_need_rental_pressure_tier: { value: 'High' },
+          ownership_need_ownership_pressure_tier: { value: 'Very High' },
+          ownership_need_ownership_fit_tier: { value: 'High' },
+          ownership_need_affordability_classification: { value: 'priced-out' },
           pct_renters: { value: 42.9 },
           overcrowding_rate: { value: 1.1 },
           pct_housing_built_pre1970: { value: 18.2 },
@@ -536,6 +546,13 @@ test('regional comparison renderer paints distinct digest values side by side', 
   assert.ok(html.includes('67.6%'), 'renders Aspen cost burden');
   assert.ok(html.includes('$589,000'), 'renders Garfield home value');
   assert.ok(html.includes('$2,500,000'), 'renders Aspen home value');
+  assert.ok(html.includes('Ownership Need'), 'renders ownership section');
+  assert.ok(html.includes('Tenure strategy recommendation'), 'renders ownership recommendation row label');
+  assert.ok(html.includes('Ownership-supportive strategy'), 'renders Garfield ownership recommendation');
+  assert.ok(html.includes('Rental + ownership mix'), 'renders Aspen ownership recommendation');
+  assert.ok(html.includes('Ownership fit tier'), 'renders ownership fit row label');
+  assert.ok(html.includes('Very High'), 'renders ownership tier text values');
+  assert.ok(html.includes('priced-out'), 'renders affordability classification text');
   assert.ok(html.includes('Side-by-side view only'), 'discloses non-aggregate mode');
   assert.equal(dom.window.document.getElementById('geoContextPill').textContent, 'Regional comparison: Garfield County + Aspen');
 });

--- a/test/jurisdiction-metrics-digest.test.js
+++ b/test/jurisdiction-metrics-digest.test.js
@@ -264,6 +264,34 @@ test('regional BIPOC population row is labeled as population, not households', (
   assert.ok(src.indexOf("key: 'pct_bipoc_population'") < src.indexOf("key: 'pct_bipoc_households'"), 'population row should precede household row');
 });
 
+test('regional comparison exposes existing ownership need digest metrics as text rows', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-renderers.js'), 'utf8');
+  const rows = [
+    "label: 'Tenure strategy recommendation', key: 'ownership_need_recommendation', format: 'text'",
+    "label: 'Rental pressure tier', key: 'ownership_need_rental_pressure_tier', format: 'text'",
+    "label: 'Ownership pressure tier', key: 'ownership_need_ownership_pressure_tier', format: 'text'",
+    "label: 'Ownership fit tier', key: 'ownership_need_ownership_fit_tier', format: 'text'",
+    "label: 'Modeled affordability classification', key: 'ownership_need_affordability_classification', format: 'text'",
+  ];
+  for (const needle of rows) {
+    assert.ok(src.includes(needle), `regional comparison missing row: ${needle}`);
+  }
+  assert.ok(src.includes("section: 'Ownership Need'"), 'ownership rows should be grouped under Ownership Need');
+  assert.ok(src.includes("if (format === 'text')"), 'regional formatter should handle text-valued digest rows');
+
+  const digest = readJson(path.join(DIGEST_DIR, '08045.json'));
+  for (const key of [
+    'ownership_need_recommendation',
+    'ownership_need_rental_pressure_tier',
+    'ownership_need_ownership_pressure_tier',
+    'ownership_need_ownership_fit_tier',
+    'ownership_need_affordability_classification',
+  ]) {
+    assert.ok(digest.metrics[key], `fixture digest missing ${key}`);
+    assert.strictEqual(typeof digest.metrics[key].value, 'string', `${key} should be text-valued in the digest`);
+  }
+});
+
 test('bipocPopulationPct returns null when required DP05 fields are missing', () => {
   const probe = [
     `import { bipocPopulationPct } from ${JSON.stringify(`file://${BUILDER}`)};`,


### PR DESCRIPTION
## Summary
- Adds an Ownership Need group to the Regional Comparison table using the existing ownership digest metrics: recommendation, rental pressure, ownership pressure, ownership fit, and modeled affordability classification.
- Adds text formatting for Regional Comparison rows so string-valued digest metrics render instead of falling through to dashes.
- Extends renderer and digest guard coverage so the ownership digest metrics remain surfaced in side-by-side mode.

## Independent verification
- Confirmed rows are added in js/hna/hna-renderers.js:8094 and use the existing ownership_need_* digest keys.
- Confirmed text-valued regional rows are handled in js/hna/hna-renderers.js:8110.
- Confirmed the regional renderer fixture paints distinct ownership recommendations/tier values in test/combined-geo.test.js:489.
- Confirmed the digest guard checks existing Garfield ownership metrics are text-valued and represented in Regional Comparison in test/jurisdiction-metrics-digest.test.js:267.

## Validation
- node test/combined-geo.test.js
- npm run test:jurisdiction-metrics-digest
- npm run test:hna
- npm run validate
- npm run test:ci

Refs #1167.

Do not merge until external QA completes.