### PR TITLE
Translate COPY-1 public data wording

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
           <div class="home-job-route">
             <span class="home-job-route__kicker">Verify data</span>
             <strong>Review sources and freshness</strong>
-            <span>Open the Data Trust Center for freshness, sources, QA coverage, and limitations.</span>
+            <span>Open the Data Trust Center for freshness, sources, how we check the data, and limitations.</span>
             <span class="home-job-route__links">
               <a href="data-review-hub.html">Data Trust Center</a>
             </span>
@@ -367,8 +367,8 @@
         <span class="home-snapshot__label">Colorado at a glance</span>
         <!-- F118/F2.3 — banner points readers to the Data Trust Center instead
              of overclaiming cross-surface reconciliation. Public stats should
-             be sourced and monitored, with freshness/coverage limits visible. -->
-        <span class="home-snapshot__note-global"><span style="color:var(--good);font-weight:700;">LIVE</span> · Public datasets are sourced and monitored; freshness, coverage, and limitations are tracked in the <a href="data-review-hub.html" style="color:inherit;text-decoration:underline;">Data Trust Center</a>.</span>
+             be sourced and monitored, with freshness and data limits visible. -->
+        <span class="home-snapshot__note-global"><span style="color:var(--good);font-weight:700;">LIVE</span> · Public datasets are sourced and monitored; freshness, what each dataset includes, and limitations are tracked in the <a href="data-review-hub.html" style="color:inherit;text-decoration:underline;">Data Trust Center</a>.</span>
         <div class="home-snapshot__grid" role="list">
 
           <!-- Removed: "9% Credit Rate — 9.00%" card. The rate is

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -72,15 +72,15 @@
       // docs/audits/CODEX-HANDOFF-AUDIT-PHASE2-2026-07.md item 2.1.
       label: "Data",
       items: [
-        { label: "Data Trust Center",      href: "data-review-hub.html",           desc: "Start here · sources, freshness, QA coverage, and discovery" },
-        { label: "File Browser",          href: "data-explorer.html",             desc: "Inspect every JSON / GeoJSON / CSV in data/ with schema previews" },
+        { label: "Data Trust Center",      href: "data-review-hub.html",           desc: "Start here · sources, freshness, how we check the data, and discovery" },
+        { label: "File Browser",          href: "data-explorer.html",             desc: "Browse every dataset with previews" },
         { label: "Data Map",              href: "data-map-browser.html",          desc: "Interactive map of every geographic dataset — LIHTC, QCT/DDA, OZ, amenities, flood zones", isNew: true },
       ]
     },
     {
       label: "Insights",
       items: [
-        { label: "Housing News",           href: "policy-briefs.html",             desc: "Machine-summarized headlines (not editorially reviewed)" },
+        { label: "Housing News",           href: "policy-briefs.html",             desc: "Auto-generated summaries — always check the linked source" },
         { label: "Market Insights",       href: "insights.html",                  desc: "Analysis & commentary" },
         { label: "Market Intelligence",   href: "market-intelligence.html",       desc: "Statewide demand & supply data" },
         { label: "Housing Legislation",   href: "housing-legislation-2026.html",  desc: "2026 bills tracker" },

--- a/test/homepage-job-routing.test.js
+++ b/test/homepage-job-routing.test.js
@@ -12,6 +12,7 @@ const path = require('node:path');
 
 const ROOT = path.resolve(__dirname, '..');
 const index = fs.readFileSync(path.join(ROOT, 'index.html'), 'utf8');
+const navigation = fs.readFileSync(path.join(ROOT, 'js', 'navigation.js'), 'utf8');
 
 function pos(needle) {
   const idx = index.indexOf(needle);
@@ -53,11 +54,37 @@ for (const href of [
 
 assert(
   index.includes('Public datasets are sourced and monitored') &&
+  index.includes('what each dataset includes') &&
   index.includes('href="data-review-hub.html"'),
   'homepage data snapshot must use narrowed trust language and link Data Trust Center'
 );
 assert(!index.includes('every stat is sourced'), 'homepage must not overclaim that every stat is sourced');
 assert(!index.includes('docs/demo-mode-audit.csv'), 'homepage trust claim must not point public readers to the old demo-mode audit');
+
+assert(
+  index.includes('freshness, sources, how we check the data, and limitations'),
+  'homepage Data Trust Center route must use public wording for data checks'
+);
+assert(
+  navigation.includes('Start here · sources, freshness, how we check the data, and discovery'),
+  'navigation Data Trust Center description must avoid maintainer QA vocabulary'
+);
+assert(
+  navigation.includes('Browse every dataset with previews'),
+  'navigation File Browser description must use public dataset-browsing language'
+);
+assert(
+  navigation.includes('Auto-generated summaries — always check the linked source'),
+  'navigation Housing News description must use public caution language'
+);
+for (const oldPhrase of [
+  'QA coverage',
+  'Inspect every JSON / GeoJSON / CSV in data/ with schema previews',
+  'Machine-summarized headlines (not editorially reviewed)'
+]) {
+  assert(!index.includes(oldPhrase), `homepage must not include old maintainer wording: ${oldPhrase}`);
+  assert(!navigation.includes(oldPhrase), `navigation must not include old maintainer wording: ${oldPhrase}`);
+}
 
 const leadMatch = index.match(/<p class="home-opening__lead">([\s\S]*?)<\/p>/);
 assert(leadMatch, 'homepage hero lead copy must exist');


### PR DESCRIPTION
Refs COPY-1. Do not merge until external QA completes.

## Summary
- Replaces homepage “QA coverage” wording with “how we check the data.”
- Replaces Data Trust Center nav description with “Start here · sources, freshness, how we check the data, and discovery.”
- Replaces File Browser nav description with “Browse every dataset with previews.”
- Replaces Housing News nav description with “Auto-generated summaries — always check the linked source.”
- Rewrites the homepage LIVE snapshot note to say “what each dataset includes” instead of “coverage.”
- Extends homepage job-routing assertions to pin the new public wording and reject the old maintainer phrases.

## Verification
- npm run test:homepage-job-routing
- npm run test:navigation-paths
- npm run validate

No behavior, data, routing, or layout changes.