### PR TITLE
Fix Section 168(k) equity-pricing driver

### DIFF
--- a/data/market/novogradac-equity-pricing.json
+++ b/data/market/novogradac-equity-pricing.json
@@ -36,20 +36,21 @@
       "Falling 10y Treasury yield (debt becomes cheaper → cap rates fall → residual value rises → investor IRR up)",
       "CRA reform creating new buyer demand",
       "Tax-credit policy certainty (e.g., extending placed-in-service windows, raising 9% credit cap)",
+      "Permanent 100% bonus depreciation under Section 168(k) for qualified property acquired after January 19, 2025 (Public Law 119-21, section 70301)",
       "Strong sponsor track record (CHFA-allocator-tier syndicators get premium)",
       "Larger deals (50+ units, $20M+ TDC) get premium of 1-2 cents over smaller"
     ],
     "what_moves_pricing_down": [
       "Rising 10y Treasury yield (compresses residual values)",
-      "Bonus-depreciation phase-down (Section 168(k) drops by 20% per year)",
       "Tax-rate cut concerns (lower top-rate = lower credit value)",
       "Bank-stress / capital-charge headwinds",
       "Rural / smaller / first-time-sponsor / non-traditional populations discount"
     ]
   },
   "validation_check": {
-    "last_verified": "2026-07-15",
-    "verified_against": "Novogradac.com public-facing equity pricing summary (subscription required for full report)",
+    "last_verified": "2026-07-17",
+    "verified_against": "Novogradac.com public-facing equity pricing summary (subscription required for full report); Public Law 119-21 section 70301 for Section 168(k) bonus depreciation treatment",
+    "policy_source_url": "https://www.govinfo.gov/app/details/PLAW-119publ21",
     "next_review": "Quarterly — refresh data + verify against current Novogradac publication",
     "ingestion_note": "Future: build a script that pulls the public Novogradac monthly headline article + parses national 9%/4% from the lede. Manual quarterly update for now."
   }

--- a/data/policy/tax-credit-legislation.json
+++ b/data/policy/tax-credit-legislation.json
@@ -49,6 +49,19 @@
       "review_by": "2026-10-15"
     },
     {
+      "id": "obbba-168k-permanent-bonus-depreciation",
+      "title": "Permanent 100% bonus depreciation under Section 168(k)",
+      "scope": "lihtc",
+      "status": "enacted",
+      "effective_date": "2025-01-20",
+      "sunset_date": null,
+      "pricing_impact": "Restores permanent 100% additional first-year depreciation for qualified property acquired after January 19, 2025. Treat the Section 168(k) change as an after-tax yield tailwind, not a continuing phase-down headwind.",
+      "source_url": "https://www.govinfo.gov/app/details/PLAW-119publ21",
+      "source_note": "Public Law 119-21, section 70301, 100 percent expensing; amendments generally apply to property acquired after January 19, 2025.",
+      "last_verified": "2026-07-17",
+      "review_by": "2026-10-17"
+    },
+    {
       "id": "obbba-nmtc-permanent-extension",
       "title": "Permanent extension of the New Markets Tax Credit",
       "scope": "nmtc",

--- a/test/deal-calc-equity-pricing.test.js
+++ b/test/deal-calc-equity-pricing.test.js
@@ -8,6 +8,7 @@ const { JSDOM } = require('jsdom');
 const root = path.join(__dirname, '..');
 const benchmark = require(path.join(root, 'data', 'market', 'novogradac-equity-pricing.json'));
 const assumptions = require(path.join(root, 'data', 'policy', 'lihtc-assumptions.json'));
+const legislation = require(path.join(root, 'data', 'policy', 'tax-credit-legislation.json'));
 const Predictor = require(path.join(root, 'js', 'lihtc-deal-predictor.js'));
 const dcSrc = fs.readFileSync(path.join(root, 'js', 'deal-calculator.js'), 'utf8');
 const constantsSrc = fs.readFileSync(path.join(root, 'js', 'config', 'financial-constants.js'), 'utf8');
@@ -33,6 +34,21 @@ assert.strictEqual(constants.credit_4pct, 0.84, 'financial constants 4% fallback
 assert.strictEqual(assumptions.equityPricing.default9Pct, constants.credit_9pct, 'assumptions 9% fallback is synced to financial constants');
 assert.strictEqual(assumptions.equityPricing.default4Pct, constants.credit_4pct, 'assumptions 4% fallback is synced to financial constants');
 assert(fs.readFileSync(path.join(root, 'scripts', 'audit', 'benchmark-freshness-check.mjs'), 'utf8').includes('data/policy/lihtc-assumptions.json'), 'freshness audit includes LIHTC assumptions');
+
+const bonusDepreciationEntry = legislation.entries.find((entry) => entry.id === 'obbba-168k-permanent-bonus-depreciation');
+assert(bonusDepreciationEntry, 'legislation watchlist includes the enacted Section 168(k) bonus-depreciation entry');
+assert.strictEqual(bonusDepreciationEntry.status, 'enacted', 'Section 168(k) bonus-depreciation watchlist entry is enacted');
+assert.match(bonusDepreciationEntry.source_note, /Public Law 119-21, section 70301/, 'Section 168(k) watchlist entry cites PL 119-21 section 70301');
+const equityDriverText = JSON.stringify(benchmark.key_drivers);
+assert.match(
+  equityDriverText,
+  /Permanent 100% bonus depreciation under Section 168\(k\)/,
+  'equity-pricing drivers treat enacted Section 168(k) 100% bonus depreciation as a pricing tailwind'
+);
+assert(
+  !/phase-down|drops by 20% per year/i.test(equityDriverText),
+  'equity-pricing drivers do not contradict the enacted Section 168(k) watchlist entry with stale phase-down language'
+);
 
 const dom = new JSDOM('<!DOCTYPE html><body><div id="dealCalcMount"></div></body>', {
   url: 'http://localhost/deal-calculator.html'


### PR DESCRIPTION
Refs #1227

Do not merge until external QA completes.

## Summary
- Moves the Novogradac equity-pricing benchmark's Section 168(k) language from a stale bonus-depreciation phase-down headwind to a permanent 100% bonus-depreciation tailwind.
- Bumps the benchmark's last_verified date to 2026-07-17 and cites Public Law 119-21 section 70301 via GovInfo.
- Adds an enacted tax-credit legislation watchlist entry for the OBBBA Section 168(k) provision so the market driver has a policy source of truth.
- Extends the equity-pricing guard to fail if benchmark drivers reintroduce stale phase-down / 20%-per-year language while the watchlist entry is enacted.

## Source verification
- GovInfo Public Law 119-21 content details: https://www.govinfo.gov/app/details/PLAW-119publ21
- IRS 2025 Publication 946 / current IRS guidance confirms Section 168(k), as amended by PL 119-21, provides 100% special depreciation allowance for qualified property acquired and placed in service after January 19, 2025.

## Verification
- npm run validate
- node scripts/audit/source-url-sweep.mjs --quiet (0 hard failures; WAF/bot-blocked only)
- npm run test:file-manifest
- npm run test:deal-calc-equity-pricing
- npm run test:tax-credit-equity-markets
- npm run test:ci