### PR TITLE
OWN-2: add ownership price-band screen

### DIFF
--- a/js/hna/hna-ownership-need.js
+++ b/js/hna/hna-ownership-need.js
@@ -10,6 +10,7 @@
 
   var BANDS = ['lte30', '31to50', '51to80', '81to100', '100plus'];
   var MODERATE_BANDS = ['51to80', '81to100'];
+  var PRICE_BAND_SCREEN_LABEL = 'potential buyer pool (moderate-income renter households) - not committed demand';
   var OWNER_VALUE_BINS = [
     ['B25075_002E', 0, 9999],
     ['B25075_003E', 10000, 14999],
@@ -309,6 +310,78 @@
     };
   }
 
+  function supplyUnitsInPriceRange(ownerValueSupply, lowerExclusive, upperInclusive) {
+    if (!ownerValueSupply || !Array.isArray(ownerValueSupply.bands)) return null;
+    var total = 0;
+    var sawAny = false;
+    ownerValueSupply.bands.forEach(function (band) {
+      var units = num(band.ownerOccupiedUnits);
+      if (units == null || units <= 0) return;
+      var lower = num(band.lower);
+      var upper = num(band.upper);
+      if (lower == null) return;
+      if (upper == null) {
+        if (upperInclusive == null || lower <= upperInclusive) {
+          total += units;
+          sawAny = true;
+        }
+        return;
+      }
+      var overlapLower = Math.max(lower, Math.floor(cleanNumber(lowerExclusive)) + 1);
+      var overlapUpper = upperInclusive == null ? upper : Math.min(upper, Math.floor(upperInclusive));
+      if (overlapUpper < overlapLower) return;
+      var width = upper - lower + 1;
+      if (width <= 0) return;
+      total += units * ((overlapUpper - overlapLower + 1) / width);
+      sawAny = true;
+    });
+    return sawAny ? round(total, 1) : null;
+  }
+
+  function priceBandDemandScreen(amiGapEntry, ownerValueSupply, chas, assumptions) {
+    var ami = num(amiGapEntry && amiGapEntry.ami_4person);
+    if (!ami || !ownerValueSupply || !chas) return null;
+    var max80 = maxAffordablePrice(ami, 0.80, assumptions);
+    var max100 = maxAffordablePrice(ami, 1.00, assumptions);
+    var max120 = maxAffordablePrice(ami, 1.20, assumptions);
+    if (!max80 || !max100 || !max120) return null;
+
+    var configs = [
+      { key: 'lte80', label: 'Up to 80% AMI affordable price', amiCeiling: 80, lowerPriceExclusive: 0, upperPrice: max80, demandBands: ['51to80'] },
+      { key: '81to100', label: '81-100% AMI affordable price', amiCeiling: 100, lowerPriceExclusive: max80, upperPrice: max100, demandBands: ['81to100'] },
+      { key: '101to120', label: '101-120% AMI middle-income price', amiCeiling: 120, lowerPriceExclusive: max100, upperPrice: max120, demandBands: [] },
+    ];
+
+    return {
+      label: PRICE_BAND_SCREEN_LABEL,
+      method: 'CURRENT_SCREEN',
+      screeningOnly: true,
+      noConversionMultiplierApplied: true,
+      totalPotentialBuyerPoolHouseholds: round(sumBands(chas.renterBands, MODERATE_BANDS, 'total'), 1),
+      sourceLabel: chas.source + ' + ' + ownerValueSupply.sourceLabel + ' + HNA maxAffordablePrice',
+      dataQuality: ownerValueSupply.dataQuality === 'High' && chas.source ? 'High' : 'Medium',
+      caveat: 'Screening estimate only; 101-120% AMI is shown as a middle-income price/supply band, but the CHAS ownership-fit count only isolates 51-100% HAMFI renters.',
+      rows: configs.map(function (cfg) {
+        var demand = sumBands(chas.renterBands, cfg.demandBands, 'total');
+        var supply = supplyUnitsInPriceRange(ownerValueSupply, cfg.lowerPriceExclusive, cfg.upperPrice);
+        return {
+          key: cfg.key,
+          label: cfg.label,
+          amiCeiling: cfg.amiCeiling,
+          priceRange: {
+            lowerExclusive: cfg.lowerPriceExclusive,
+            upperInclusive: cfg.upperPrice,
+          },
+          maxAffordablePrice: cfg.upperPrice,
+          potentialBuyerPoolHouseholds: round(demand, 1),
+          ownerValueSupplyUnits: supply,
+          currentGapHouseholds: supply == null ? null : round(Math.max(0, demand - supply), 1),
+          demandSourceBands: cfg.demandBands.slice(),
+        };
+      }),
+    };
+  }
+
   function rentalGap(amiGapEntry) {
     var gaps = amiGapEntry && amiGapEntry.gap_units_minus_households_le_ami_pct;
     if (!gaps) return null;
@@ -404,6 +477,7 @@
     var ownerValueSupply = input.ownerValueSupply || ownerValueSupplySeries(input.ownerValueSupplyProfile || input.acsProfile || input.profile, {
       asOf: input.ownerValueSupplyAsOf,
     });
+    var priceBandScreen = priceBandDemandScreen(input.amiGapEntry, ownerValueSupply, chas, input.assumptions);
     if (homeTest && homeTest.classification === 'market-attainable') {
       fitTier = capTier(fitTier, 'Moderate');
       caveats.push('Market home values screen near modeled attainability; emphasize down-payment assistance and owner stabilization before below-market construction assumptions.');
@@ -473,6 +547,7 @@
       },
       affordabilityTest: homeTest,
       ownerValueSupply: ownerValueSupply,
+      priceBandScreen: priceBandScreen,
       tenureMixRecommendation: recommendation,
       recommendationDetail: detail,
       existingRentalGap: rentalGap(input.amiGapEntry),
@@ -484,9 +559,11 @@
   window.HNAOwnershipNeed = {
     computeOwnershipNeed: computeOwnershipNeed,
     maxAffordablePrice: maxAffordablePrice,
+    priceBandDemandScreen: priceBandDemandScreen,
     monthlyMortgageFactor: monthlyMortgageFactor,
     ownerValueSupplySeries: ownerValueSupplySeries,
     OWNER_VALUE_BINS: OWNER_VALUE_BINS,
+    PRICE_BAND_SCREEN_LABEL: PRICE_BAND_SCREEN_LABEL,
     CONSTANTS: CONSTANTS,
   };
 }());

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -4749,6 +4749,43 @@
     '</tr>';
   }
 
+  function _ownRenderPriceBandScreen(screen) {
+    if (!screen || !Array.isArray(screen.rows) || !screen.rows.length) return '';
+    var rows = screen.rows.map(function (row) {
+      var supply = row.ownerValueSupplyUnits == null ? 'Unavailable' : _ownFmtNum(row.ownerValueSupplyUnits);
+      var gap = row.currentGapHouseholds == null ? 'Unavailable' : _ownFmtNum(row.currentGapHouseholds);
+      var demand = row.potentialBuyerPoolHouseholds == null ? 'Unavailable' : _ownFmtNum(row.potentialBuyerPoolHouseholds);
+      return '<tr>' +
+        '<th scope="row" style="text-align:left;padding:.45rem .5rem;border-top:1px solid var(--border);font-weight:700;">' + escHtml(row.label) + '</th>' +
+        '<td style="padding:.45rem .5rem;border-top:1px solid var(--border);">' + escHtml(_ownFmtMoney(row.maxAffordablePrice)) + '</td>' +
+        '<td style="padding:.45rem .5rem;border-top:1px solid var(--border);">' + escHtml(demand) + '</td>' +
+        '<td style="padding:.45rem .5rem;border-top:1px solid var(--border);">' + escHtml(supply) + '</td>' +
+        '<td style="padding:.45rem .5rem;border-top:1px solid var(--border);font-weight:700;">' + escHtml(gap) + '</td>' +
+      '</tr>';
+    }).join('');
+    return '<div style="border:1px solid var(--border);border-radius:6px;padding:.85rem;margin:.85rem 0 1rem;background:var(--card);">' +
+      '<div style="display:flex;align-items:flex-start;justify-content:space-between;gap:.75rem;flex-wrap:wrap;margin-bottom:.45rem;">' +
+        '<div>' +
+          '<h3 style="font-size:.98rem;margin:0 0 .2rem;">Current for-sale price-band screen</h3>' +
+          '<p style="margin:0;color:var(--muted);font-size:.8rem;line-height:1.45;">' + escHtml(screen.label) + '. Screening-only caveat applies.</p>' +
+        '</div>' +
+        _ownPill(screen.sourceLabel || 'Ownership data', screen.method || 'CURRENT_SCREEN') +
+      '</div>' +
+      '<div style="overflow-x:auto;">' +
+        '<table style="width:100%;border-collapse:collapse;font-size:.8rem;" aria-label="Current for-sale price-band screen">' +
+          '<thead><tr>' +
+            '<th scope="col" style="text-align:left;padding:.45rem .5rem;">Affordable price band</th>' +
+            '<th scope="col" style="text-align:left;padding:.45rem .5rem;">Ceiling price</th>' +
+            '<th scope="col" style="text-align:left;padding:.45rem .5rem;">Potential buyer pool</th>' +
+            '<th scope="col" style="text-align:left;padding:.45rem .5rem;">Owner-value supply</th>' +
+            '<th scope="col" style="text-align:left;padding:.45rem .5rem;">Current gap</th>' +
+          '</tr></thead><tbody>' + rows + '</tbody>' +
+        '</table>' +
+      '</div>' +
+      (screen.caveat ? '<p style="margin:.55rem 0 0;color:var(--muted);font-size:.76rem;line-height:1.45;">' + escHtml(screen.caveat) + '</p>' : '') +
+    '</div>';
+  }
+
   function _ownFindCountyAmiGap(data, fips) {
     if (!data || !fips) return null;
     var counties = data.counties || data;
@@ -4955,6 +4992,7 @@
 
     container.innerHTML =
       '<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(210px,1fr));gap:.8rem;margin:.75rem 0 1rem;">' + cardHtml + '</div>' +
+      _ownRenderPriceBandScreen(result.priceBandScreen) +
       '<div style="overflow-x:auto;margin-top:.75rem;">' +
         '<table style="width:100%;border-collapse:collapse;font-size:.8rem;" aria-label="Tenure strategy indicators">' +
           '<thead><tr>' +

--- a/test/combined-geo.test.js
+++ b/test/combined-geo.test.js
@@ -634,6 +634,17 @@ test('HNA executive decision strip mirrors detailed renderer values', () => {
     ownershipPressure: { tier: 'Moderate', inputs: { ownerCostBurdenedShare: 0.23, moderateIncomeOwnerCostBurdenedShare: 0.06 } },
     ownershipFit: { tier: 'Moderate', inputs: { moderateIncomeRenterShare: 0.13 } },
     affordabilityTest: { medianHomeValue: 350000, classification: 'constrained', source: 'fixture home values' },
+    priceBandScreen: {
+      label: 'potential buyer pool (moderate-income renter households) - not committed demand',
+      method: 'CURRENT_SCREEN',
+      sourceLabel: 'HUD CHAS + ACS B25075 owner-occupied units by value + HNA maxAffordablePrice',
+      caveat: 'Screening estimate only; 101-120% AMI is shown as a middle-income price/supply band.',
+      rows: [
+        { key: 'lte80', label: 'Up to 80% AMI affordable price', maxAffordablePrice: 280000, potentialBuyerPoolHouseholds: 45, ownerValueSupplyUnits: 22, currentGapHouseholds: 23 },
+        { key: '81to100', label: '81-100% AMI affordable price', maxAffordablePrice: 350000, potentialBuyerPoolHouseholds: 30, ownerValueSupplyUnits: 15, currentGapHouseholds: 15 },
+        { key: '101to120', label: '101-120% AMI middle-income price', maxAffordablePrice: 420000, potentialBuyerPoolHouseholds: 0, ownerValueSupplyUnits: 10, currentGapHouseholds: 0 },
+      ],
+    },
     caveats: [],
   });
   dom.window.HNARenderers.renderHnaScorecardPanel('08009');
@@ -643,6 +654,11 @@ test('HNA executive decision strip mirrors detailed renderer values', () => {
   assert.equal(doc.getElementById('decisionProductionValue').textContent, doc.getElementById('statUnitsNeed').textContent, 'production tile mirrors unit-need stat');
   assert.equal(doc.getElementById('decisionOwnershipValue').textContent, 'Rental plus shared-equity ownership', 'ownership tile mirrors ownership recommendation');
   assert.equal(doc.getElementById('decisionConfidenceValue').textContent, 'High', 'confidence tile mirrors ownership data-quality field');
+  const ownershipHtml = doc.getElementById('hnaAffordableOwnershipNeed').textContent;
+  assert.ok(ownershipHtml.includes('Current for-sale price-band screen'), 'renders current price-band screen');
+  assert.ok(ownershipHtml.includes('potential buyer pool (moderate-income renter households) - not committed demand'), 'renders C2 potential-buyer framing');
+  assert.ok(ownershipHtml.includes('101-120% AMI middle-income price'), 'renders middle-income price band');
+  assert.ok(ownershipHtml.includes('Screening estimate only'), 'price-band screen carries screening caveat');
   const needValue = doc.getElementById('decisionNeedValue').textContent;
   assert.match(needValue, /^\d+\/100$/, 'need tile renders scorecard composite');
   assert.ok(doc.getElementById('hnaScorecardPanel').textContent.includes(needValue.replace('/100', '')), 'scorecard panel contains same composite score');

--- a/test/hna-ownership-need.test.js
+++ b/test/hna-ownership-need.test.js
@@ -241,6 +241,39 @@ test('B25075 owner-value supply series is non-vacuous and labeled', () => {
   assert.equal(Ownership.ownerValueSupplySeries(empty), null, 'empty owner-value bins must not produce a supply series');
 });
 
+test('current price-band screen recomputes from CHAS demand and B25075 supply', () => {
+  const profile = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/hna/summary/08045.json'), 'utf8')).acsProfile;
+  const countyChas = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/hna/chas_affordability_gap.json'), 'utf8')).counties['08045'];
+  const amiGap = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/co_ami_gap_by_county.json'), 'utf8')).counties
+    .find((row) => row.fips === '08045');
+  const cascade = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/hna/home-value-cascade.json'), 'utf8'));
+  const out = compute({
+    countyChasEntry: countyChas,
+    geographyId: '08045',
+    geographyName: 'Garfield County',
+    geoLevel: 'county',
+    amiGapEntry: amiGap,
+    homeValueEntry: cascade.counties['08045'],
+    ownerValueSupplyProfile: profile,
+  });
+  const screen = out.priceBandScreen;
+  assert.ok(screen, 'Garfield County should produce a price-band screen');
+  assert.equal(screen.label, Ownership.PRICE_BAND_SCREEN_LABEL);
+  assert.equal(screen.label, 'potential buyer pool (moderate-income renter households) - not committed demand');
+  assert.equal(screen.screeningOnly, true);
+  assert.equal(screen.noConversionMultiplierApplied, true);
+  assert.equal(screen.totalPotentialBuyerPoolHouseholds, out.moderateIncomeRenterHouseholds);
+  assert.equal(JSON.stringify(screen.rows.map((row) => row.key)), JSON.stringify(['lte80', '81to100', '101to120']));
+  assert.equal(JSON.stringify(screen.rows.map((row) => row.maxAffordablePrice)), JSON.stringify([283024, 353780, 424536]));
+  assert.equal(JSON.stringify(screen.rows.map((row) => row.potentialBuyerPoolHouseholds)), JSON.stringify([1945, 848, 0]));
+  assert.equal(JSON.stringify(screen.rows.map((row) => row.ownerValueSupplyUnits)), JSON.stringify([3183.7, 1229.6, 1486.3]));
+  assert.equal(JSON.stringify(screen.rows.map((row) => row.currentGapHouseholds)), JSON.stringify([0, 0, 0]));
+  assert.equal(JSON.stringify(screen.rows[0].demandSourceBands), JSON.stringify(['51to80']));
+  assert.equal(JSON.stringify(screen.rows[1].demandSourceBands), JSON.stringify(['81to100']));
+  assert.equal(JSON.stringify(screen.rows[2].demandSourceBands), JSON.stringify([]));
+  assert.ok(screen.caveat.includes('Screening estimate only'));
+});
+
 test('county affordability classification uses FHFA-backed county cascade anchor', () => {
   const countyChas = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/hna/chas_affordability_gap.json'), 'utf8')).counties;
   const gaps = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/co_ami_gap_by_county.json'), 'utf8')).counties;
@@ -279,6 +312,7 @@ test('deep affordability recommendation requires rate, count, and total-househol
 test('copy contains screening framing and avoids banned phrases', () => {
   const src = fs.readFileSync(path.join(ROOT, 'js/hna/hna-ownership-need.js'), 'utf8').toLowerCase();
   assert.ok(src.includes('screening estimate'));
+  assert.ok(src.includes('potential buyer pool (moderate-income renter households) - not committed demand'));
   [
     'qualified ' + 'buyer',
     'qualified ' + 'buyers',
@@ -289,6 +323,10 @@ test('copy contains screening framing and avoids banned phrases', () => {
     'absorption ' + ('fore' + 'cast'),
     'homeownership ' + 'prediction',
     'fore' + 'cast',
+    'time-' + 'phased',
+    'time ' + 'phasing',
+    'capture ' + 'rate',
+    'capture ' + 'rates',
   ].forEach(phrase => assert.equal(src.includes(phrase), false, phrase + ' should be absent'));
 });
 


### PR DESCRIPTION
Refs #1167

Do not merge until external QA completes.

Stacked on PR #1291 / OWN-1 because GitHub still reports #1291 as OPEN, not merged. After #1291 lands, this PR can be retargeted/rebased onto `main`.

## Summary
- Adds a current for-sale price-band screen to the affordable ownership path. This is a static screen only, not a forecast.
- Derives 80%, 100%, and 120% AMI affordable price ceilings from `HNAOwnershipNeed.maxAffordablePrice`.
- Crosses the potential buyer pool from existing moderate-income renter CHAS bands with OWN-1 B25075 owner-value supply bands to show current demand/supply/gap rows.
- Bakes in C2 recommended framing: `potential buyer pool (moderate-income renter households) - not committed demand`; no renter-to-buyer conversion multiplier is applied.

## Method Notes
- 51-80% HAMFI renters populate the up-to-80% AMI row.
- 81-100% HAMFI renters populate the 81-100% AMI row.
- 101-120% AMI is shown as a middle-income price/supply band, but demand is not invented because CHAS does not isolate 101-120% renter households in the existing ownership-fit count.
- B25075 supply is apportioned into the modeled price ranges by overlap with owner-value bins.

## Pinned Garfield County Recompute
- Price ceilings: 80% `$283,024`; 100% `$353,780`; 120% `$424,536`.
- Potential buyer pool rows: `1,945`, `848`, `0`.
- Owner-value supply rows: `3,183.7`, `1,229.6`, `1,486.3`.

## Tests
- `npm run test:hna-ownership-need`
- `npm run test:combined-geo`
- `npm run test:hna`
- `npm run test:hna-home-values`
- `npm run validate`