### PR TITLE
docs: RFC — barrier-aware PMA + commute-shed delineation (#1232 final phase)

### DIFF
--- a/docs/audits/CALIBRATION-FRUITA-MEWS-PMA-2026-07.md
+++ b/docs/audits/CALIBRATION-FRUITA-MEWS-PMA-2026-07.md
@@ -1,0 +1,77 @@
+# Calibration Benchmark — Fruita Mews II Professional PMA vs Tool PMA
+
+**Companion to:** RFC-PMA-BARRIER-COMMUTE-SHED-2026-07.md (§6, benchmark path 1)
+**Recorded:** 2026-07-18 by Claude QA from an owner-provided review artifact.
+
+## Benchmark artifact
+
+Market Study of The Fruita Mews II, Kinetic Valuation Group (Amanda Baker MAI /
+Brent Griffiths MAI), effective 2026-01-29, prepared to CHFA's Market Study
+Guide for a 40-unit 9% LIHTC application at 1138 18 1/2 Road, Fruita, Mesa
+County (site census tract 15.03). PMA reviewed and **approved by CHFA's
+collateral/review appraiser**. Owner-provided PDF (not publicly published);
+retained in the owner's application files. A second artifact (the 2022 Phase I
+study) exists but sits behind a macOS-restricted Dropbox path; add it to this
+record when copied to a readable location.
+
+## Professional PMA (verbatim facts)
+
+- **Shape:** "a polygon encompassing a portion of northwestern Mesa County
+  that includes Fruita and portions of Western Grand Junction."
+- **Tract list (8, Mesa County 08077):** 0009.00, 0014.02, 0014.03, 0014.04,
+  0015.02, 0015.03, 0015.04, 0016.00. (The study prints a doubled-digit
+  county prefix typo "08777…"; the tract numbers are unambiguous.)
+- **Delineation basis:** "physical boundaries, which include traffic and
+  commute patterns," market surveys, resident managers, planning staff.
+  Rationale is explicitly commute-economic: Grand Junction (~12 miles) is the
+  hub; smaller-community residents commute to it.
+- **On barriers:** "There are no natural boundaries in Fruita that would
+  inhibit anyone from relocating to the Subject." The PMA polygon's southwest
+  edge nonetheless *runs along* the Colorado River / Colorado National
+  Monument — a boundary of convenience, not an exclusion claim.
+- **Observed migration (Phase I leasing, ~129 applications since 2024):**
+  44% of applicants from PMA zips, 56% outside, 9% from outside Mesa County;
+  the study infers in-migration "9 percent to 56 percent."
+- SMA = Mesa County. PMA totals used in demand: 995 qualifying renter
+  households across 30–80% AMI bands; overall penetration 13.9%.
+
+## Tool output at the same site (computed 2026-07-18, current main)
+
+Centroid-inclusion 3-mile buffer at 39.1660, −108.7080:
+
+| Result | Tracts |
+|---|---|
+| Tool 3-mile PMA | **2**: 08077001503 (0.88 mi), 08077001504 (1.39 mi) |
+| Overlap with professional PMA | 2 of 8 (25% of the professional set) |
+| Tool-only (false inclusions) | **none** |
+| Professional-only (missed) | 0009.00, 0014.02, 0014.03, 0014.04, 0015.02, 0016.00 — the Fruita periphery and western Grand Junction commute extension |
+
+## Calibration findings
+
+- **F-CAL-1 — the first-order gap at small-town sites is commute extension,
+  not barriers.** The professional PMA reaches ~12 miles toward the economic
+  hub, asymmetrically (western Grand Junction only). A circular buffer of any
+  radius cannot reproduce an asymmetric commute-shaped polygon: 3 miles
+  captures 25% of the professional set; a 12-mile circle would over-include
+  east Grand Junction the professional excluded.
+- **F-CAL-2 — the professional affirms the M3 never-exclude posture.** With a
+  major river and a national monument adjacent, the study still finds no
+  inhibiting natural boundary; features appear as edges of convenience.
+  Barrier *exclusion* would have contradicted the professional here; bounded
+  friction downweighting (or nothing) would not.
+- **F-CAL-3 — capture humility.** Even the professional PMA contained only
+  44% of actual Phase I applicants. Any future D-full capture threshold must
+  accommodate documented 9–56% in-migration; over-tight PMAs are wrong in
+  the direction the leasing data can prove.
+- **F-CAL-4 — no false inclusions.** The tool's conservatism errs by
+  under-extension only at this site, which is the correctable direction.
+
+## Effect on the RFC (amendment applied same-day)
+
+Priority reorder: **D (commute-shed) is promoted from optional follow-on to
+the primary realism gap for rural/small-town sites**, with barriers (C2/C3)
+retained as specified but explicitly second-order pending a benchmark where
+barriers bind (an urban river/interstate site would be the right second
+artifact). One benchmark satisfies the RFC's floor to *proceed with C1/D-lite
+scoping*; the C3 barrier-enable gate still requires a benchmark where barrier
+treatment has observable effect.

--- a/docs/audits/CALIBRATION-FRUITA-MEWS-PMA-2026-07.md
+++ b/docs/audits/CALIBRATION-FRUITA-MEWS-PMA-2026-07.md
@@ -3,16 +3,18 @@
 **Companion to:** RFC-PMA-BARRIER-COMMUTE-SHED-2026-07.md (§6, benchmark path 1)
 **Recorded:** 2026-07-18 by Claude QA from an owner-provided review artifact.
 
-## Benchmark artifact
+## Benchmark artifacts (two, independent firms, same site)
 
 Market Study of The Fruita Mews II, Kinetic Valuation Group (Amanda Baker MAI /
 Brent Griffiths MAI), effective 2026-01-29, prepared to CHFA's Market Study
 Guide for a 40-unit 9% LIHTC application at 1138 18 1/2 Road, Fruita, Mesa
 County (site census tract 15.03). PMA reviewed and **approved by CHFA's
 collateral/review appraiser**. Owner-provided PDF (not publicly published);
-retained in the owner's application files. A second artifact (the 2022 Phase I
-study) exists but sits behind a macOS-restricted Dropbox path; add it to this
-record when copied to a readable location.
+retained in the owner's application files.
+
+**Artifact 2:** Rental Market Study, The Fruita Mews (Phase I), Prior &
+Associates (Thad Rahn / Josh Roberts), effective 2022-01-05, revised
+2022-01-26, same site. Independent firm from Artifact 1. Owner-provided.
 
 ## Professional PMA (verbatim facts)
 
@@ -34,6 +36,42 @@ record when copied to a readable location.
   the study infers in-migration "9 percent to 56 percent."
 - SMA = Mesa County. PMA totals used in demand: 995 qualifying renter
   households across 30–80% AMI bands; overall penetration 13.9%.
+
+## Artifact 2 — professional PMA (verbatim facts, 2022)
+
+- **Composition:** "Fruita, Mack, Loma, Redlands, Appleton and northwestern
+  Grand Junction." 45,285 inhabitants, ~440 square miles.
+- **Named boundaries:** North — Mesa County line; **South — Colorado River /
+  Colorado National Monument**; **East — 25 Road / South 5th Street**,
+  explicitly because areas east "associate more with central Grand Junction
+  which has different commuting patterns and socioeconomic characteristics";
+  West — Mesa County line.
+- **Tracts (2010 vintage):** 9.00, 14.02, 14.03, 14.04, 15.01, 15.02, 16.00 —
+  identical to Artifact 1's set modulo the 2020 census split of 15.01 into
+  15.03/15.04.
+- **Supplemental demand:** a 40% outside-PMA factor, grounded in the PMA's
+  one LIHTC property drawing >25% of tenants from outside.
+
+## Cross-artifact findings
+
+- **F-CAL-5 — professional convergence.** Two independent firms, four years
+  apart, drew the same PMA (modulo tract-split). Professional delineation at
+  this site is stable and reproducible — a legitimate algorithmic target,
+  not one analyst's taste.
+- **F-CAL-6 — how professionals actually use barriers.** The 2022 study
+  *names* the river/Monument as the southern boundary — but that edge runs
+  through uninhabited monument land (nothing excluded), and the analytically
+  live eastern edge is a **commuting/socioeconomic line through the middle of
+  Grand Junction** (25 Rd/S 5th), not a physical feature. Reconciled with
+  Artifact 1's "no inhibiting natural boundaries": barriers serve as polygon
+  edges of convenience across empty land; populated-tract exclusion decisions
+  are made on commute/socio structure. This sharpens F-CAL-2 and confirms the
+  C3 gate: neither artifact shows barriers *binding* — that benchmark is
+  still outstanding and must come from a different site type.
+- **F-CAL-7 — in-migration prediction vs observation.** 2022 predicted ~40%
+  outside-PMA demand; 2024–26 Phase I leasing observed 56% (Artifact 1). Any
+  D-full capture threshold must treat outside-PMA demand of 40–56% as the
+  professionally documented range at this site.
 
 ## Tool output at the same site (computed 2026-07-18, current main)
 

--- a/docs/audits/RFC-PMA-BARRIER-COMMUTE-SHED-2026-07.md
+++ b/docs/audits/RFC-PMA-BARRIER-COMMUTE-SHED-2026-07.md
@@ -1,0 +1,245 @@
+# RFC — Barrier-Aware PMA and Commute-Shed Delineation
+
+**Issue:** #1232 (final phase) · **Handoff honored:** CODEX-HANDOFF-PMA-BARRIER-COMMUTE-SHED-RFC-2026-07.md
+**Author:** Claude QA · **Date:** 2026-07-18 · **Status:** decision-ready, awaiting owner sign-off
+**Scope:** methodology decision record only — no production code was written for this RFC.
+
+## 0. Decision summary (what the owner is approving)
+
+1. **Complete the barrier dataset before any method ships** (C1): the committed
+   barriers file is materially narrower than documented — see §2. Method work
+   on incomplete data would bake in blind spots.
+2. **Adopt friction-downweighting (M3), reject exclusion-by-crossing (M2), defer
+   graph connectivity (M1)**: cross-barrier tracts get a disclosed, bounded
+   downweight — never silent exclusion — until crossing data exists (§3).
+3. **Commute-shed ships first as a context overlay (D-lite), not an analytic
+   extension**: the committed LODES surface cannot support per-site capture
+   math (§5). D-full requires a new build artifact and separate approval.
+4. **Calibration is a hard gate**: C3 (enabling barrier-aware mode by default)
+   is blocked until at least one professional site-level PMA benchmark is in
+   hand (§6). Application market studies are not publicly published; the
+   likeliest source is owner-provided studies.
+5. Staged PRs C1 → C2 (flag off) → C3 (enable, disclosed) → D-lite → D-full (§9).
+
+Everything below is evidence for those five calls.
+
+## 1. Prior-art audit (js/pma-barriers.js, js/pma-commuting.js)
+
+**pma-barriers.js** — heuristic *area-percentage* subtraction, not tract logic:
+`WATER_EXCLUSION_FACTOR = 0.02` ("each water body covers ~2% of PMA area"),
+`HIGHWAY_EXCLUSION_FACTOR = 0.01`, land-cover factors, capped sums; plus
+`MIN_BARRIER_AADT = 10000` (line 193) and a straight-line site→centroid
+crossing helper. **Verdict: none of it survives.** The area-percentage factors
+are exactly the fabricated-calibration class the handoff bans; the AADT floor
+is a weak discriminator on the current data (§2); the straight-line crossing
+helper is the M2 shape rejected in §3. Salvage value: the fetch wrappers'
+bbox plumbing only.
+
+**pma-commuting.js** — contains `buildConvexHullPolygon` (the geometry we just
+eliminated from the PMA display) and `_buildSyntheticWorkplaces` fallback with
+`lastDataCoverage = 'fallback'`. **Verdict: the synthetic path and hull path
+must never reach shipped analysis** (test-guarded in §8). Salvage value: the
+`lastDataCoverage` flag is the right *shape* for a data-coverage gate — invert
+it into a hard precondition (`!== 'fallback'`) rather than a fallback marker.
+
+## 2. Barrier dataset audit (data/market/natural_barriers_co.geojson)
+
+11,175 features. Audited 2026-07-18:
+
+| Slice | Count | Notes |
+|---|---:|---|
+| highway (LineString, CDOT) | 10,084 | **All `route_sign: "I"` — interstates only**: I-70 (4,773 segs), I-25 (3,627), I-76 (1,341), I-225, I-270 |
+| water (Polygon, TIGERweb) | 1,091 | `lake` 1,016 / `water` 75 — **areal water only; zero linear rivers** |
+
+Findings that gate method work:
+
+- **F-DATA-1 — the `sub_type` field is degenerate**: every highway segment is
+  labeled `interstate`. The fetch script requests CDOT `ROUTESIGN` "I" *and*
+  "U", but the committed file contains no US routes — the "U" fetch failed
+  silently at generation (the script warns and continues). US-285/US-160/US-50
+  and all state highways are absent.
+- **F-DATA-2 — no rivers**: TIGERweb areal water gives lakes/reservoirs, but
+  the Colorado, Arkansas, and canyon rivers — the classic Western-slope market
+  separators — are not in the file as linear features.
+- **F-DATA-3 — AADT is present on 100% of highway segments** (min 8,200 · p25
+  19,000 · median 33,000 · p95 197,000). The prior `MIN_BARRIER_AADT = 10000`
+  keeps 96% of segments — a near-no-op on interstates-only data. AADT tiering
+  is only meaningful after US/state routes are added, and thresholds may then
+  come **only** from calibration (§6), not from this distribution.
+- Useful fields that DO exist: `route`, `route_sign`, `county_fips`,
+  `speed_limit`, `name`, `source`.
+
+**C1 therefore includes a data-completion task**: re-run
+`scripts/market/fetch_natural_barriers.py` with the "U" fetch fixed and add
+TIGER linear hydrography (rivers/streams above a named-feature floor), with a
+non-vacuousness test on route-sign diversity and river presence so a silent
+partial fetch can never be committed again (the same failure class the
+file-manifest shrink guard covers).
+
+## 3. Barrier-aware method options
+
+### M1 — Tract-graph connectivity (deferred)
+Build tract adjacency (build-step, from the canonical tract geometry — the
+simplified display derivative may break shared edges, so adjacency must be
+computed from `tract_boundaries_co.geojson` with a buffered-intersection test),
+cut/downweight edges crossed by hard barriers, take the site's connected
+component. *Strengths:* principled; catches detour-only connectivity and
+"near but separated" tracts; the only method that can honor bridges properly.
+*Fatal blocker today:* crossing recognition. Urban interstates are crossed by
+dozens of streets per mile; without a crossings/interchange inventory (not
+committed; CDOT publishes one but it is unaudited here) M1 over-excludes most
+of metro Denver. *Cost:* build-step precompute + trivial browser BFS.
+**Defer until a crossings dataset is audited into C1 or later.**
+
+### M2 — Site-to-tract straight-line crossing screen (rejected as exclusion)
+The prior-art shape: if the straight line from site to tract representative
+point crosses a barrier, exclude the tract. *Why rejected:* false positives
+everywhere a bridge exists (Denver I-25: practically every east-west pair);
+false negatives where practical access detours around the line; especially
+fragile for large rural/resort tracts whose representative point is far from
+the populated area. Exclusion on this signal would move scores on wrong data.
+
+### M3 — Crossing-informed friction downweight (recommended)
+Same crossing signal as M2, but the consequence is a **bounded, disclosed
+multiplier on the tract's `_bufferShare`** — never exclusion, never zero. A
+cross-barrier tract keeps contributing; its weight drops by a calibrated
+factor and the UI badges it ("separated by I-70 · weight reduced"). *Why this
+first:* bounded harm under known data gaps (a bridge false-positive costs a
+fraction of a weight, not a tract); composes with the existing PR-B
+apportionment (multiplies the polygon share); trivially testable; reversible
+by flag. The multiplier value (e.g. ×0.5) is **not proposed here** — it is a
+calibration output (§6), and C2 ships with the flag off and the multiplier
+sourced from a fixture file marked non-production until C3.
+*Water polygons:* lakes have no crossings, so for `water` barriers the same
+crossing test is meaningful as-is (a line through Dillon Reservoir is a real
+separation); interstates carry the bridge caveat above.
+
+**Public disclosure line (M3):** "Barrier-aware weighting reduces — never
+removes — the contribution of tracts separated from the site by an interstate
+or major water body. Weights and the barrier inventory are disclosed per
+tract."
+
+## 4. Crossing and connectivity logic (for M3 now, M1 later)
+
+- Crossing test: segment-intersection between the site→tract-point line and
+  barrier LineStrings / polygon boundaries, in the PR-B local-mile projection.
+  Multiple crossings of the same route count once per `route`.
+- Tract point: use the tract's largest-ring centroid-on-surface (compute at
+  build time into the display-geometry derivative; a plain centroid can fall
+  outside irregular mountain tracts — the handoff's rural fragility warning).
+- Bridges/interchanges: **not representable with committed data** — recorded
+  as the reason M3 downweights instead of excludes, and the reason M1 waits.
+- Same-route double-count guard and reservoir-vs-river distinction get
+  fixtures (§8).
+
+## 5. Commute-shed scoping
+
+Committed LODES surface (audited): `lodes_co.json` — tract-level WAC/RAC,
+all 1,447 tracts, 2023 vintage, real data; `lodes_od_arcs_co.geojson` —
+**top-500 statewide arcs only**, not a matrix; place-level OD flows exist per
+place in `data/hna/lehd/`. Consequence: *per-site* capture math ("tracts
+supplying 70–80% of workers to jobs near this site") is **not computable from
+committed data** for arbitrary sites.
+
+- **D-lite (recommended first): context overlay, no analytic change.** Job
+  density from WAC per included tract + any of the top-500 arcs touching the
+  buffer, rendered as a labeled overlay ("LODES 2023 commute context — does
+  not change PMA scores"). Ships with committed data; no capture threshold
+  claimed, so none must be defended.
+- **D-full (separate approval): analytic extension.** Requires a new
+  build-step artifact — a tract-to-tract OD matrix for Colorado filtered to a
+  materiality floor — plus decisions on capture threshold, home-vs-workplace
+  anchoring, and barrier interaction. Not scoped further here; it should get
+  its own one-page decision record if the owner wants it after D-lite.
+- Hard guard carried from the handoff: the synthetic-workplace and hull paths
+  in pma-commuting.js are dead code for analysis; a test asserts shipped
+  output cannot change when the synthetic path is force-enabled (§8).
+
+## 6. Calibration evidence plan (hard gate for C3)
+
+Searched for fetchable professional site-level PMA maps: CHFA application
+market studies are **not publicly published**; the public normative source is
+CHFA's market-feasibility guidance (PMA drawn from commuting patterns, transit
+access, natural boundaries, economic linkages — browser-UA fetch). Therefore:
+
+1. **Primary path — owner-provided artifacts**: 1–2 professional market
+   studies with PMA maps/descriptions from the owner's files (the EPS Phase II
+   regional HNA on hand is region-level, not site-PMA — usable as context,
+   not as the benchmark). Per-benchmark comparison table exactly as the
+   handoff specifies (professional PMA vs current buffer PMA vs M3 output,
+   directional verdict, mismatch notes).
+2. **Secondary path — council-packet hunting** (C1 task, time-boxed): full
+   market studies occasionally appear in municipal agenda packets for projects
+   seeking local funds; if found and fetchable they become citable artifacts.
+3. **Normative supplement (not sufficient alone)**: conformance review of M3
+   output against the CHFA guidance factors on 3–4 owner-picked sites
+   (urban / suburban / rural / resort).
+
+**If neither path 1 nor 2 produces at least one site-level benchmark, C3 does
+not ship** — C2's flag stays off and the phase pauses. No invented multipliers,
+no invented thresholds. (Handoff rule honored verbatim.)
+
+## 7. UX and disclosure contract
+
+- Modes: **Circular buffer (default, unchanged)** · **Barrier-aware (toggle,
+  default off until C3; "beta" label until a benchmark round passes)** ·
+  **Commute context (overlay toggle, D-lite)**.
+- Whole-tract fills with weight opacity remain the only geometry — no clipped
+  arcs, no decorative trimming (owner decision, restated).
+- Downweighted tracts: badge in the per-tract audit table ("−I-70 separation ·
+  weight ×0.5 [calibrated]") and in the PMA export/summary, which also records
+  mode, barrier inventory vintage, and multiplier source.
+- Missing/partial barrier data: warning chip ("Barrier data unavailable —
+  circular-buffer weights in use"), never a silent fallback.
+- Score movement at C3: migration table in docs/PMA_SCORING.md (urban /
+  suburban / rural / resort fixtures), re-pinned tests — same protocol as
+  PR B (#1238).
+
+## 8. Test and QA plan (implementation PRs must land these)
+
+1. Cross-barrier fixture: a known I-70-separated tract pair (Glenwood Canyon
+   area) — separated tract downweighted under flag-on, untouched flag-off.
+2. Same-side control: adjacent same-side tract keeps weight exactly.
+3. Reservoir fixture: Dillon Reservoir separation recognized from water
+   polygons; reservoir-vs-lake subtype does not matter to the result.
+4. Bridge false-positive bound: a Denver I-25 pair may lose at most the
+   calibrated fraction — assert no exclusion path exists (grep + behavior).
+5. Barrier file removed → warning surfaced, weights identical to flag-off,
+   scores unchanged (the silent-fallback killer).
+6. Synthetic-commute guard: force `_buildSyntheticWorkplaces` on → shipped
+   analysis output byte-identical; `lastDataCoverage === 'fallback'` blocks
+   the overlay with a data warning.
+7. Rendered tract set === analytic tract set under every mode (extends the
+   #1237 exact-set guard).
+8. Data non-vacuousness after C1 refresh: route-sign diversity (I **and** U
+   present), river LineStrings present, counts within shrink-guard tolerance
+   of the prior vintage.
+9. External QA pre-registered sabotage: disable one crossing/downweight
+   branch — at least one of tests 1/3/4 must fail.
+
+## 9. Recommended PR split
+
+- **C1 — data completion + audit (no behavior change):** fix the U-route
+  fetch, add linear hydrography, regenerate barriers with non-vacuousness
+  tests (item 8); compute centroid-on-surface points into the display
+  derivative; benchmark acquisition (§6 paths 1–2); commit calibration
+  fixtures as clearly-marked non-production artifacts.
+- **C2 — M3 behind a default-off flag:** crossing test + downweight wiring,
+  multiplier from fixture marked non-production, tests 1–7, zero default
+  score movement (CI-asserted).
+- **C3 — enable after benchmark sign-off:** calibrated multiplier with cited
+  evidence, migration table, re-pinned scores, browser QA evidence, "beta"
+  label until one post-ship benchmark validation round.
+- **D-lite — commute context overlay:** independent of C2/C3; committed data
+  only; test 6.
+- **D-full — analytic commute-shed:** separate decision record; not approved
+  by this RFC.
+
+## 10. Owner decisions requested
+
+1. Approve M3-first / M2-rejected / M1-deferred (§3).
+2. Approve C1 data completion as a prerequisite (§2).
+3. Confirm you can provide 1–2 professional market studies as calibration
+   artifacts (§6 path 1) — or direct the time-boxed council-packet hunt only.
+4. Approve D-lite as the only commute-shed work in this phase (§5).
+5. Approve the staged split and the C3 hard gate (§6, §9).

--- a/docs/audits/RFC-PMA-BARRIER-COMMUTE-SHED-2026-07.md
+++ b/docs/audits/RFC-PMA-BARRIER-COMMUTE-SHED-2026-07.md
@@ -15,11 +15,20 @@
 3. **Commute-shed ships first as a context overlay (D-lite), not an analytic
    extension**: the committed LODES surface cannot support per-site capture
    math (§5). D-full requires a new build artifact and separate approval.
-4. **Calibration is a hard gate**: C3 (enabling barrier-aware mode by default)
-   is blocked until at least one professional site-level PMA benchmark is in
-   hand (§6). Application market studies are not publicly published; the
-   likeliest source is owner-provided studies.
-5. Staged PRs C1 → C2 (flag off) → C3 (enable, disclosed) → D-lite → D-full (§9).
+4. **Calibration is a hard gate — and the first benchmark is in hand and
+   already reordered priorities**: the owner supplied the Fruita Mews II
+   study (CHFA-approved PMA; see CALIBRATION-FRUITA-MEWS-PMA-2026-07.md).
+   The tool's 3-mile buffer captures 2 of the professional PMA's 8 tracts
+   with zero false inclusions; the professional PMA is an asymmetric
+   commute-shaped polygon reaching ~12 miles to the economic hub; and the
+   professional explicitly found *no* inhibiting natural boundary despite
+   river/monument adjacency. Consequence: **commute-shed work (D) is the
+   primary realism gap for small-town sites and is promoted; barrier work
+   stays second-order**, with the M3 never-exclude posture directly
+   affirmed. C3 additionally requires a benchmark where barriers
+   observably bind (urban river/interstate site).
+5. Staged PRs C1 → D-lite (promoted) → C2 (flag off) → C3 (enable, gated) →
+   D-full (own decision record) (§9).
 
 Everything below is evidence for those five calls.
 
@@ -218,6 +227,11 @@ no invented thresholds. (Handoff rule honored verbatim.)
    branch — at least one of tests 1/3/4 must fail.
 
 ## 9. Recommended PR split
+
+*Amended 2026-07-18 after the Fruita benchmark (see calibration doc): D-lite
+moves ahead of C2 — it addresses the demonstrated first-order gap with
+committed data and no score change, while barrier work awaits a benchmark
+where barriers observably bind.*
 
 - **C1 — data completion + audit (no behavior change):** fix the U-route
   fetch, add linear hydrography, regenerate barriers with non-vacuousness

--- a/docs/audits/RFC-PMA-BARRIER-COMMUTE-SHED-2026-07.md
+++ b/docs/audits/RFC-PMA-BARRIER-COMMUTE-SHED-2026-07.md
@@ -12,9 +12,14 @@
 2. **Adopt friction-downweighting (M3), reject exclusion-by-crossing (M2), defer
    graph connectivity (M1)**: cross-barrier tracts get a disclosed, bounded
    downweight — never silent exclusion — until crossing data exists (§3).
-3. **Commute-shed ships first as a context overlay (D-lite), not an analytic
-   extension**: the committed LODES surface cannot support per-site capture
-   math (§5). D-full requires a new build artifact and separate approval.
+3. **Commute-shed ships first as a context overlay (D-lite); D-full is
+   approved in principle as a user-selectable mode** (owner decision
+   2026-07-18): "commute-shaped PMA" becomes an explicit opt-in toggle,
+   default off, never the default geography — same rollout pattern as the
+   barrier flag. The committed LODES surface cannot support per-site capture
+   math (§5), so D-full still gates on the OD build artifact and a
+   calibration-grounded extension rule; the toggle framing lowers rollout
+   risk, not the honesty bar.
 4. **Calibration is a hard gate — and the first benchmark is in hand and
    already reordered priorities**: the owner supplied the Fruita Mews II
    study (CHFA-approved PMA; see CALIBRATION-FRUITA-MEWS-PMA-2026-07.md).
@@ -28,7 +33,7 @@
    affirmed. C3 additionally requires a benchmark where barriers
    observably bind (urban river/interstate site).
 5. Staged PRs C1 → D-lite (promoted) → C2 (flag off) → C3 (enable, gated) →
-   D-full (own decision record) (§9).
+   D-full (opt-in mode; evidence-gated, scope pre-approved) (§9).
 
 Everything below is evidence for those five calls.
 
@@ -155,11 +160,20 @@ committed data** for arbitrary sites.
   buffer, rendered as a labeled overlay ("LODES 2023 commute context — does
   not change PMA scores"). Ships with committed data; no capture threshold
   claimed, so none must be defended.
-- **D-full (separate approval): analytic extension.** Requires a new
-  build-step artifact — a tract-to-tract OD matrix for Colorado filtered to a
-  materiality floor — plus decisions on capture threshold, home-vs-workplace
-  anchoring, and barrier interaction. Not scoped further here; it should get
-  its own one-page decision record if the owner wants it after D-lite.
+- **D-full (approved in principle as a user-selectable mode, 2026-07-18):**
+  a "commute-shaped PMA" toggle, default off, buffer PMA always one click
+  back — the user chooses the professional-style geography explicitly, with
+  disclosure, rather than the tool changing anyone's default numbers. Two
+  hard requirements survive the toggle framing: (a) the extension rule must
+  be calibration-grounded — anchored to the professional-convergence target
+  and the documented 40–56% outside-PMA bracket (F-CAL-5/-7), never an
+  invented threshold — and requires the new build-step OD artifact (a
+  tract-to-tract matrix filtered to a materiality floor); (b) **every output
+  and export carries its mode label**, because demand counts and capture
+  rates mean different things under a buffer vs a commute-shaped PMA.
+  Remaining design decisions (home-vs-workplace anchoring, barrier
+  interaction, materiality floor) are settled in the D-full implementation
+  PR against those anchors — no separate scope approval needed.
 - Hard guard carried from the handoff: the synthetic-workplace and hull paths
   in pma-commuting.js are dead code for analysis; a test asserts shipped
   output cannot change when the synthetic path is force-enabled (§8).
@@ -246,8 +260,10 @@ where barriers observably bind.*
   label until one post-ship benchmark validation round.
 - **D-lite — commute context overlay:** independent of C2/C3; committed data
   only; test 6.
-- **D-full — analytic commute-shed:** separate decision record; not approved
-  by this RFC.
+- **D-full — commute-shaped PMA as opt-in mode:** scope pre-approved by the
+  owner (2026-07-18); ships only when the OD artifact exists and the
+  extension rule passes calibration QA against F-CAL-5/-7. Default remains
+  the circular buffer; mode labels on all outputs.
 
 ## 10. Owner decisions requested
 
@@ -255,5 +271,7 @@ where barriers observably bind.*
 2. Approve C1 data completion as a prerequisite (§2).
 3. Confirm you can provide 1–2 professional market studies as calibration
    artifacts (§6 path 1) — or direct the time-boxed council-packet hunt only.
-4. Approve D-lite as the only commute-shed work in this phase (§5).
+4. ~~Approve D-lite as the only commute-shed work in this phase~~ —
+   **decided 2026-07-18**: D-lite now; D-full approved in principle as a
+   user-selectable, default-off mode, evidence-gated per §5.
 5. Approve the staged split and the C3 hard gate (§6, §9).


### PR DESCRIPTION
Decision-ready RFC for the last phase of #1232, per the merged handoff (CODEX-HANDOFF-PMA-BARRIER-COMMUTE-SHED-RFC-2026-07.md). Doc-only; no production code.

**Headline audit findings feeding the recommendations:**
- The barriers dataset is materially narrower than documented: **interstates only** (the CDOT U-route fetch failed silently at generation — every segment is route_sign "I") and **lakes only, zero linear rivers**. Data completion is a C1 prerequisite with non-vacuousness guards so a partial fetch can't silently commit again.
- Prior art rejected with line-level evidence: pma-barriers.js's area-percentage exclusion factors are fabricated-calibration class; pma-commuting.js's synthetic-workplace and convex-hull paths are dead code for analysis (test-guarded).
- LODES surface cannot support per-site commute capture (top-500 arc sample, no OD matrix) → commute-shed ships as a context overlay first (D-lite); analytic D-full needs its own artifact + approval.

**Core recommendation:** friction **downweighting** (M3) over exclusion — cross-barrier tracts keep contributing at a calibrated, disclosed, bounded reduced weight; exclusion-by-straight-line (M2) rejected on bridge false positives; graph connectivity (M1) deferred until a crossings inventory exists. Calibration is a **hard gate**: C3 (default-on) is blocked until at least one professional site-level PMA benchmark is in hand — likeliest source is owner-provided market studies, since CHFA application studies aren't published.

**Owner decisions requested** (§10): M3-first approval, C1 prerequisite, calibration-artifact availability, D-lite-only commute scope, staged split + C3 gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)