### PR TITLE
Fix behavioral guards for issue 1296

### DIFF
--- a/test/colorado-equity-pricing-factors.test.js
+++ b/test/colorado-equity-pricing-factors.test.js
@@ -27,6 +27,21 @@ function roundedShare(part, whole) {
   return Number((part / whole).toFixed(4));
 }
 
+function countyInsuranceHazardSignal(countyFips, hazardsUsed) {
+  return (hazardsUsed || []).reduce((score, hazardKey) => {
+    const hazard = climate.hazard_summary && climate.hazard_summary[hazardKey];
+    const highRiskCounties = hazard && Array.isArray(hazard.key_counties_high_risk)
+      ? hazard.key_counties_high_risk
+      : [];
+    return score + (highRiskCounties.includes(countyFips) ? 1 : 0);
+  }, 0);
+}
+
+function countyInsuranceContextFactor(countyFips, hazardsUsed) {
+  const signal = countyInsuranceHazardSignal(countyFips, hazardsUsed);
+  return Number((1 + signal * 0.05).toFixed(2));
+}
+
 console.log('\nColorado equity-pricing factor tests');
 console.log('='.repeat(44));
 
@@ -67,8 +82,22 @@ assert.equal(insurance.formula, null, 'insurance factor is prose, not a formula'
 assert.equal(insurance.data_pointer, 'data/market/climate_hazards_co.json', 'insurance factor points to local climate hazard data');
 assert(insurance.hazards_used.includes('hail_risk'), 'insurance factor uses hail risk');
 assert(insurance.hazards_used.includes('wildfire_risk'), 'insurance factor uses wildfire risk');
-assert.equal(climate.hazard_summary.hail_risk.level, 'high', 'climate data has hail risk context');
-assert.equal(climate.hazard_summary.wildfire_risk.level, 'very_high', 'climate data has wildfire risk context');
+const highHazardCounty = '08059';
+const lowHazardCounty = '08051';
+assert.equal(countyInsuranceHazardSignal(highHazardCounty, insurance.hazards_used), 2,
+  'Jefferson County is flagged by both insurance-relevant hazards');
+assert.equal(countyInsuranceHazardSignal(lowHazardCounty, insurance.hazards_used), 0,
+  'Gunnison County is not flagged by the insurance-relevant hazard set');
+assert(
+  countyInsuranceContextFactor(highHazardCounty, insurance.hazards_used) >
+    countyInsuranceContextFactor(lowHazardCounty, insurance.hazards_used),
+  'hazards_used drives a differentiated insurance context output between high- and low-hazard counties'
+);
+assert.notEqual(
+  countyInsuranceContextFactor(highHazardCounty, insurance.hazards_used),
+  countyInsuranceContextFactor(highHazardCounty, ['hail_risk']),
+  'wildfire_risk contributes to the high-hazard county output, not just a stored severity string'
+);
 assert.match(insurance.source_url, /^https:\/\/doi\.colorado\.gov\//, 'insurance source is Colorado DOI');
 
 const pabFactor = factors.factors.pab_volume_cap_pressure;

--- a/test/hna-ownership-need.test.js
+++ b/test/hna-ownership-need.test.js
@@ -107,6 +107,49 @@ const amiGap = {
   gap_units_minus_households_le_ami_pct: { 80: 120 },
 };
 
+function entryForRenterPressure(renterCb30Share, renterCb50Share, renterShare) {
+  const totalHouseholds = 10000;
+  const renter = Math.round(totalHouseholds * renterShare);
+  return fixtureEntry({
+    renter,
+    owner: totalHouseholds - renter,
+    renterCb30: Math.round(renter * renterCb30Share),
+    renterCb50: Math.round(renter * renterCb50Share),
+    modRenter: Math.max(1, Math.round(renter * 0.20)),
+    ownerCb30: 100,
+    ownerCb50: 40,
+    modOwnerCb: 40,
+  });
+}
+
+function entryForOwnershipPressure(ownerCb30Share, ownerCb50Share, moderateOwnerCbShare) {
+  return fixtureEntry({
+    renter: 1000,
+    owner: 1000,
+    renterCb30: 100,
+    renterCb50: 40,
+    modRenter: 150,
+    ownerCb30: Math.round(1000 * ownerCb30Share),
+    ownerCb50: Math.round(1000 * ownerCb50Share),
+    modOwner: 1000,
+    modOwnerCb: Math.round(1000 * moderateOwnerCbShare),
+  });
+}
+
+function entryForOwnershipFit(moderateRenterHouseholds, moderateRenterShare) {
+  const renter = Math.round(moderateRenterHouseholds / moderateRenterShare);
+  return fixtureEntry({
+    renter,
+    owner: 1000,
+    renterCb30: Math.round(renter * 0.20),
+    renterCb50: Math.round(renter * 0.06),
+    modRenter: moderateRenterHouseholds,
+    ownerCb30: 100,
+    ownerCb50: 40,
+    modOwnerCb: 40,
+  });
+}
+
 console.log('Affordable Ownership Need — unit tests');
 
 test('null/missing entry returns unavailable without NaN or undefined', () => {
@@ -292,15 +335,58 @@ test('copy contains screening framing and avoids banned phrases', () => {
   ].forEach(phrase => assert.equal(src.includes(phrase), false, phrase + ' should be absent'));
 });
 
-test('EPS Phase II benchmark remains documented before ownership roadmap expansion', () => {
-  assert.deepStrictEqual(Array.from(Ownership.CONSTANTS.rentalPressure.renterCb30Share), [0.35, 0.42, 0.47]);
-  assert.deepStrictEqual(Array.from(Ownership.CONSTANTS.rentalPressure.renterCb50Share), [0.15, 0.21, 0.24]);
-  assert.deepStrictEqual(Array.from(Ownership.CONSTANTS.rentalPressure.renterShare), [0.24, 0.28, 0.32]);
-  assert.deepStrictEqual(Array.from(Ownership.CONSTANTS.ownershipPressure.ownerCb30Share), [0.19, 0.21, 0.25]);
-  assert.deepStrictEqual(Array.from(Ownership.CONSTANTS.ownershipPressure.ownerCb50Share), [0.08, 0.09, 0.10]);
-  assert.deepStrictEqual(Array.from(Ownership.CONSTANTS.ownershipPressure.moderateOwnerCbShare), [0.18, 0.29, 0.36]);
-  assert.deepStrictEqual(Array.from(Ownership.CONSTANTS.ownershipFit.moderateRenterHouseholds), [200, 500, 1400]);
-  assert.deepStrictEqual(Array.from(Ownership.CONSTANTS.ownershipFit.moderateRenterShare), [0.30, 0.33, 0.36]);
+test('ownership screening tiers flip at the EPS benchmark threshold boundaries', () => {
+  [
+    ['rentalPressure', 'Low', 'Moderate',
+      entryForRenterPressure(0.349, 0.149, 0.239),
+      entryForRenterPressure(0.351, 0.151, 0.241)],
+    ['rentalPressure', 'Moderate', 'High',
+      entryForRenterPressure(0.419, 0.209, 0.279),
+      entryForRenterPressure(0.421, 0.211, 0.281)],
+    ['rentalPressure', 'High', 'Very High',
+      entryForRenterPressure(0.469, 0.239, 0.319),
+      entryForRenterPressure(0.471, 0.241, 0.321)],
+    ['ownershipPressure', 'Low', 'Moderate',
+      entryForOwnershipPressure(0.189, 0.079, 0.179),
+      entryForOwnershipPressure(0.191, 0.081, 0.181)],
+    ['ownershipPressure', 'Moderate', 'High',
+      entryForOwnershipPressure(0.209, 0.089, 0.289),
+      entryForOwnershipPressure(0.211, 0.091, 0.291)],
+    ['ownershipPressure', 'High', 'Very High',
+      entryForOwnershipPressure(0.249, 0.099, 0.359),
+      entryForOwnershipPressure(0.251, 0.101, 0.361)],
+    ['ownershipFit', 'Low', 'Moderate',
+      entryForOwnershipFit(199, 0.299),
+      entryForOwnershipFit(201, 0.301)],
+    ['ownershipFit', 'Moderate', 'High',
+      entryForOwnershipFit(499, 0.329),
+      entryForOwnershipFit(501, 0.331)],
+    ['ownershipFit', 'High', 'Very High',
+      entryForOwnershipFit(1399, 0.359),
+      entryForOwnershipFit(1401, 0.361)],
+  ].forEach(([field, belowTier, aboveTier, belowEntry, aboveEntry]) => {
+    const below = compute({ placeChasEntry: belowEntry, amiGapEntry: amiGap });
+    const above = compute({ placeChasEntry: aboveEntry, amiGapEntry: amiGap });
+    assert.equal(below[field].tier, belowTier, `${field} below-boundary fixture stays ${belowTier}`);
+    assert.equal(above[field].tier, aboveTier, `${field} above-boundary fixture becomes ${aboveTier}`);
+  });
+
+  const belowFit = compute({
+    placeChasEntry: entryForOwnershipPressure(0.251, 0.101, 0.361),
+    amiGapEntry: amiGap,
+  });
+  assert.notEqual(belowFit.tenureMixRecommendation, 'Ownership-supportive strategy');
+
+  const fitModerate = entryForOwnershipFit(201, 0.301);
+  fitModerate.summary.owner_cb30_count = 251;
+  fitModerate.summary.owner_cb30_share = 0.251;
+  fitModerate.summary.owner_cb50_count = 101;
+  fitModerate.summary.owner_cb50_share = 0.101;
+  fitModerate.owner_hh_by_ami['51to80'] = band(600, 217, 20);
+  fitModerate.owner_hh_by_ami['81to100'] = band(400, 144, 5);
+  const aboveFit = compute({ placeChasEntry: fitModerate, amiGapEntry: amiGap });
+  assert.equal(aboveFit.tenureMixRecommendation, 'Ownership-supportive strategy',
+    'recommendation flips once the moderate-income renter base crosses the fit boundary');
 
   const benchmark = fs.readFileSync(path.join(ROOT, 'docs/audits/OWNERSHIP-BENCHMARK-EPS-PHASE2-2026-07.md'), 'utf8');
   const methodology = fs.readFileSync(path.join(ROOT, 'docs/methodology/AFFORDABLE-OWNERSHIP-METHODOLOGY.md'), 'utf8');

--- a/test/pma-barrier-data.test.js
+++ b/test/pma-barrier-data.test.js
@@ -21,6 +21,23 @@ function geoidOf(feature) {
 const barriers = readJson('data/market/natural_barriers_co.geojson');
 const display = readJson('data/market/pma_tract_display_geometry.geojson');
 const fixture = readJson('test/fixtures/pma/fruita-mews-calibration.json');
+const tractCentroids = readJson('data/market/tract_centroids_co.json');
+
+function loadPmaEngine() {
+  global.window = {
+    PMAMarketScoring: require('../js/market-analysis-scoring.js'),
+  };
+  global.document = {
+    addEventListener() {},
+    getElementById() { return null; },
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+  };
+  const modulePath = path.join(ROOT, 'js/market-analysis.js');
+  delete require.cache[require.resolve(modulePath)];
+  require(modulePath);
+  return global.window.PMAEngine;
+}
 
 assert.equal(barriers.type, 'FeatureCollection', 'barrier artifact is a GeoJSON FeatureCollection');
 assert(barriers.features.length > 10000, `barrier artifact is non-vacuous (${barriers.features.length} features)`);
@@ -72,19 +89,34 @@ for (const feature of display.features) {
 assert.equal(fixture.production_use, false, 'Fruita calibration fixture is explicitly non-production');
 assert.equal(fixture.source_doc, 'docs/audits/CALIBRATION-FRUITA-MEWS-PMA-2026-07.md',
   'Fruita fixture points to the calibration doc');
-assert.deepStrictEqual(
-  [...fixture.professional_pma.tract_geoids_2020].sort(),
-  ['08077000900', '08077001402', '08077001403', '08077001404',
-   '08077001502', '08077001503', '08077001504', '08077001600'],
-  'Fruita professional PMA fixture pins the exact CHFA-approved 8-tract set'
-);
-assert.deepEqual(
-  fixture.tool_buffer_current_main.tract_geoids,
-  ['08077001503', '08077001504'],
-  'Fruita current-tool fixture pins the 2-tract buffer set'
-);
-assert.equal(fixture.tool_buffer_current_main.tool_only_count, 0,
-  'Fruita fixture pins zero current-tool false inclusions');
+
+const professionalSet = new Set(fixture.professional_pma.tract_geoids_2020);
+assert(professionalSet.size >= 8, 'Fruita professional PMA fixture is non-vacuous');
+const centroidRows = tractCentroids.tracts || tractCentroids;
+const centroidGeoids = new Set(centroidRows.map((row) => String(row.geoid || row.GEOID || row.GEOID20 || row.tract_geoid)));
+professionalSet.forEach((geoid) => {
+  assert(centroidGeoids.has(geoid), `professional tract ${geoid} exists in the tract-centroid authority`);
+});
+
+const pmaEngine = loadPmaEngine();
+assert(pmaEngine && typeof pmaEngine.tractInBuffer === 'function',
+  'PMAEngine exposes the current tractInBuffer selection helper');
+const site = fixture.site;
+assert.match(fixture.tool_buffer_current_main.method, /centroid-inclusion 3-mile buffer/,
+  'Fruita current-tool benchmark documents centroid-inclusion semantics');
+const computedToolBuffer = centroidRows
+  .map((row) => ({
+    geoid: row.geoid || row.GEOID || row.GEOID20 || row.tract_geoid,
+    lat: row.lat,
+    lon: row.lon,
+  }))
+  .filter((row) => pmaEngine.tractInBuffer(row, site.lat, site.lon, 3))
+  .map((row) => String(row.geoid || row.GEOID || row.GEOID20 || row.tract_geoid))
+  .sort();
+const recomputedToolOnly = computedToolBuffer.filter((geoid) => !professionalSet.has(geoid));
+assert(computedToolBuffer.length > 0, 'current PMA buffer selection recomputes a non-empty Fruita tract set');
+assert.equal(recomputedToolOnly.length, 0,
+  `current PMA buffer recomputes zero false inclusions versus professional set; got ${recomputedToolOnly.join(', ') || 'none'}`);
 
 const scoringSource = fs.readFileSync(path.join(ROOT, 'js/market-analysis-scoring.js'), 'utf8');
 assert(!scoringSource.includes('natural_barriers_co.geojson'), 'C1 does not wire barriers into PMA scoring');


### PR DESCRIPTION
Refs #1296

Do not merge until external QA completes.

## Summary
- Replaced the Affordable Ownership Need constant self-pins with fixtures just below/above the EPS benchmark thresholds, asserting rental pressure, ownership pressure, ownership fit, and recommendation boundary behavior.
- Replaced Fruita PMA fixture self-pins with a recomputed current-tool buffer selection using the real PMAEngine.tractInBuffer helper and the tract-centroid authority, then computed false inclusions against the professional PMA set.
- Replaced stored climate severity pins with a differentiated insurance-context output driven by property_insurance_regional_adjustment.hazards_used.

## Sabotage gates
- Nudging ownership threshold constants changes the fixture side/tier and fails the HNA ownership test.
- Changing current centroid-based PMA selection to admit a tract outside the Fruita professional set fails the recomputed false-inclusion assertion.
- Removing or changing the insurance hazards_used linkage removes the high-vs-low county differentiation and fails the Colorado factor test.

## Verification
- npm run test:hna-ownership-need
- npm run test:pma-barrier-data
- npm run test:colorado-equity-pricing-factors
- npm run validate