### PR TITLE
Add homebuyer help page to sitemaps

### DIFF
--- a/sitemap.html
+++ b/sitemap.html
@@ -168,6 +168,10 @@
             <div class="site-card-name">Housing Legislation 2026</div>
             <div class="site-card-desc">2026 bills tracker</div>
           </a>
+          <a class="site-card" href="help-for-homebuyers.html">
+            <div class="site-card-name">Help for Homebuyers</div>
+            <div class="site-card-desc">Credits, grants, and down-payment assistance</div>
+          </a>
           <a class="site-card" href="policy-briefs.html">
             <div class="site-card-name">Policy Briefs</div>
             <div class="site-card-desc">Research summaries</div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -133,6 +133,10 @@
     <lastmod>2026-06-15</lastmod>
   </url>
   <url>
+    <loc>https://cohoanalytics.com/help-for-homebuyers.html</loc>
+    <lastmod>2026-07-16</lastmod>
+  </url>
+  <url>
     <loc>https://cohoanalytics.com/housing-needs-assessment.html</loc>
     <lastmod>2026-06-26</lastmod>
   </url>

--- a/test/pages-availability-check.js
+++ b/test/pages-availability-check.js
@@ -76,6 +76,7 @@ const HTML_PAGES = [
     'regional.html',
     'state-allocation-map.html',       // redirect stub → lihtc-allocations.html
     'housing-legislation-2026.html',
+    'help-for-homebuyers.html',
     'about.html',
     'insights.html',
 ];
@@ -227,8 +228,9 @@ test('sitemap.xml: public sitemap includes generated place pages and excludes pr
     const sitemap = fs.readFileSync(path.join(ROOT, sitemapPath), 'utf8');
     const urls = sitemap.match(/<loc>https:\/\/[^<]+<\/loc>/g) || [];
     const placeUrls = sitemap.match(/<loc>https:\/\/[^<]+\/places\/\d{7}\.html<\/loc>/g) || [];
-    assert(urls.length >= 500, `sitemap includes public tool pages plus place profiles (${urls.length} URLs)`);
+    assert(urls.length >= 537, `sitemap includes public tool pages plus place profiles (${urls.length} URLs)`);
     assert(placeUrls.length >= 480, `sitemap includes generated place profiles (${placeUrls.length} place URLs)`);
+    assert(sitemap.includes('<loc>https://cohoanalytics.com/help-for-homebuyers.html</loc>'), 'sitemap includes Help for Homebuyers page');
     assert(!sitemap.includes('_template.html'), 'sitemap excludes place template');
     assert(!sitemap.includes('404.html'), 'sitemap excludes 404 page');
     assert(!sitemap.includes('developer-brief'), 'sitemap excludes private developer pages');


### PR DESCRIPTION
Refs #1218

Cites docs/audits/CODEX-HANDOFF-POST-MERGE-AUDIT-2026-07-16.md. Do not merge until external QA completes.

## Summary
- Added https://cohoanalytics.com/help-for-homebuyers.html to sitemap.xml.
- Added Help for Homebuyers to the human-readable sitemap.html Intelligence section.
- Updated the pinned deploy-gate test first: help-for-homebuyers.html is now in the root HTML page list, sitemap URL minimum is 537, and the exact public URL is asserted.

## Scope notes
- Did not touch robots.txt or CNAME.
- Did not add a js/navigation.js entry. The page already has an Insights card inbound link; adding it to a nav dropdown should get owner sign-off per the handoff.

## Verification
- node test/pages-availability-check.js
- npm run validate
- npm run test:ci

## Non-vacuous proof
- The deploy gate now fails if help-for-homebuyers.html is removed from the root page list or if the exact sitemap loc is absent.
