### PR TITLE
fix(links): heal dead Yardi Matrix URL breaking the Source URL Sweep

### DIFF
--- a/data/market/yardi-matrix-national-multifamily.json
+++ b/data/market/yardi-matrix-national-multifamily.json
@@ -2,7 +2,7 @@
   "meta": {
     "title": "Yardi Matrix — National Multifamily Report",
     "source": "Yardi Matrix",
-    "source_url": "https://www.yardimatrix.com/Publications/Multifamily-Reports",
+    "source_url": "https://www.yardimatrix.com/publications",
     "report_name": "National Multifamily Report",
     "vintage": "2026-Q2 (April-May 2026 data)",
     "release_cadence": "Monthly",

--- a/economic-dashboard.html
+++ b/economic-dashboard.html
@@ -617,7 +617,7 @@ document.addEventListener('DOMContentLoaded', function () {
      Boulder). Pairs with Apartment List + Zillow ZORI for triangulation.
      Data: data/market/yardi-matrix-national-multifamily.json. -->
 <section id="yardi-section" aria-label="Yardi Matrix multifamily benchmarks" class="card" style="margin-top: 2rem; padding: var(--sp4);"
-         data-source="Yardi Matrix" data-source-url="https://www.yardimatrix.com/Publications/Multifamily-Reports" data-vintage="2026-Q2" data-source-type="industry-research">
+         data-source="Yardi Matrix" data-source-url="https://www.yardimatrix.com/publications" data-vintage="2026-Q2" data-source-type="industry-research">
   <h2 style="margin-top:0;">Multifamily rent benchmarks <small style="font-size:.65em;font-weight:400;color:var(--muted);">— Yardi Matrix National Multifamily Report</small></h2>
   <p style="font-size:.9rem;color:var(--muted);max-width:80ch;margin-bottom:var(--sp3);">
     Industry-standard asking-rent growth + occupancy by metro. Yardi tracks ~17M stabilized

--- a/index.html
+++ b/index.html
@@ -477,7 +477,7 @@
           <a href="https://www.novoco.com/" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;"><strong>Novogradac &amp; Co.</strong> · LIHTC equity pricing</a>
           <a href="https://nlihc.org/oor" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;"><strong>NLIHC</strong> · Out of Reach housing wage</a>
           <a href="https://www.jchs.harvard.edu/" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;"><strong>Harvard JCHS</strong> · State of Nation's Housing</a>
-          <a href="https://www.yardimatrix.com/Publications/Multifamily-Reports" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;"><strong>Yardi Matrix</strong> · Multifamily rent + occupancy</a>
+          <a href="https://www.yardimatrix.com/publications" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;"><strong>Yardi Matrix</strong> · Multifamily rent + occupancy</a>
           <a href="https://mf.freddiemac.com/" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;"><strong>Freddie Mac</strong> · Multifamily debt + cap-rate</a>
           <a href="https://www.brookings.edu/program/metropolitan-policy-program/" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;"><strong>Brookings</strong> · Schuetz / Cortright land-use research</a>
           <a href="https://www.lewis.ucla.edu/" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;"><strong>UCLA Lewis Center</strong> · Housing Voice podcast</a>


### PR DESCRIPTION
## Root cause
The **Source URL Sweep** was hard-failing (exit 1) on a single genuine dead link:
`https://www.yardimatrix.com/Publications/Multifamily-Reports` → **404** (verified 404 even with a real browser user-agent; the host root is 200, but that path was removed — so it is **not** a WAF/CI false-positive). Because the sweep runs repo-wide, this pre-existing dead link fails the gate on every PR (surfaced on #1341).

The 8 WAF/403 entries in the summary (incl. NCSHA and Novoco) are **already soft-classified** by the sweep and were never the cause — no allow-list change was needed or made.

## Fix
Heal the dead URL → the working landing page `https://www.yardimatrix.com/publications` (verified 200; already used elsewhere in the repo) in the 3 source occurrences:
- `index.html`
- `economic-dashboard.html`
- `data/market/yardi-matrix-national-multifamily.json` (`source_url`)

Audit output files (`data/url-health.json`, `data/reports/repo-link-audit.json`) are left to regenerate.

## Verification
- `node --check scripts/audit/source-url-sweep.mjs` → OK
- `node scripts/audit/source-url-sweep.mjs --quiet` → **`Scanned 183 URLs · hard failures: 0 · WAF/bot-blocked: 8 · timeouts: 21` · exit 0**

Unblocks the Source URL Sweep for #1341 and all future PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)