### PR TITLE
Wire PROV-1 provenance surfaces

### DIFF
--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -526,7 +526,7 @@
 
           <div class="stat"><div class="k">Tenure</div><div class="v" id="statTenure">—</div><div class="s" id="statTenureSrc">ACS DP04 0046/0047 · <a href="https://data.census.gov/table/ACSDP5Y2024.DP04" target="_blank" rel="noopener">data.census.gov</a></div></div>
           <div class="stat"><div class="k">Rent burdened (≥30%)</div><div class="v" id="statRentBurden">—</div><div class="s" id="statRentBurdenSrc">ACS DP04 GRAPI bins · <a href="https://data.census.gov/table/ACSDP5Y2024.DP04" target="_blank" rel="noopener">data.census.gov</a></div></div>
-          <div class="stat"><div class="k">Income needed to buy (est.)</div><div class="v" id="statIncomeNeed">—</div><div class="s" id="statIncomeNeedNote">30% of income rule</div><div class="s" style="font-size:.68rem;opacity:.85">ACS DP04_0089E median home value · <a href="https://www.freddiemac.com/pmms" target="_blank" rel="noopener">Freddie Mac PMMS</a></div></div>
+          <div class="stat"><div class="k">Income needed to buy (est.)</div><div class="v" id="statIncomeNeed">—</div><div class="s" id="statIncomeNeedNote">30% of income rule</div><div class="s" id="statIncomeNeedSrc" style="font-size:.68rem;opacity:.85">—</div></div>
           <div class="stat"><div class="k">Mean commute time</div><div class="v" id="statCommute">—</div><div class="s" id="statCommuteSrc">ACS S0801 mean travel time (min) · <a href="https://data.census.gov/table/ACSST5Y2024.S0801" target="_blank" rel="noopener">data.census.gov</a></div></div>
         </div>
         <!-- Affordability Gap Coverage — 7 AMI bands sourced from ACS-derived
@@ -1018,6 +1018,7 @@
           </div>
           <div class="chart-card span-4" style="margin:0">
             <h2>Housing need summary</h2>
+            <p id="projectionScopeBadge" style="margin:4px 0 0;font-size:.78rem;color:var(--muted)" hidden></p>
             <div class="stats" style="grid-template-columns:repeat(2,minmax(0,1fr));margin-top:10px">
               <div class="stat"><div class="k">Current requirement</div><div class="v" id="statBaseUnits">—</div><div class="s" id="statBaseUnitsSrc">—</div></div>
               <div class="stat"><div class="k">Target vacancy</div><div class="v" id="statTargetVac">—</div><div class="s">Assumption</div></div>
@@ -1260,6 +1261,7 @@
             <h3 style="margin:0 0 4px;">Projected housing demand by affordability tier (renter households)</h3>
             <p id="demandTierDesc" style="font-size:.82rem;color:var(--muted);margin:0 0 8px">Estimated renter households by AMI tier over the 10-year horizon. Used to identify missing AMI tiers for LIHTC applications. Based on statewide CO income distributions (ACS CHAS).</p>
             <div class="chart-box tall" data-source="DOLA Households + HUD CHAS AMI Tier Shares" data-source-url="https://www.huduser.gov/portal/datasets/cp.html" data-vintage="DOLA 2024 · CHAS 2018–2022" data-source-type="modeled"><canvas id="chartHouseholdDemand" role="img" aria-label="Housing demand by AMI affordability tier chart showing projected renter households at each income tier"></canvas></div>
+            <p id="householdDemandScopeCaption" style="font-size:.78rem;color:var(--muted);margin:6px 0 0" aria-live="polite">—</p>
           </div>
         </div>
 

--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -2029,6 +2029,8 @@
       if (window.HNAState.els.statUnitsNeed) window.HNAState.els.statUnitsNeed.textContent = '—';
       if (window.HNAState.els.statNetMig) window.HNAState.els.statNetMig.textContent = '—';
       if (window.HNAState.els.needNote) window.HNAState.els.needNote.textContent = 'Projections module not available yet (run the Build HNA data workflow).';
+      const projectionScopeBadge = document.getElementById('projectionScopeBadge');
+      if (projectionScopeBadge) { projectionScopeBadge.textContent = ''; projectionScopeBadge.hidden = true; }
       clearProductionVsNeed();
       // Show a visible notice in the scenario section so users know charts are unavailable
       const scenNote = document.getElementById('scenarioProjectionsNote');
@@ -2500,6 +2502,26 @@
       }
     } else if (selection && selection.geoType !== 'county' && selection.geoType !== 'state' && !_isMultiJurisdictionSelection(selection)) {
       projectionMethodNote = ' Need is scaled from the containing county DOLA projection.';
+    }
+    const projectionScopeBadge = document.getElementById('projectionScopeBadge');
+    if (projectionScopeBadge) {
+      if (selection && selection.geoType !== 'county' && selection.geoType !== 'state' && !_isMultiJurisdictionSelection(selection)) {
+        const countyName = selection.contextCounty || countyFips5;
+        const scope = usedPlaceProjection ? 'scaled' : 'county';
+        projectionScopeBadge.innerHTML = (usedPlaceProjection
+          ? 'Place-level projection inputs: '
+          : 'Projection source: ') +
+          (window.DataScope && window.DataScope.scopeBadge
+            ? window.DataScope.scopeBadge(scope, { countyName: countyName, inline: true })
+            : '') +
+          (usedPlaceProjection
+            ? ' DOLA county forecast blended with local ACS/BPS shares.'
+            : ' DOLA county forecast scaled to selected place/CDP.');
+        projectionScopeBadge.hidden = false;
+      } else {
+        projectionScopeBadge.textContent = '';
+        projectionScopeBadge.hidden = true;
+      }
     }
 
     // Net migration scaled for places/CDPs (share of county base).
@@ -2984,9 +3006,20 @@
       dlLink.style.cssText = 'color:inherit;text-decoration:underline';
       dlLink.textContent = 'Download Debug Log';
       window.HNAState.els.banner.textContent = '';
+      const fetchErrorTarget = document.createElement('div');
+      fetchErrorTarget.id = 'hnaProfileFetchError';
       window.HNAState.els.banner.appendChild(msgSpan);
       window.HNAState.els.banner.appendChild(dlLink);
+      window.HNAState.els.banner.appendChild(fetchErrorTarget);
       window.HNAState.els.banner.classList.add('show');
+      if (window.FetchErrorSurface && typeof window.FetchErrorSurface.render === 'function') {
+        window.FetchErrorSurface.render(fetchErrorTarget, {
+          source: 'Census ACS profile',
+          url: 'https://api.census.gov/data.html',
+          error: new Error('No ACS Census profile data returned for ' + geoType + ':' + geoid),
+          severity: 'error'
+        });
+      }
     }
 
     // F192 + F195 — Resolve contextCounty BEFORE the `if (profile)` block

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -15,6 +15,19 @@
     return U().homeValueInfo ? U().homeValueInfo(profile) : { value: null, display: null, sourceLabel: 'ACS DP04_0089E', asOf: null };
   }
 
+  function dataScopeBadge(scope, options) {
+    if (window.DataScope && typeof window.DataScope.scopeBadge === 'function') {
+      return window.DataScope.scopeBadge(scope, options || {});
+    }
+    return '';
+  }
+
+  function chasTierSourceLabel(source) {
+    if (source === 'place-chas') return 'TIGER place-CHAS';
+    if (source === 'county-chas') return 'County CHAS Table 7';
+    return 'CO statewide baseline — low confidence';
+  }
+
   /**
    * escHtml — escape a string for safe insertion into innerHTML.
    * @param {*} v - value to escape
@@ -491,6 +504,11 @@
             ? `Median HH income is $${fmtNum(Math.round(gap))} below what's needed.`
             : 'Median income meets or exceeds the income needed.';
       }
+    }
+    const incomeNeedSrc = document.getElementById('statIncomeNeedSrc');
+    if (incomeNeedSrc) {
+      const sourceText = U().homeValueSourceText ? U().homeValueSourceText(homeInfo) : homeInfo.sourceText;
+      incomeNeedSrc.textContent = (sourceText || 'Home-value source unavailable') + ' · Freddie Mac PMMS';
     }
 
     // Commute (S0801 mean travel time C01_046E)
@@ -3793,9 +3811,7 @@
             tooltip: {
               callbacks: {
                 label: ctx => `${ctx.dataset.label}: ${fmtNum(ctx.parsed.y)}`,
-                footer: () => 'Source: ' + (tierMeta.source === 'place-chas' ? 'TIGER place-CHAS' :
-                                              tierMeta.source === 'county-chas' ? 'County CHAS Table 7' :
-                                              'CO statewide baseline'),
+                footer: () => 'Source: ' + chasTierSourceLabel(tierMeta.source),
               },
             },
           },
@@ -3805,6 +3821,18 @@
           },
         },
       });
+      const caption = document.getElementById('householdDemandScopeCaption');
+      if (caption) {
+        const scope = tierMeta.source === 'place-chas'
+          ? 'place'
+          : (tierMeta.source === 'county-chas' ? 'county' : 'scaled');
+        caption.innerHTML = 'AMI tier shares source: ' + escHtml(chasTierSourceLabel(tierMeta.source)) +
+          dataScopeBadge(scope, { countyName: tierMeta.source === 'county-chas' ? escHtml(tierMeta.name) : null, inline: true }) +
+          (tierMeta.source === 'statewide-heuristic'
+            ? ' <span style="font-weight:600;color:var(--warn,#d97706)">CO statewide baseline — low confidence</span>'
+            : '');
+        caption.hidden = false;
+      }
     }
 
     // Render data quality badge for current geography

--- a/js/market-analysis.js
+++ b/js/market-analysis.js
@@ -1401,6 +1401,11 @@
       rentPressure:    '⚠ Verify: <a href="https://www.huduser.gov/portal/datasets/fmr.html" target="_blank" rel="noopener">HUD FMR</a> (lags ~18 mo) · spot-check vs. current market rents',
       marketTightness: '⚠ Verify: ACS 5-yr vacancy (lags ~18 mo) · does not reflect buildable-land constraints'
     };
+    function _scopeBadge(scope, options) {
+      return (window.DataScope && typeof window.DataScope.scopeBadge === 'function')
+        ? window.DataScope.scopeBadge(scope, options || {})
+        : '';
+    }
     var listEl = el('pmaDimList');
     if (listEl) {
       listEl.innerHTML = dimNames.map(function (k, i) {
@@ -1432,6 +1437,11 @@
         var verifyHint = (hasData && dimVerify[k])
           ? '<span class="kpi-source kpi-verify" style="display:block;margin-top:.25rem;font-size:.68rem">' + dimVerify[k] + '</span>'
           : '';
+        if (k === 'captureRisk' && result.captureDenominator && result.captureDenominator.source === 'chas_lihtc_eligible') {
+          verifyHint += '<span class="kpi-source kpi-scope" style="display:block;margin-top:.2rem;font-size:.68rem">' +
+            'CHAS denominator scope ' + _scopeBadge('county', { inline: true }) +
+            ' county income mix scaled to PMA buffer.</span>';
+        }
         // Tooltip uses the site-wide .info-tooltip pattern (<details>/<summary>)
         // instead of native HTML title attrs — title attrs don't show on touch
         // devices and a parent <li> title silently masks a nested span's title.

--- a/js/pma-ui-controller.js
+++ b/js/pma-ui-controller.js
@@ -70,6 +70,15 @@
   /* ── Element references ─────────────────────────────────────────── */
   function $id(id) { return document.getElementById(id); }
 
+  function _dataScopeBadge(scope, options) {
+    if (window.DataScope && typeof window.DataScope.scopeBadge === 'function') {
+      return window.DataScope.scopeBadge(scope, options || {});
+    }
+    return scope === 'county'
+      ? '<span class="ds-pill ds-pill--county" style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:.68rem;font-weight:600;line-height:1.3;background:var(--warn-dim,#3f2a1a);color:var(--warn,#fbbf24);border:1px solid var(--warn,#fbbf24);">county-scope</span>'
+      : '';
+  }
+
   /* ── Internal state ─────────────────────────────────────────────── */
   // CHFA tightening (2026-06-11): default to Tract picker. CHFA Market
   // Study Guide (Appendix A, 2025-26 QAP) does not allow radius boundaries
@@ -294,11 +303,32 @@
     var renderer = window.LIHTCConceptCardRenderer;
     if (renderer && typeof renderer.render === 'function') {
       renderer.render(card, rec, hnsFit);
+      _renderDealHandoffScopeNote(card, dealInputs);
       return;
     }
 
     // Fallback: inline renderer (kept in sync with LIHTCConceptCardRenderer)
     _drawConceptCard(card, rec, hnsFit);
+    _renderDealHandoffScopeNote(card, dealInputs);
+  }
+
+  function _renderDealHandoffScopeNote(card, dealInputs) {
+    if (!card || !dealInputs) return;
+    var parts = [];
+    if (dealInputs.countyAffordabilityGap != null) {
+      parts.push('county affordability gap');
+    }
+    if (dealInputs.chfaHistoricalAwards != null) {
+      parts.push('CHFA award count');
+    }
+    if (!parts.length) return;
+    var note = document.createElement('p');
+    note.className = 'pma-deal-handoff-scope-note';
+    note.style.cssText = 'margin:.5rem 0 0;font-size:.76rem;color:var(--text-muted,#aaa);line-height:1.4;';
+    note.innerHTML = '<strong>Deal handoff inputs:</strong> ' + _esc(parts.join(' and ')) + ' ' +
+      _dataScopeBadge('county', { inline: true }) +
+      ' <span style="color:var(--text-muted,#aaa)">County-scope context; not site- or place-specific.</span>';
+    card.appendChild(note);
   }
 
   function _drawConceptCard(card, rec, hnsFit) {

--- a/test/data-scope.test.js
+++ b/test/data-scope.test.js
@@ -12,6 +12,11 @@ const moduleSrc = fs.readFileSync(
   path.join(__dirname, '..', 'js', 'components', 'data-scope.js'),
   'utf8'
 );
+const hnaRenderersSrc = fs.readFileSync(path.join(__dirname, '..', 'js', 'hna', 'hna-renderers.js'), 'utf8');
+const hnaControllerSrc = fs.readFileSync(path.join(__dirname, '..', 'js', 'hna', 'hna-controller.js'), 'utf8');
+const pmaUiSrc = fs.readFileSync(path.join(__dirname, '..', 'js', 'pma-ui-controller.js'), 'utf8');
+const marketAnalysisSrc = fs.readFileSync(path.join(__dirname, '..', 'js', 'market-analysis.js'), 'utf8');
+const hnaHtml = fs.readFileSync(path.join(__dirname, '..', 'housing-needs-assessment.html'), 'utf8');
 const win = { console: { warn: () => {} } };
 new Function('window', 'console', moduleSrc)(win, win.console);
 const DataScope = win.DataScope;
@@ -98,6 +103,28 @@ run('guardCountyOnly identifies a dataset with no 7-digit keys', () => {
   assert.strictEqual(DataScope.guardCountyOnly({ '0815700': {}, '08015': {} }), false);
   assert.strictEqual(DataScope.guardCountyOnly({}), false);
   assert.strictEqual(DataScope.guardCountyOnly(null), false);
+});
+
+run('HNA household-demand chart visibly invokes DataScope.scopeBadge', () => {
+  assert.ok(hnaHtml.includes('id="householdDemandScopeCaption"'), 'HNA has a visible household-demand source caption');
+  assert.ok(hnaRenderersSrc.includes('householdDemandScopeCaption'), 'renderer targets the visible household-demand source caption');
+  assert.ok(/DataScope\.scopeBadge\(scope/.test(hnaRenderersSrc), 'renderer calls DataScope.scopeBadge for CHAS tier scope');
+  assert.ok(hnaRenderersSrc.includes('CO statewide baseline — low confidence'), 'statewide heuristic is labeled low confidence wherever surfaced');
+});
+
+run('HNA county-scaled projection charts visibly invoke DataScope.scopeBadge', () => {
+  assert.ok(hnaHtml.includes('id="projectionScopeBadge"'), 'HNA has a visible projection scope chip target');
+  assert.ok(hnaControllerSrc.includes('projectionScopeBadge'), 'controller targets the projection scope chip');
+  assert.ok(/DataScope\.scopeBadge\(scope/.test(hnaControllerSrc), 'controller calls DataScope.scopeBadge for county-scaled projections');
+  assert.ok(hnaControllerSrc.includes('DOLA county forecast scaled to selected place/CDP'), 'projection scope text discloses county scaling');
+});
+
+run('PMA deal handoff and capture-risk surfaces invoke DataScope.scopeBadge', () => {
+  assert.ok(pmaUiSrc.includes('pma-deal-handoff-scope-note'), 'PMA deal handoff renders a scope note');
+  assert.ok(pmaUiSrc.includes('county affordability gap') && pmaUiSrc.includes('CHFA award count'), 'PMA handoff names both county-level inputs');
+  assert.ok(/DataScope\.scopeBadge\(scope/.test(pmaUiSrc), 'PMA handoff calls DataScope.scopeBadge');
+  assert.ok(marketAnalysisSrc.includes('CHAS denominator scope'), 'PMA capture risk displays denominator scope');
+  assert.ok(/DataScope\.scopeBadge\(scope/.test(marketAnalysisSrc), 'PMA capture-risk disclosure calls DataScope.scopeBadge');
 });
 
 console.log('Done.');

--- a/test/fetch-error-surface.test.js
+++ b/test/fetch-error-surface.test.js
@@ -28,6 +28,14 @@ const moduleSrc = fs.readFileSync(
   path.join(__dirname, '..', 'js', 'components', 'fetch-error-surface.js'),
   'utf8'
 );
+const hnaControllerSrc = fs.readFileSync(
+  path.join(__dirname, '..', 'js', 'hna', 'hna-controller.js'),
+  'utf8'
+);
+const hnaHtml = fs.readFileSync(
+  path.join(__dirname, '..', 'housing-needs-assessment.html'),
+  'utf8'
+);
 const win = { console: { warn: () => {} } };
 new Function('window', 'console', moduleSrc)(win, win.console);
 const FES = win.FetchErrorSurface;
@@ -99,6 +107,14 @@ run('renders View raw file link when url provided', () => {
 run('null target is a no-op (does not throw)', () => {
   FES.render(null, { source: 'test', error: 'test' });
   // No assertion needed — just must not throw
+});
+
+run('HNA profile-fetch failure path invokes FetchErrorSurface', () => {
+  assert.ok(hnaHtml.includes('js/components/fetch-error-surface.js'), 'HNA page loads FetchErrorSurface');
+  assert.ok(hnaControllerSrc.includes('hnaProfileFetchError'), 'HNA creates a dedicated profile fetch-error target');
+  assert.ok(/FetchErrorSurface\.render\(fetchErrorTarget/.test(hnaControllerSrc), 'HNA profile failure calls FetchErrorSurface.render');
+  assert.ok(hnaControllerSrc.includes("source: 'Census ACS profile'"), 'HNA failure surface labels the failing source');
+  assert.ok(hnaControllerSrc.includes('Download Debug Log'), 'HNA keeps the existing support debug-log link');
 });
 
 console.log('Done.');

--- a/test/hna-home-value-cascade.test.js
+++ b/test/hna-home-value-cascade.test.js
@@ -54,6 +54,8 @@ assert(hnaUtils.includes('function homeValueInfo'), 'HNA utils should expose the
 assert(/function homeValueInfo\(profile\) \{\n\s+return U\(\)\.homeValueInfo/.test(hnaRenderers), 'HNA renderers should delegate to the shared home-value cascade helper');
 assert(/function renderAffordChart[\s\S]*homeValueInfo\(profile\)/.test(hnaRenderers), 'Affordability chart should use the home-value cascade helper');
 assert(/function renderWageAffordability[\s\S]*homeValueInfo\(profile\)/.test(hnaRenderers), 'Wage affordability panel should use the home-value cascade helper');
+assert(/statIncomeNeedSrc[\s\S]*homeValueSourceText[\s\S]*Freddie Mac PMMS/.test(hnaRenderers), 'Income-needed sublabel should consume shared homeValueInfo sourceText plus PMMS assumptions');
+assert(!/ACS DP04_0089E median home value · <a href="https:\/\/www\.freddiemac\.com\/pmms"/.test(fs.readFileSync(path.join(ROOT, 'housing-needs-assessment.html'), 'utf8')), 'Income-needed card must not carry the old hard-coded ACS home-value source label');
 assert(!/function renderAffordChart[\s\S]{0,900}safeNum\(profile\.DP04_0089E\) \|\| 0/.test(hnaRenderers), 'Affordability chart should not fall back to raw DP04 directly');
 assert(!/function renderWageAffordability[\s\S]{0,900}profile && profile\.DP04_0089E/.test(hnaRenderers), 'Wage affordability panel should not read raw DP04 directly');
 assert(/geoType === 'place' \|\| geoType === 'cdp' \|\| geoType === 'county'/.test(hnaController), 'Controller should lazy-load home-value cascade for county ownership views');

--- a/test/pma-scoring.test.js
+++ b/test/pma-scoring.test.js
@@ -11,6 +11,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 const Scoring = require('../js/market-analysis-scoring.js');
 
 let passed = 0;
@@ -30,6 +31,13 @@ function assertClose(actual, expected, tolerance, message) {
   assert(Math.abs(actual - expected) <= tolerance,
     `${message} (got ${actual}, expected ${expected} ±${tolerance})`);
 }
+
+test('PROV-1 does not modify PMA scoring constants/helper', () => {
+  const scoringPath = path.resolve(__dirname, '..', 'js', 'market-analysis-scoring.js');
+  const hash = crypto.createHash('sha256').update(fs.readFileSync(scoringPath)).digest('hex');
+  assert(hash === '17a4388a411e4c08c6a25765cb757661e9d34d9da6f820a21019ea11acf5e701',
+    'js/market-analysis-scoring.js remains byte-identical for provenance-only work');
+});
 
 function test(name, fn) {
   console.log(`\n[test] ${name}`);


### PR DESCRIPTION
## Summary
- Wires existing DataScope badges into HNA household-demand CHAS captions, HNA county-scaled projection chips, PMA deal-handoff county inputs, and PMA capture-risk denominator disclosure.
- Wires FetchErrorSurface into the HNA ACS profile failure path while preserving the debug-log link.
- Replaces the hardcoded income-needed source label with the shared home-value cascade source text plus PMMS assumptions.
- Pins statewide CHAS heuristic labeling as "CO statewide baseline — low confidence" and guards PMA scoring helper byte identity.

Do not merge until external QA completes.

## Test evidence
- npm run test:hna
- npm run test:hna-home-values
- npm run test:pma-scoring
- npm run test:data-scope
- npm run test:fetch-error-surface
- npm run validate

## Non-vacuousness guards
- test:data-scope now asserts the actual HNA/PMA call sites invoke DataScope.scopeBadge and have visible targets.
- test:fetch-error-surface now asserts HNA profile failure invokes FetchErrorSurface.render with a Census ACS source label.
- test:hna-home-values pins the income-needed source label to homeValueSourceText and rejects the old hardcoded ACS label.
- test:pma-scoring hashes js/market-analysis-scoring.js to prove this provenance-only PR does not modify scoring.