### PR TITLE
UI polish: counts, date stamps, and mobile FAB spacing

### DIFF
--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -110,6 +110,7 @@
   --border-strong:rgba(13,31,53,.20);
   --link:         #005a9c;
   --link-hover:   #004880;
+  --workflow-mobile-bottom-cta-offset: 0px;
 
   /* Accent colors */
   --accent:       #096e65;
@@ -1656,6 +1657,7 @@ html.dark-mode {
   --border-strong: rgba(90,150,210,.22);
   --link:          #5ecbcc;
   --link-hover:    #7dd8d9;
+  --workflow-mobile-bottom-cta-offset: 0px;
   --accent:        #0fd4cf;
   --accent-dim:    rgba(15,212,207,.12);
   --on-accent:     #0a0f1d; /* F122 — see top of file for paired-token rationale */
@@ -1736,6 +1738,14 @@ html.dark-mode ::-moz-selection { background: var(--accent); color: #0d1f35; }
 .dark-mode-toggle:focus-visible {
   outline: none;
   box-shadow: var(--focus-ring), var(--shadow);
+}
+
+@media (max-width: 700px) {
+  .dark-mode-toggle {
+    bottom: calc(var(--workflow-mobile-bottom-cta-offset, 0px) + env(safe-area-inset-bottom, 0px) + 1.25rem);
+    left: 1.25rem;
+    right: auto;
+  }
 }
 
 /* ----------------------------------------------------------------

--- a/js/components/next-action-cta.js
+++ b/js/components/next-action-cta.js
@@ -123,7 +123,7 @@
       '.naca-btn:hover { background: var(--accent); color: var(--on-accent, #fff);',
       '  border-color: var(--accent); transform: translateY(-1px); text-decoration: none; }',
       '@media (max-width: 700px) { .naca-strip { padding: 8px 12px; }',
-      '  :root { --workflow-mobile-bottom-cta-offset: 156px; }',
+      '  :root, html.dark-mode { --workflow-mobile-bottom-cta-offset: 156px; }',
       '  .naca-strip__inner { gap: 6px; } .naca-btn { padding: 4px 8px; font-size: .78rem; } }'
     ].join('\n');
     document.head.appendChild(s);

--- a/js/components/next-action-cta.js
+++ b/js/components/next-action-cta.js
@@ -123,6 +123,7 @@
       '.naca-btn:hover { background: var(--accent); color: var(--on-accent, #fff);',
       '  border-color: var(--accent); transform: translateY(-1px); text-decoration: none; }',
       '@media (max-width: 700px) { .naca-strip { padding: 8px 12px; }',
+      '  :root { --workflow-mobile-bottom-cta-offset: 156px; }',
       '  .naca-strip__inner { gap: 6px; } .naca-btn { padding: 4px 8px; font-size: .78rem; } }'
     ].join('\n');
     document.head.appendChild(s);

--- a/js/components/watchlist.js
+++ b/js/components/watchlist.js
@@ -169,9 +169,9 @@
           ' padding: 6px 10px; font-size: .78rem;' +
         '}' +
         '@media (max-width: 700px) {' +
-          // Clear typical footer link cluster (~50-90px); auto-shrink the
+          // Clear the wrapped mobile footer CTA; auto-shrink the
           // collapsed chip so it doesn't visually compete with content.
-          '#coho-watchlist-panel { bottom: 76px !important; right: 12px !important; }' +
+          '#coho-watchlist-panel { bottom: calc(var(--workflow-mobile-bottom-cta-offset, 76px) + env(safe-area-inset-bottom, 0px) + 12px) !important; right: 12px !important; }' +
           '#coho-watchlist-panel > details:not([open]) > summary {' +
             ' padding: 5px 9px; font-size: .72rem;' +
           '}' +

--- a/js/data-status-footer.js
+++ b/js/data-status-footer.js
@@ -153,10 +153,9 @@
     var updateKey    = body.getAttribute('data-page-update-key');
     var staticDate   = body.getAttribute('data-page-last-updated');
     var sourceStr    = body.getAttribute('data-page-source');
-    var resolvedUpdateKey = updateKey || (staticDate ? 'manifest' : null);
 
     // If neither key nor static date is provided, skip
-    if (!resolvedUpdateKey && !staticDate) return;
+    if (!updateKey && !staticDate) return;
 
     function render(dateStr) {
       var bar = buildStatusBar(dateStr, sourceStr);
@@ -169,8 +168,8 @@
       }
     }
 
-    if (resolvedUpdateKey) {
-      fetchTimestamp(resolvedUpdateKey, function (dateStr) {
+    if (updateKey) {
+      fetchTimestamp(updateKey, function (dateStr) {
         render(dateStr || (staticDate ? formatDate(staticDate) : null));
       });
     } else {

--- a/js/data-status-footer.js
+++ b/js/data-status-footer.js
@@ -153,9 +153,10 @@
     var updateKey    = body.getAttribute('data-page-update-key');
     var staticDate   = body.getAttribute('data-page-last-updated');
     var sourceStr    = body.getAttribute('data-page-source');
+    var resolvedUpdateKey = updateKey || (staticDate ? 'manifest' : null);
 
     // If neither key nor static date is provided, skip
-    if (!updateKey && !staticDate) return;
+    if (!resolvedUpdateKey && !staticDate) return;
 
     function render(dateStr) {
       var bar = buildStatusBar(dateStr, sourceStr);
@@ -168,8 +169,8 @@
       }
     }
 
-    if (updateKey) {
-      fetchTimestamp(updateKey, function (dateStr) {
+    if (resolvedUpdateKey) {
+      fetchTimestamp(resolvedUpdateKey, function (dateStr) {
         render(dateStr || (staticDate ? formatDate(staticDate) : null));
       });
     } else {

--- a/js/market-analysis.js
+++ b/js/market-analysis.js
@@ -4911,7 +4911,11 @@
       if (tsEl) {
         var generated = (tractData && tractData.meta && tractData.meta.generated) || null;
         if (generated) {
-          tsEl.textContent = 'Data as of ' + generated;
+          var generatedDate = new Date(generated);
+          var generatedLabel = isNaN(generatedDate.getTime())
+            ? generated
+            : generatedDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
+          tsEl.textContent = 'Data as of ' + generatedLabel;
         } else {
           tsEl.textContent = 'Data as of ' + new Date().toLocaleDateString();
         }

--- a/lihtc-opportunity-finder.html
+++ b/lihtc-opportunity-finder.html
@@ -2101,7 +2101,7 @@
                 higher the score (out of 100). A Prop 123 filing is referenced in CHFA QAP
                 scoring criteria; the other six matter for permit timelines, letters of support, and
                 soft-debt sources to stack with the LIHTC equity.
-                <br><em>Data:</em> hand-curated policy scorecard (547 Colorado jurisdictions × 7
+                <br><em>Data:</em> hand-curated policy scorecard (546 Colorado jurisdictions × 7
                 dimensions) + DOLA's Prop 123 commitment list (217 jurisdictions filed) + the
                 local-resources directory.
               </li>
@@ -2459,7 +2459,7 @@
               <li><a href="https://www.huduser.gov/portal/datasets/cp.html" target="_blank" rel="noopener">HUD CHAS 2018–2022</a> — county-level (64) + tract-level (1,447 records)</li>
               <li><a href="https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-line-file.2024.html" target="_blank" rel="noopener">TIGER 2024</a> — place-tract spatial join (<code>data/hna/place-tract-membership.json</code>)</li>
               <li><a href="https://cdola.colorado.gov/commitment-filings" target="_blank" rel="noopener">DOLA Prop 123 commitments</a> — 217 filings (<code>data/policy/prop123_jurisdictions.json</code>)</li>
-              <li>Housing policy scorecard — 547 jurisdictions × 7 civic dimensions (<code>data/policy/housing-policy-scorecard.json</code>)</li>
+              <li>Housing policy scorecard — 546 jurisdictions × 7 civic dimensions (<code>data/policy/housing-policy-scorecard.json</code>)</li>
               <li>Local resources — housing leads, authorities, advocacy URLs (<code>data/hna/local-resources.json</code>)</li>
             </ul>
           </div>

--- a/market-analysis.html
+++ b/market-analysis.html
@@ -74,7 +74,7 @@
   <!-- F162 — gated CRM CRUD. Only hydrated for visitors with a live
        developer session; mount stays empty for the public visitor. -->
 </head>
-<body data-page-last-updated="2026-03-22" data-page-source="Census ACS · HUD LIHTC · FRED · CoStar (public)">
+<body data-page-update-key="manifest" data-page-last-updated="2026-07-29" data-page-source="Census ACS · HUD LIHTC · FRED · CoStar (public)">
   <a class="skip-link" href="#main-content">Skip to main content</a>
 
   <header class="site-header">

--- a/test/public-facing-numbers.test.js
+++ b/test/public-facing-numbers.test.js
@@ -28,6 +28,17 @@ assert(indexHtml.includes(`ranks all ${rankingCount} Colorado`), 'homepage compa
 assert(!/all\s+645\s+Colorado\s+jurisdictions/.test(indexHtml), 'homepage no longer uses stale 645 jurisdiction count');
 assert(!/ranks\s+all\s+547\s+Colorado/.test(indexHtml), 'homepage no longer uses stale 547 ranking count');
 
+const lofHtml = read('lihtc-opportunity-finder.html');
+assert(
+  !/\b547\b[^.\n]{0,80}\bjurisdictions\b|\bjurisdictions\b[^.\n]{0,80}\b547\b/.test(lofHtml),
+  'Opportunity Finder no longer uses stale 547 jurisdiction scorecard count'
+);
+assert(
+  lofHtml.includes(`policy scorecard (${rankingCount} Colorado jurisdictions × 7`) &&
+    lofHtml.includes(`Housing policy scorecard — ${rankingCount} jurisdictions × 7`),
+  'Opportunity Finder policy scorecard count matches canonical ranking count'
+);
+
 const lihtc = readJson('data/chfa-lihtc.json');
 const dataQualitySrc = read('js/data-quality-check.js');
 const coverageMatch = dataQualitySrc.match(/coverageLabel:\s*"(\d+)\s+placed-in-service CO LIHTC projects"/);


### PR DESCRIPTION
## Summary
- Fix two stale Opportunity Finder policy-scorecard jurisdiction counts from 547 to the canonical 546.
- Keep static-date pages honest: the shared data-status footer now uses manifest freshness only when a page explicitly sets `data-page-update-key`.
- Mark `market-analysis.html` as manifest-backed with `data-page-update-key="manifest"`, keeping its static date as the fetch-failure fallback.
- Format the PMA data timestamp as a human-readable UTC vintage date instead of a raw ISO string.
- Raise fixed mobile controls above the wrapped sticky next-action footer, including dark mode, and move the dark-mode toggle to the lower-left on mobile to avoid fixed-control stacking.

## Date Sources
- Market Analysis footer uses `data/manifest.json.generated`; browser check rendered `July 29, 2026`.
- Preservation footer reverted to its own static page date; browser check rendered `March 21, 2026` and did not show the manifest date.
- `#pmaDataTimestamp` continues to use `tractData.meta.generated` from the PMA tract data and now formats it as `Jun 11, 2026` instead of a raw ISO string.

## Browser Check
- Checked `market-analysis.html` at 375px width in light and dark mode via local browser automation.
- Computed `--workflow-mobile-bottom-cta-offset`: light `156px`, dark `156px`.
- No overlap between `.naca-strip`, `#coho-watchlist-panel`, and `.dark-mode-toggle` in either theme.
- No horizontal overflow.

## Verification
- `npm run test:public-facing-numbers` ✅
- `npm run test:mobile-overflow-containment` ✅
- `npm run test:pill-contrast` ✅
- `npm run test:inline-contrast` ✅
- `npm run test:phantom-css-vars` ✅
- `npm run test:ci` ✅
- `git merge-tree --write-tree HEAD origin/main` ✅

## Scope
PR diff covers the original F2/F3/F4 work. Follow-up commit `9716d806a` is limited to `js/components/next-action-cta.js`, `js/data-status-footer.js`, and `market-analysis.html`.