### PR TITLE
Compute review_by dynamically in market data builders

### DIFF
--- a/scripts/market/build_fhfa_hpi_subcounty.py
+++ b/scripts/market/build_fhfa_hpi_subcounty.py
@@ -15,7 +15,7 @@ import os
 import sys
 import tempfile
 import urllib.request
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Iterable
 
@@ -44,6 +44,10 @@ MIN_PLACES = 300
 
 def utc_today() -> str:
     return datetime.now(timezone.utc).date().isoformat()
+
+
+def review_by(days: int = 90) -> str:
+    return (datetime.now(timezone.utc).date() + timedelta(days=days)).isoformat()
 
 
 def clean_number(value):
@@ -232,7 +236,7 @@ def build_artifact():
             "state_fips": "08",
             "as_of": f"{latest_year}-12-31",
             "last_verified": utc_today(),
-            "review_by": "2026-10-18",
+            "review_by": review_by(),
             "latest_year": latest_year,
             "county_count": len(counties),
             "tract_count": len(tracts),

--- a/scripts/market/fetch_hud_zip_tract_crosswalk.py
+++ b/scripts/market/fetch_hud_zip_tract_crosswalk.py
@@ -17,7 +17,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 
@@ -42,6 +42,10 @@ MIN_CO_TRACTS = 1_000
 
 def utc_today() -> str:
     return datetime.now(timezone.utc).date().isoformat()
+
+
+def review_by(days: int = 90) -> str:
+    return (datetime.now(timezone.utc).date() + timedelta(days=days)).isoformat()
 
 
 def normalize_digits(raw: object, width: int) -> str:
@@ -160,7 +164,7 @@ def build_output(payload_meta: dict, rows: list[dict]) -> dict:
             "vintage_quarter": quarter,
             "as_of": f"{year}-{quarter_label}" if year and quarter_label else utc_today(),
             "last_verified": utc_today(),
-            "review_by": "2026-10-18",
+            "review_by": review_by(),
             "row_count": len(rows),
             "zip_count": len({row["zip"] for row in rows}),
             "tract_count": len({row["tract"] for row in rows}),

--- a/scripts/market/fetch_opportunity_zones.py
+++ b/scripts/market/fetch_opportunity_zones.py
@@ -24,7 +24,7 @@ import math
 import tempfile
 import zipfile
 import urllib.request
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 try:
@@ -58,6 +58,10 @@ WEB_MERCATOR_RADIUS = 6378137.0
 
 def utc_now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def review_by(days: int = 90) -> str:
+    return (datetime.now(timezone.utc).date() + timedelta(days=days)).isoformat()
 
 
 def log(msg: str, level: str = "INFO") -> None:
@@ -175,7 +179,7 @@ def build_opportunity_zones() -> dict:
             "vintage": "2018 designations (Notice 2018-48, amplified by Notice 2019-42)",
             "generated": generated,
             "last_verified": generated[:10],
-            "review_by": "2026-10-18",
+            "review_by": review_by(),
             "feature_count": len(co_features),
             "designated_count": len(co_features),
             "note": "Rebuild via scripts/market/fetch_opportunity_zones.py",


### PR DESCRIPTION
## Summary
- The HUD ZIP-tract crosswalk (#1254), FHFA subcounty HPI (#1255), and Opportunity Zones (#1252) builders hardcoded `review_by: "2026-10-18"` as a string literal, so every regeneration after that date would emit an already-stale review date and `scripts/audit/benchmark-freshness-check.mjs` would warn forever.
- Each builder now computes `review_by` as run date + 90 days (UTC, ISO `YYYY-MM-DD`), matching how `last_verified` already derives from `utc_today()`.
- The same fix for the Redfin place market tracker (#1257, not yet merged) was pushed directly to its branch (`agent/1242-redfin-zip-adopt-lite`, commit 8ae4d08ae).
- Committed artifacts are intentionally untouched — regeneration needs `HUD_API_TOKEN` / large downloads, and the stale literal in the artifacts is fine until their next scheduled refresh.

## Test plan
- `node test/hud-zip-tract-crosswalk.test.js` ✅
- `node test/fhfa-hpi-subcounty.test.js` ✅
- `node test/opportunity-zones-data.test.js` ✅
- `npm run validate` ✅
- Guard tests assert ISO format only (not the literal value), so no test changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)