### PR TITLE
Surface Scenario Builder saved scenarios in HNA

### DIFF
--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -156,9 +156,11 @@
   <script defer src="js/dark-mode-toggle.js"></script>
   <script defer src="js/mobile-menu.js"></script>
   <script defer src="js/prop123-historical-tracker.js"></script>
-  <!-- HNA modules — load order: utils → narratives → renderers → export → controller -->
+  <!-- HNA modules — load order: projection presets/storage/model → utils → narratives → renderers → export → controller -->
   <script defer src="js/utils/data-quality.js"></script>
   <script defer src="js/projections/scenario-presets.js"></script>
+  <script defer src="js/projections/scenario-storage.js"></script>
+  <script defer src="js/projections/cohort-component-model.js"></script>
   <script defer src="js/hna/hna-utils.js"></script>
   <script defer src="js/hna/hna-narratives.js"></script>
   <!-- F216 — Per-section data-derived takeaways. Auto-injects one
@@ -1230,6 +1232,7 @@
 
         <!-- Scenario data unavailability notice (hidden by default; shown when projection data fails to load) -->
         <p id="scenarioProjectionsNote" hidden class="scenario-proj-notice"></p>
+        <p id="customScenarioDisclosure" hidden class="scenario-proj-notice" style="margin-top:8px"></p>
 
         <!-- Population view -->
         <div id="projViewPop" style="margin-top:12px">

--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -2632,10 +2632,60 @@
 
     // ---- Scenario comparison charts (5–10 year horizon section) ----
     try {
-      window.HNARenderers._renderScenarioSection(proj, popSel, years, baseYear, countyFips5, t);
+      const selectedScenario = getSelectedScenario();
+      const customScenario = await buildScenarioBuilderOverlay(
+        selectedScenario,
+        proj,
+        popSel,
+        years,
+        baseYear,
+        countyFips5,
+        selection,
+        baseUnits,
+        headship0,
+        targetVac
+      );
+      window.HNARenderers._renderScenarioSection(proj, popSel, years, baseYear, countyFips5, t, {
+        customScenario: customScenario,
+      });
+      const builtInSeries = {};
+      const scenarios = window.HNAUtils.PROJECTION_SCENARIOS || {};
+      Object.keys(scenarios).forEach(function (key) {
+        let series = [];
+        if (proj.scenarios && proj.scenarios[key]) {
+          series = proj.scenarios[key].map(function (d, idx) {
+            return { year: years[idx], population: d.population || d.pop || 0 };
+          });
+        } else if (key === 'low_growth') {
+          series = _scenarioGrowthSensitivitySeriesForExport(popSel, 0.85, years);
+        } else if (key === 'high_growth') {
+          series = _scenarioGrowthSensitivitySeriesForExport(popSel, 1.15, years);
+        } else {
+          series = (popSel || []).map(function (p, idx) { return { year: years[idx], population: p }; });
+        }
+        builtInSeries[key] = series;
+      });
+      if (customScenario && customScenario.series) builtInSeries[customScenario.key] = customScenario.series;
+      window.HNAState.state.lastScenarioSeries = builtInSeries;
     } catch(scErr) {
       console.error('[HNA] _renderScenarioSection failed:', scErr);
     }
+  }
+
+  function _scenarioGrowthSensitivitySeriesForExport(baseline, growthFactor, years){
+    const series = Array.isArray(baseline) ? baseline : [];
+    const p0 = series.find(v => v != null && Number.isFinite(Number(v)));
+    if (p0 == null || !Number.isFinite(Number(growthFactor))) {
+      return series.map(function (_, idx) { return { year: years[idx], population: null }; });
+    }
+    const base = Number(p0);
+    return series.map(function (p, idx) {
+      const value = Number(p);
+      return {
+        year: years[idx],
+        population: Number.isFinite(value) ? base + (growthFactor * (value - base)) : null,
+      };
+    });
   }
 
   /**
@@ -2648,6 +2698,55 @@
   const scenarioState = {
     current: 'baseline',
   };
+  const SCENARIO_BUILDER_PREFIX = 'builder:';
+  const SCENARIO_BUILDER_LABEL = 'Custom (Scenario Builder) · 20-yr cohort model';
+
+  function scenarioBuilderKey(id){
+    return SCENARIO_BUILDER_PREFIX + String(id || '');
+  }
+
+  function scenarioBuilderIdFromKey(key){
+    const raw = String(key || '');
+    return raw.indexOf(SCENARIO_BUILDER_PREFIX) === 0 ? raw.slice(SCENARIO_BUILDER_PREFIX.length) : null;
+  }
+
+  function listScenarioBuilderRecords(){
+    if (!window.ScenarioStorage || typeof window.ScenarioStorage.list !== 'function') return [];
+    try {
+      return window.ScenarioStorage.list().filter(function (rec) {
+        return rec && rec.id && rec.name && rec.parameters;
+      });
+    } catch (_) {
+      return [];
+    }
+  }
+
+  function getScenarioBuilderRecord(key){
+    const id = scenarioBuilderIdFromKey(key);
+    if (!id) return null;
+    if (window.ScenarioStorage && typeof window.ScenarioStorage.get === 'function') {
+      try {
+        const rec = window.ScenarioStorage.get(id);
+        if (rec) return rec;
+      } catch (_) { /* fall through to list lookup */ }
+    }
+    return listScenarioBuilderRecords().find(function (rec) { return rec.id === id; }) || null;
+  }
+
+  function syncScenarioBuilderOptions(){
+    const scenarioSel = document.getElementById('projScenario');
+    if (!scenarioSel) return;
+    scenarioSel.querySelectorAll('option[data-scenario-builder-option="true"]').forEach(function (opt) {
+      opt.remove();
+    });
+    listScenarioBuilderRecords().forEach(function (rec) {
+      const opt = document.createElement('option');
+      opt.value = scenarioBuilderKey(rec.id);
+      opt.textContent = String(rec.name) + ' (Scenario Builder)';
+      opt.dataset.scenarioBuilderOption = 'true';
+      scenarioSel.appendChild(opt);
+    });
+  }
 
 
   function getSelectedScenario(){
@@ -2658,9 +2757,112 @@
 
   function updateScenarioDescription(){
     const sc   = getSelectedScenario();
-    const meta = window.HNAUtils.PROJECTION_SCENARIOS[sc];
+    const custom = getScenarioBuilderRecord(sc);
+    const meta = custom ? null : window.HNAUtils.PROJECTION_SCENARIOS[sc];
     const el   = document.getElementById('scenarioDescription');
-    if (el && meta) el.textContent = meta.description;
+    if (el && custom) {
+      el.textContent = String(custom.name) + ' from Scenario Builder. Custom cohort-component projection; not a DOLA-aligned preset.';
+    } else if (el && meta) {
+      el.textContent = meta.description;
+    }
+  }
+
+  function setCustomScenarioDisclosure(customMeta){
+    const el = document.getElementById('customScenarioDisclosure');
+    if (!el) return;
+    if (!customMeta || !customMeta.active) {
+      el.textContent = '';
+      el.hidden = true;
+      return;
+    }
+    el.textContent = 'Custom Scenario Builder line shown with a cohort-component model and current HNA base data; built-in scenarios remain DOLA-aligned. The custom line is truncated to the chart year range with no extrapolated tail.';
+    el.hidden = false;
+  }
+
+  function scaleDolaSyaData(dolaData, scaleFactor, selection, countyFips5){
+    if (!dolaData || !Number.isFinite(scaleFactor) || scaleFactor === 1) return dolaData;
+    const scaled = Object.assign({}, dolaData, {
+      geoid: selection && selection.geoid,
+      placeName: selection && selection.label,
+      downscaledFromCounty: countyFips5,
+      scaleFactor: scaleFactor,
+    });
+    if (Array.isArray(dolaData.male)) scaled.male = dolaData.male.map(function (v) { return v * scaleFactor; });
+    if (Array.isArray(dolaData.female)) scaled.female = dolaData.female.map(function (v) { return v * scaleFactor; });
+    if (Array.isArray(dolaData.pyramid)) {
+      scaled.pyramid = dolaData.pyramid.map(function (row) {
+        return Object.assign({}, row, {
+          male: (row.male || 0) * scaleFactor,
+          female: (row.female || 0) * scaleFactor,
+        });
+      });
+    }
+    return scaled;
+  }
+
+  async function buildScenarioBuilderOverlay(selectedKey, proj, popSel, years, baseYear, countyFips5, selection, baseUnits, headship0, targetVac){
+    const rec = getScenarioBuilderRecord(selectedKey);
+    if (!rec) {
+      setCustomScenarioDisclosure(null);
+      return null;
+    }
+    if (!window.CohortComponentModel || typeof window.CohortComponentModel !== 'function') {
+      setCustomScenarioDisclosure(null);
+      return null;
+    }
+    let dolaData = null;
+    if (window.HNAState.state.lastDolaSya && window.HNAState.state.lastDolaFips === countyFips5) {
+      dolaData = window.HNAState.state.lastDolaSya;
+    } else if (countyFips5) {
+      try {
+        dolaData = await loadJson(window.HNAUtils.PATHS.dolaSya(countyFips5));
+      } catch (_) {
+        dolaData = null;
+      }
+    }
+    if (!dolaData) {
+      setCustomScenarioDisclosure(null);
+      return null;
+    }
+
+    const countyBase = window.HNAUtils.safeNum((proj && proj.population_dola && proj.population_dola[0]) || null);
+    const selectedBase = window.HNAUtils.safeNum((popSel && popSel[0]) || null);
+    const isSubCounty = selection && selection.geoType !== 'county' && selection.geoType !== 'state' && !_isMultiJurisdictionSelection(selection);
+    const scaleFactor = isSubCounty && countyBase && selectedBase
+      ? Math.min(1, Math.max(0.0001, selectedBase / countyBase))
+      : 1;
+    const scopedDola = scaleDolaSyaData(dolaData, scaleFactor, selection, countyFips5);
+    const basePopulation = window.CohortComponentModel.buildBasePopFromDola(scopedDola);
+    const chartEndYear = years && years.length ? Number(years[years.length - 1]) : (baseYear + 20);
+    const requestedEnd = Number(rec.targetYear || rec.horizonEndYear || rec.endYear || 2050);
+    const targetYear = Number.isFinite(requestedEnd) ? Math.min(requestedEnd, 2050) : 2050;
+    const model = new window.CohortComponentModel({
+      basePopulation: basePopulation,
+      baseYear: baseYear || 2024,
+      targetYear: targetYear,
+      scenario: rec.parameters || {},
+      headshipRate: headship0 || 0.38,
+      vacancyTarget: targetVac || 0.05,
+      baseUnits: baseUnits || 0,
+    });
+    const projected = model.project();
+    const allowedYears = new Set((years || []).map(function (y) { return Number(y); }));
+    const series = projected
+      .filter(function (row) { return allowedYears.has(Number(row.year)) && Number(row.year) <= chartEndYear; })
+      .map(function (row) {
+        return { year: row.year, population: row.totalPopulation, pop: row.totalPopulation };
+      });
+    const meta = {
+      active: true,
+      key: selectedKey,
+      id: rec.id,
+      name: rec.name,
+      label: SCENARIO_BUILDER_LABEL,
+      color: '#a855f7',
+      series: series,
+    };
+    setCustomScenarioDisclosure(meta);
+    return meta;
   }
 
   function updateScenarioBuilderLink(selection){
@@ -2683,14 +2885,16 @@
   function wireScenarioControls(){
     const scenarioSel = document.getElementById('projScenario');
     if (scenarioSel){
+      syncScenarioBuilderOptions();
       scenarioSel.addEventListener('change', () => {
         const sc   = scenarioSel.value;
-        const meta = window.HNAUtils.PROJECTION_SCENARIOS[sc];
+        const meta = window.HNAUtils.PROJECTION_SCENARIOS[sc] || getScenarioBuilderRecord(sc);
         if (!meta) return;
         updateScenarioDescription();
         // Re-render the projection charts if data is loaded
         if (window.HNAState.state.lastProj && window.HNAState.state.current){ applyAssumptions(window.HNAState.state.lastProj, window.HNAState.state.current); }
       });
+      scenarioSel.addEventListener('focus', syncScenarioBuilderOptions);
     }
 
     // View toggle (population / household / housing demand)
@@ -2764,6 +2968,8 @@
     // Build header row
     const header = ['Year', ...scenarios.map(sc => {
       const meta = (window.HNAUtils && window.HNAUtils.PROJECTION_SCENARIOS[sc]) || {};
+      const custom = getScenarioBuilderRecord(sc);
+      if (custom) return SCENARIO_BUILDER_LABEL;
       return meta.label || sc;
     })];
 
@@ -3350,6 +3556,8 @@
       try{
         dola = await loadJson(window.HNAUtils.PATHS.dolaSya('08'));
         cacheFlags.dola = true;
+        window.HNAState.state.lastDolaSya = dola;
+        window.HNAState.state.lastDolaFips = '08';
       }catch(e){
         console.warn(e);
       }
@@ -3366,6 +3574,8 @@
       try{
         dola = await loadJson(window.HNAUtils.PATHS.dolaSya(contextCounty));
         cacheFlags.dola = true;
+        window.HNAState.state.lastDolaSya = dola;
+        window.HNAState.state.lastDolaFips = contextCounty;
       }catch(e){
         console.warn(e);
       }

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -3630,8 +3630,10 @@
    * @param {string}  countyFips5
    * @param {object}  t          - Chart theme
    */
-  function _renderScenarioSection(proj, popSel, years, baseYear, countyFips5, t) {
+  function _renderScenarioSection(proj, popSel, years, baseYear, countyFips5, t, opts) {
     const fmtNum = window.HNAUtils.fmtNum;
+    const customScenario = opts && opts.customScenario && opts.customScenario.active ? opts.customScenario : null;
+    const customScenarioLabel = 'Custom (Scenario Builder) · 20-yr cohort model';
 
     // ── Chart 1: chartScenarioComparison — multi-scenario population trends ──
     // ID drift fix: HTML canvas is "chartScenarioComparison"; this code
@@ -3665,6 +3667,18 @@
           { label: 'Growth +15%', data: _scenarioGrowthSensitivitySeries(baseline, 1.15), borderColor: t.c6, borderWidth: 2, borderDash: [4,4], pointRadius: 0, tension: 0.25 }
         );
       }
+      if (customScenario && Array.isArray(customScenario.series) && customScenario.series.length) {
+        datasets.push({
+          label: customScenarioLabel,
+          data: customScenario.series.map(d => d.population || d.pop || 0),
+          borderColor: customScenario.color || '#a855f7',
+          backgroundColor: 'transparent',
+          borderWidth: 2.5,
+          borderDash: [8, 4],
+          pointRadius: 2,
+          tension: 0.25,
+        });
+      }
       makeChart(compCanvas.getContext('2d'), {
         type: 'line',
         data: { labels: years, datasets },
@@ -3690,8 +3704,18 @@
       const scenarios = window.HNAUtils.PROJECTION_SCENARIOS || {};
       const meta = scenarios[scenarioSel] || { label: 'Baseline (DOLA)', color: t.c1 };
       let series = popSel;
+      let detailLabel = meta.label || scenarioSel;
+      let detailColor = meta.color || t.c1;
+      let detailDash = [];
+      let detailFill = true;
       if (proj.scenarios && proj.scenarios[scenarioSel]) {
         series = proj.scenarios[scenarioSel].map(d => d.population || d.pop || 0);
+      } else if (customScenario && scenarioSel === customScenario.key) {
+        series = customScenario.series.map(d => d.population || d.pop || 0);
+        detailLabel = customScenarioLabel;
+        detailColor = customScenario.color || '#a855f7';
+        detailDash = [8, 4];
+        detailFill = false;
       } else if (scenarioSel === 'low_growth') {
         series = _scenarioGrowthSensitivitySeries(popSel, 0.85);
       } else if (scenarioSel === 'high_growth') {
@@ -3702,12 +3726,13 @@
         data: {
           labels: years,
           datasets: [{
-            label: meta.label || scenarioSel,
+            label: detailLabel,
             data: series,
-            borderColor: meta.color || t.c1,
-            backgroundColor: (meta.color || t.c1) + '22',
-            fill: true,
+            borderColor: detailColor,
+            backgroundColor: detailColor + '22',
+            fill: detailFill,
             borderWidth: 2,
+            borderDash: detailDash,
             pointRadius: 3,
             tension: 0.25,
           }],

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typecheck": "echo \"No dedicated typecheck script for this static site\"",
     "test:validate": "node test/validate-site.js",
     "test:fetch-helper": "node test/fetch-helper-resolve.js",
-    "test:hna": "node test/hna-functionality-check.js && node test/hna-profile-fetch-batches.test.js && npm run test:metric-semantics && npm run test:scenario-presets",
+    "test:hna": "node test/hna-functionality-check.js && node test/hna-profile-fetch-batches.test.js && npm run test:metric-semantics && npm run test:scenario-presets && node test/hna-scenario-builder-saved.test.js",
     "test:metric-semantics": "node test/metric-semantics-wording.test.js",
     "test:scenario-presets": "node test/scenario-presets-shared.test.js",
     "test:hna-ownership-need": "node test/hna-ownership-need.test.js",

--- a/test/hna-scenario-builder-saved.test.js
+++ b/test/hna-scenario-builder-saved.test.js
@@ -28,7 +28,7 @@ function makeDom() {
     <p id="customScenarioDisclosure" hidden></p>
     <canvas id="chartScenarioComparison"></canvas>
     <canvas id="chartProjectionDetail"></canvas>
-  `, { url: 'https://coho.test/housing-needs-assessment.html' });
+  `, { url: 'http://127.0.0.1/housing-needs-assessment.html' });
 }
 
 function installDomGlobals(dom, charts) {

--- a/test/hna-scenario-builder-saved.test.js
+++ b/test/hna-scenario-builder-saved.test.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { JSDOM } = require('jsdom');
+
+const ROOT = path.resolve(__dirname, '..');
+
+function read(rel) {
+  return fs.readFileSync(path.join(ROOT, rel), 'utf8');
+}
+
+function freshRequire(rel) {
+  const abs = path.join(ROOT, rel);
+  delete require.cache[require.resolve(abs)];
+  return require(abs);
+}
+
+function makeDom() {
+  return new JSDOM(`
+    <select id="projScenario">
+      <option value="baseline">Baseline</option>
+      <option value="low_growth">Low growth</option>
+      <option value="high_growth">High growth</option>
+    </select>
+    <p id="customScenarioDisclosure" hidden></p>
+    <canvas id="chartScenarioComparison"></canvas>
+    <canvas id="chartProjectionDetail"></canvas>
+  `, { url: 'https://coho.test/housing-needs-assessment.html' });
+}
+
+function installDomGlobals(dom, charts) {
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.localStorage = dom.window.localStorage;
+  global.Chart = function ChartStub(ctx, config) {
+    charts.push(config);
+    return { destroy() {} };
+  };
+  window.Chart = global.Chart;
+  window.HNAState = {
+    charts: {},
+    els: {
+      geoType: { value: 'county' },
+      geoSelect: { value: '08045' },
+    },
+  };
+  window.HNAUtils = {
+    fmtNum(value) { return String(Math.round(Number(value) || 0)); },
+    PROJECTION_SCENARIOS: {
+      baseline: { label: 'Baseline', color: '#4a90d9' },
+      low_growth: { label: 'Low growth', color: '#e07b39' },
+      high_growth: { label: 'High growth', color: '#4caf50' },
+    },
+  };
+  window.HTMLCanvasElement.prototype.getContext = function getContext() {
+    return { canvas: this };
+  };
+}
+
+const hnaHtml = read('housing-needs-assessment.html');
+const controllerSrc = read('js/hna/hna-controller.js');
+const renderersSrc = read('js/hna/hna-renderers.js');
+const pkg = JSON.parse(read('package.json'));
+
+const order = [
+  'js/projections/scenario-presets.js',
+  'js/projections/scenario-storage.js',
+  'js/projections/cohort-component-model.js',
+  'js/hna/hna-utils.js',
+  'js/hna/hna-controller.js',
+];
+for (let i = 0; i < order.length - 1; i += 1) {
+  assert(
+    hnaHtml.indexOf(order[i]) >= 0 && hnaHtml.indexOf(order[i]) < hnaHtml.indexOf(order[i + 1]),
+    `HNA script order keeps ${order[i]} before ${order[i + 1]}`,
+  );
+}
+
+assert(controllerSrc.includes('ScenarioStorage.list()'), 'controller reads saved Scenario Builder scenarios');
+assert(controllerSrc.includes("(Scenario Builder)'"), 'controller labels saved select options with Scenario Builder suffix');
+assert(controllerSrc.includes('SCENARIO_BUILDER_PREFIX'), 'controller namespaces saved scenario option values');
+assert(controllerSrc.includes('Custom (Scenario Builder) · 20-yr cohort model'), 'custom legend/disclosure label is pinned');
+assert(controllerSrc.includes('CohortComponentModel'), 'controller recomputes saved scenario series with CohortComponentModel');
+assert(controllerSrc.includes('filter(function (row) { return allowedYears.has(Number(row.year))'), 'controller truncates custom series to HNA chart years');
+assert(!controllerSrc.includes('localStorage.setItem') || controllerSrc.includes('ScenarioStorage'), 'controller does not persist computed projection series');
+assert(renderersSrc.includes('borderDash: [8, 4]'), 'custom scenario renders as a dashed line');
+
+let charts = [];
+let dom = makeDom();
+installDomGlobals(dom, charts);
+freshRequire('js/projections/scenario-storage.js');
+freshRequire('js/projections/cohort-component-model.js');
+freshRequire('js/hna/hna-renderers.js');
+
+window.ScenarioStorage.save({
+  id: 'custom-workforce-growth',
+  name: 'Workforce growth',
+  parameters: {
+    fertility_multiplier: 1.03,
+    mortality_multiplier: 0.99,
+    net_migration_annual: 800,
+  },
+});
+assert.equal(window.ScenarioStorage.list().length, 1, 'seeded localStorage fixture produces one saved scenario');
+
+const model = new window.CohortComponentModel({
+  basePopulation: {
+    male: new Array(18).fill(1000),
+    female: new Array(18).fill(1000),
+  },
+  baseYear: 2024,
+  targetYear: 2050,
+  scenario: window.ScenarioStorage.list()[0].parameters,
+  headshipRate: 0.38,
+  vacancyTarget: 0.05,
+  baseUnits: 1000,
+});
+const hnaYears = Array.from({ length: 21 }, (_, idx) => 2024 + idx);
+const hnaLastYear = hnaYears[hnaYears.length - 1];
+const customSeries = model.project()
+  .filter(row => hnaYears.includes(row.year))
+  .map(row => ({ year: row.year, population: row.totalPopulation, pop: row.totalPopulation }));
+assert.equal(customSeries.at(-1).year, hnaLastYear, 'custom 2050 Builder series is truncated at the HNA chart last year');
+assert(!customSeries.some(row => row.year > hnaLastYear), 'custom series has no padded or extrapolated tail past the HNA chart');
+
+const customOpt = document.createElement('option');
+customOpt.value = 'builder:custom-workforce-growth';
+customOpt.textContent = 'Workforce growth (Scenario Builder)';
+customOpt.dataset.scenarioBuilderOption = 'true';
+document.getElementById('projScenario').appendChild(customOpt);
+document.getElementById('projScenario').value = 'builder:custom-workforce-growth';
+window.HNARenderers._renderScenarioSection(
+  {
+    population_dola: hnaYears.map((_, idx) => 20000 + idx * 100),
+    scenarios: {},
+    housing_need: {},
+  },
+  hnaYears.map((_, idx) => 20000 + idx * 100),
+  hnaYears,
+  2024,
+  '08045',
+  {
+    c1: '#4a90d9',
+    c5: '#e07b39',
+    c6: '#4caf50',
+    text: '#111827',
+    muted: '#6b7280',
+    border: '#e5e7eb',
+  },
+  {
+    customScenario: {
+      active: true,
+      key: 'builder:custom-workforce-growth',
+      name: 'Workforce growth',
+      label: 'Custom (Scenario Builder) · 20-yr cohort model',
+      color: '#a855f7',
+      series: customSeries,
+    },
+  },
+);
+
+assert.equal(charts.length, 2, 'scenario renderer produced comparison and detail charts');
+const comparisonLabels = charts[0].data.datasets.map(ds => ds.label);
+assert(comparisonLabels.includes('Custom (Scenario Builder) · 20-yr cohort model'), 'comparison chart renders custom scenario label');
+const customDataset = charts[0].data.datasets.find(ds => ds.label === 'Custom (Scenario Builder) · 20-yr cohort model');
+assert.deepEqual(customDataset.borderDash, [8, 4], 'comparison custom scenario is visually distinct');
+assert.equal(customDataset.data.length, customSeries.length, 'comparison custom dataset uses the truncated series only');
+assert.equal(charts[1].data.datasets[0].label, 'Custom (Scenario Builder) · 20-yr cohort model', 'detail chart uses custom disclosure label');
+
+charts = [];
+dom = makeDom();
+installDomGlobals(dom, charts);
+freshRequire('js/hna/hna-renderers.js');
+window.HNARenderers._renderScenarioSection(
+  {
+    population_dola: hnaYears.map((_, idx) => 20000 + idx * 100),
+    scenarios: {},
+    housing_need: {},
+  },
+  hnaYears.map((_, idx) => 20000 + idx * 100),
+  hnaYears,
+  2024,
+  '08045',
+  {
+    c1: '#4a90d9',
+    c5: '#e07b39',
+    c6: '#4caf50',
+    text: '#111827',
+    muted: '#6b7280',
+    border: '#e5e7eb',
+  },
+  {}
+);
+assert(!charts[0].data.datasets.some(ds => /Scenario Builder/.test(ds.label)), 'empty storage/no active custom scenario leaves built-in comparison unchanged');
+
+assert(pkg.scripts['test:hna'].includes('node test/hna-scenario-builder-saved.test.js'), 'test:hna runs the saved Scenario Builder HNA guard');
+
+console.log('hna-scenario-builder-saved: PASS');


### PR DESCRIPTION
Refs #1253.\n\nDo not merge until external QA completes.\n\n## Summary\n- Loads ScenarioStorage and CohortComponentModel on housing-needs-assessment.html before HNA utils/controller.\n- Adds Scenario Builder saved scenarios to the read-only HNA scenario selector after the three built-ins.\n- Recomputes selected saved scenarios from stored parameters against the current HNA DOLA base data via CohortComponentModel; no projection series is persisted.\n- Overlays the selected custom series on the comparison/detail charts as a dashed custom line labeled "Custom (Scenario Builder) · 20-yr cohort model" with a visible disclosure that built-ins remain DOLA-aligned.\n- Truncates custom series to the existing HNA chart year window, with no extrapolation or padded tail.\n\n## Non-vacuousness / guards\n- Added test/hna-scenario-builder-saved.test.js and wired it into npm run test:hna.\n- The guard seeds ScenarioStorage, runs CohortComponentModel, checks truncation to the HNA year range, and invokes the real HNA renderer with a Chart stub to assert the custom label/dashed series renders.\n- Empty/no active custom scenario path asserts no Scenario Builder dataset appears.\n- Load-order and controller wiring pins verify storage/model load before HNA controller and saved options use the Scenario Builder suffix.\n\n## Verification\n- node test/hna-scenario-builder-saved.test.js\n- npm run test:hna\n- npm run test:ranking-scenarios\n- npm run validate\n\nExternal QA browser flow requested: save in Scenario Builder → HNA selector shows saved scenario → overlay appears with custom/cohort-model label and disclosure.