### PR TITLE
Surface ownership permit context

### DIFF
--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -8,7 +8,7 @@
   'use strict';
 
   window.HNAState = {
-    state: { current: null, lastProj: null, trendCache: {}, derived: null, prevProfile: {}, chasData: null, combinedMembers: [], combinedRegions: null, combinedDatasets: null },
+    state: { current: null, lastProj: null, trendCache: {}, derived: null, prevProfile: {}, chasData: null, permitsDoc: null, combinedMembers: [], combinedRegions: null, combinedDatasets: null },
     charts: {},
     map: null,
     boundaryLayer: null,
@@ -3244,6 +3244,12 @@
         .then((data) => { window.HNAState.state.homeValueCascade = data; return data; })
         .catch(() => { window.HNAState.state.homeValueCascade = null; return null; });
     }
+    let ownershipPermitsPromise = null;
+    if ((geoType === 'place' || geoType === 'cdp' || geoType === 'county') && !window.HNAState.state.permitsDoc) {
+      ownershipPermitsPromise = loadPermitsDoc()
+        .then((data) => { window.HNAState.state.permitsDoc = data; return data; })
+        .catch(() => { window.HNAState.state.permitsDoc = null; return null; });
+    }
     // ACS-derived AMI gap (households-at-AMI minus units-priced-affordable
     // at each band). Used by renderGapCoverageStats as a fallback when the
     // cached CHAS file's ≤30% AMI row is suspect for the selected county
@@ -3293,6 +3299,7 @@
     }
     if (window.HNARenderers.tryRenderAffordableOwnershipNeedFromState) {
       if (ownershipHomeValueCascadePromise) await ownershipHomeValueCascadePromise;
+      if (ownershipPermitsPromise) await ownershipPermitsPromise;
       window.HNARenderers.tryRenderAffordableOwnershipNeedFromState(profile, geoType, geoid, label, contextCounty);
     }
 

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -4666,6 +4666,12 @@
     return U() && U().fmtMoney ? U().fmtMoney(v) : '—';
   }
 
+  function _ownFmtPermitAvg(v) {
+    var n = Number(v);
+    if (!Number.isFinite(n)) return '—';
+    return _ownFmtNum(Math.round(n));
+  }
+
   function _ownPill(text, method) {
     var source = String(text || 'source');
     var isCountyFallback = /county-CHAS fallback/i.test(source);
@@ -4717,6 +4723,32 @@
     return rec ? Object.assign({ gapSource: 'place' }, rec) : null;
   }
 
+  function _ownPermitContextForSelection(geoType, geoid, permitsDoc) {
+    if (!permitsDoc || !geoid || geoType === 'state') return null;
+    var rec = null;
+    var level = null;
+    if (geoType === 'county') {
+      rec = (permitsDoc.counties || {})[String(geoid)] || null;
+      level = 'county';
+    } else if (geoType === 'place' || geoType === 'cdp') {
+      var canonical = _ownCanonicalGeoid(geoid);
+      rec = (permitsDoc.places || {})[canonical] || (permitsDoc.places || {})[String(geoid)] || null;
+      level = 'place';
+    }
+    if (!rec) return null;
+    var sf = rec.avg_annual_sf_5yr || {};
+    var mf = rec.avg_annual_mf_5yr || {};
+    var total = rec.avg_annual_total_5yr || {};
+    if (sf.value == null && total.value == null) return null;
+    return {
+      level: level,
+      window: sf.window || total.window || '',
+      sfAnnual: sf.value,
+      mfAnnual: mf.value,
+      totalAnnual: total.value,
+    };
+  }
+
   function _ownReviewFlagSet(reviewFlags) {
     var set = {};
     Object.keys(reviewFlags || {}).forEach(function (key) {
@@ -4751,7 +4783,7 @@
     } : null;
   }
 
-  function renderAffordableOwnershipNeed(result) {
+  function renderAffordableOwnershipNeed(result, context) {
     var container = document.getElementById('hnaAffordableOwnershipNeed');
     if (!container) return;
     if (!window.HNAOwnershipNeed || typeof window.HNAOwnershipNeed.computeOwnershipNeed !== 'function') {
@@ -4823,12 +4855,20 @@
     }).join('');
 
     var home = result.affordabilityTest;
+    var permitContext = context && context.permitContext;
     var tableRows = [
       _ownMetricRow('Renter cost-burdened households', _ownFmtNum(result.renterCostBurdened) + ' (' + _ownFmtPct(rental.inputs.renterCostBurdenedShare) + ')', source, 'RAW', 'Rental-oriented pressure signal.'),
       _ownMetricRow('Severely burdened renter households', _ownFmtNum(result.severeRenterCostBurdened) + ' (' + _ownFmtPct(rental.inputs.severeRenterCostBurdenedShare) + ')', source, 'RAW', 'Deep affordability pressure.'),
       _ownMetricRow('Owner cost-burdened households', _ownFmtNum(result.ownerCostBurdened) + ' (' + _ownFmtPct(owner.inputs.ownerCostBurdenedShare) + ')', source, 'RAW', 'Ownership stress among current owners.'),
       _ownMetricRow('Severely burdened owner households', _ownFmtNum(result.severeOwnerCostBurdened) + ' (' + _ownFmtPct(owner.inputs.severeOwnerCostBurdenedShare) + ')', source, 'RAW', 'Severe ownership cost pressure.'),
       _ownMetricRow('Moderate-income renter households', _ownFmtNum(result.moderateIncomeRenterHouseholds) + ' (' + _ownFmtPct(fit.inputs.moderateIncomeRenterShare) + ' of renters)', source, 'DERIVED', '51-100% HAMFI renter base.'),
+      permitContext ? _ownMetricRow(
+        'Single-family permit pace',
+        _ownFmtPermitAvg(permitContext.sfAnnual) + '/yr' + (permitContext.window ? ' (' + permitContext.window + ' avg)' : ''),
+        'Census BPS',
+        'CONTEXT',
+        'Recent market single-family production context only; not an affordable ownership count or purchase-readiness signal. Total recent permits: ' + _ownFmtPermitAvg(permitContext.totalAnnual) + '/yr' + (permitContext.mfAnnual != null ? '; multifamily: ' + _ownFmtPermitAvg(permitContext.mfAnnual) + '/yr.' : '.')
+      ) : '',
       _ownMetricRow('Moderate-income owner cost-burdened households', _ownFmtNum(result.moderateIncomeOwnerCostBurdened) + ' (' + _ownFmtPct(owner.inputs.moderateIncomeOwnerCostBurdenedShare) + ')', source, 'DERIVED', 'Owner pressure in the 51-100% HAMFI bands.'),
       _ownMetricRow('Median home value', home ? _ownFmtMoney(home.medianHomeValue) : 'Unavailable', home ? (home.source || 'home-value input') : 'home-value input', home ? 'MODELED' : 'VERIFY', home ? ('Modeled as ' + home.classification + ' at 80-100% AMI purchase thresholds.') : 'Usable home-value input unavailable or flagged.'),
       _ownMetricRow('Existing rental gap', result.existingRentalGap == null ? 'Unavailable' : _ownFmtNum(result.existingRentalGap) + ' units at or below 80% AMI', 'AMI gap data', result.existingRentalGap == null ? 'VERIFY' : 'DERIVED', 'Rental supply context; not an ownership count.'),
@@ -4902,6 +4942,7 @@
         : _ownFindCountyAmiGap(stateRef.acsAmiGapData, geoid);
       if (!amiGapEntry && contextCounty) amiGapEntry = _ownFindCountyAmiGap(stateRef.acsAmiGapData, contextCounty);
       var homeValueEntry = _ownHomeValueForSelection(profile, geoType, geoid, stateRef.homeValueCascade);
+      var permitContext = _ownPermitContextForSelection(geoType, geoid, stateRef.permitsDoc);
       var afford = U() && U().AFFORD;
       var result = window.HNAOwnershipNeed.computeOwnershipNeed({
         placeChasEntry: geoLevel === 'place' ? chasRecord : null,
@@ -4924,7 +4965,7 @@
           source: 'HNAUtils.AFFORD',
         } : null,
       });
-      renderAffordableOwnershipNeed(result);
+      renderAffordableOwnershipNeed(result, { permitContext: permitContext });
     } catch (e) {
       console.warn('[HNA] tryRenderAffordableOwnershipNeedFromState failed', e);
       var container = document.getElementById('hnaAffordableOwnershipNeed');

--- a/test/combined-geo.test.js
+++ b/test/combined-geo.test.js
@@ -702,6 +702,47 @@ test('ownership renderer receives permits doc from controller state for ownershi
   assert.ok(controllerSrc.includes('if (ownershipPermitsPromise) await ownershipPermitsPromise'), 'ownership render waits for permit context load');
 });
 
+test('place ownership permit context does not fall back to county-only permit records', () => {
+  const dom = loadRenderersDom();
+  dom.window.HNAState.state.permitsDoc = {
+    counties: {
+      '08035': {
+        avg_annual_sf_5yr: { value: 500, window: '2021-2025' },
+        avg_annual_total_5yr: { value: 625, window: '2021-2025' },
+      },
+    },
+    places: {},
+  };
+  dom.window.HNAOwnershipNeed = {
+    computeOwnershipNeed() {
+      return {
+        dataQuality: 'High',
+        tenureMixRecommendation: 'Ownership-supportive strategy',
+        recommendationDetail: 'Fixture recommendation detail.',
+        renterCostBurdened: 240,
+        severeRenterCostBurdened: 100,
+        ownerCostBurdened: 90,
+        severeOwnerCostBurdened: 40,
+        moderateIncomeRenterHouseholds: 75,
+        moderateIncomeOwnerCostBurdened: 25,
+        existingRentalGap: 125,
+        rentalPressure: { tier: 'Moderate', inputs: { source: 'HUD CHAS', renterCostBurdenedShare: 0.4, severeRenterCostBurdenedShare: 0.17 } },
+        ownershipPressure: { tier: 'High', inputs: { ownerCostBurdenedShare: 0.23, moderateIncomeOwnerCostBurdenedShare: 0.06 } },
+        ownershipFit: { tier: 'High', inputs: { moderateIncomeRenterShare: 0.13 } },
+        affordabilityTest: { medianHomeValue: 350000, classification: 'priced-out', source: 'fixture home values' },
+        caveats: [],
+      };
+    },
+  };
+
+  dom.window.HNARenderers.tryRenderAffordableOwnershipNeedFromState({}, 'place', '0807850', 'Boulder city', '08035');
+  const html = dom.window.document.getElementById('hnaAffordableOwnershipNeed').innerHTML;
+
+  assert.equal(html.includes('Single-family permit pace'), false, 'place render must not surface county-only permit data');
+  assert.equal(html.includes('500/yr'), false, 'county-only SF permit pace must not leak into a place render');
+  assert.equal(html.includes('Census BPS'), false, 'no BPS context row appears without a place permit record');
+});
+
 test('combined add button preserves rejection warning by skipping update on false', () => {
   const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-controller.js'), 'utf8');
   const handlerStart = src.indexOf("window.HNAState.els.btnAddCombinedGeo?.addEventListener('click', () => {");

--- a/test/combined-geo.test.js
+++ b/test/combined-geo.test.js
@@ -648,6 +648,60 @@ test('HNA executive decision strip mirrors detailed renderer values', () => {
   assert.ok(doc.getElementById('hnaScorecardPanel').textContent.includes(needValue.replace('/100', '')), 'scorecard panel contains same composite score');
 });
 
+test('ownership renderer surfaces single-family permit context without treating it as affordable supply', () => {
+  const dom = loadRenderersDom();
+  dom.window.HNAOwnershipNeed = { computeOwnershipNeed() {} };
+  const result = {
+    dataQuality: 'High',
+    tenureMixRecommendation: 'Ownership-supportive strategy',
+    recommendationDetail: 'Fixture recommendation detail.',
+    renterCostBurdened: 240,
+    severeRenterCostBurdened: 100,
+    ownerCostBurdened: 90,
+    severeOwnerCostBurdened: 40,
+    moderateIncomeRenterHouseholds: 75,
+    moderateIncomeOwnerCostBurdened: 25,
+    existingRentalGap: 125,
+    rentalPressure: { tier: 'Moderate', inputs: { source: 'HUD CHAS', renterCostBurdenedShare: 0.4, severeRenterCostBurdenedShare: 0.17 } },
+    ownershipPressure: { tier: 'High', inputs: { ownerCostBurdenedShare: 0.23, moderateIncomeOwnerCostBurdenedShare: 0.06 } },
+    ownershipFit: { tier: 'High', inputs: { moderateIncomeRenterShare: 0.13 } },
+    affordabilityTest: { medianHomeValue: 350000, classification: 'priced-out', source: 'fixture home values' },
+    caveats: [],
+  };
+  dom.window.HNARenderers.renderAffordableOwnershipNeed(result, {
+    permitContext: {
+      level: 'county',
+      window: '2021-2025',
+      sfAnnual: 51.8,
+      mfAnnual: 25.2,
+      totalAnnual: 77,
+    },
+  });
+  const html = dom.window.document.getElementById('hnaAffordableOwnershipNeed').innerHTML;
+  assert.ok(html.includes('Single-family permit pace'), 'renders SF permit context row');
+  assert.ok(html.includes('52/yr'), 'rounds average annual SF permits for display');
+  assert.ok(html.includes('2021-2025 avg'), 'shows BPS averaging window');
+  assert.ok(html.includes('Census BPS'), 'labels BPS source');
+  assert.ok(html.includes('CONTEXT'), 'marks permits as context');
+  assert.ok(html.includes('not an affordable ownership count'), 'does not treat SF permits as affordable ownership supply');
+  assert.ok(html.includes('purchase-readiness signal'), 'does not turn permits into buyer-readiness evidence');
+
+  dom.window.HNARenderers.renderAffordableOwnershipNeed(result);
+  const noPermitHtml = dom.window.document.getElementById('hnaAffordableOwnershipNeed').innerHTML;
+  assert.equal(noPermitHtml.includes('Single-family permit pace'), false, 'does not fabricate permit context when BPS record is absent');
+});
+
+test('ownership renderer receives permits doc from controller state for ownership context', () => {
+  const rendererSrc = fs.readFileSync(path.join(ROOT, 'js/hna/hna-renderers.js'), 'utf8');
+  const controllerSrc = fs.readFileSync(path.join(ROOT, 'js/hna/hna-controller.js'), 'utf8');
+  assert.ok(rendererSrc.includes('function _ownPermitContextForSelection'), 'renderer has ownership permit context helper');
+  assert.ok(rendererSrc.includes('stateRef.permitsDoc'), 'renderer reads permits doc from HNA state');
+  assert.ok(rendererSrc.includes('renderAffordableOwnershipNeed(result, { permitContext: permitContext })'), 'renderer passes permit context into ownership panel');
+  assert.ok(controllerSrc.includes('ownershipPermitsPromise'), 'controller starts ownership permit load');
+  assert.ok(controllerSrc.includes('window.HNAState.state.permitsDoc = data'), 'controller caches permits doc on HNA state');
+  assert.ok(controllerSrc.includes('if (ownershipPermitsPromise) await ownershipPermitsPromise'), 'ownership render waits for permit context load');
+});
+
 test('combined add button preserves rejection warning by skipping update on false', () => {
   const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-controller.js'), 'utf8');
   const handlerStart = src.indexOf("window.HNAState.els.btnAddCombinedGeo?.addEventListener('click', () => {");


### PR DESCRIPTION
## Summary
- Adds an optional Affordable Ownership Need table row for recent single-family permit pace from the existing BPS permit document.
- Loads and caches data/hna/permits.json through the HNA controller before ownership rendering for place/CDP/county selections.
- Labels the row as Census BPS / CONTEXT and explicitly states it is not an affordable ownership count or purchase-readiness signal.

## Independent verification
- Controller state and lazy-load path: js/hna/hna-controller.js:11 and js/hna/hna-controller.js:3247.
- Ownership render waits for the permit load before rendering: js/hna/hna-controller.js:3300.
- Renderer extracts county/place permit context without changing ownership tier calculations: js/hna/hna-renderers.js:4726 and js/hna/hna-renderers.js:4945.
- Rendered row copy/source/method keep permits as context only: js/hna/hna-renderers.js:4865.
- Non-vacuous regression coverage proves the row renders with BPS context and is omitted when no permit context exists: test/combined-geo.test.js:651.
- Static integration guard proves the controller provides permitsDoc to the renderer path: test/combined-geo.test.js:694.

## Validation
- node test/combined-geo.test.js
- npm run test:hna-ownership-need
- npm run test:hna
- npm run validate
- npm run test:ci

Refs #1167.

Do not merge until external QA completes.