### PR TITLE
Compute review_by dynamically in Redfin place tracker builder

### DIFF
--- a/scripts/market/build_redfin_place_market_tracker.py
+++ b/scripts/market/build_redfin_place_market_tracker.py
@@ -22,7 +22,7 @@ import sys
 import tempfile
 import urllib.request
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 
@@ -45,6 +45,10 @@ MIN_MONTHS = 12
 
 def utc_today() -> str:
     return datetime.now(timezone.utc).date().isoformat()
+
+
+def review_by(days: int = 90) -> str:
+    return (datetime.now(timezone.utc).date() + timedelta(days=days)).isoformat()
 
 
 def clean_number(raw):
@@ -293,7 +297,7 @@ def build_artifact() -> dict:
             "state_fips": "08",
             "as_of": as_of,
             "last_verified": utc_today(),
-            "review_by": "2026-10-18",
+            "review_by": review_by(),
             "latest_redfin_updated": latest_source_updated,
             "period_duration_days": 90,
             "months_retained": KEEP_MONTHS,


### PR DESCRIPTION
Companion to #1258 — the same fix for the fourth builder.

The original commit (8ae4d08ae) was pushed to `agent/1242-redfin-zip-adopt-lite` 93 seconds **after** PR #1257 merged, so it never reached main and the branch is dead. This PR cherry-picks that exact commit onto current main: `review_by` computed as run date + 90 days (UTC ISO), matching `last_verified`'s `utc_today()` derivation. The committed artifact is intentionally untouched (same rationale as #1258 — the literal in the artifact is fine until the next scheduled regeneration).

Verified: `node test/redfin-place-market-tracker.test.js` PASS (121 places, 24 retained months); `python3 -m py_compile` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)