### PR TITLE
Unify LIHTC equity pricing defaults

### DIFF
--- a/data/policy/lihtc-assumptions.json
+++ b/data/policy/lihtc-assumptions.json
@@ -1,11 +1,19 @@
 {
-  "version": "2026-Q1",
-  "lastUpdated": "2026-03-20",
+  "version": "2026-Q2",
+  "lastUpdated": "2026-07-16",
+  "meta": {
+    "title": "LIHTC Deal Predictor Non-Pricing Assumptions",
+    "as_of": "2026-07-16",
+    "source": "COHO policy assumptions synced to js/config/financial-constants.js and Novogradac benchmark fallback",
+    "source_url": "https://www.novoco.com/resource-centers/affordable-housing-tax-credits/equity-pricing",
+    "review_by": "2026-10-16",
+    "methodology": "Hard costs, soft costs, developer fee, soft-funding, and concept mix assumptions support screening-level LIHTC concept recommendations. EquityPricing values are documented offline fallbacks only; live predictor pricing loads data/market/novogradac-equity-pricing.json first and otherwise falls back to js/config/financial-constants.js."
+  },
   "equityPricing": {
-    "default9Pct": 0.87,
-    "default4Pct": 0.85,
+    "default9Pct": 0.86,
+    "default4Pct": 0.84,
     "range": [0.75, 1.05],
-    "source": "CHFA syndication market, March 2026"
+    "source": "Offline fallback synced to financial-constants.js; live benchmark source is data/market/novogradac-equity-pricing.json"
   },
   "hardCostPerUnit": {
     "family": 275000,

--- a/js/deal-calculator.js
+++ b/js/deal-calculator.js
@@ -14,8 +14,8 @@
   var _countyFips = null;   // 5-digit FIPS of the currently selected county
   var _creditRate = _cfg.creditRate9Pct || 0.09;
   var _equityPricingDefaults = {
-    credit_9pct: _cfg.equityPrice9Pct || 0.90,
-    credit_4pct: _cfg.equityPrice4Pct || 0.85
+    credit_9pct: _cfg.equityPrice9Pct || 0.86,
+    credit_4pct: _cfg.equityPrice4Pct || 0.84
   };
   var EQUITY_PRICE_DEFAULT = _equityPricingDefaults.credit_9pct;
   var _amiGapData = null;       // cached co_ami_gap_by_county.json
@@ -98,8 +98,8 @@
     if (!input) return defaultPrice;
     var current = _numOrNull(input.value);
     var shouldUpdate = opts.force || current == null ||
-      Math.abs(current - (_cfg.equityPrice9Pct || 0.90)) < 0.0001 ||
-      Math.abs(current - (_cfg.equityPrice4Pct || 0.85)) < 0.0001;
+      Math.abs(current - (_cfg.equityPrice9Pct || 0.86)) < 0.0001 ||
+      Math.abs(current - (_cfg.equityPrice4Pct || 0.84)) < 0.0001;
     if (shouldUpdate) {
       input.value = defaultPrice.toFixed(2);
       if (opts.dispatch !== false) {
@@ -5349,6 +5349,7 @@
     /* Q5 — exposed so the test harness can inject ZORI fixtures without DOM */
     getZoriCountyRent:          getZoriCountyRent,
     getZoriPerBrRent:           getZoriPerBrRent,
+    getEquityPricingDefaults:   function () { return Object.assign({}, _equityPricingDefaults); },
     _setZoriDataForTest:        function (d) { _zoriData = d; },
     DEFAULT_CONSTANTS:          DEFAULT_CONSTANTS,
     /* Test helpers — mutate the live constants and read back */

--- a/js/lihtc-deal-predictor.js
+++ b/js/lihtc-deal-predictor.js
@@ -86,8 +86,8 @@
   var DEFAULT_ASSUMPTIONS = {
     creditRate9Pct:           _coho.creditRate9Pct  || 0.09,
     creditRate4Pct:           _coho.creditRate4Pct  || 0.04,
-    equityPrice9Pct:          _coho.equityPrice9Pct || 0.87,
-    equityPrice4Pct:          _coho.equityPrice4Pct || 0.85,
+    equityPrice9Pct:          _coho.equityPrice9Pct || 0.86,
+    equityPrice4Pct:          _coho.equityPrice4Pct || 0.84,
     hardCostPerUnit:          350000,
     softCostPct:              0.22,
     devFeePct:                0.15,
@@ -107,10 +107,52 @@
   var _assumptionsLoaded = false;
   var _assumptionsPromise = null;
 
+  function _numOrNull(value) {
+    var n = Number(value);
+    return isFinite(n) && n > 0 ? n : null;
+  }
+
+  function _getEquityPricingDefaults() {
+    return {
+      credit_9pct: DEFAULT_ASSUMPTIONS.equityPrice9Pct,
+      credit_4pct: DEFAULT_ASSUMPTIONS.equityPrice4Pct
+    };
+  }
+
+  function _applyNovogradacPricingDefaults(doc) {
+    var nat = doc && doc.pricing && doc.pricing.national_avg;
+    var nine = _numOrNull(nat && nat.credit_9pct);
+    var four = _numOrNull(nat && nat.credit_4pct);
+    if (!nine || !four) return false;
+    DEFAULT_ASSUMPTIONS.equityPrice9Pct = nine;
+    DEFAULT_ASSUMPTIONS.equityPrice4Pct = four;
+    return true;
+  }
+
+  function _resetPricingDefaultsForTest() {
+    DEFAULT_ASSUMPTIONS.equityPrice9Pct = _coho.equityPrice9Pct || 0.86;
+    DEFAULT_ASSUMPTIONS.equityPrice4Pct = _coho.equityPrice4Pct || 0.84;
+    return _getEquityPricingDefaults();
+  }
+
+  function _assetUrl(path) {
+    return (typeof window !== 'undefined' && typeof window.resolveAssetUrl === 'function')
+      ? window.resolveAssetUrl(path)
+      : path;
+  }
+
+  function _fetchJson(path) {
+    return fetch(_assetUrl(path)).then(function (r) {
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+      return r.json();
+    });
+  }
+
   /**
-   * Load constants from data/policy/lihtc-assumptions.json (once, cached).
-   * Overrides DEFAULT_ASSUMPTIONS where the JSON provides values.
-   * Falls back silently to hardcoded defaults on fetch failure.
+   * Load non-pricing assumptions from data/policy/lihtc-assumptions.json and
+   * current equity pricing from data/market/novogradac-equity-pricing.json.
+   * The assumptions file may document synced fallback pricing, but it must not
+   * override the centralized constants or the Novogradac benchmark.
    */
   function _loadAssumptions() {
     if (_assumptionsPromise) return _assumptionsPromise;
@@ -119,13 +161,18 @@
       _assumptionsLoaded = true;
       return (_assumptionsPromise = Promise.resolve());
     }
-    var url = (typeof window !== 'undefined' && typeof window.resolveAssetUrl === 'function')
-      ? window.resolveAssetUrl('data/policy/lihtc-assumptions.json')
-      : 'data/policy/lihtc-assumptions.json';
-    _assumptionsPromise = fetch(url).then(function (r) {
-      if (!r.ok) throw new Error('HTTP ' + r.status);
-      return r.json();
-    }).then(function (data) {
+    _assumptionsPromise = Promise.all([
+      _fetchJson('data/policy/lihtc-assumptions.json').catch(function (err) {
+        console.warn('[LIHTCDealPredictor] Could not load lihtc-assumptions.json, using defaults:', err);
+        return null;
+      }),
+      _fetchJson('data/market/novogradac-equity-pricing.json').catch(function (err) {
+        console.warn('[LIHTCDealPredictor] Could not load Novogradac equity pricing benchmark, using constants:', err);
+        return null;
+      })
+    ]).then(function (results) {
+      var data = results[0] || {};
+      var benchmark = results[1] || null;
       if (data.hardCostPerUnit && typeof data.hardCostPerUnit === 'object') {
         _hardCostByConcept = {
           family:      data.hardCostPerUnit.family      || DEFAULT_ASSUMPTIONS.hardCostPerUnit,
@@ -134,16 +181,13 @@
           supportive:  data.hardCostPerUnit.supportive   || DEFAULT_ASSUMPTIONS.hardCostPerUnit
         };
       }
-      if (data.equityPricing) {
-        if (data.equityPricing.default9Pct) DEFAULT_ASSUMPTIONS.equityPrice9Pct = data.equityPricing.default9Pct;
-        if (data.equityPricing.default4Pct) DEFAULT_ASSUMPTIONS.equityPrice4Pct = data.equityPricing.default4Pct;
-      }
       if (data.softCostPct)  DEFAULT_ASSUMPTIONS.softCostPct = data.softCostPct;
       if (data.devFeePct)    DEFAULT_ASSUMPTIONS.devFeePct    = data.devFeePct;
+      _applyNovogradacPricingDefaults(benchmark);
       _assumptionsLoaded = true;
-      console.log('[LIHTCDealPredictor] Loaded assumptions from lihtc-assumptions.json');
+      console.log('[LIHTCDealPredictor] Loaded assumptions and equity pricing defaults');
     }).catch(function (err) {
-      console.warn('[LIHTCDealPredictor] Could not load lihtc-assumptions.json, using defaults:', err);
+      console.warn('[LIHTCDealPredictor] Could not load predictor defaults, using constants:', err);
       _assumptionsLoaded = true;
     });
     return _assumptionsPromise;
@@ -937,6 +981,9 @@
     predictConcept:              predictConcept,
     predict:                     predict,
     DISCLAIMER:                  DISCLAIMER,
+    _applyNovogradacPricingDefaults: _applyNovogradacPricingDefaults,
+    _getEquityPricingDefaults:   _getEquityPricingDefaults,
+    _resetPricingDefaultsForTest: _resetPricingDefaultsForTest,
     _computeScenarioSensitivity: _computeScenarioSensitivity,
     _computeFmrAlignment:        _computeFmrAlignment,
     _computeChfaAwardContext:    _computeChfaAwardContext

--- a/scripts/audit/benchmark-freshness-check.mjs
+++ b/scripts/audit/benchmark-freshness-check.mjs
@@ -11,6 +11,7 @@
  *   - data/market/tax-credit-transfer-pricing.json (tax-credit transfer pricing)
  *   - data/policy/tax-credit-legislation.json (tax-credit legislation watchlist)
  *   - data/policy/homeownership-programs.json (consumer homebuyer program watchlist)
+ *   - data/policy/lihtc-assumptions.json (predictor non-pricing assumptions)
  *
  * Each was added in a one-time commit and has no refresh workflow. The UI
  * discloses the vintage honestly (shows `as_of` inline, links the source,
@@ -72,6 +73,11 @@ const BENCHMARK_FILES = [
     file: 'data/policy/homeownership-programs.json',
     label: 'Homeownership programs watchlist',
     reviewByPaths: ['meta.review_by', 'programs[].review_by'],
+  },
+  {
+    file: 'data/policy/lihtc-assumptions.json',
+    label: 'LIHTC predictor assumptions',
+    reviewByPaths: ['meta.review_by'],
   },
 ];
 

--- a/test/deal-calc-equity-pricing.test.js
+++ b/test/deal-calc-equity-pricing.test.js
@@ -7,13 +7,32 @@ const { JSDOM } = require('jsdom');
 
 const root = path.join(__dirname, '..');
 const benchmark = require(path.join(root, 'data', 'market', 'novogradac-equity-pricing.json'));
+const assumptions = require(path.join(root, 'data', 'policy', 'lihtc-assumptions.json'));
+const Predictor = require(path.join(root, 'js', 'lihtc-deal-predictor.js'));
 const dcSrc = fs.readFileSync(path.join(root, 'js', 'deal-calculator.js'), 'utf8');
+const constantsSrc = fs.readFileSync(path.join(root, 'js', 'config', 'financial-constants.js'), 'utf8');
+
+function constantValue(key) {
+  const match = constantsSrc.match(new RegExp(`${key}:\\s*([0-9.]+)`));
+  assert(match, `financial constant found: ${key}`);
+  return Number(match[1]);
+}
+
+const constants = {
+  credit_9pct: constantValue('equityPrice9Pct'),
+  credit_4pct: constantValue('equityPrice4Pct')
+};
 
 console.log('\nDeal Calculator equity-pricing benchmark tests');
 console.log('='.repeat(56));
 
 assert.strictEqual(benchmark.pricing.national_avg.credit_9pct, 0.86, 'benchmark 9% price is Q2 2026 value');
 assert.strictEqual(benchmark.pricing.national_avg.credit_4pct, 0.84, 'benchmark 4% price is Q2 2026 value');
+assert.strictEqual(constants.credit_9pct, 0.86, 'financial constants 9% fallback matches Q2 2026 benchmark');
+assert.strictEqual(constants.credit_4pct, 0.84, 'financial constants 4% fallback matches Q2 2026 benchmark');
+assert.strictEqual(assumptions.equityPricing.default9Pct, constants.credit_9pct, 'assumptions 9% fallback is synced to financial constants');
+assert.strictEqual(assumptions.equityPricing.default4Pct, constants.credit_4pct, 'assumptions 4% fallback is synced to financial constants');
+assert(fs.readFileSync(path.join(root, 'scripts', 'audit', 'benchmark-freshness-check.mjs'), 'utf8').includes('data/policy/lihtc-assumptions.json'), 'freshness audit includes LIHTC assumptions');
 
 const dom = new JSDOM('<!DOCTYPE html><body><div id="dealCalcMount"></div></body>', {
   url: 'http://localhost/deal-calculator.html'
@@ -26,8 +45,8 @@ global.Event = dom.window.Event;
 window.COHO_DEFAULTS = {
   creditRate9Pct: 0.09,
   creditRate4Pct: 0.04,
-  equityPrice9Pct: 0.91,
-  equityPrice4Pct: 0.83
+  equityPrice9Pct: constants.credit_9pct,
+  equityPrice4Pct: constants.credit_4pct
 };
 window.DealCalculatorMath = require('../js/deal-calculator-math.js');
 window.fetch = () => Promise.reject(new Error('fixture fetch disabled'));
@@ -37,6 +56,9 @@ document.dispatchEvent(new Event('DOMContentLoaded', { bubbles: true }));
 
 const dc = window.__DealCalc;
 assert(dc && typeof dc.applyNovogradacPricingDefaults === 'function', 'benchmark application helper exported');
+assert(dc && typeof dc.getEquityPricingDefaults === 'function', 'deal calculator pricing default getter exported');
+assert(Predictor && typeof Predictor._applyNovogradacPricingDefaults === 'function', 'predictor benchmark application helper exported');
+assert(Predictor && typeof Predictor._getEquityPricingDefaults === 'function', 'predictor pricing default getter exported');
 
 const input = document.getElementById('dc-equity-price');
 const rate9 = document.getElementById('dc-rate-9');
@@ -44,9 +66,15 @@ const rate4 = document.getElementById('dc-rate-4');
 assert(input && rate9 && rate4, 'pricing input and rate toggles render');
 assert.strictEqual(input.value, '0.90', 'markup starts from legacy static value before benchmark helper');
 
+Predictor._resetPricingDefaultsForTest();
+assert.deepStrictEqual(dc.getEquityPricingDefaults(), constants, 'calculator fallback defaults match financial constants without benchmark');
+assert.deepStrictEqual(Predictor._getEquityPricingDefaults(), constants, 'predictor fallback defaults match calculator constants without benchmark');
+
 const applied = dc.applyNovogradacPricingDefaults(benchmark, { force: true, dispatch: false });
 assert.strictEqual(applied, true, 'valid benchmark data applies');
 assert.strictEqual(input.value, '0.86', '9% input prefers benchmark over fallback constant');
+assert.strictEqual(Predictor._applyNovogradacPricingDefaults(benchmark), true, 'predictor accepts valid Novogradac benchmark');
+assert.deepStrictEqual(Predictor._getEquityPricingDefaults(), dc.getEquityPricingDefaults(), 'calculator and predictor benchmark defaults match');
 
 rate4.checked = true;
 rate4.dispatchEvent(new Event('change', { bubbles: true }));
@@ -56,5 +84,8 @@ const before = input.value;
 const missing = dc.applyNovogradacPricingDefaults({ pricing: { national_avg: { credit_9pct: null } } }, { force: true, dispatch: false });
 assert.strictEqual(missing, false, 'incomplete benchmark data is rejected');
 assert.strictEqual(input.value, before, 'rejected benchmark leaves current value untouched');
+const predictorBefore = Predictor._getEquityPricingDefaults();
+assert.strictEqual(Predictor._applyNovogradacPricingDefaults({ pricing: { national_avg: { credit_9pct: null } } }), false, 'predictor rejects incomplete benchmark data');
+assert.deepStrictEqual(Predictor._getEquityPricingDefaults(), predictorBefore, 'predictor rejected benchmark leaves current defaults untouched');
 
 console.log('All Deal Calculator equity-pricing benchmark tests passed.');

--- a/test/deal-calc-equity-pricing.test.js
+++ b/test/deal-calc-equity-pricing.test.js
@@ -88,4 +88,20 @@ const predictorBefore = Predictor._getEquityPricingDefaults();
 assert.strictEqual(Predictor._applyNovogradacPricingDefaults({ pricing: { national_avg: { credit_9pct: null } } }), false, 'predictor rejects incomplete benchmark data');
 assert.deepStrictEqual(Predictor._getEquityPricingDefaults(), predictorBefore, 'predictor rejected benchmark leaves current defaults untouched');
 
+// Parity must hold for benchmark values that DIFFER from the constants —
+// otherwise a module that silently ignores the benchmark passes because the
+// current benchmark happens to equal the fallback constants (QA #1226 gap).
+const synthetic = { pricing: { national_avg: { credit_9pct: 0.91, credit_4pct: 0.89 } } };
+assert.strictEqual(dc.applyNovogradacPricingDefaults(synthetic, { force: true, dispatch: false }), true, 'calculator accepts synthetic benchmark');
+assert.strictEqual(Predictor._applyNovogradacPricingDefaults(synthetic), true, 'predictor accepts synthetic benchmark');
+assert.deepStrictEqual(dc.getEquityPricingDefaults(), { credit_9pct: 0.91, credit_4pct: 0.89 }, 'calculator adopts divergent benchmark values');
+assert.deepStrictEqual(Predictor._getEquityPricingDefaults(), { credit_9pct: 0.91, credit_4pct: 0.89 }, 'predictor adopts divergent benchmark values');
+assert.deepStrictEqual(Predictor._getEquityPricingDefaults(), dc.getEquityPricingDefaults(), 'calculator and predictor stay in parity on divergent benchmark');
+
+// Reset both back to the real benchmark/constants so later assertions or
+// suites see production values.
+Predictor._resetPricingDefaultsForTest();
+dc.applyNovogradacPricingDefaults(benchmark, { force: true, dispatch: false });
+assert.deepStrictEqual(Predictor._getEquityPricingDefaults(), { credit_9pct: constants.credit_9pct, credit_4pct: constants.credit_4pct }, 'predictor reset restores constants fallback');
+
 console.log('All Deal Calculator equity-pricing benchmark tests passed.');


### PR DESCRIPTION
Refs #1218

Cites docs/audits/CODEX-HANDOFF-POST-MERGE-AUDIT-2026-07-16.md. Do not merge until external QA completes.

## Summary
- Updated LIHTC Deal Predictor to load current equity pricing from data/market/novogradac-equity-pricing.json at init, while retaining data/policy/lihtc-assumptions.json for non-pricing assumptions.
- Synced predictor and calculator emergency fallback literals to financial-constants.js / Q2 2026 values: 9% = 0.86, 4% = 0.84.
- Added metadata and review_by to data/policy/lihtc-assumptions.json, and added that file to benchmark-freshness-check.mjs.
- Extended the equity-pricing test so Deal Calculator and Deal Predictor resolve identical 9%/4% defaults with the benchmark present and identical constants fallbacks without the benchmark.

## Scope note
- Touched js/deal-calculator.js only to align stale emergency fallback literals and expose the current pricing-default getter for the parity test. The calculator benchmark UI behavior is unchanged.

## Non-vacuous proof
- Temporarily changed data/policy/lihtc-assumptions.json equityPricing.default9Pct from 0.86 to 0.87.
- node test/deal-calc-equity-pricing.test.js failed by exit code 1 on: assumptions 9% fallback is synced to financial constants.
- Restored the value to 0.86 and reran the focused tests green.

## Verification
- node test/deal-calc-equity-pricing.test.js
- node test/lihtc-deal-predictor.test.js
- node scripts/audit/benchmark-freshness-check.mjs
- npm run validate
- npm run test:ci
- node scripts/audit/source-url-sweep.mjs --quiet (0 hard failures; WAF/timeouts only)
