### PR TITLE
Allow-list bot-blocked URLs from the weekly sweep (#1268)

### DIFF
--- a/scripts/audit/source-url-sweep.mjs
+++ b/scripts/audit/source-url-sweep.mjs
@@ -28,6 +28,19 @@ const TIMEOUT_MS = 10_000;
 const CONCURRENT = 8;
 
 const ALLOW_LIST = new Set([
+  // Bot-blocked / transient hosts verified live in a real browser during the
+  // 2026-07-20 weekly sweep triage (#1268). All returned 200 (or a Cloudflare
+  // bot-gate for congress.gov) with a browser UA; none are genuinely dead.
+  // Keep in sync with url-health-sweep.mjs.
+  'https://cdphe.colorado.gov/air-pollution/building-performance-standard-rule',
+  'https://dpt.colorado.gov/property-tax-exemption-for-senior-citizens-and-veterans-with-a-disability',
+  'https://federalfunds.colorado.gov/solar-for-all',
+  'https://www.aspendailynews.com/news/aspen-voters-approve-tax-on-strs/article_38fb65be-5fd1-11ed-a044-07397408fcc4.html',
+  'https://www.colorado.gov/governor/news/polis-administration-announces-funding-support-large-building-energy-efficiency-and',
+  'https://www.congress.gov/bill/119th-congress/house-bill/2854',
+  'https://www.congress.gov/bill/119th-congress/senate-bill/1686',
+  'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/Transportation/MapServer/2/query',
+  'https://www.townofpagosasprings.com/AgendaCenter',
   "https://overpass-api.de/api/interpreter", // POST-only API
   // CFPB HMDA Data Browser API — returns 400 to bare GET (requires query
   // params like states/counties/years/actions_taken). The endpoint is

--- a/scripts/audit/url-health-sweep.mjs
+++ b/scripts/audit/url-health-sweep.mjs
@@ -64,6 +64,19 @@ const DIFF_ONLY = process.argv.includes('--diff-only');
 // Re-use the allow-list from source-url-sweep — these are known-good URLs
 // that block CI user-agents (DOL, BLS, CHFA QAP, etc.). Keep in sync.
 const ALLOW_LIST = new Set([
+  // Bot-blocked / transient hosts verified live in a real browser during the
+  // 2026-07-20 weekly sweep triage (#1268). All returned 200 (or a Cloudflare
+  // bot-gate for congress.gov) with a browser UA; none are genuinely dead.
+  // Keep in sync with source-url-sweep.mjs.
+  'https://cdphe.colorado.gov/air-pollution/building-performance-standard-rule',
+  'https://dpt.colorado.gov/property-tax-exemption-for-senior-citizens-and-veterans-with-a-disability',
+  'https://federalfunds.colorado.gov/solar-for-all',
+  'https://www.aspendailynews.com/news/aspen-voters-approve-tax-on-strs/article_38fb65be-5fd1-11ed-a044-07397408fcc4.html',
+  'https://www.colorado.gov/governor/news/polis-administration-announces-funding-support-large-building-energy-efficiency-and',
+  'https://www.congress.gov/bill/119th-congress/house-bill/2854',
+  'https://www.congress.gov/bill/119th-congress/senate-bill/1686',
+  'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/Transportation/MapServer/2/query',
+  'https://www.townofpagosasprings.com/AgendaCenter',
   'https://overpass-api.de/api/interpreter',
   'https://ffiec.cfpb.gov/v2/data-browser-api/view/aggregations',
   'https://www.novoco.com/',


### PR DESCRIPTION
Closes #1268.

The 2026-07-20 `url-health-weekly` sweep filed 10 "newly-broken" URLs. QA fetched each with a real browser User-Agent (and a live browser for the Cloudflare-gated pages) — **all 10 are false positives**, none genuinely dead:

| URL | verified |
|---|---|
| cdphe / dpt / federalfunds.colorado.gov, colorado.gov/governor, aspendailynews | 200 |
| congress.gov house-bill/2854 + senate-bill/1686 | Cloudflare bot-gate (pages exist) |
| tigerweb …/MapServer/2/query | service live (param-less query hangs; not dead) |
| townofpagosasprings.com/AgendaCenter | 200 (earlier 502 transient) |

`polymarket.com` was already allow-listed. This adds the other 9 exact URLs to `ALLOW_LIST` in both `url-health-sweep.mjs` and `source-url-sweep.mjs` (the matcher is exact-URL, so the existing root `congress.gov/` entry didn't cover the deep bill URLs), so the weekly sweep stops re-filing them.

Additive change to two `Set` literals; both files pass `node --check`. No data edits.

🤖 Prepared by Claude Code QA.