### PR TITLE
Fix behavioral contrast guard for issue 1297

### DIFF
--- a/scripts/audit/contrast-utils.cjs
+++ b/scripts/audit/contrast-utils.cjs
@@ -1,0 +1,77 @@
+'use strict';
+
+function normalizeRgb(value) {
+  if (Array.isArray(value)) {
+    return { r: +value[0], g: +value[1], b: +value[2], a: value[3] == null ? 1 : +value[3] };
+  }
+  return {
+    r: +value.r,
+    g: +value.g,
+    b: +value.b,
+    a: value.a == null ? 1 : +value.a,
+  };
+}
+
+function srgbToLin(channel) {
+  const c = channel / 255;
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+function luminance(rgbValue) {
+  const rgb = normalizeRgb(rgbValue);
+  return 0.2126 * srgbToLin(rgb.r) + 0.7152 * srgbToLin(rgb.g) + 0.0722 * srgbToLin(rgb.b);
+}
+
+function contrastRatio(fgValue, bgValue) {
+  const L1 = luminance(fgValue);
+  const L2 = luminance(bgValue);
+  const lighter = Math.max(L1, L2);
+  const darker = Math.min(L1, L2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function parseCssColor(raw) {
+  if (!raw) return null;
+  const s = String(raw).trim();
+  const hex = s.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+  if (hex) {
+    const h = hex[1].length === 3
+      ? hex[1].split('').map((ch) => ch + ch).join('')
+      : hex[1];
+    return {
+      r: parseInt(h.slice(0, 2), 16),
+      g: parseInt(h.slice(2, 4), 16),
+      b: parseInt(h.slice(4, 6), 16),
+      a: 1,
+    };
+  }
+  const rgb = s.match(/^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)$/i);
+  if (rgb) {
+    return {
+      r: +rgb[1],
+      g: +rgb[2],
+      b: +rgb[3],
+      a: rgb[4] == null ? 1 : +rgb[4],
+    };
+  }
+  return null;
+}
+
+function blendOver(fgValue, bgValue) {
+  const fg = normalizeRgb(fgValue);
+  const bg = normalizeRgb(bgValue);
+  const a = fg.a == null ? 1 : fg.a;
+  if (a >= 1) return { r: fg.r, g: fg.g, b: fg.b, a: 1 };
+  return {
+    r: fg.r * a + bg.r * (1 - a),
+    g: fg.g * a + bg.g * (1 - a),
+    b: fg.b * a + bg.b * (1 - a),
+    a: 1,
+  };
+}
+
+module.exports = {
+  contrastRatio,
+  parseCssColor,
+  blendOver,
+};

--- a/test/site-review-build-pause-regressions.test.js
+++ b/test/site-review-build-pause-regressions.test.js
@@ -7,57 +7,205 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const { JSDOM } = require('jsdom');
+const { contrastRatio, parseCssColor, blendOver } = require('../scripts/audit/contrast-utils.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
 
-function assertIncludes(haystack, needle, message) {
-  assert.ok(haystack.includes(needle), message);
+const siteTheme = read('css/site-theme.css');
+
+function declarationsFromBlock(block) {
+  const out = {};
+  const clean = block.replace(/\/\*[\s\S]*?\*\//g, '');
+  clean.replace(/--([\w-]+)\s*:\s*([^;]+);/g, (_, name, value) => {
+    out[`--${name}`] = value.trim();
+    return _;
+  });
+  return out;
+}
+
+function rootBlockFor(mode) {
+  if (mode === 'dark') {
+    const dark = siteTheme.match(/@media\s*\(prefers-color-scheme:\s*dark\)\s*\{\s*:root\s*\{([\s\S]*?)\n\s*\}/);
+    assert.ok(dark, 'dark-mode token block is present');
+    return dark[1];
+  }
+  const light = siteTheme.match(/:root\s*\{([\s\S]*?)\n\}/);
+  assert.ok(light, 'light-mode token block is present');
+  return light[1];
+}
+
+function varsFor(mode) {
+  return declarationsFromBlock(rootBlockFor(mode));
+}
+
+function splitVarArgs(contents) {
+  let depth = 0;
+  for (let i = 0; i < contents.length; i += 1) {
+    const ch = contents[i];
+    if (ch === '(') depth += 1;
+    else if (ch === ')') depth -= 1;
+    else if (ch === ',' && depth === 0) {
+      return [contents.slice(0, i).trim(), contents.slice(i + 1).trim()];
+    }
+  }
+  return [contents.trim(), ''];
+}
+
+function resolveOneVar(value, vars) {
+  const start = value.indexOf('var(');
+  if (start < 0) return value;
+  let depth = 0;
+  let end = -1;
+  for (let i = start; i < value.length; i += 1) {
+    if (value[i] === '(') depth += 1;
+    else if (value[i] === ')') {
+      depth -= 1;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  assert.ok(end > start, `CSS var expression is balanced: ${value}`);
+  const [name, fallback] = splitVarArgs(value.slice(start + 4, end));
+  const replacement = vars[name] || fallback;
+  return value.slice(0, start) + replacement + value.slice(end + 1);
+}
+
+function resolveCss(raw, vars) {
+  let value = String(raw || '').replace(/!important/g, '').trim();
+  for (let i = 0; i < 8 && value.includes('var('); i += 1) {
+    value = resolveOneVar(value, vars).trim();
+  }
+  return value;
+}
+
+function color(raw, mode, baseRaw) {
+  const vars = varsFor(mode);
+  const resolved = resolveCss(raw, vars);
+  const parsed = parseCssColor(resolved);
+  assert.ok(parsed, `resolved ${raw} in ${mode} mode to a parseable color (${resolved})`);
+  if (parsed.a < 1) {
+    const base = baseRaw ? color(baseRaw, mode) : color('var(--card)', mode);
+    return blendOver(parsed, base);
+  }
+  return parsed;
+}
+
+function contrastFor(fgRaw, bgRaw, mode) {
+  const bg = color(bgRaw, mode);
+  const fgParsed = parseCssColor(resolveCss(fgRaw, varsFor(mode)));
+  assert.ok(fgParsed, `resolved ${fgRaw} in ${mode} mode to a parseable foreground`);
+  const fg = fgParsed.a < 1 ? blendOver(fgParsed, bg) : fgParsed;
+  return contrastRatio(fg, bg);
+}
+
+function assertContrast(name, fgRaw, bgRaw, options) {
+  const threshold = options && options.large ? 3 : 4.5;
+  const modes = options && options.modes ? options.modes : ['light', 'dark'];
+  modes.forEach((mode) => {
+    const ratio = contrastFor(fgRaw, bgRaw, mode);
+    assert.ok(ratio >= threshold,
+      `${name} ${mode} contrast ${ratio.toFixed(2)}:1 clears ${threshold}:1`);
+  });
+}
+
+function cssBlock(source, selector, label, occurrence) {
+  let cursor = -1;
+  let found = -1;
+  const limit = occurrence == null ? Infinity : occurrence;
+  for (let i = 0; i < limit; i += 1) {
+    found = source.indexOf(selector, cursor + 1);
+    if (found < 0) break;
+    cursor = found;
+    if (occurrence == null) {
+      const next = source.indexOf(selector, cursor + 1);
+      if (next < 0) break;
+    }
+  }
+  if (occurrence == null) {
+    let next;
+    while ((next = source.indexOf(selector, cursor + 1)) >= 0) cursor = next;
+    found = cursor;
+  }
+  assert.ok(found >= 0, `${label || selector} rule is present`);
+  const open = source.indexOf('{', found);
+  const close = source.indexOf('}', open);
+  assert.ok(open > found && close > open, `${label || selector} rule has declarations`);
+  return source.slice(open + 1, close);
+}
+
+function cssProp(source, selector, prop, label, occurrence) {
+  const block = cssBlock(source, selector, label, occurrence);
+  const re = new RegExp(`${prop.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*:\\s*([^;]+);`);
+  const match = block.match(re);
+  assert.ok(match, `${label || selector} declares ${prop}`);
+  return match[1].trim();
+}
+
+function inlineStyleProp(source, id, prop) {
+  const re = new RegExp(`id=["']${id}["'][^>]*style=["']([^"']+)["']`);
+  const match = source.match(re);
+  assert.ok(match, `${id} inline style is present`);
+  const decl = match[1].match(new RegExp(`${prop}\\s*:\\s*([^;]+)`));
+  assert.ok(decl, `${id} inline style declares ${prop}`);
+  return decl[1].trim();
 }
 
 const census = read('census-dashboard.html');
-assertIncludes(census, '.mf-stat__label {\n        font-size: 0.78rem;\n        color: var(--faint);', 'census multifamily stat labels use an explicit accessible text token');
-assertIncludes(census, '.mf-stat__value {\n        font-size: 1.45rem;\n        font-weight: 700;\n        margin-top: 2px;\n        color: var(--text-strong);', 'census multifamily stat values use text-strong');
+const mfStatBg = cssProp(census, '.mf-stat {', 'background', 'census multifamily stat card');
+assertContrast('census multifamily stat label', cssProp(census, '.mf-stat__label {', 'color'), mfStatBg);
+assertContrast('census multifamily stat value', cssProp(census, '.mf-stat__value {', 'color'), mfStatBg, { large: true });
 assert.doesNotMatch(census, /\.mf-stat__(?:label|sub)\s*\{[^}]*opacity\s*:/s, 'census multifamily stat text no longer relies on opacity-thinned inherited color');
 
 const economic = read('economic-dashboard.html');
 assert.doesNotMatch(economic, /id="yardiNational"[^>]*color:var\(--muted\)/, 'Yardi national callout is not muted in light mode');
-assertIncludes(economic, "m.asking_rent_yoy_pct < 1 ? '#92400e'", 'Yardi low-growth warning color is the accessible light-mode brown');
+assertContrast('Yardi national callout', inlineStyleProp(economic, 'yardiNational', 'color'), inlineStyleProp(economic, 'yardiNational', 'background'));
+const yardiLowGrowth = economic.match(/asking_rent_yoy_pct\s*<\s*1\s*\?\s*'([^']+)'/);
+assert.ok(yardiLowGrowth, 'Yardi low-growth warning color branch is present');
+assertContrast('Yardi low-growth warning value', yardiLowGrowth[1], 'var(--surface-2)', { modes: ['light'] });
 
 const insights = read('insights.html');
 assert.doesNotMatch(insights, /id="jchsCoNarrative"[^>]*color:var\(--muted\)/, 'JCHS narrative block is not muted in light mode');
+assertContrast('JCHS narrative callout', inlineStyleProp(insights, 'jchsCoNarrative', 'color'), inlineStyleProp(insights, 'jchsCoNarrative', 'background'));
 
 const complianceCss = read('css/pages/compliance-dashboard.css');
-assertIncludes(complianceCss, '.cd-kpi-yellow .cd-kpi-value { color: var(--warn); }', 'compliance KPI warning values keep theme-token default');
-assertIncludes(complianceCss, 'html.light-mode .cd-kpi-yellow .cd-kpi-value { color: #92400e; }', 'compliance KPI warning values scope the accessible hard color to light mode');
-assertIncludes(complianceCss, 'html.light-mode .cd-kpi-red    .cd-kpi-value { color: #b91c1c; }', 'compliance KPI red values scope the accessible hard color to light mode');
-assertIncludes(complianceCss, 'html.light-mode .cd-kpi-green  .cd-kpi-value { color: #047857; }', 'compliance KPI green values scope the accessible hard color to light mode');
+assertContrast('compliance green KPI value', cssProp(complianceCss, 'html.light-mode .cd-kpi-green  .cd-kpi-value', 'color'), 'var(--card)', { modes: ['light'] });
+assertContrast('compliance yellow KPI value', cssProp(complianceCss, 'html.light-mode .cd-kpi-yellow .cd-kpi-value', 'color'), 'var(--card)', { modes: ['light'] });
+assertContrast('compliance red KPI value', cssProp(complianceCss, 'html.light-mode .cd-kpi-red    .cd-kpi-value', 'color'), 'var(--card)', { modes: ['light'] });
+assertContrast('compliance green KPI value', cssProp(complianceCss, '.cd-kpi-green  .cd-kpi-value', 'color'), 'var(--card)', { modes: ['dark'] });
+assertContrast('compliance yellow KPI value', cssProp(complianceCss, '.cd-kpi-yellow .cd-kpi-value', 'color'), 'var(--card)', { modes: ['dark'] });
+assertContrast('compliance red KPI value', cssProp(complianceCss, '.cd-kpi-red    .cd-kpi-value', 'color'), 'var(--card)', { modes: ['dark'] });
 
 const pagesCss = read('css/pages.css');
-assertIncludes(pagesCss, 'html.light-mode .kicker { color: #054a42; background: #e6f3f1; }', 'shared kicker scopes the solid AA pair to light mode');
-assertIncludes(pagesCss, '.tag-green  { background: var(--good-dim);    color: var(--good)    !important; }', 'shared tag-green keeps theme-token default');
-assertIncludes(pagesCss, 'html.light-mode .tag-green { background: #e6f4ee; color: #065f46 !important; }', 'shared tag-green scopes the solid AA pair to light mode');
+assertContrast('shared kicker', cssProp(pagesCss, 'html.light-mode .kicker', 'color'), cssProp(pagesCss, 'html.light-mode .kicker', 'background'), { modes: ['light'] });
+assertContrast('shared kicker', cssProp(siteTheme, 'html.dark-mode .kicker', 'color'), cssProp(pagesCss, '.kicker {', 'background', 'shared pages kicker', 1), { modes: ['dark'] });
+assertContrast('shared green tag', cssProp(pagesCss, 'html.light-mode .tag-green', 'color'), cssProp(pagesCss, 'html.light-mode .tag-green', 'background'), { modes: ['light'] });
+assertContrast('shared green tag', cssProp(pagesCss, '.tag-green', 'color'), cssProp(pagesCss, '.tag-green', 'background'), { modes: ['dark'] });
 
 const hnaRenderers = read('js/hna/hna-renderers.js');
-assertIncludes(hnaRenderers, 'background:rgba(var(--bg-rgb,255,255,255),0.92)', 'HNA chart loading overlay uses a high-opacity backdrop');
-assertIncludes(hnaRenderers, 'color:var(--text-strong);font-weight:600', 'HNA chart loading overlay text is high contrast');
+const overlayStyle = hnaRenderers.match(/background:([^;']+);[^']*color:([^;']+);font-weight:600/);
+assert.ok(overlayStyle, 'HNA chart loading overlay declares a foreground/background pair');
+assertContrast('HNA chart loading overlay', overlayStyle[2], overlayStyle[1]);
 
-const siteTheme = read('css/site-theme.css');
-assertIncludes(siteTheme, '.leaflet-control-zoom a, .leaflet-control-zoom a:hover { background: var(--card) !important; color: var(--text-strong) !important;', 'Leaflet zoom controls use text-strong on card');
-assert.match(siteTheme, /\.leaflet-tooltip,[\s\S]*?\.leaflet-bar a\s*\{[\s\S]*?color: var\(--text-strong\) !important;/, 'Leaflet generic controls use text-strong on card');
-assertIncludes(siteTheme, '.tag.tag-green { background: var(--good-dim); color: var(--good) !important; }', 'shared green tags keep theme-token default');
-assertIncludes(siteTheme, 'html.light-mode .tag.tag-green { background: #e6f4ee; color: #065f46 !important; }', 'shared green tags scope the solid AA pair to light mode');
-assertIncludes(siteTheme, 'html.dark-mode .kicker { color: var(--accent) !important; }', 'kickers retain an explicit dark-mode color');
-assertIncludes(siteTheme, 'html.light-mode .kicker { color: #054a42 !important; background: #e6f3f1; }', 'kickers scope the solid AA pair to light mode');
+assertContrast('Leaflet zoom controls', cssProp(siteTheme, '.leaflet-control-zoom a, .leaflet-control-zoom a:hover', 'color'), cssProp(siteTheme, '.leaflet-control-zoom a, .leaflet-control-zoom a:hover', 'background'));
+assertContrast('Leaflet generic controls', cssProp(siteTheme, '.leaflet-control-layers,', 'color'), cssProp(siteTheme, '.leaflet-control-layers,', 'background'));
+assertContrast('site-theme green tag', cssProp(siteTheme, 'html.light-mode .tag.tag-green', 'color'), cssProp(siteTheme, 'html.light-mode .tag.tag-green', 'background'), { modes: ['light'] });
+assertContrast('site-theme green tag', cssProp(siteTheme, '.tag.tag-green', 'color'), cssProp(siteTheme, '.tag.tag-green', 'background'), { modes: ['dark'] });
+assertContrast('site-theme kicker', cssProp(siteTheme, 'html.light-mode .kicker', 'color'), cssProp(siteTheme, 'html.light-mode .kicker', 'background'), { modes: ['light'] });
+assertContrast('site-theme kicker', cssProp(siteTheme, 'html.dark-mode .kicker', 'color'), cssProp(pagesCss, '.kicker {', 'background', 'shared pages kicker', 1), { modes: ['dark'] });
 
 const fetchErrorSurface = read('js/components/fetch-error-surface.js');
-assertIncludes(fetchErrorSurface, "warn:  { bg: 'var(--warn-dim,#3f2a1a)',  fg: 'var(--warn,#fbbf24)'", 'fetch-error raw links use theme-aware warning foreground');
+const fetchWarn = fetchErrorSurface.match(/warn:\s*\{\s*bg:\s*'([^']+)'\s*,\s*fg:\s*'([^']+)'/);
+assert.ok(fetchWarn, 'fetch-error warn style declares a foreground/background pair');
+assertContrast('fetch-error warning surface', fetchWarn[2], fetchWarn[1]);
 
 const hca = read('hna-comparative-analysis.html');
-assertIncludes(hca, '.hca-explore-banner__link{font-size:.82rem;font-weight:700;color:var(--text-strong) !important;', 'HCA explore banner link uses text-strong on tinted banner');
+assertContrast('HCA explore banner link', cssProp(hca, '.hca-explore-banner__link', 'color', 'HCA explore banner link', 1), 'var(--bg2)');
 
 const contrastGuard = read('js/contrast-guard.js');
-assertIncludes(contrastGuard, '.kicker, .tag, .chart-source, .chart-source *, .fes-error, .fes-error *', 'contrast guard leaves explicitly theme-styled kicker/tag/source/error badges alone');
+assert.ok(contrastGuard.includes('.kicker, .tag, .chart-source, .chart-source *, .fes-error, .fes-error *'), 'contrast guard leaves explicitly theme-styled kicker/tag/source/error badges alone');
 
 const legislationDom = new JSDOM(read('housing-legislation-2026.html'));
 const watchlist = legislationDom.window.document.getElementById('bill-status-cards');


### PR DESCRIPTION
Refs #1297

Do not merge until external QA completes.

## Summary
- Replaced the build-pause M2 contrast source-string pins with computed WCAG contrast assertions over the same regression surfaces.
- Factored the WCAG contrast math into scripts/audit/contrast-utils.cjs and reused it from the unit guard.
- Kept the existing DOM role=list / role=listitem assertion and the M3 private-runtime path checks.

## Behavioral guard coverage
- Resolves light/dark theme tokens for mf-stat labels/values, Yardi/JCHS callouts, compliance KPI values, kicker/tag surfaces, HNA chart loading overlay, Leaflet controls, fetch-error warning surfaces, and the HCA explore link.
- Asserts 4.5:1 for normal text and 3:1 for large text.
- A low-contrast sabotage on one of these foreground/background pairs now fails the unit test instead of passing after updating a literal string.

## Verification
- npm run test:site-review-build-pause
- npm run validate