### PR TITLE
OWN-1: wire ownership supply and county anchors

### DIFF
--- a/data/hna/home-value-cascade.json
+++ b/data/hna/home-value-cascade.json
@@ -1,11 +1,12 @@
 {
   "meta": {
-    "generated_at": "2026-07-14T14:00:27.653Z",
+    "generated_at": "2026-07-22T05:08:35.821Z",
     "schema": "median_home_value = { value, source, as_of, confidence }; counties are display-only affordability inputs and are ignored by rank/score models",
     "sources": {
       "zhvi_city_csv": "https://files.zillowstatic.com/research/public_csvs/zhvi/City_zhvi_uc_sfrcondo_tier_0.33_0.67_sm_sa_month.csv",
       "zhvi_county_csv": null,
-      "acs_raw": "ACS DP04_0089E, 2020-2024 5-year"
+      "acs_raw": "ACS DP04_0089E, 2020-2024 5-year",
+      "fhfa_county_hpi": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
     },
     "latest_zhvi_month": "2026-05-31",
     "colorado_zhvi_rows": 315,
@@ -14,6 +15,7 @@
       "acs_raw": 218,
       "total": 482,
       "counties": {
+        "fhfa_county_hpi_anchor": 64,
         "acs_raw": 64,
         "missing": 0,
         "total": 64
@@ -3445,452 +3447,1284 @@
   },
   "counties": {
     "08001": {
-      "value": 519500,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 645333,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 519500,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 340,
+        "hpi_10y_base": 165,
+        "change_10y": 1.060606,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 273.7035,
+        "adjustment_factor": 1.24222,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08003": {
-      "value": 239100,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 290632,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 239100,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 230,
+        "hpi_10y_base": 120,
+        "change_10y": 0.916667,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 189.2186,
+        "adjustment_factor": 1.215525,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08005": {
-      "value": 589300,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 737710,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 589300,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 370,
+        "hpi_10y_base": 175,
+        "change_10y": 1.114286,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 295.5647,
+        "adjustment_factor": 1.251841,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08007": {
-      "value": 478100,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 588610,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 478100,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 290,
+        "hpi_10y_base": 145,
+        "change_10y": 1,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 235.5532,
+        "adjustment_factor": 1.231144,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08009": {
-      "value": 122900,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 145366,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 122900,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 175,
+        "hpi_10y_base": 100,
+        "change_10y": 0.75,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 147.954,
+        "adjustment_factor": 1.1828,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08011": {
-      "value": 146900,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 175037,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 146900,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 165,
+        "hpi_10y_base": 92,
+        "change_10y": 0.793478,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 138.4762,
+        "adjustment_factor": 1.191541,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08013": {
-      "value": 783000,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 993369,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 783000,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 420,
+        "hpi_10y_base": 190,
+        "change_10y": 1.210526,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 331.0553,
+        "adjustment_factor": 1.26867,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08014": {
-      "value": 686200,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 868657,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 686200,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 395,
+        "hpi_10y_base": 180,
+        "change_10y": 1.194444,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 312.0324,
+        "adjustment_factor": 1.265894,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08015": {
-      "value": 665700,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 827675,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 665700,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 310,
+        "hpi_10y_base": 150,
+        "change_10y": 1.066667,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 249.3335,
+        "adjustment_factor": 1.243315,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08017": {
-      "value": 187500,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 222825,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 187500,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 160,
+        "hpi_10y_base": 90,
+        "change_10y": 0.777778,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 134.6346,
+        "adjustment_factor": 1.188402,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08019": {
-      "value": 608500,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 763399,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 608500,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 345,
+        "hpi_10y_base": 162,
+        "change_10y": 1.12963,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 274.9969,
+        "adjustment_factor": 1.254559,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08021": {
-      "value": 193400,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 228151,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 193400,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 170,
+        "hpi_10y_base": 98,
+        "change_10y": 0.734694,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 144.106,
+        "adjustment_factor": 1.179687,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08023": {
-      "value": 184700,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 218888,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 184700,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 155,
+        "hpi_10y_base": 88,
+        "change_10y": 0.761364,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 130.7907,
+        "adjustment_factor": 1.185099,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08025": {
-      "value": 116200,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 137304,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 116200,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 150,
+        "hpi_10y_base": 86,
+        "change_10y": 0.744186,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 126.9444,
+        "adjustment_factor": 1.18162,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08027": {
-      "value": 392100,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 484982,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 392100,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 260,
+        "hpi_10y_base": 128,
+        "change_10y": 1.03125,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 210.2056,
+        "adjustment_factor": 1.236884,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08029": {
-      "value": 343200,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 416932,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 343200,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 220,
+        "hpi_10y_base": 115,
+        "change_10y": 0.913043,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 181.0945,
+        "adjustment_factor": 1.214835,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08031": {
-      "value": 636400,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 799441,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 636400,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 385,
+        "hpi_10y_base": 180,
+        "change_10y": 1.138889,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 306.4815,
+        "adjustment_factor": 1.256193,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08033": {
-      "value": 247600,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 297785,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 247600,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 185,
+        "hpi_10y_base": 100,
+        "change_10y": 0.85,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 153.8226,
+        "adjustment_factor": 1.202684,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08035": {
-      "value": 742700,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 941550,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 742700,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 430,
+        "hpi_10y_base": 195,
+        "change_10y": 1.205128,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 339.1863,
+        "adjustment_factor": 1.26774,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08037": {
-      "value": 839500,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 1086663,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 839500,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 520,
+        "hpi_10y_base": 220,
+        "change_10y": 1.363636,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 401.7253,
+        "adjustment_factor": 1.294417,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08039": {
-      "value": 709800,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 899934,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 709800,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 375,
+        "hpi_10y_base": 170,
+        "change_10y": 1.205882,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 295.7717,
+        "adjustment_factor": 1.26787,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08041": {
-      "value": 486000,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 603398,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 486000,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 325,
+        "hpi_10y_base": 158,
+        "change_10y": 1.056962,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 261.7674,
+        "adjustment_factor": 1.24156,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08043": {
-      "value": 324000,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 394014,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 324000,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 215,
+        "hpi_10y_base": 112,
+        "change_10y": 0.919643,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 176.796,
+        "adjustment_factor": 1.216091,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08045": {
-      "value": 527800,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 664226,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 527800,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 340,
+        "hpi_10y_base": 158,
+        "change_10y": 1.151899,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 270.167,
+        "adjustment_factor": 1.258481,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08047": {
-      "value": 573900,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 723106,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 573900,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 350,
+        "hpi_10y_base": 162,
+        "change_10y": 1.160494,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 277.7807,
+        "adjustment_factor": 1.259987,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08049": {
-      "value": 601500,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 759559,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 601500,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 370,
+        "hpi_10y_base": 170,
+        "change_10y": 1.176471,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 293.0056,
+        "adjustment_factor": 1.262775,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08051": {
-      "value": 621800,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 777397,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 621800,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 320,
+        "hpi_10y_base": 152,
+        "change_10y": 1.105263,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 255.9517,
+        "adjustment_factor": 1.250236,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08053": {
-      "value": 437900,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 538531,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 437900,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 275,
+        "hpi_10y_base": 138,
+        "change_10y": 0.992754,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 223.6128,
+        "adjustment_factor": 1.229805,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08055": {
-      "value": 247800,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 294880,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 247800,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 175,
+        "hpi_10y_base": 98,
+        "change_10y": 0.785714,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 147.06,
+        "adjustment_factor": 1.189991,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08057": {
-      "value": 239600,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 285804,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 239600,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 180,
+        "hpi_10y_base": 100,
+        "change_10y": 0.8,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 150.9005,
+        "adjustment_factor": 1.192839,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08059": {
-      "value": 668600,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 839413,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 668600,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 380,
+        "hpi_10y_base": 178,
+        "change_10y": 1.134831,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 302.6736,
+        "adjustment_factor": 1.255478,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08061": {
-      "value": 161500,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 190832,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 161500,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 150,
+        "hpi_10y_base": 86,
+        "change_10y": 0.744186,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 126.9444,
+        "adjustment_factor": 1.18162,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08063": {
-      "value": 239500,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 285374,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 239500,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 165,
+        "hpi_10y_base": 92,
+        "change_10y": 0.793478,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 138.4762,
+        "adjustment_factor": 1.191541,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08065": {
-      "value": 466100,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 580416,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 466100,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 295,
+        "hpi_10y_base": 142,
+        "change_10y": 1.077465,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 236.8983,
+        "adjustment_factor": 1.24526,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08067": {
-      "value": 591500,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 744391,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 591500,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 340,
+        "hpi_10y_base": 158,
+        "change_10y": 1.151899,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 270.167,
+        "adjustment_factor": 1.258481,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08069": {
-      "value": 610000,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 766704,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 610000,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 360,
+        "hpi_10y_base": 168,
+        "change_10y": 1.142857,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 286.4208,
+        "adjustment_factor": 1.256892,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08071": {
-      "value": 237600,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 281289,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 237600,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 165,
+        "hpi_10y_base": 94,
+        "change_10y": 0.755319,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 139.3725,
+        "adjustment_factor": 1.183878,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08073": {
-      "value": 246500,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 292941,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 246500,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 160,
+        "hpi_10y_base": 90,
+        "change_10y": 0.777778,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 134.6346,
+        "adjustment_factor": 1.188402,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08075": {
-      "value": 245300,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 295107,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 245300,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 200,
+        "hpi_10y_base": 108,
+        "change_10y": 0.851852,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 166.2448,
+        "adjustment_factor": 1.203045,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08077": {
-      "value": 410200,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 505589,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 410200,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 265,
+        "hpi_10y_base": 132,
+        "change_10y": 1.007576,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 215.0029,
+        "adjustment_factor": 1.232542,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08079": {
-      "value": 430500,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 522987,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 430500,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 220,
+        "hpi_10y_base": 115,
+        "change_10y": 0.913043,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 181.0945,
+        "adjustment_factor": 1.214835,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08081": {
-      "value": 289500,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 348282,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 289500,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 200,
+        "hpi_10y_base": 108,
+        "change_10y": 0.851852,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 166.2448,
+        "adjustment_factor": 1.203045,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08083": {
-      "value": 331400,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 403653,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 331400,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 220,
+        "hpi_10y_base": 114,
+        "change_10y": 0.929825,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 180.6206,
+        "adjustment_factor": 1.218023,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08085": {
-      "value": 388400,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 478176,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 388400,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 240,
+        "hpi_10y_base": 120,
+        "change_10y": 1,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 194.9406,
+        "adjustment_factor": 1.231144,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08087": {
-      "value": 338600,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 407700,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 338600,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 195,
+        "hpi_10y_base": 105,
+        "change_10y": 0.857143,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 161.95,
+        "adjustment_factor": 1.204075,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08089": {
-      "value": 168900,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 200600,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 168900,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 165,
+        "hpi_10y_base": 93,
+        "change_10y": 0.774194,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 138.926,
+        "adjustment_factor": 1.187682,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08091": {
-      "value": 739800,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 924924,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 739800,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 320,
+        "hpi_10y_base": 152,
+        "change_10y": 1.105263,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 255.9517,
+        "adjustment_factor": 1.250236,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08093": {
-      "value": 532100,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 667495,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 532100,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 330,
+        "hpi_10y_base": 155,
+        "change_10y": 1.129032,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 263.0627,
+        "adjustment_factor": 1.254454,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08095": {
-      "value": 258200,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 305993,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 258200,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 155,
+        "hpi_10y_base": 88,
+        "change_10y": 0.761364,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 130.7907,
+        "adjustment_factor": 1.185099,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08097": {
-      "value": 1139100,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 1491949,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 1139100,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 590,
+        "hpi_10y_base": 240,
+        "change_10y": 1.458333,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 450.4637,
+        "adjustment_factor": 1.309762,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08099": {
-      "value": 160600,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 191361,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 160600,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 165,
+        "hpi_10y_base": 92,
+        "change_10y": 0.793478,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 138.4762,
+        "adjustment_factor": 1.191541,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08101": {
-      "value": 301800,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 364435,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 301800,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 210,
+        "hpi_10y_base": 112,
+        "change_10y": 0.875,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 173.9077,
+        "adjustment_factor": 1.207537,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08103": {
-      "value": 274400,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 330398,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 274400,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 195,
+        "hpi_10y_base": 105,
+        "change_10y": 0.857143,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 161.95,
+        "adjustment_factor": 1.204075,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08105": {
-      "value": 239500,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 285685,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 239500,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 180,
+        "hpi_10y_base": 100,
+        "change_10y": 0.8,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 150.9005,
+        "adjustment_factor": 1.192839,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08107": {
-      "value": 854700,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 1091501,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 854700,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 470,
+        "hpi_10y_base": 208,
+        "change_10y": 1.259615,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 368.0336,
+        "adjustment_factor": 1.277057,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08109": {
-      "value": 212600,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 252358,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 212600,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 170,
+        "hpi_10y_base": 96,
+        "change_10y": 0.770833,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 143.2173,
+        "adjustment_factor": 1.187007,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08111": {
-      "value": 432500,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 538105,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 432500,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 290,
+        "hpi_10y_base": 140,
+        "change_10y": 1.071429,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 233.0864,
+        "adjustment_factor": 1.244174,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08113": {
-      "value": 720700,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 930012,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 720700,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 510,
+        "hpi_10y_base": 218,
+        "change_10y": 1.33945,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 395.2174,
+        "adjustment_factor": 1.290429,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08115": {
-      "value": 149000,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 176596,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 149000,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 148,
+        "hpi_10y_base": 84,
+        "change_10y": 0.761905,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 124.8726,
+        "adjustment_factor": 1.185208,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08117": {
-      "value": 939900,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 1207068,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 939900,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 495,
+        "hpi_10y_base": 215,
+        "change_10y": 1.302326,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 385.4386,
+        "adjustment_factor": 1.284251,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08119": {
-      "value": 479900,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 596159,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 479900,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 305,
+        "hpi_10y_base": 148,
+        "change_10y": 1.060811,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 245.5209,
+        "adjustment_factor": 1.242257,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08121": {
-      "value": 226200,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 268347,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 226200,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 152,
+        "hpi_10y_base": 86,
+        "change_10y": 0.767442,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 128.1268,
+        "adjustment_factor": 1.186325,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08123": {
-      "value": 496100,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 615938,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 496100,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 325,
+        "hpi_10y_base": 158,
+        "change_10y": 1.056962,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 261.7674,
+        "adjustment_factor": 1.24156,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     },
     "08125": {
-      "value": 211700,
-      "source": "acs_raw",
-      "as_of": "ACS 2020-2024 5-year",
-      "confidence": "low",
-      "geography_level": "county"
+      "value": 252249,
+      "source": "fhfa_county_hpi_anchor",
+      "as_of": "ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI 2025-12-31",
+      "confidence": "medium",
+      "geography_level": "county",
+      "acs_raw_value": 211700,
+      "fhfa_hpi": {
+        "source_level": "fhfa_county_direct",
+        "hpi_latest": 165,
+        "hpi_10y_base": 92,
+        "change_10y": 0.793478,
+        "acs_midpoint_year": 2022,
+        "midpoint_hpi_estimate": 138.4762,
+        "adjustment_factor": 1.191541,
+        "adjustment_method": "ACS 2020-2024 5-year midpoint (2022) adjusted to FHFA 2025 using county 10-year HPI CAGR",
+        "as_of": "2025-12-31",
+        "source_url": "https://www.fhfa.gov/hpi/download/annual/hpi_at_county.xlsx"
+      }
     }
   },
   "review_flags": {

--- a/js/hna/hna-ownership-need.js
+++ b/js/hna/hna-ownership-need.js
@@ -10,6 +10,34 @@
 
   var BANDS = ['lte30', '31to50', '51to80', '81to100', '100plus'];
   var MODERATE_BANDS = ['51to80', '81to100'];
+  var OWNER_VALUE_BINS = [
+    ['B25075_002E', 0, 9999],
+    ['B25075_003E', 10000, 14999],
+    ['B25075_004E', 15000, 19999],
+    ['B25075_005E', 20000, 24999],
+    ['B25075_006E', 25000, 29999],
+    ['B25075_007E', 30000, 34999],
+    ['B25075_008E', 35000, 39999],
+    ['B25075_009E', 40000, 49999],
+    ['B25075_010E', 50000, 59999],
+    ['B25075_011E', 60000, 69999],
+    ['B25075_012E', 70000, 79999],
+    ['B25075_013E', 80000, 89999],
+    ['B25075_014E', 90000, 99999],
+    ['B25075_015E', 100000, 124999],
+    ['B25075_016E', 125000, 149999],
+    ['B25075_017E', 150000, 174999],
+    ['B25075_018E', 175000, 199999],
+    ['B25075_019E', 200000, 249999],
+    ['B25075_020E', 250000, 299999],
+    ['B25075_021E', 300000, 399999],
+    ['B25075_022E', 400000, 499999],
+    ['B25075_023E', 500000, 749999],
+    ['B25075_024E', 750000, 999999],
+    ['B25075_025E', 1000000, 1499999],
+    ['B25075_026E', 1500000, 1999999],
+    ['B25075_027E', 2000000, null],
+  ];
 
   var CONSTANTS = {
     rentalPressure: {
@@ -116,6 +144,50 @@
     if (geoLevel === 'state') return 'state-CHAS';
     if (geoLevel === 'combined') return 'combined-CHAS';
     return geoLevel === 'county' ? 'county-CHAS' : 'place-CHAS';
+  }
+
+  function ownerValueBandLabel(lower, upper) {
+    function fmt(v) {
+      if (v >= 1000000) return '$' + (v / 1000000) + 'M';
+      return '$' + Math.round(v / 1000) + 'k';
+    }
+    return upper == null ? fmt(lower) + '+' : fmt(lower) + '-' + fmt(upper);
+  }
+
+  function ownerValueSupplySeries(profile, options) {
+    profile = profile && profile.acsProfile ? profile.acsProfile : (profile || {});
+    options = options || {};
+    var total = num(profile.B25075_001E);
+    var bands = [];
+    var finiteBins = 0;
+    var sum = 0;
+    OWNER_VALUE_BINS.forEach(function (bin) {
+      var value = num(profile[bin[0]]);
+      if (value != null) {
+        finiteBins += 1;
+        sum += value;
+      }
+      bands.push({
+        code: bin[0],
+        lower: bin[1],
+        upper: bin[2],
+        label: ownerValueBandLabel(bin[1], bin[2]),
+        ownerOccupiedUnits: value,
+      });
+    });
+    if ((total == null || total <= 0) && sum > 0) total = sum;
+    if (!total || !finiteBins || sum <= 0) return null;
+    var dataQuality = finiteBins === OWNER_VALUE_BINS.length ? 'High' : 'Medium';
+    if (Math.abs(sum - total) > Math.max(25, total * 0.05)) dataQuality = 'Medium';
+    return {
+      source: 'ACS B25075',
+      sourceLabel: 'ACS B25075 owner-occupied units by value',
+      asOf: options.asOf || (profile._acsYear ? 'ACS ' + profile._acsYear + ' 5-year' : 'ACS 2020-2024 5-year'),
+      dataQuality: dataQuality,
+      totalOwnerOccupiedUnits: round(total, 1),
+      summedBandUnits: round(sum, 1),
+      bands: bands,
+    };
   }
 
   function normalizeChas(input) {
@@ -329,6 +401,9 @@
     ) / 2;
     var fitTier = tierFromScore(fitScore);
     var homeTest = affordabilityTest(input.amiGapEntry, input.homeValueEntry, input.assumptions);
+    var ownerValueSupply = input.ownerValueSupply || ownerValueSupplySeries(input.ownerValueSupplyProfile || input.acsProfile || input.profile, {
+      asOf: input.ownerValueSupplyAsOf,
+    });
     if (homeTest && homeTest.classification === 'market-attainable') {
       fitTier = capTier(fitTier, 'Moderate');
       caveats.push('Market home values screen near modeled attainability; emphasize down-payment assistance and owner stabilization before below-market construction assumptions.');
@@ -397,6 +472,7 @@
         },
       },
       affordabilityTest: homeTest,
+      ownerValueSupply: ownerValueSupply,
       tenureMixRecommendation: recommendation,
       recommendationDetail: detail,
       existingRentalGap: rentalGap(input.amiGapEntry),
@@ -409,6 +485,8 @@
     computeOwnershipNeed: computeOwnershipNeed,
     maxAffordablePrice: maxAffordablePrice,
     monthlyMortgageFactor: monthlyMortgageFactor,
+    ownerValueSupplySeries: ownerValueSupplySeries,
+    OWNER_VALUE_BINS: OWNER_VALUE_BINS,
     CONSTANTS: CONSTANTS,
   };
 }());

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -5016,6 +5016,7 @@
         countyFallback: countyFallback,
         amiGapEntry: amiGapEntry,
         homeValueEntry: homeValueEntry,
+        ownerValueSupplyProfile: profile,
         assumptions: afford ? {
           pmms30YearRate: afford.rateAnnual,
           termYears: afford.termYears,

--- a/js/hna/hna-utils.js
+++ b/js/hna/hna-utils.js
@@ -361,6 +361,7 @@
     if (display) {
       if (display.source === 'zhvi') sourceLabel = 'Zillow ZHVI city index';
       else if (display.source === 'county_zhvi_adjusted') sourceLabel = 'County-adjusted Zillow/ACS estimate';
+      else if (display.source === 'fhfa_county_hpi_anchor') sourceLabel = 'ACS DP04_0089E + FHFA county HPI anchor';
       else if (display.source === 'acs_raw') sourceLabel = 'ACS DP04_0089E raw floor';
       else sourceLabel = display.source || sourceLabel;
     }

--- a/scripts/hna/build_home_value_cascade.mjs
+++ b/scripts/hna/build_home_value_cascade.mjs
@@ -23,6 +23,8 @@ const REGISTRY = path.join(ROOT, 'data', 'hna', 'geography-registry.json');
 const SUMMARY_DIR = path.join(ROOT, 'data', 'hna', 'summary');
 const OUT = path.join(ROOT, 'data', 'hna', 'home-value-cascade.json');
 const CROSSWALK_OUT = path.join(ROOT, 'data', 'hna', 'zhvi-place-crosswalk.json');
+const FHFA_HPI = path.join(ROOT, 'data', 'market', 'fhfa_hpi_subcounty_co.json');
+const ACS_HOME_VALUE_MIDPOINT_YEAR = 2022;
 
 function readJson(file) {
   return JSON.parse(fs.readFileSync(file, 'utf8'));
@@ -112,10 +114,29 @@ async function loadZhviRows() {
   return { byKey, latestAsOf: month.key, coRows };
 }
 
-function buildCountyAcsRows(registry) {
+function buildCountyAcsRows(registry, fhfaDoc) {
   const counties = {};
   let acsCount = 0;
   let missingCount = 0;
+  let fhfaCount = 0;
+  const latestYear = Number(fhfaDoc?.meta?.latest_year) || Number(String(fhfaDoc?.meta?.as_of || '').slice(0, 4)) || null;
+
+  function countyHpiAdjustment(fhfa) {
+    const latest = Number(fhfa?.hpi_latest);
+    const base10 = Number(fhfa?.hpi_10y_base);
+    if (!Number.isFinite(latest) || latest <= 0 || !Number.isFinite(base10) || base10 <= 0 || !Number.isFinite(latestYear)) return null;
+    const baseYear = latestYear - 10;
+    if (ACS_HOME_VALUE_MIDPOINT_YEAR <= baseYear || ACS_HOME_VALUE_MIDPOINT_YEAR >= latestYear) return null;
+    const yearsFromMidpoint = latestYear - ACS_HOME_VALUE_MIDPOINT_YEAR;
+    const annualizedRatio = Math.pow(latest / base10, 1 / (latestYear - baseYear));
+    const adjustmentFactor = Math.pow(annualizedRatio, yearsFromMidpoint);
+    if (!Number.isFinite(adjustmentFactor) || adjustmentFactor <= 0) return null;
+    return {
+      factor: adjustmentFactor,
+      midpoint_hpi_estimate: latest / adjustmentFactor,
+      method: `ACS 2020-2024 5-year midpoint (${ACS_HOME_VALUE_MIDPOINT_YEAR}) adjusted to FHFA ${latestYear} using county 10-year HPI CAGR`,
+    };
+  }
 
   for (const county of (registry.geographies || []).filter((geo) => geo.type === 'county').sort((a, b) => a.geoid.localeCompare(b.geoid))) {
     const summaryPath = path.join(SUMMARY_DIR, `${county.geoid}.json`);
@@ -123,24 +144,44 @@ function buildCountyAcsRows(registry) {
     const profile = summary && summary.acsProfile || {};
     const acsValue = Number(profile.DP04_0089E);
     const hasValue = Number.isFinite(acsValue) && acsValue > 0;
+    const fhfa = fhfaDoc && fhfaDoc.counties && fhfaDoc.counties[county.geoid] || null;
+    const hasFhfa = !!(fhfa && Number.isFinite(Number(fhfa.hpi_latest)));
+    const adjustment = hasFhfa ? countyHpiAdjustment(fhfa) : null;
+    const hasAdjustedFhfa = hasValue && !!adjustment;
+    const value = hasAdjustedFhfa ? Math.round(acsValue * adjustment.factor) : (hasValue ? acsValue : null);
     counties[county.geoid] = {
-      value: hasValue ? acsValue : null,
-      source: 'acs_raw',
-      as_of: 'ACS 2020-2024 5-year',
-      confidence: hasValue ? 'low' : 'missing',
+      value,
+      source: hasAdjustedFhfa ? 'fhfa_county_hpi_anchor' : 'acs_raw',
+      as_of: hasAdjustedFhfa ? `ACS 2020-2024 5-year midpoint-adjusted to FHFA HPI ${fhfaDoc.meta && fhfaDoc.meta.as_of || ''}`.trim() : 'ACS 2020-2024 5-year',
+      confidence: hasValue ? (hasAdjustedFhfa ? 'medium' : 'low') : 'missing',
       geography_level: 'county',
+      acs_raw_value: hasValue ? acsValue : null,
+      fhfa_hpi: hasAdjustedFhfa ? {
+        source_level: fhfa.source_level,
+        hpi_latest: fhfa.hpi_latest,
+        hpi_10y_base: fhfa.hpi_10y_base,
+        change_10y: fhfa.change_10y,
+        acs_midpoint_year: ACS_HOME_VALUE_MIDPOINT_YEAR,
+        midpoint_hpi_estimate: Number(adjustment.midpoint_hpi_estimate.toFixed(4)),
+        adjustment_factor: Number(adjustment.factor.toFixed(6)),
+        adjustment_method: adjustment.method,
+        as_of: fhfaDoc.meta && fhfaDoc.meta.as_of,
+        source_url: fhfaDoc.meta && fhfaDoc.meta.county_source_url,
+      } : null,
     };
     if (hasValue) acsCount += 1;
     else missingCount += 1;
+    if (hasAdjustedFhfa) fhfaCount += 1;
   }
 
-  return { counties, acsCount, missingCount };
+  return { counties, acsCount, missingCount, fhfaCount };
 }
 
 async function main() {
   const centroids = readJson(CENTROIDS).byGeoid || {};
   const placeCounties = readJson(PLACE_COUNTIES).places || {};
   const registry = readJson(REGISTRY);
+  const fhfaDoc = fs.existsSync(FHFA_HPI) ? readJson(FHFA_HPI) : null;
   const countyNames = countyNamesByFips(registry);
   const hasCityZhvi = fs.existsSync(ZHVI_CSV);
   const existing = fs.existsSync(OUT) ? readJson(OUT) : {};
@@ -219,7 +260,7 @@ async function main() {
     places[geoid] = display;
   }
 
-  const countyRows = buildCountyAcsRows(registry);
+  const countyRows = buildCountyAcsRows(registry, fhfaDoc);
 
   fs.writeFileSync(OUT, JSON.stringify({
     meta: {
@@ -229,6 +270,7 @@ async function main() {
         zhvi_city_csv: 'https://files.zillowstatic.com/research/public_csvs/zhvi/City_zhvi_uc_sfrcondo_tier_0.33_0.67_sm_sa_month.csv',
         zhvi_county_csv: null,
         acs_raw: 'ACS DP04_0089E, 2020-2024 5-year',
+        fhfa_county_hpi: fhfaDoc && fhfaDoc.meta ? fhfaDoc.meta.county_source_url : null,
       },
       latest_zhvi_month: latestAsOf,
       colorado_zhvi_rows: coRows,
@@ -237,6 +279,7 @@ async function main() {
         acs_raw: acsCount,
         total: zhviCount + acsCount,
         counties: {
+          fhfa_county_hpi_anchor: countyRows.fhfaCount,
           acs_raw: countyRows.acsCount,
           missing: countyRows.missingCount,
           total: Object.keys(countyRows.counties).length,

--- a/scripts/hna/build_jurisdiction_metrics_digest.mjs
+++ b/scripts/hna/build_jurisdiction_metrics_digest.mjs
@@ -586,6 +586,10 @@ function reviewFlagSet(reviewFlags) {
 }
 
 function homeValueEntry(entry, summary, homeValueCascade, flaggedHomeValues) {
+  if (entry.type === 'county' && homeValueCascade?.counties) {
+    const rec = homeValueCascade.counties[String(entry.geoid)];
+    if (rec) return { geography_level: 'county', ...rec };
+  }
   if (entry.type !== 'county' && homeValueCascade?.places) {
     if (flaggedHomeValues.has(String(entry.geoid))) return null;
     const rec = homeValueCascade.places[String(entry.geoid)];

--- a/test/hna-home-value-cascade.test.js
+++ b/test/hna-home-value-cascade.test.js
@@ -14,6 +14,7 @@ const hnaNarratives = fs.readFileSync(path.join(ROOT, 'js/hna/hna-narratives.js'
 const hnaRenderers = fs.readFileSync(path.join(ROOT, 'js/hna/hna-renderers.js'), 'utf8');
 const hnaController = fs.readFileSync(path.join(ROOT, 'js/hna/hna-controller.js'), 'utf8');
 const ownershipNeed = fs.readFileSync(path.join(ROOT, 'js/hna/hna-ownership-need.js'), 'utf8');
+const homeValueBuilder = fs.readFileSync(path.join(ROOT, 'scripts/hna/build_home_value_cascade.mjs'), 'utf8');
 
 assert(fruitaHomeValue, 'Fruita summary should be stamped with median_home_value');
 assert.equal(fruitaHomeValue.source, 'zhvi', 'Fruita should use Zillow ZHVI as the display home value');
@@ -26,14 +27,23 @@ assert(flags.some((row) => row.geoid === '0803620' && row.ratio > 3), 'Aspen sho
 assert.equal(cascade.meta.counts.total, 482, 'home-value cascade should cover all Colorado places in the public HNA set');
 assert.equal(cascade.meta.counts.counties.total, 64, 'home-value cascade should cover all Colorado counties');
 assert.equal(cascade.meta.counts.counties.acs_raw, 64, 'county home values should be populated from committed ACS summaries when no county ZHVI CSV exists');
+assert.equal(cascade.meta.counts.counties.fhfa_county_hpi_anchor, 64, 'county rows with FHFA coverage should carry FHFA HPI anchors');
 
 for (const geoid of ['08097', '08045']) {
   const row = cascade.counties && cascade.counties[geoid];
   const profile = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/hna/summary', `${geoid}.json`), 'utf8')).acsProfile;
   assert(row, `${geoid}: county cascade row should exist`);
   assert.equal(row.geography_level, 'county', `${geoid}: county cascade row should be labeled county`);
-  assert.equal(row.source, 'acs_raw', `${geoid}: county cascade row should use ACS fallback in this repo state`);
-  assert.equal(row.value, profile.DP04_0089E, `${geoid}: county cascade should match summary DP04_0089E`);
+  assert.equal(row.source, 'fhfa_county_hpi_anchor', `${geoid}: county cascade row should use the committed FHFA county anchor`);
+  assert.equal(row.confidence, 'medium', `${geoid}: FHFA county anchor should upgrade confidence above raw ACS`);
+  assert.equal(row.acs_raw_value, profile.DP04_0089E, `${geoid}: county cascade should retain the ACS dollar-value floor`);
+  assert.notEqual(row.value, row.acs_raw_value, `${geoid}: FHFA county anchor should shift the ACS midpoint value toward current dollars`);
+  assert(row.value > row.acs_raw_value, `${geoid}: spot-check county HPI adjustment should move the value upward`);
+  assert.ok(row.fhfa_hpi && row.fhfa_hpi.source_level === 'fhfa_county_direct', `${geoid}: county cascade should carry direct FHFA HPI provenance`);
+  assert.equal(row.fhfa_hpi.acs_midpoint_year, 2022, `${geoid}: adjustment should document the ACS 5-year midpoint`);
+  assert(row.fhfa_hpi.adjustment_factor > 1, `${geoid}: adjustment factor should be non-vacuous`);
+  assert(row.fhfa_hpi.adjustment_method.includes('10-year HPI CAGR'), `${geoid}: adjustment method should disclose the midpoint estimate`);
+  assert.ok(row.fhfa_hpi.source_url && row.fhfa_hpi.source_url.includes('fhfa.gov'), `${geoid}: FHFA county source URL should be official`);
 }
 
 const adjustedSummaries = fs.readdirSync(path.join(ROOT, 'data/hna/summary'))
@@ -61,6 +71,10 @@ assert(!/function renderWageAffordability[\s\S]{0,900}profile && profile\.DP04_0
 assert(/geoType === 'place' \|\| geoType === 'cdp' \|\| geoType === 'county'/.test(hnaController), 'Controller should lazy-load home-value cascade for county ownership views');
 assert(/geoType === 'county'[\s\S]{0,220}homeValueData\.counties/.test(hnaRenderers), 'Ownership renderer should read county cascade rows before profile fallback');
 assert(/Object\.assign\(\{ geography_level: 'county' \}, countyRec\)/.test(hnaRenderers), 'Ownership renderer should mark county home-value rows as county inputs');
+assert(hnaUtils.includes("display.source === 'fhfa_county_hpi_anchor'"), 'HNA utils should label FHFA county HPI anchors');
+assert(hnaRenderers.includes('ownerValueSupplyProfile: profile'), 'Ownership renderer should pass the loaded ACS profile for B25075 owner-value supply');
+assert(ownershipNeed.includes('function ownerValueSupplySeries'), 'Ownership module should expose B25075 owner-value supply');
+assert(homeValueBuilder.includes("data', 'market', 'fhfa_hpi_subcounty_co.json"), 'home-value cascade builder should consume the committed FHFA sub-county HPI artifact');
 
 const ownershipCtx = { window: {} };
 vm.createContext(ownershipCtx);
@@ -82,6 +96,7 @@ for (const [geoid, label] of [['08097', 'Pitkin County'], ['08045', 'Garfield Co
   assert(result.affordabilityTest, `${label}: county ownership computation should render an affordability classification`);
   assert(['priced-out', 'stretch'].includes(result.affordabilityTest.classification), `${label}: resort-area county value should classify as priced-out or stretch`);
   assert.equal(result.affordabilityTest.medianHomeValue, cascade.counties[geoid].value, `${label}: computation should use the county cascade value`);
+  assert.equal(cascade.counties[geoid].source, 'fhfa_county_hpi_anchor', `${label}: county cascade should use FHFA-primary owner decision C1 default`);
 }
 
 const context = {

--- a/test/hna-ownership-need.test.js
+++ b/test/hna-ownership-need.test.js
@@ -225,6 +225,46 @@ test('max-price math matches hand-computed PITI case', () => {
   assert.equal(max80, 289983);
 });
 
+test('B25075 owner-value supply series is non-vacuous and labeled', () => {
+  const profile = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/hna/summary/08045.json'), 'utf8')).acsProfile;
+  const series = Ownership.ownerValueSupplySeries(profile);
+  assert.ok(series, 'Garfield County B25075 supply series should compute');
+  assert.equal(series.source, 'ACS B25075');
+  assert.equal(series.sourceLabel, 'ACS B25075 owner-occupied units by value');
+  assert.equal(series.dataQuality, 'High');
+  assert.equal(series.bands.length, Ownership.OWNER_VALUE_BINS.length);
+  assert.ok(series.totalOwnerOccupiedUnits > 10000, 'Garfield owner-occupied denominator is non-vacuous');
+  assert.ok(series.summedBandUnits > 10000, 'Garfield owner-value bins are non-vacuous');
+  assert.ok(series.bands.some((band) => band.code === 'B25075_023E' && band.ownerOccupiedUnits > 0), 'high-value owner band is populated');
+  const empty = { B25075_001E: profile.B25075_001E };
+  Ownership.OWNER_VALUE_BINS.forEach((bin) => { empty[bin[0]] = 0; });
+  assert.equal(Ownership.ownerValueSupplySeries(empty), null, 'empty owner-value bins must not produce a supply series');
+});
+
+test('county affordability classification uses FHFA-backed county cascade anchor', () => {
+  const countyChas = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/hna/chas_affordability_gap.json'), 'utf8')).counties;
+  const gaps = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/co_ami_gap_by_county.json'), 'utf8')).counties;
+  const cascade = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/hna/home-value-cascade.json'), 'utf8'));
+  const geoid = '08045';
+  const gap = gaps.find((row) => row.fips === geoid);
+  assert.equal(cascade.counties[geoid].source, 'fhfa_county_hpi_anchor');
+  assert.equal(cascade.counties[geoid].confidence, 'medium');
+  assert.ok(cascade.counties[geoid].fhfa_hpi && cascade.counties[geoid].fhfa_hpi.source_level === 'fhfa_county_direct');
+  const out = compute({
+    geographyId: geoid,
+    geographyName: 'Garfield County',
+    geoLevel: 'county',
+    countyChasEntry: countyChas[geoid],
+    amiGapEntry: gap,
+    homeValueEntry: cascade.counties[geoid],
+    ownerValueSupplyProfile: JSON.parse(fs.readFileSync(path.join(ROOT, 'data/hna/summary/08045.json'), 'utf8')).acsProfile,
+  });
+  assert.ok(out.affordabilityTest, 'F4 county-null benchmark is resolved for Garfield County');
+  assert.ok(['market-attainable', 'stretch', 'priced-out'].includes(out.affordabilityTest.classification));
+  assert.equal(out.affordabilityTest.medianHomeValue, cascade.counties[geoid].value);
+  assert.ok(out.ownerValueSupply && out.ownerValueSupply.totalOwnerOccupiedUnits > 0, 'county ownership result carries B25075 supply context');
+});
+
 test('deep affordability recommendation requires rate, count, and total-household share', () => {
   const tinyBand = fixtureEntry({ renter: 9000, owner: 878, renterCb30: 500, renterCb50: 130, modRenter: 1800 });
   tinyBand.renter_hh_by_ami.lte30 = band(150, 140, 130);

--- a/test/jurisdiction-metrics-digest.test.js
+++ b/test/jurisdiction-metrics-digest.test.js
@@ -196,6 +196,17 @@ test('county ownership metrics are labeled county-level', () => {
   assert.strictEqual(digest.metrics.ownership_need_affordability_classification.geography_level, 'county');
 });
 
+test('ownership digest builder consumes FHFA-backed county home-value cascade rows', () => {
+  const builder = fs.readFileSync(BUILDER, 'utf8');
+  assert.ok(builder.includes("entry.type === 'county' && homeValueCascade?.counties"), 'county cascade branch must be wired');
+  const cascade = readJson(HOME_VALUE_CASCADE_PATH);
+  const garfield = cascade.counties?.['08045'];
+  assert.ok(garfield, 'missing Garfield County cascade row');
+  assert.strictEqual(garfield.source, 'fhfa_county_hpi_anchor');
+  assert.strictEqual(garfield.confidence, 'medium');
+  assert.strictEqual(garfield.fhfa_hpi?.source_level, 'fhfa_county_direct');
+});
+
 test('home-value review flags suppress downstream affordability classification', () => {
   const cascade = readJson(HOME_VALUE_CASCADE_PATH);
   const ownership = readJson(OWNERSHIP_PATH);


### PR DESCRIPTION
Refs #1167

Do not merge until external QA completes.

## Summary
- Adds an owner-value supply helper over committed ACS B25075 bins and threads it into the affordable ownership calculation path as screening-only data.
- Rebuilds `data/hna/home-value-cascade.json` so county rows use the committed FHFA HPI county artifact as a current-dollar county price anchor: ACS DP04_0089E is retained as `acs_raw_value`, then adjusted from the ACS 2020-2024 5-year midpoint (2022) to FHFA HPI 2025-12-31 using the county 10-year HPI CAGR.
- Updates future digest/ownership rebuilds to consume county cascade rows, so counties do not drift back to summary-only home values on regeneration.

## Owner Decision
- C1, FHFA-primary county anchor, is implemented as the recommended default for owner confirmation. The county anchor now produces an adjusted current-dollar `value`; the unadjusted ACS value remains available as `acs_raw_value`.

## Verification Notes
- Verified current `data/hna/home-value-cascade.json` counties were not null before this change; they were low-confidence `acs_raw` rows.
- Garfield County (`08045`) now shifts from raw ACS `$527,800` to FHFA-adjusted `$664,226`, with `source: fhfa_county_hpi_anchor`, `confidence: medium`, retained `acs_raw_value`, and direct FHFA county HPI metadata.
- Pitkin County (`08097`) now shifts from raw ACS `$1,139,100` to FHFA-adjusted `$1,491,949`.
- F4 county-null benchmark no longer reproduces on current main; county affordability classes were already present. This PR pins Garfield County to non-null classification and upgrades the source/provenance path.
- No threshold constants or projection/scoring math changed; no new UI claims were added.

## Tests
- `npm run test:hna-home-values`
- `npm run test:hna-ownership-need`
- `npm run validate`
- Earlier PR gate also passed: `npm run test:jurisdiction-metrics-digest`, `npm run test:hna`, `npm run test:combined-geo`, `npm run test:file-manifest`