### PR TITLE
Resolve open maintenance issues: url-health false-positives + freshness issue-dedup bug

### DIFF
--- a/.github/workflows/data-freshness-check.yml
+++ b/.github/workflows/data-freshness-check.yml
@@ -75,7 +75,12 @@ jobs:
           # 5 piled up from before the auto-close logic was correct),
           # each green run only closed one. Issues #744–748 piled up that
           # way — a recovery should now close ALL of them in one pass.
-          MARKER="${ISSUE_TITLE_MARKER}" \
+          # NOTE: `export` is required. A `VAR=val prefix` before an assignment
+          # (not a command) does NOT place VAR in the child process environment,
+          # so gh's jq saw `env.MARKER == null`, `contains(null)` errored, the
+          # filter fell through `|| true` to empty, and every stale run opened a
+          # brand-new duplicate issue (see #1347/#1357/#1359). Export fixes it.
+          export MARKER="${ISSUE_TITLE_MARKER}"
           numbers=$(gh issue list --state open --limit 100 --json number,title \
             --jq '[.[] | select(.title | contains(env.MARKER)) | .number] | join(" ")' \
             || true)

--- a/.github/workflows/data-sentinels-check.yml
+++ b/.github/workflows/data-sentinels-check.yml
@@ -64,7 +64,10 @@ jobs:
         run: |
           # Scan up to 100 open issues for the title marker. Client-side
           # jq filter via env.MARKER survives special chars (brackets).
-          MARKER="${ISSUE_TITLE_MARKER}" \
+          # `export` is required: a `VAR=val prefix` before an assignment (not a
+          # command) never reaches the child's environment, so gh's jq saw
+          # env.MARKER == null and opened a duplicate issue every run. Export fixes it.
+          export MARKER="${ISSUE_TITLE_MARKER}"
           number=$(gh issue list --state open --limit 100 --json number,title \
             --jq '[.[] | select(.title | contains(env.MARKER)) | .number] | first // empty' \
             || true)

--- a/data/jurisdiction-briefs/0817375.json
+++ b/data/jurisdiction-briefs/0817375.json
@@ -272,10 +272,10 @@
     },
     {
       "id": "s16",
-      "label": "Park Village Housing RFQ announcement — City of Cortez CivicAlerts",
-      "url": "https://www.cortezco.gov/CivicAlerts.aspx?AID=1135&ARC=1807",
+      "label": "Park Village Housing RFQ (full document, issued 2025-03-26) — City of Cortez",
+      "url": "https://www.downtowncoloradoinc.org/wp-content/uploads/25.03.26-Cortez-7th-St-RFQ-FINAL.pdf",
       "kind": "primary",
-      "accessed": "2026-06-12"
+      "accessed": "2026-07-30"
     },
     {
       "id": "s23",

--- a/data/jurisdiction-briefs/_verified/0817375.json
+++ b/data/jurisdiction-briefs/_verified/0817375.json
@@ -98,10 +98,10 @@
       "section_id": "park-village-rfq",
       "paragraph_index": 0,
       "source_id": "s16",
-      "source_url": "https://www.cortezco.gov/CivicAlerts.aspx?AID=1135&ARC=1807",
+      "source_url": "https://www.downtowncoloradoinc.org/wp-content/uploads/25.03.26-Cortez-7th-St-RFQ-FINAL.pdf",
       "verdict": "supported",
       "supporting_quote": "The housing RFQ, issued March 26, 2025... eastern 7.01 acres of the site... approximately seven acres on the west side of the site will be developed into a park, and the remaining seven acres on the east side of the site will be developed into housing... households earning between 80% and 120% of the area median income... submit their qualifications... by May 6, 2025.",
-      "notes": "Direct URL fetch via curl."
+      "notes": "Direct URL fetch of the full RFQ PDF; all quoted figures (7.01 acres for housing, 80-120% AMI preferred, May 6 2025 due date) verbatim in the source. Repointed from a rotted CivicAlerts announcement (404) to the durable RFQ document 2026-07-30."
     },
     {
       "section_id": "regional-capacity",
@@ -152,7 +152,7 @@
       "section_id": "cortez-recent-business-developments",
       "paragraph_index": 0,
       "source_id": "s16",
-      "source_url": "https://www.cortezco.gov/CivicAlerts.aspx?AID=1135&ARC=1807",
+      "source_url": "https://www.downtowncoloradoinc.org/wp-content/uploads/25.03.26-Cortez-7th-St-RFQ-FINAL.pdf",
       "verdict": "supported",
       "supporting_quote": "The housing RFQ, issued March 26, 2025... eastern 7.01 acres of the site... approximately seven acres on the west side of the site will be developed into a park, and the remaining seven acres on the east side of the site will be developed into housing... households earning between 80% and 120% of the area median income... submit their qualifications... by May 6, 2025.",
       "notes": "Reuses directly verified source text already present in this brief; B4 expansion claim is limited to the quoted material."

--- a/scripts/audit/source-url-sweep.mjs
+++ b/scripts/audit/source-url-sweep.mjs
@@ -259,6 +259,14 @@ const ALLOW_LIST = new Set([
   "https://www.novoco.com/rss.xml",
   "https://www.hudexchange.info/feed/",
   "https://leg.colorado.gov/rss.xml",
+  // Bot-blocked / transient hosts verified live in a real browser during the
+  // 2026-07-30 weekly sweep triage (#1326). Keep in sync with url-health-sweep.mjs.
+  "https://andthewest.stanford.edu/2019/astride-two-wests-colorado-county-faces-a-tricky-economic-balance/",
+  "https://www.chaffeecountytimes.com/news/chaffee-county-rejects-lodging-tax/article_53e3089a-a079-48b4-a8c8-9c5c0e76db4b.html",
+  "https://www.deltaschools.com/",
+  "https://www.novoco.com/products/novogradac-qualified-census-tract-estimator",
+  "https://www.novoco.com/resource-centers/affordable-housing-tax-credits/rent-income-limit-calculator",
+  "https://www.purgatory.ski/",
 ]);
 
 const SKIP_PATTERNS = [

--- a/scripts/audit/url-health-sweep.mjs
+++ b/scripts/audit/url-health-sweep.mjs
@@ -154,7 +154,17 @@ const ALLOW_LIST = new Set([
   'https://polymarket.com/event/us-recession-by-end-of-2026',
   'https://polymarket.com/event/what-will-the-median-home-value-in-chicago-be-on-april-30',
   'https://polymarket.com/event/what-will-the-median-home-value-in-the-los-angeles-metro-area-be-on-april-30',
-  'https://polymarket.com/event/what-will-the-median-home-value-in-the-us-be-on-april-30'
+  'https://polymarket.com/event/what-will-the-median-home-value-in-the-us-be-on-april-30',
+  // Bot-blocked / transient hosts verified live in a real browser during the
+  // 2026-07-30 weekly sweep triage (#1326). All returned 200 with a browser UA
+  // (novoco Cloudflare-gates CI but both tool pages render live); none are dead.
+  // Keep in sync with source-url-sweep.mjs.
+  'https://andthewest.stanford.edu/2019/astride-two-wests-colorado-county-faces-a-tricky-economic-balance/',
+  'https://www.chaffeecountytimes.com/news/chaffee-county-rejects-lodging-tax/article_53e3089a-a079-48b4-a8c8-9c5c0e76db4b.html',
+  'https://www.deltaschools.com/',
+  'https://www.novoco.com/products/novogradac-qualified-census-tract-estimator',
+  'https://www.novoco.com/resource-centers/affordable-housing-tax-credits/rent-income-limit-calculator',
+  'https://www.purgatory.ski/'
 ]);
 
 /* ── URL collection ───────────────────────────────────────────────── */


### PR DESCRIPTION
Resolves the actionable automated-maintenance issues in one pass.

## url-health weekly (#1326) — 7 flagged URLs, browser-verified
- **6 false positives** (CI timeout / 429 / 502 / Cloudflare 403) that render live in a real browser → added to `ALLOW_LIST` in both `url-health-sweep.mjs` and `source-url-sweep.mjs`:
  - `andthewest.stanford.edu` (timeout→200), `chaffeecountytimes.com` lodging-tax article (429→200), `deltaschools.com` (502→200), both **Novogradac** tool pages — QCT estimator + rent/income limit calculator (403→confirmed live in-browser), `purgatory.ski` (403→200).
- **1 genuinely dead (404)**: Cortez `CivicAlerts` announcement `AID=1135` in brief `0817375`. Repointed source `s16` to the durable primary **RFQ document**, which substantiates every cited figure verbatim (7.01 acres for housing, 80–120% AMI preferred, May 6 2025 due date). `_verified` updated too. `test:briefs` passes 13/13.

## Data-freshness alerts (#1347 / #1357 / #1359) — dedup bug
The three duplicate NHPD alerts were caused by a real bug: the find-existing-issue step used a `MARKER=val \` prefix before an **assignment** (`numbers=$(gh …)`), so `MARKER` never reached the child environment, gh's jq saw `env.MARKER == null`, `contains(null)` threw, and every stale run opened a fresh duplicate. Fixed with `export MARKER` in `data-freshness-check.yml` and the identical copy-pasted block in `data-sentinels-check.yml`. Verified locally (pre-fix: jq errors; post-fix: returns the issue number). #1347/#1357 closed as dups; #1359 kept as the single tracker with root-cause triage.

> Note: the underlying NHPD staleness is a *true* signal — `nhpd_co.geojson` is a 20-feature hand-built stub and the NHPD API is Cloudflare-gated/unauthenticated, so it can't auto-refresh. That's an owner decision (credentialed export vs. relax the SLA), documented on #1359 — out of scope for this PR.

## Verification
- `node --check` on both sweep scripts ✓
- `python3 scripts/validate-jurisdiction-briefs.py` → 13/13 ✓
- YAML parse on both workflows ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)