### PR TITLE
GEO-1 QA fixes: recover the two commits stranded by the #1278 merge race

### DIFF
--- a/js/components/jurisdiction-url-context.js
+++ b/js/components/jurisdiction-url-context.js
@@ -73,6 +73,7 @@
           geoid: jx.geoid,
           geoType: jx.geoType,
           countyFips: jx.countyFips || (jx.geoType === 'county' ? jx.geoid : null),
+          name: jx.name || jx.displayName || null,
           displayName: jx.name || jx.displayName || jx.countyName || null,
           countyName: jx.countyName || (jx.geoType === 'county' ? jx.name : null),
           placeGeoid: jx.placeGeoid || (/^\d{7}$/.test(jx.geoid) ? jx.geoid : null),

--- a/js/deal-calculator.js
+++ b/js/deal-calculator.js
@@ -3435,13 +3435,14 @@
   function _renderJurisdictionContext(ctx) {
     var el = document.getElementById('dc-jurisdiction-context');
     if (!el) return;
-    if (!ctx || (ctx.geoType !== 'place' && ctx.geoType !== 'cdp') || !ctx.name) {
+    var placeName = ctx && (ctx.name || ctx.displayName);
+    if (!ctx || (ctx.geoType !== 'place' && ctx.geoType !== 'cdp') || !placeName) {
       el.hidden = true;
       el.textContent = '';
       return;
     }
     var countyName = ctx.countyName || 'selected county';
-    el.textContent = 'Analyzing ' + ctx.name + ', ' + countyName + ' County context for HUD AMI/FMR inputs.';
+    el.textContent = 'Analyzing ' + placeName + ', ' + countyName + ' County context for HUD AMI/FMR inputs.';
     el.textContent = el.textContent.replace(/ County County context/, ' County context');
     el.hidden = false;
   }

--- a/js/workflow-state-api.js
+++ b/js/workflow-state-api.js
@@ -86,6 +86,9 @@
     if (!countyFips && (geoType === 'place' || geoType === 'cdp') && src.fips && String(src.fips).length === 5) {
       countyFips = src.fips;
     }
+    if ((geoType === 'place' || geoType === 'cdp') && !countyFips && global.console && typeof global.console.warn === 'function') {
+      global.console.warn('[WorkflowState] Missing county context for ' + geoType + ' jurisdiction ' + (geoid || src.name || src.displayName || '(unknown)'));
+    }
 
     var name = src.name || src.displayName || src.countyName || null;
     var countyName = src.countyName || (geoType === 'county' ? name : null);

--- a/test/canonical-geography-contract.test.js
+++ b/test/canonical-geography-contract.test.js
@@ -96,6 +96,8 @@ async function main() {
 
   const selector = read('js/jurisdiction-selector.js');
   assert(selector.includes('findPlaceByGeoid'), 'selector resolves places/CDPs by registry geoid');
+  assert(selector.includes('countyFips: placeCountyFips'), 'selector place payload stores non-null countyFips from registry');
+  assert(selector.includes('fips: placeCountyFips'), 'selector place payload keeps legacy fips aligned to containing county');
   assert(!/stripSuffix\(allP\[i\]\.label\)\s*===\s*target/.test(execOnly(selector)),
     'selector no longer relies on final label-string matching in handleContinue');
 

--- a/test/deal-calc-workflow-prefill.test.js
+++ b/test/deal-calc-workflow-prefill.test.js
@@ -15,6 +15,7 @@
 
 const fs   = require('fs');
 const path = require('path');
+const { JSDOM } = require('jsdom');
 
 let passed = 0, failed = 0;
 function assert(cond, msg) {
@@ -31,6 +32,10 @@ function execOnly(src) {
 const root = path.join(__dirname, '..');
 const dc   = fs.readFileSync(path.join(root, 'js/deal-calculator.js'),    'utf8');
 const pma  = fs.readFileSync(path.join(root, 'js/pma-ui-controller.js'),  'utf8');
+const resolver = fs.readFileSync(path.join(root, 'js/components/jurisdiction-url-context.js'), 'utf8');
+const workflowCore = fs.readFileSync(path.join(root, 'js/workflow-state-core.js'), 'utf8');
+const workflowApi = fs.readFileSync(path.join(root, 'js/workflow-state-api.js'), 'utf8');
+const geoConfig = JSON.parse(fs.readFileSync(path.join(root, 'data/hna/geo-config.json'), 'utf8'));
 
 console.log('\n[test] deal-calculator.js reads canonical countyFips before legacy fips');
 const dcExec = execOnly(dc);
@@ -46,6 +51,66 @@ assert(!/_jx\.countyFips|jx\.countyFips/.test(pmaExec),
 assert(/_jx\s*&&\s*_jx\.fips\s*\)\s*countyFips\s*=\s*_jx\.fips/.test(pmaExec),
   'CHFA-awards / AMI-gap wiring uses _jx.fips correctly');
 
-console.log('\n=========================================');
-console.log('Results: ' + passed + ' passed, ' + failed + ' failed');
-process.exit(failed === 0 ? 0 : 1);
+console.log('\n[test] deal calculator context line renders from JurisdictionUrlContext.resolve path');
+function extractFunction(src, name) {
+  const start = src.indexOf('function ' + name + '(');
+  if (start < 0) throw new Error('missing function ' + name);
+  const open = src.indexOf('{', start);
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth += 1;
+    else if (src[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return src.slice(start, i + 1);
+    }
+  }
+  throw new Error('unterminated function ' + name);
+}
+
+(async function testResolvePathContextLine() {
+  const cdp = geoConfig.cdps.find((row) => row.geoid === '0800320');
+  const county = geoConfig.counties.find((row) => row.geoid === cdp.containingCounty);
+  const dom = new JSDOM('<!doctype html><span id="dc-jurisdiction-context" hidden></span>', {
+    url: 'http://127.0.0.1/deal-calculator.html',
+    runScripts: 'outside-only'
+  });
+  const win = dom.window;
+  win.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve(geoConfig) });
+  win.eval(workflowCore);
+  win.eval(workflowApi);
+  win.eval(resolver);
+  win.WorkflowState.setJurisdiction({
+    geoType: 'cdp',
+    geoid: cdp.geoid,
+    name: cdp.label,
+    countyFips: cdp.containingCounty,
+    countyName: county.label,
+    fips: cdp.containingCounty,
+    type: 'city',
+    displayName: cdp.label,
+    placeGeoid: cdp.geoid
+  });
+  const ctx = await win.JurisdictionUrlContext.resolve();
+  assert(ctx && ctx.source === 'workflow', 'JurisdictionUrlContext.resolve returns workflow context');
+  assert(ctx && ctx.geoType === 'cdp', 'resolve path preserves CDP geoType');
+  assert(ctx && ctx.name === cdp.label, 'resolve path emits name for renderer');
+  win.eval(extractFunction(dc, '_renderJurisdictionContext'));
+  win._renderJurisdictionContext(ctx);
+  const line = win.document.getElementById('dc-jurisdiction-context');
+  assert(!line.hidden, 'resolved place/CDP context line is visible');
+  assert(line.textContent.includes('Analyzing ' + cdp.label), 'context line includes CDP name');
+  assert(line.textContent.includes(county.label + ' context'), 'context line includes containing county context');
+
+  const displayOnlyCtx = Object.assign({}, ctx);
+  delete displayOnlyCtx.name;
+  win._renderJurisdictionContext(displayOnlyCtx);
+  assert(!line.hidden && line.textContent.includes(cdp.label),
+    'renderer also accepts displayName-only resolver contexts');
+
+  console.log('\n=========================================');
+  console.log('Results: ' + passed + ' passed, ' + failed + ' failed');
+  process.exit(failed === 0 ? 0 : 1);
+}()).catch((err) => {
+  console.error('  ❌ FAIL: threw —', err.message);
+  process.exit(1);
+});

--- a/test/workflow-state-set-jurisdiction.test.js
+++ b/test/workflow-state-set-jurisdiction.test.js
@@ -170,6 +170,24 @@ test('legacy city payload coerces into canonical place tuple', function () {
   assert(j.placeGeoid === '0812345', 'legacy placeGeoid remains populated');
 });
 
+test('explicit geoType city coerces to place (not dropped to null)', function () {
+  reset();
+  // A caller passing geoType:'city' directly must land on canonical 'place' —
+  // without the city/town coercion in _geoTypeFromLegacy this normalizes to
+  // null and the tuple silently loses its geography type.
+  WorkflowState.setJurisdiction({
+    geoType: 'city',
+    geoid: '0812345',
+    name: 'Some Town',
+    countyFips: '08059',
+    countyName: 'Boulder',
+  });
+  const j = WorkflowState.getJurisdiction();
+  assert(j.geoType === 'place', 'explicit geoType city coerces to canonical place');
+  assert(j.geoid === '0812345', 'geoid survives coercion');
+  assert(j.countyFips === '08059', 'county context survives coercion');
+});
+
 test('jurisdiction step counts as complete after setJurisdiction', function () {
   reset();
   WorkflowState.setJurisdiction({

--- a/test/workflow-state-set-jurisdiction.test.js
+++ b/test/workflow-state-set-jurisdiction.test.js
@@ -124,6 +124,52 @@ test('setJurisdiction preserves place/CDP identity while keeping legacy fields',
   assert(j.placeGeoid === '0800320', 'legacy placeGeoid remains populated');
 });
 
+test('setJurisdiction warns when place/CDP county context is missing', function () {
+  reset();
+  const originalWarn = window.console.warn;
+  const warnings = [];
+  window.console.warn = function () {
+    warnings.push(Array.prototype.join.call(arguments, ' '));
+  };
+  try {
+    WorkflowState.setJurisdiction({
+      geoType: 'place',
+      geoid: '0812345',
+      name: 'Some Town',
+      countyFips: null,
+      countyName: null,
+      fips: null,
+      type: 'city',
+      displayName: 'Some Town',
+      placeGeoid: '0812345',
+    });
+  } finally {
+    window.console.warn = originalWarn;
+  }
+  const j = WorkflowState.getJurisdiction();
+  assert(j.geoType === 'place', 'place write still stores a place tuple');
+  assert(j.countyFips === null, 'missing county context remains null instead of being fabricated');
+  assert(warnings.some(function (msg) {
+    return msg.indexOf('Missing county context') !== -1 && msg.indexOf('0812345') !== -1;
+  }), 'missing place county context triggers a named console.warn');
+});
+
+test('legacy city payload coerces into canonical place tuple', function () {
+  reset();
+  WorkflowState.setJurisdiction({
+    type: 'city',
+    placeGeoid: '0812345',
+    fips: '08059',
+    displayName: 'Some Town',
+    name: 'Boulder',
+  });
+  const j = WorkflowState.getJurisdiction();
+  assert(j.geoType === 'place', 'legacy type=city coerces to geoType place');
+  assert(j.geoid === '0812345', 'legacy placeGeoid becomes canonical geoid');
+  assert(j.countyFips === '08059', 'legacy county fips becomes canonical countyFips');
+  assert(j.placeGeoid === '0812345', 'legacy placeGeoid remains populated');
+});
+
 test('jurisdiction step counts as complete after setJurisdiction', function () {
   reset();
   WorkflowState.setJurisdiction({


### PR DESCRIPTION
**#1278 was merged from its pre-fix head** (mergedAt 21:02Z) — the QA fix round landed on the branch around/after the merge and never reached main. This PR cherry-picks both stranded commits onto current main, unchanged:

- `d51fe7606` (Codex) — the three QA items from the [first verdict](https://github.com/pggLLC/Housing-Analytics/pull/1278#issuecomment-5026454327): context-line renders on the JurisdictionUrlContext resolve path (`ctx.name || ctx.displayName`), `console.warn` on place/cdp writes with no county context, resolve-path + completeness + legacy-pin test coverage.
- `2e1c1eaf8` (QA) — pins explicit `geoType:'city'` → canonical `'place'` so the coercion line itself is sabotage-guarded.

Without these, main's GEO-1 has: a context line that never displays on the Deal Calculator's default path, no completeness warning, and three unguarded sabotage gates.

Verified on this branch: contract + setJurisdiction (31) + prefill (11) tests pass; validate green; the full browser chain (CDP tuple → Jefferson pre-select + visible context line) was verified on identical content pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)