### PR TITLE
fix: resolve pre-existing CodeQL alerts (9 findings, all fixed — no dismissals)

### DIFF
--- a/.github/workflows/redeploy-zip.yml
+++ b/.github/workflows/redeploy-zip.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate-and-zip:
     runs-on: ubuntu-latest

--- a/js/components/subject-rent-comparison.js
+++ b/js/components/subject-rent-comparison.js
@@ -175,7 +175,7 @@
           $h('td', { style: { padding: '5px 6px', textAlign: 'right' } }, [$money(maxGross)]),
           $h('td', { style: { padding: '5px 6px', textAlign: 'right',
             color: headroom == null ? 'var(--muted)' : (headroom < 0 ? 'var(--bad,#c14545)' : 'var(--good,#3da670)') } }, [
-            headroom == null ? '—' : (headroom >= 0 ? '+' : '') + $money(headroom).replace('$', '$')
+            headroom == null ? '—' : (headroom >= 0 ? '+' : '') + $money(headroom)
           ]),
           $h('td', { style: { padding: '5px 6px', textAlign: 'right', color: 'var(--muted)' } }, [$money(fmrVal)]),
           $h('td', { style: { padding: '5px 6px', textAlign: 'right',

--- a/js/deal-calculator-share.js
+++ b/js/deal-calculator-share.js
@@ -93,7 +93,10 @@
       // F221 — Previously this set el.value = raw which mutated the value
       // attribute on a single radio, instead of selecting the radio whose
       // value matches. Find the matching member of the group and check it.
-      var match = document.querySelector('input[name="' + el.name + '"][value="' + String(raw).replace(/"/g, '\\"') + '"]');
+      // Escape backslashes before quotes so the value can't break out of the
+      // CSS string literal (backslash-escaping order matters).
+      var cssVal = String(raw).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      var match = document.querySelector('input[name="' + el.name + '"][value="' + cssVal + '"]');
       if (match) {
         match.checked = true;
         match.dispatchEvent(new Event('input',  { bubbles: true }));

--- a/js/lihtc-opportunity-finder.js
+++ b/js/lihtc-opportunity-finder.js
@@ -3848,7 +3848,7 @@
       if (days <= 60) return '<span style="background:#f59e0b22;color:#f59e0b;padding:0 5px;border-radius:8px;font-size:.65rem;font-weight:600;margin-left:5px">≤ 60d</span>';
       return '';
     }
-    function esc(s) { return String(s == null ? '' : s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+    function esc(s) { return String(s == null ? '' : s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;'); }
 
     var bodyHtml = rows.map(function (r) {
       var compColor = r.competitiveness === 'high' ? '#dc2626' : (r.competitiveness === 'moderate' ? '#f59e0b' : '#0891b2');
@@ -3897,7 +3897,7 @@
     var sm = state.qapSummary;
     if (!sf || !sm) { host.innerHTML = ''; return; }
 
-    function esc(s) { return String(s == null ? '' : s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+    function esc(s) { return String(s == null ? '' : s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;'); }
     function _pct(num, denom) {
       if (!denom) return 0;
       return Math.max(0, Math.min(100, Math.round((num / denom) * 100)));

--- a/js/pipeline.js
+++ b/js/pipeline.js
@@ -397,11 +397,16 @@
   function mountError(err) {
     var root = document.getElementById('ippMount');
     if (!root) return;
-    root.innerHTML =
-      '<div style="padding:2rem;background:var(--card);border:1px solid var(--border);border-radius:8px;">' +
-      '<h2 style="margin-top:0;color:var(--bad,#b91c1c);">Could not load the pipeline content.</h2>' +
-      '<p style="color:var(--muted);">Reload the page or check Data Health for ingest issues. Details: ' +
-      String(err && err.message ? err.message : err) + '</p></div>';
+    root.innerHTML = '';
+    root.appendChild(el('div', {
+      style: 'padding:2rem;background:var(--card);border:1px solid var(--border);border-radius:8px;'
+    }, [
+      el('h2', { style: 'margin-top:0;color:var(--bad,#b91c1c);' },
+        'Could not load the pipeline content.'),
+      el('p', { style: 'color:var(--muted);' },
+        'Reload the page or check Data Health for ingest issues. Details: ' +
+        String(err && err.message ? err.message : err))
+    ]));
   }
 
   function init() {

--- a/scripts/audit/repo-link-audit.mjs
+++ b/scripts/audit/repo-link-audit.mjs
@@ -286,6 +286,43 @@ async function probeAll(entries) {
   return results;
 }
 
+// Remove <script>/<pre>/<code> blocks so link extraction skips them.
+// Removing a block can splice a new tag together, so re-apply until stable.
+function stripIgnoredBlocks(html) {
+  const tags = ['script', 'pre', 'code'];
+  let out = String(html ?? '');
+  let changed;
+  do {
+    changed = false;
+    const lower = out.toLowerCase();
+    let block = null;
+    for (const tag of tags) {
+      const startToken = `<${tag}`;
+      let start = lower.indexOf(startToken);
+      while (start !== -1) {
+        const boundary = lower[startToken.length + start];
+        if (boundary && boundary !== '>' && boundary !== '/' && boundary.trim() !== '') {
+          start = lower.indexOf(startToken, start + 1);
+          continue;
+        }
+        const openEnd = lower.indexOf('>', start);
+        if (openEnd === -1) break;
+        const closeStart = lower.indexOf(`</${tag}`, openEnd + 1);
+        if (closeStart === -1) break;
+        const closeEnd = lower.indexOf('>', closeStart);
+        if (closeEnd === -1) break;
+        if (!block || start < block.start) block = { start, end: closeEnd + 1 };
+        break;
+      }
+    }
+    if (block) {
+      out = out.slice(0, block.start) + out.slice(block.end);
+      changed = true;
+    }
+  } while (changed);
+  return out;
+}
+
 async function main() {
   const files = await walk(ROOT);
   const externalMap = new Map();
@@ -307,10 +344,7 @@ async function main() {
     }
 
     if (/\.(html|svg)$/i.test(file)) {
-      const localScanSrc = src
-        .replace(/<script\b[\s\S]*?<\/script>/gi, '')
-        .replace(/<pre\b[\s\S]*?<\/pre>/gi, '')
-        .replace(/<code\b[\s\S]*?<\/code>/gi, '');
+      const localScanSrc = stripIgnoredBlocks(src);
       while ((match = LOCAL_ATTR_RE.exec(localScanSrc)) !== null) {
         const link = trimUrl(match[2]);
         if (isExternal(link)) {

--- a/scripts/enrich_lihtc_award_year.mjs
+++ b/scripts/enrich_lihtc_award_year.mjs
@@ -25,7 +25,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -111,7 +111,7 @@ async function main() {
   }
   console.log('');
   console.log('Re-running recency augmentation…');
-  execSync('node ' + path.join(__dirname, 'augment_ranking_index_recency.mjs'), { stdio: 'inherit' });
+  execFileSync(process.execPath, [path.join(__dirname, 'augment_ranking_index_recency.mjs')], { stdio: 'inherit' });
 }
 
 main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/hna/build_hna_data.py
+++ b/scripts/hna/build_hna_data.py
@@ -118,8 +118,10 @@ def http_get_text(url: str, timeout: int = 30, retries: int = 3, backoff: float 
                 body = ''
             print(f"← HTTP {status}  {elapsed:.1f}s  fetching external source (attempt {attempt + 1}/{retries})", file=sys.stderr)
             if status >= 400:
-                # Log response body preview for all API errors to aid debugging
-                print(f"  Response: {body[:1000]}", file=sys.stderr)
+                # Log response body preview for all API errors to aid debugging.
+                # Error bodies can echo the request URL (with API key) — redact
+                # before truncating so a key can't straddle the cut.
+                print(f"  Response: {redact(body)[:1000]}", file=sys.stderr)
             if status in (408, 429, 500, 502, 503, 504) and attempt < retries - 1:
                 time.sleep(wait)
                 wait *= backoff
@@ -141,7 +143,7 @@ def http_get_json(url: str, timeout: int = 30) -> dict | list | None:
     status, text = http_get_text(url, timeout=timeout, retries=1)
     if status != 200:
         print(f"⚠ Failed to fetch JSON from external source: HTTP {status}", file=sys.stderr)
-        print(f"  Response preview: {text[:500]}", file=sys.stderr)
+        print(f"  Response preview: {redact(text)[:500]}", file=sys.stderr)
         return None
     try:
         return json.loads(text)

--- a/tools/check-links.mjs
+++ b/tools/check-links.mjs
@@ -70,11 +70,45 @@ function exists(p) {
   }
 }
 
+// Remove <script>/<pre>/<code> blocks so link extraction skips them.
+// Removing a block can splice a new tag together, so re-apply until stable.
+function stripIgnoredBlocks(html) {
+  const tags = ["script", "pre", "code"];
+  let out = String(html ?? "");
+  let changed;
+  do {
+    changed = false;
+    const lower = out.toLowerCase();
+    let block = null;
+    for (const tag of tags) {
+      const startToken = `<${tag}`;
+      let start = lower.indexOf(startToken);
+      while (start !== -1) {
+        const boundary = lower[startToken.length + start];
+        if (boundary && boundary !== ">" && boundary !== "/" && boundary.trim() !== "") {
+          start = lower.indexOf(startToken, start + 1);
+          continue;
+        }
+        const openEnd = lower.indexOf(">", start);
+        if (openEnd === -1) break;
+        const closeStart = lower.indexOf(`</${tag}`, openEnd + 1);
+        if (closeStart === -1) break;
+        const closeEnd = lower.indexOf(">", closeStart);
+        if (closeEnd === -1) break;
+        if (!block || start < block.start) block = { start, end: closeEnd + 1 };
+        break;
+      }
+    }
+    if (block) {
+      out = out.slice(0, block.start) + out.slice(block.end);
+      changed = true;
+    }
+  } while (changed);
+  return out;
+}
+
 function checkHtmlFile(file) {
-  const html = read(file)
-    .replace(/<script\b[\s\S]*?<\/script>/gi, "")
-    .replace(/<pre\b[\s\S]*?<\/pre>/gi, "")
-    .replace(/<code\b[\s\S]*?<\/code>/gi, "");
+  const html = stripIgnoredBlocks(read(file));
   const dir = path.dirname(file);
   const rawLinks = extractLinks(html);
 


### PR DESCRIPTION
Triages the pre-existing CodeQL alerts that surfaced during #1213 (its wide diff broadened analysis scope; none originate there). All nine are fixed in code — no dismissals needed, so the alerts should auto-close when CodeQL re-analyzes after merge.

## High severity

| Alert | Fix |
|---|---|
| `js/components/subject-rent-comparison.js:178` — incomplete-sanitization + identity-replacement | `.replace('$', '$')` was a pure no-op (replaces `$` with itself, first occurrence only); removed. Rendered output is unchanged. |
| `tools/check-links.mjs` — bad-tag-filter + incomplete-multi-character-sanitization | New `stripIgnoredBlocks()`: closing-tag regexes tolerate whitespace (`</script >`), and stripping re-applies until the output is stable so removals can't splice a fresh `<script` together. |
| `scripts/audit/repo-link-audit.mjs` — same two alerts | Same `stripIgnoredBlocks()` fixpoint helper. |
| `js/deal-calculator-share.js:96` — incomplete-sanitization | Radio-restore selector now escapes backslashes before quotes when building `[value="…"]`. |
| `scripts/hna/build_hna_data.py` — clear-text-logging | HTTP error-body previews now go through `redact()` (Census/FRED error bodies can echo the request URL including the API key); redaction happens before truncation so a key can't straddle the cut. Fixed at both log sites (`body[:1000]` and `text[:500]`). |

## Medium severity

| Alert | Fix |
|---|---|
| `js/pipeline.js:401` — exception text as HTML | `mountError()` now builds the card with the file's existing `el()` helper, so the exception message lands in a text node instead of `innerHTML` concatenation. |
| `js/lihtc-opportunity-finder.js:3873` — incomplete attribute sanitization | Both local `esc()` helpers now escape `"` and `'` (attribute-safe for the `contactUrl` href and every other attr use). |
| `scripts/enrich_lihtc_award_year.mjs:114` — uncontrolled path in shell command | `execSync('node ' + path)` → `execFileSync(process.execPath, [path])` — no shell, path passed as argv. |
| `.github/workflows/redeploy-zip.yml` — missing token permissions | Added top-level `permissions: contents: read` (the job only checks out and uploads an artifact). |

## Verification

- `npm run test:ci` green (exit 0).
- `tools/check-links.mjs` output byte-identical before/after the stripping refactor (2 pre-existing dead links to the removed `WEEKLY-REVIEW.md` are unrelated and flagged separately).
- Browser e2e on the pipeline error path: served a page where `content.json` contains `<img src=x onerror=…>` invalid JSON — the parse-error message renders as inert text (no element injected, handler never fires). Old code injected a live element for the same input.
- Browser e2e on the selector escaping: a radio whose value contains backslash+quote is found by the new selector; the old escaping threw a `querySelector` syntax error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)