### PR TITLE
Make HNA scenario comparison read-only

### DIFF
--- a/hna-scenario-builder.html
+++ b/hna-scenario-builder.html
@@ -381,6 +381,7 @@
       var loadBtn  = document.getElementById('sbLoadCounty');
       var statusEl = document.getElementById('sbGeoStatus');
       var root     = (window.__REPO_ROOT || '');
+      var urlParams = new URLSearchParams(window.location.search || '');
 
       // Lookup of GEOID → { name, type, containingCounty, population } so the
       // click handler can resolve a place's containing county + share factor
@@ -448,6 +449,7 @@
           // F154 — Hand the freshly-populated set to the combobox so the
           // type-to-filter dropdown has something to search against.
           mountCombobox(counties, places, cdps);
+          applyUrlGeographyParams();
         })
         .catch(function (err) {
           select.innerHTML = '<option value="">— Failed to load geographies —</option>';
@@ -574,6 +576,32 @@
           e.preventDefault();
           pick(li.dataset.geoid);
         });
+      }
+
+      function applyUrlGeographyParams() {
+        var requestedGeoType = urlParams.get('geoType');
+        var requestedGeoid = urlParams.get('geoid');
+        if (!requestedGeoType || !requestedGeoid) return;
+
+        var entry = geoIndex[requestedGeoid];
+        if (!entry && requestedGeoType !== 'county') return;
+        if (entry && requestedGeoType !== 'county' && entry.type !== requestedGeoType) return;
+
+        select.value = requestedGeoid;
+        if (select.value !== requestedGeoid) return;
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+
+        var input = document.getElementById('sbGeoSearch');
+        var selectedEl = document.getElementById('sbGeoSelected');
+        var displayType = requestedGeoType === 'county' ? 'County' :
+          (requestedGeoType === 'cdp' ? 'CDP / Unincorporated' : 'Incorporated Place');
+        var displayName = entry ? entry.name : (select.options[select.selectedIndex] && select.options[select.selectedIndex].text);
+        if (input && displayName) input.value = displayName;
+        if (selectedEl && displayName) selectedEl.textContent = 'Selected: ' + displayName + ' (' + displayType + ')';
+
+        if (urlParams.get('auto') === '1' && loadBtn) {
+          loadBtn.click();
+        }
       }
 
       loadBtn.addEventListener('click', function () {

--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -1173,11 +1173,12 @@
           </div>
         </div>
         <p>
-          Cohort-component forward projections under three growth scenarios, aligned with
+          Read-only cohort-component projections under fixed low, baseline, and high growth scenarios, aligned with
           <a href="https://dlg.colorado.gov/news-article/final-housing-needs-assessment-methodology-and-displacement-risk-assessment-guidance" target="_blank" rel="noopener" style="color:var(--accent)" aria-label="DLG final HNA methodology and displacement risk assessment guidance (opens in new tab)">DLG HNA methodology</a>.
-          Adjust scenario assumptions and switch views to compare population, household formation,
-          and housing demand by affordability tier. Sensitivity bands share the observed base year
-          and scale only the projected growth increment.
+          The comparison charts keep a shared observed base year and scale only the projected growth increment from
+          DOLA-aligned assumptions. To model custom fertility, migration, or mortality assumptions, use the dedicated
+          <a id="scenarioBuilderLink" href="hna-scenario-builder.html" style="color:var(--accent);font-weight:700">Scenario Builder &rarr;</a>
+          for the selected geography.
         </p>
 
         <!-- Scenario selector row -->
@@ -1261,60 +1262,6 @@
             <div class="chart-box tall" data-source="DOLA Households + HUD CHAS AMI Tier Shares" data-source-url="https://www.huduser.gov/portal/datasets/cp.html" data-vintage="DOLA 2024 · CHAS 2018–2022" data-source-type="modeled"><canvas id="chartHouseholdDemand" role="img" aria-label="Housing demand by AMI affordability tier chart showing projected renter households at each income tier"></canvas></div>
           </div>
         </div>
-
-        <!-- Projection assumption sliders (demographic rates) -->
-        <details style="margin-top:16px">
-          <summary style="cursor:pointer;font-weight:700;font-size:.92rem;padding:6px 0">
-            ⚙️ Override projection assumptions
-          </summary>
-          <div class="chart-card" style="padding:12px;margin-top:10px;background:rgba(255,255,255,.04)">
-            <p style="margin:0 0 10px;font-size:.85rem;color:var(--muted)">
-              Adjust the demographic rate assumptions for the selected scenario.
-              Changes apply immediately to all projection charts.
-              These parameters follow the DLG cohort-component model methodology.
-            </p>
-            <div class="hna-grid" style="grid-template-columns:repeat(12,1fr);gap:10px;margin-top:0">
-              <div class="span-4">
-                <label for="scenFertility" style="display:block;color:var(--muted);font-size:.85rem;margin-bottom:4px">
-                  Fertility rate multiplier
-                  <span style="font-size:.78rem;font-weight:400"> (1.0 = baseline ACS rates)</span>
-                </label>
-                <div style="display:flex;gap:8px;align-items:center">
-                  <input id="scenFertility" type="range" min="0.5" max="2.0" step="0.01" value="1.0" class="scenario-range" aria-label="Fertility rate multiplier (1.0 is baseline)" />
-                  <div id="scenFertilityVal" style="min-width:40px;text-align:right;color:var(--text);font-weight:700">1.00</div>
-                </div>
-              </div>
-              <div class="span-4">
-                <label for="scenMigration" style="display:block;color:var(--muted);font-size:.85rem;margin-bottom:4px">
-                  Net migration (persons/year)
-                  <span style="font-size:.78rem;font-weight:400"> (baseline: 500/yr avg)</span>
-                </label>
-                <div style="display:flex;gap:8px;align-items:center">
-                  <input id="scenMigration" type="range" min="-500" max="3000" step="50" value="500" class="scenario-range" aria-label="Annual net migration (baseline is 500 persons per year)" />
-                  <div id="scenMigrationVal" style="min-width:48px;text-align:right;color:var(--text);font-weight:700">500</div>
-                </div>
-              </div>
-              <div class="span-4">
-                <label for="scenMortality" style="display:block;color:var(--muted);font-size:.85rem;margin-bottom:4px">
-                  Mortality rate multiplier
-                  <span style="font-size:.78rem;font-weight:400"> (1.0 = standard life-table)</span>
-                </label>
-                <div style="display:flex;gap:8px;align-items:center">
-                  <input id="scenMortality" type="range" min="0.8" max="1.2" step="0.01" value="1.0" class="scenario-range" aria-label="Mortality rate multiplier (1.0 is standard life-table)" />
-                  <div id="scenMortalityVal" style="min-width:40px;text-align:right;color:var(--text);font-weight:700">1.00</div>
-                </div>
-              </div>
-            </div>
-            <div style="margin-top:12px;display:flex;align-items:center;gap:10px;flex-wrap:wrap">
-              <button id="btnSaveCustomScenario" class="control" style="padding:8px 16px;font-size:.88rem;cursor:pointer;min-height:44px">
-                💾 Save as custom scenario
-              </button>
-              <button id="btnResetScenarioDefaults" class="control" style="padding:8px 16px;font-size:.88rem;cursor:pointer;min-height:44px;background:var(--bg2)">
-                ↺ Reset to scenario defaults
-              </button>
-            </div>
-          </div>
-        </details>
 
         <!-- Scenario summary note -->
         <div id="scenarioNeedSummary" class="scenario-need-summary" style="display:none" role="region" aria-label="Scenario comparison summary">

--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -2601,18 +2601,6 @@
   }
 
 
-  function getScenarioRateOverrides(){
-    const fertility  = parseFloat((document.getElementById('scenFertility')  || {}).value);
-    const migration  = parseFloat((document.getElementById('scenMigration')  || {}).value);
-    const mortality  = parseFloat((document.getElementById('scenMortality')  || {}).value);
-    return {
-      fertilityMultiplier: Number.isFinite(fertility)  ? fertility  : 1.0,
-      netMigrationAnnual:  Number.isFinite(migration)  ? migration  : 500,
-      mortalityMultiplier: Number.isFinite(mortality)  ? mortality  : 1.0,
-    };
-  }
-
-
   function updateScenarioDescription(){
     const sc   = getSelectedScenario();
     const meta = window.HNAUtils.PROJECTION_SCENARIOS[sc];
@@ -2644,97 +2632,8 @@
         const sc   = scenarioSel.value;
         const meta = window.HNAUtils.PROJECTION_SCENARIOS[sc];
         if (!meta) return;
-        // Pre-populate sliders with scenario defaults
-        const defaults = {
-          baseline:   { fertility: 1.0,  migration: 500,  mortality: 1.0  },
-          low_growth: { fertility: 0.90, migration: 250,  mortality: 1.02 },
-          high_growth:{ fertility: 1.05, migration: 1000, mortality: 0.98 },
-        };
-        const d = defaults[sc] || defaults.baseline;
-        const fEl = document.getElementById('scenFertility');
-        const mEl = document.getElementById('scenMigration');
-        const rEl = document.getElementById('scenMortality');
-        if (fEl){ fEl.value = d.fertility;  _updateSliderLabel('scenFertilityVal',  d.fertility.toFixed(2)); }
-        if (mEl){ mEl.value = d.migration;  _updateSliderLabel('scenMigrationVal',  Math.round(d.migration)); }
-        if (rEl){ rEl.value = d.mortality;  _updateSliderLabel('scenMortalityVal',  d.mortality.toFixed(2)); }
         updateScenarioDescription();
         // Re-render the projection charts if data is loaded
-        if (window.HNAState.state.lastProj && window.HNAState.state.current){ applyAssumptions(window.HNAState.state.lastProj, window.HNAState.state.current); }
-      });
-    }
-
-    // Slider live-update labels
-    // Debounce timer: chart re-renders are deferred 300 ms so rapid slider
-    // drags don't trigger a repaint on every pixel move (performance).
-    let _sliderDebounce = null;
-    [
-      ['scenFertility', 'scenFertilityVal', v => Number(v).toFixed(2)],
-      ['scenMigration', 'scenMigrationVal', v => Math.round(Number(v)).toLocaleString()],
-      ['scenMortality', 'scenMortalityVal', v => Number(v).toFixed(2)],
-    ].forEach(([sliderId, labelId, fmt]) => {
-      const slider = document.getElementById(sliderId);
-      if (slider){
-        slider.addEventListener('input', () => {
-          _updateSliderLabel(labelId, fmt(slider.value));
-          // Debounce chart re-render to avoid rapid repaints on slider drag
-          clearTimeout(_sliderDebounce);
-          _sliderDebounce = setTimeout(() => {
-            if (window.HNAState.state.lastProj && window.HNAState.state.current){ applyAssumptions(window.HNAState.state.lastProj, window.HNAState.state.current); }
-          }, 300);
-        });
-      }
-    });
-
-    // Save custom scenario button
-    const saveBtn = document.getElementById('btnSaveCustomScenario');
-    if (saveBtn){
-      saveBtn.addEventListener('click', () => {
-        const overrides = getScenarioRateOverrides();
-        const name = 'Custom: f×' + overrides.fertilityMultiplier.toFixed(2) +
-                     ' mig ' + Math.round(overrides.netMigrationAnnual) +
-                     ' mort×' + overrides.mortalityMultiplier.toFixed(2);
-        window.HNAUtils.PROJECTION_SCENARIOS['custom'] = {
-          label:       'Custom',
-          description: name,
-          color:       '#9c27b0',
-        };
-        const sel = document.getElementById('projScenario');
-        if (sel){
-          // Add custom option if not already present
-          if (!sel.querySelector('option[value="custom"]')){
-            const opt = document.createElement('option');
-            opt.value = 'custom';
-            opt.textContent = 'Custom';
-            sel.appendChild(opt);
-          }
-          sel.value = 'custom';
-        }
-        updateScenarioDescription();
-        if (window.HNAState.state.lastProj && window.HNAState.state.current){ applyAssumptions(window.HNAState.state.lastProj, window.HNAState.state.current); }
-        if (typeof window.__announceUpdate === 'function') {
-          window.__announceUpdate('Custom scenario saved: ' + name);
-        }
-      });
-    }
-
-    // Reset to scenario defaults button
-    const resetBtn = document.getElementById('btnResetScenarioDefaults');
-    if (resetBtn){
-      resetBtn.addEventListener('click', () => {
-        const sc = getSelectedScenario();
-        const defaults = {
-          baseline:   { fertility: 1.0,  migration: 500,  mortality: 1.0  },
-          low_growth: { fertility: 0.90, migration: 250,  mortality: 1.02 },
-          high_growth:{ fertility: 1.05, migration: 1000, mortality: 0.98 },
-          custom:     { fertility: 1.0,  migration: 500,  mortality: 1.0  },
-        };
-        const d = defaults[sc] || defaults.baseline;
-        const fEl = document.getElementById('scenFertility');
-        const mEl = document.getElementById('scenMigration');
-        const rEl = document.getElementById('scenMortality');
-        if (fEl){ fEl.value = d.fertility;  _updateSliderLabel('scenFertilityVal',  d.fertility.toFixed(2)); }
-        if (mEl){ mEl.value = d.migration;  _updateSliderLabel('scenMigrationVal',  Math.round(d.migration).toLocaleString()); }
-        if (rEl){ rEl.value = d.mortality;  _updateSliderLabel('scenMortalityVal',  d.mortality.toFixed(2)); }
         if (window.HNAState.state.lastProj && window.HNAState.state.current){ applyAssumptions(window.HNAState.state.lastProj, window.HNAState.state.current); }
       });
     }
@@ -2839,12 +2738,6 @@
     if (typeof window.__announceUpdate === 'function') {
       window.__announceUpdate('Scenario comparison exported to CSV.');
     }
-  }
-
-
-  function _updateSliderLabel(labelId, text){
-    const el = document.getElementById(labelId);
-    if (el) el.textContent = text;
   }
 
   // ---------------------------------------------------------------------------

--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -500,6 +500,7 @@
   }
 
   async function updateCombined(region) {
+    updateScenarioBuilderLink(null);
     window.HNARenderers.showAllChartsLoading();
     window.HNARenderers.clearStats();
     const members = region ? (region.members || []) : (window.HNAState.state.combinedMembers || []);
@@ -541,6 +542,7 @@
   }
 
   async function updateRegionalComparison(region) {
+    updateScenarioBuilderLink(null);
     window.HNARenderers.showAllChartsLoading();
     window.HNARenderers.clearStats();
     const members = region ? (region.members || []) : (window.HNAState.state.combinedMembers || []);
@@ -2618,6 +2620,22 @@
     if (el && meta) el.textContent = meta.description;
   }
 
+  function updateScenarioBuilderLink(selection){
+    const link = document.getElementById('scenarioBuilderLink');
+    if (!link) return;
+    const geoType = selection && selection.geoType;
+    const geoid = selection && selection.geoid;
+    if (!geoType || !geoid || geoType === 'combined' || geoType === 'regional-comparison') {
+      link.setAttribute('href', 'hna-scenario-builder.html');
+      return;
+    }
+    const params = new URLSearchParams();
+    params.set('geoType', geoType);
+    params.set('geoid', geoid);
+    params.set('auto', '1');
+    link.setAttribute('href', 'hna-scenario-builder.html?' + params.toString());
+  }
+
 
   function wireScenarioControls(){
     const scenarioSel = document.getElementById('projScenario');
@@ -2840,6 +2858,7 @@
     window.HNARenderers.showAllChartsLoading();
     const geoType = window.HNAState.els.geoType.value;
     const geoid = window.HNAState.els.geoSelect.value;
+    updateScenarioBuilderLink({ geoType, geoid });
     const selectedRegion = _regionFromCurrentSelect();
     const combineOn = !!(window.HNAState.els.combineGeosToggle && window.HNAState.els.combineGeosToggle.checked);
     if (selectedRegion) {

--- a/test/hna-functionality-check.js
+++ b/test/hna-functionality-check.js
@@ -917,6 +917,24 @@ test('HTML: non-functional scenario override controls are removed from HNA', () 
     assert(!html.includes('Reset to scenario defaults'), 'old reset copy is removed');
 });
 
+test('JS: non-functional scenario override handlers are removed from HNA', () => {
+    [
+        'getScenarioRateOverrides',
+        '_updateSliderLabel',
+        '_sliderDebounce',
+        'scenFertility',
+        'scenFertilityVal',
+        'scenMigration',
+        'scenMigrationVal',
+        'scenMortality',
+        'scenMortalityVal',
+        'btnSaveCustomScenario',
+        'btnResetScenarioDefaults',
+    ].forEach(token => {
+        assert(!js.includes(token), `${token} dead handler code is absent from HNA JS`);
+    });
+});
+
 test('JS: scenario builder link carries selected geography', () => {
     assert(js.includes('function updateScenarioBuilderLink'), 'scenario builder link updater exists');
     assert(js.includes("params.set('geoType', geoType)"), 'scenario builder link includes geoType');
@@ -924,6 +942,22 @@ test('JS: scenario builder link carries selected geography', () => {
     assert(js.includes("params.set('auto', '1')"), 'scenario builder link includes auto=1');
     assert(js.includes("link.setAttribute('href', 'hna-scenario-builder.html?' + params.toString())"),
         'scenario builder link writes parameterized href');
+});
+
+test('Scenario Builder: consumes HNA CTA geography URL params', () => {
+    const builderHtml = fs.readFileSync(path.join(ROOT, 'hna-scenario-builder.html'), 'utf8');
+    assert(builderHtml.includes('new URLSearchParams(window.location.search || \'\')'),
+        'Scenario Builder reads URLSearchParams from location.search');
+    assert(builderHtml.includes("urlParams.get('geoType')"),
+        'Scenario Builder reads geoType URL parameter');
+    assert(builderHtml.includes("urlParams.get('geoid')"),
+        'Scenario Builder reads geoid URL parameter');
+    assert(builderHtml.includes('geoIndex[requestedGeoid]'),
+        'Scenario Builder resolves place/CDP params through geoIndex');
+    assert(builderHtml.includes('select.value = requestedGeoid'),
+        'Scenario Builder writes URL geoid into sbGeoSelect');
+    assert(builderHtml.includes("urlParams.get('auto') === '1'") && builderHtml.includes('loadBtn.click()'),
+        'Scenario Builder honors auto=1 via the Load Geography Data button path');
 });
 
 test('JS: scenario fallback sensitivity scales growth from the shared observed base year', () => {
@@ -1047,13 +1081,6 @@ test('JS: btnExportScenario is wired to exportScenarioCSV', () => {
     assert(
         js.includes('btnExportScenario') && js.includes('exportScenarioCSV'),
         'Export button is referenced and exportScenarioCSV is called'
-    );
-});
-
-test('JS: slider debouncing uses setTimeout (performance)', () => {
-    assert(
-        js.includes('_sliderDebounce') && js.includes('clearTimeout(_sliderDebounce)'),
-        'Slider input debounce uses clearTimeout/_sliderDebounce pattern'
     );
 });
 

--- a/test/hna-functionality-check.js
+++ b/test/hna-functionality-check.js
@@ -105,8 +105,7 @@ const REQUIRED_IDS = [
     'methodology',
     // Local resources
     'localResources',
-    // Scenario tool elements (PR #457 / scenario-tool fixes)
-    'btnResetScenarioDefaults',
+    // Scenario tool elements
     'scenarioNeedSummary',
 ];
 
@@ -897,10 +896,34 @@ test('JS: chart resize race condition fixed with requestAnimationFrame', () => {
     );
 });
 
-test('JS: reset button uses correct per-scenario migration defaults', () => {
-    assert(js.includes('migration: 500'),  'baseline scenario uses 500/yr migration default');
-    assert(js.includes('migration: 250'),  'low_growth scenario uses 250/yr migration default');
-    assert(js.includes('migration: 1000'), 'high_growth scenario uses 1000/yr migration default');
+test('HTML: non-functional scenario override controls are removed from HNA', () => {
+    [
+        'scenFertility',
+        'scenFertilityVal',
+        'scenMigration',
+        'scenMigrationVal',
+        'scenMortality',
+        'scenMortalityVal',
+        'btnSaveCustomScenario',
+        'btnResetScenarioDefaults',
+    ].forEach(id => {
+        assert(!html.includes(`id="${id}"`), `${id} is not present in HNA HTML`);
+    });
+    assert(html.includes('id="scenarioBuilderLink"'), 'Scenario Builder CTA link is present');
+    assert(html.includes('fixed low, baseline, and high growth scenarios'), 'scenario copy describes fixed scenarios');
+    assert(html.includes('DOLA-aligned assumptions'), 'scenario copy describes DOLA-aligned assumptions');
+    assert(!html.includes('Override projection assumptions'), 'old override heading is removed');
+    assert(!html.includes('Save as custom scenario'), 'old custom-save copy is removed');
+    assert(!html.includes('Reset to scenario defaults'), 'old reset copy is removed');
+});
+
+test('JS: scenario builder link carries selected geography', () => {
+    assert(js.includes('function updateScenarioBuilderLink'), 'scenario builder link updater exists');
+    assert(js.includes("params.set('geoType', geoType)"), 'scenario builder link includes geoType');
+    assert(js.includes("params.set('geoid', geoid)"), 'scenario builder link includes geoid');
+    assert(js.includes("params.set('auto', '1')"), 'scenario builder link includes auto=1');
+    assert(js.includes("link.setAttribute('href', 'hna-scenario-builder.html?' + params.toString())"),
+        'scenario builder link writes parameterized href');
 });
 
 test('JS: scenario fallback sensitivity scales growth from the shared observed base year', () => {

--- a/test/integration/projections.test.js
+++ b/test/integration/projections.test.js
@@ -245,21 +245,27 @@ test('HNA HTML: household demand chart canvas present', () => {
     'chartHouseholdDemand canvas present');
 });
 
-test('HNA HTML: demographic rate sliders present', () => {
-  assert(hnaHtml.includes('id="scenFertility"'),  'fertility rate slider present');
-  assert(hnaHtml.includes('id="scenMigration"'),  'migration rate slider present');
-  assert(hnaHtml.includes('id="scenMortality"'),  'mortality rate slider present');
+test('HNA HTML: demographic rate sliders removed from read-only scenario section', () => {
+  assert(!hnaHtml.includes('id="scenFertility"'),  'fertility rate slider removed');
+  assert(!hnaHtml.includes('id="scenMigration"'),  'migration rate slider removed');
+  assert(!hnaHtml.includes('id="scenMortality"'),  'mortality rate slider removed');
 });
 
-test('HNA HTML: slider value display elements present', () => {
-  assert(hnaHtml.includes('id="scenFertilityVal"'), 'fertility value display present');
-  assert(hnaHtml.includes('id="scenMigrationVal"'), 'migration value display present');
-  assert(hnaHtml.includes('id="scenMortalityVal"'), 'mortality value display present');
+test('HNA HTML: slider value display elements removed from read-only scenario section', () => {
+  assert(!hnaHtml.includes('id="scenFertilityVal"'), 'fertility value display removed');
+  assert(!hnaHtml.includes('id="scenMigrationVal"'), 'migration value display removed');
+  assert(!hnaHtml.includes('id="scenMortalityVal"'), 'mortality value display removed');
 });
 
-test('HNA HTML: save custom scenario button present', () => {
-  assert(hnaHtml.includes('id="btnSaveCustomScenario"'),
-    'btnSaveCustomScenario button present');
+test('HNA HTML: custom scenario buttons removed and Scenario Builder CTA present', () => {
+  assert(!hnaHtml.includes('id="btnSaveCustomScenario"'),
+    'btnSaveCustomScenario button removed');
+  assert(!hnaHtml.includes('id="btnResetScenarioDefaults"'),
+    'btnResetScenarioDefaults button removed');
+  assert(hnaHtml.includes('id="scenarioBuilderLink"'),
+    'scenarioBuilderLink CTA present');
+  assert(hnaHtml.includes('href="hna-scenario-builder.html"'),
+    'scenarioBuilderLink has safe default href');
 });
 
 test('Projection snapshots: directory and baseline snapshot exist', () => {


### PR DESCRIPTION
## Summary
- Removes the non-functional HNA scenario override sliders and save/reset buttons from the scenario section.
- Rewrites the section copy to describe fixed DOLA-aligned low/baseline/high comparisons while preserving the existing chart canvases and selectors.
- Adds a Scenario Builder CTA whose href carries the selected geoType/geoid plus auto=1 for single-geography selections.
- Adds removed-ID guard coverage in the HNA and projection integration tests.

Refs #1253

## Scope notes
- PR 1 only.
- No projection math changes.
- Scenario comparison chart IDs/controls remain intact: chartScenarioComparison, chartProjectionDetail, chartHouseholdDemand, projScenario, and projViewToggle.

## Verification
- npm run test:hna
- node test/integration/projections.test.js
- npm run validate
- git diff --check
- npm run test:ci passed before the final origin/main fast-forward; after the fast-forward only docs/audit inventory changed on main, and the focused gates above were rerun clean.

Do not merge until external QA completes.