### PR TITLE
briefs: draft City of Durango (0822035), published:false (#1360)

### DIFF
--- a/data/_manifest.json
+++ b/data/_manifest.json
@@ -1,11 +1,11 @@
 {
   "meta": {
-    "generated_at": "2026-07-30T13:54:39.482Z",
+    "generated_at": "2026-07-30T15:02:44.511Z",
     "root": "data/",
-    "file_count": 1600,
-    "total_size_bytes": 268809748,
+    "file_count": 1602,
+    "total_size_bytes": 268836099,
     "kinds": {
-      "json": 1565,
+      "json": 1567,
       "geojson": 31,
       "csv": 4
     }
@@ -14,8 +14,8 @@
     {
       "path": "_qa-status.json",
       "kind": "json",
-      "size_bytes": 6455,
-      "mtime": "2026-07-30T10:58:12.147Z",
+      "size_bytes": 6456,
+      "mtime": "2026-07-30T15:02:42.971Z",
       "shape": "object",
       "keys": [
         "generated_at",
@@ -33,7 +33,7 @@
       "path": "affordable-housing/chfa-awards/2026-round-one.json",
       "kind": "json",
       "size_bytes": 15112,
-      "mtime": "2026-07-30T10:58:12.149Z",
+      "mtime": "2026-07-30T15:02:42.973Z",
       "shape": "object",
       "keys": [
         "metadata",
@@ -61,7 +61,7 @@
       "path": "affordable-housing/lihtc/chfa-properties.json",
       "kind": "json",
       "size_bytes": 837046,
-      "mtime": "2026-07-30T10:58:12.152Z",
+      "mtime": "2026-07-30T15:02:42.974Z",
       "shape": "object",
       "keys": [
         "type",
@@ -82,7 +82,7 @@
       "path": "affordable-housing/local-pha-roster/denver-housing-authority.json",
       "kind": "json",
       "size_bytes": 919,
-      "mtime": "2026-07-30T10:58:12.152Z",
+      "mtime": "2026-07-30T15:02:42.974Z",
       "shape": "object",
       "keys": [
         "metadata",
@@ -97,7 +97,7 @@
       "path": "affordable-housing/local-pha-roster/garfield-county-ha.json",
       "kind": "json",
       "size_bytes": 2145,
-      "mtime": "2026-07-30T10:58:12.152Z",
+      "mtime": "2026-07-30T15:02:42.974Z",
       "shape": "object",
       "keys": [
         "metadata",
@@ -125,7 +125,7 @@
       "path": "affordable-housing/nlihc-out-of-reach-co.json",
       "kind": "json",
       "size_bytes": 9042,
-      "mtime": "2026-07-30T10:58:12.153Z",
+      "mtime": "2026-07-30T15:02:42.974Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -142,7 +142,7 @@
       "path": "affordable-housing/preservation/chfa-preservation.json",
       "kind": "json",
       "size_bytes": 648912,
-      "mtime": "2026-07-30T10:58:12.154Z",
+      "mtime": "2026-07-30T15:02:42.975Z",
       "shape": "object",
       "keys": [
         "type",
@@ -161,7 +161,7 @@
       "path": "affordable-housing/preservation/hud-multifamily-assisted.json",
       "kind": "json",
       "size_bytes": 195665,
-      "mtime": "2026-07-30T10:58:12.155Z",
+      "mtime": "2026-07-30T15:02:42.975Z",
       "shape": "object",
       "keys": [
         "type",
@@ -180,7 +180,7 @@
       "path": "affordable-housing/preservation/usda-rural-housing.json",
       "kind": "json",
       "size_bytes": 67622,
-      "mtime": "2026-07-30T10:58:12.155Z",
+      "mtime": "2026-07-30T15:02:42.975Z",
       "shape": "object",
       "keys": [
         "type",
@@ -199,7 +199,7 @@
       "path": "affordable-housing/properties-manifest.json",
       "kind": "json",
       "size_bytes": 118,
-      "mtime": "2026-07-30T10:58:12.155Z",
+      "mtime": "2026-07-30T15:02:42.975Z",
       "shape": "object",
       "keys": [
         "v",
@@ -216,7 +216,7 @@
       "path": "affordable-housing/properties.json",
       "kind": "json",
       "size_bytes": 1567913,
-      "mtime": "2026-07-30T10:58:12.157Z",
+      "mtime": "2026-07-30T15:02:42.977Z",
       "shape": "object",
       "keys": [
         "metadata",
@@ -244,7 +244,7 @@
       "path": "affordable-housing/property-aliases.json",
       "kind": "json",
       "size_bytes": 1322,
-      "mtime": "2026-07-30T10:58:12.157Z",
+      "mtime": "2026-07-30T15:02:42.977Z",
       "shape": "object",
       "keys": [
         "schema_version",
@@ -262,7 +262,7 @@
       "path": "affordable-housing/regrid-parcels-by-place.json",
       "kind": "json",
       "size_bytes": 3440,
-      "mtime": "2026-07-30T10:58:12.158Z",
+      "mtime": "2026-07-30T15:02:42.979Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -277,7 +277,7 @@
       "path": "alerts/alerts_archive.json",
       "kind": "json",
       "size_bytes": 218174,
-      "mtime": "2026-07-30T10:58:12.160Z",
+      "mtime": "2026-07-30T15:02:42.979Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -300,7 +300,7 @@
       "path": "allocations.json",
       "kind": "json",
       "size_bytes": 12560,
-      "mtime": "2026-07-30T10:58:12.160Z",
+      "mtime": "2026-07-30T15:02:42.980Z",
       "shape": "object",
       "keys": [
         "year",
@@ -320,7 +320,7 @@
       "path": "amenities/grocery_co.geojson",
       "kind": "geojson",
       "size_bytes": 955905,
-      "mtime": "2026-07-30T10:58:12.161Z",
+      "mtime": "2026-07-30T15:02:42.980Z",
       "shape": "geojson",
       "feature_count": 2440,
       "property_keys": [
@@ -338,7 +338,7 @@
       "path": "amenities/healthcare_co.geojson",
       "kind": "geojson",
       "size_bytes": 1248403,
-      "mtime": "2026-07-30T10:58:12.165Z",
+      "mtime": "2026-07-30T15:02:42.984Z",
       "shape": "geojson",
       "feature_count": 3075,
       "property_keys": [
@@ -356,7 +356,7 @@
       "path": "amenities/parks_co.geojson",
       "kind": "geojson",
       "size_bytes": 1277406,
-      "mtime": "2026-07-30T10:58:12.170Z",
+      "mtime": "2026-07-30T15:02:42.989Z",
       "shape": "geojson",
       "feature_count": 3267,
       "property_keys": [
@@ -374,7 +374,7 @@
       "path": "amenities/retail_nodes_co.geojson",
       "kind": "geojson",
       "size_bytes": 3939265,
-      "mtime": "2026-07-30T10:58:12.173Z",
+      "mtime": "2026-07-30T15:02:42.991Z",
       "shape": "geojson",
       "feature_count": 10017,
       "property_keys": [
@@ -392,7 +392,7 @@
       "path": "amenities/schools_co.geojson",
       "kind": "geojson",
       "size_bytes": 1169532,
-      "mtime": "2026-07-30T10:58:12.173Z",
+      "mtime": "2026-07-30T15:02:42.991Z",
       "shape": "geojson",
       "feature_count": 2944,
       "property_keys": [
@@ -410,7 +410,7 @@
       "path": "amenities/transit_stops_co.geojson",
       "kind": "geojson",
       "size_bytes": 2398871,
-      "mtime": "2026-07-30T10:58:12.179Z",
+      "mtime": "2026-07-30T15:02:42.997Z",
       "shape": "geojson",
       "feature_count": 7888,
       "property_keys": [
@@ -424,7 +424,7 @@
       "path": "audit/quarantine-candidates.json",
       "kind": "json",
       "size_bytes": 483,
-      "mtime": "2026-07-30T10:58:12.179Z",
+      "mtime": "2026-07-30T15:02:42.997Z",
       "shape": "object",
       "keys": [
         "generated_at",
@@ -443,7 +443,7 @@
       "path": "audit/upstream-vintage-watch.json",
       "kind": "json",
       "size_bytes": 803,
-      "mtime": "2026-07-30T10:58:12.181Z",
+      "mtime": "2026-07-30T15:02:42.998Z",
       "shape": "object",
       "keys": [
         "generated_at",
@@ -465,7 +465,7 @@
       "path": "benchmarks/str-license-counts.json",
       "kind": "json",
       "size_bytes": 3084,
-      "mtime": "2026-07-30T10:58:12.181Z",
+      "mtime": "2026-07-30T15:02:42.998Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -488,7 +488,7 @@
       "path": "boundaries/counties_co.geojson",
       "kind": "geojson",
       "size_bytes": 126391,
-      "mtime": "2026-07-30T10:58:12.182Z",
+      "mtime": "2026-07-30T15:02:42.999Z",
       "shape": "geojson",
       "feature_count": 64,
       "property_keys": [
@@ -504,7 +504,7 @@
       "path": "capital-partners.json",
       "kind": "json",
       "size_bytes": 13432,
-      "mtime": "2026-07-30T10:58:12.182Z",
+      "mtime": "2026-07-30T15:02:42.999Z",
       "shape": "object",
       "keys": [
         "metadata",
@@ -527,7 +527,7 @@
       "path": "car-market-report-2026-02.json",
       "kind": "json",
       "size_bytes": 2272,
-      "mtime": "2026-07-30T10:58:12.182Z",
+      "mtime": "2026-07-30T15:02:42.999Z",
       "shape": "object",
       "keys": [
         "month",
@@ -548,7 +548,7 @@
       "path": "car-market-report-2026-03.json",
       "kind": "json",
       "size_bytes": 2273,
-      "mtime": "2026-07-30T10:58:12.182Z",
+      "mtime": "2026-07-30T15:02:42.999Z",
       "shape": "object",
       "keys": [
         "month",
@@ -569,7 +569,7 @@
       "path": "car-market-report-2026-04.json",
       "kind": "json",
       "size_bytes": 2325,
-      "mtime": "2026-07-30T10:58:12.182Z",
+      "mtime": "2026-07-30T15:02:42.999Z",
       "shape": "object",
       "keys": [
         "month",
@@ -590,7 +590,7 @@
       "path": "car-market-report-2026-05.json",
       "kind": "json",
       "size_bytes": 65597,
-      "mtime": "2026-07-30T10:58:12.183Z",
+      "mtime": "2026-07-30T15:02:43.000Z",
       "shape": "object",
       "keys": [
         "month",
@@ -613,7 +613,7 @@
       "path": "car-market-report-2026-06.json",
       "kind": "json",
       "size_bytes": 65589,
-      "mtime": "2026-07-30T10:58:12.183Z",
+      "mtime": "2026-07-30T15:02:43.001Z",
       "shape": "object",
       "keys": [
         "month",
@@ -636,7 +636,7 @@
       "path": "car-market-report-2026-07.json",
       "kind": "json",
       "size_bytes": 2321,
-      "mtime": "2026-07-30T10:58:12.183Z",
+      "mtime": "2026-07-30T15:02:43.001Z",
       "shape": "object",
       "keys": [
         "month",
@@ -657,7 +657,7 @@
       "path": "car-market.json",
       "kind": "json",
       "size_bytes": 514,
-      "mtime": "2026-07-30T10:58:12.183Z",
+      "mtime": "2026-07-30T15:02:43.001Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -684,7 +684,7 @@
       "path": "census-acs-state.json",
       "kind": "json",
       "size_bytes": 24892,
-      "mtime": "2026-07-30T10:58:12.183Z",
+      "mtime": "2026-07-30T15:02:43.001Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -712,7 +712,7 @@
       "path": "census-multifamily-co.json",
       "kind": "json",
       "size_bytes": 118702,
-      "mtime": "2026-07-30T10:58:12.184Z",
+      "mtime": "2026-07-30T15:02:43.001Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -738,7 +738,7 @@
       "path": "chfa-income-rent-limits-2026.json",
       "kind": "json",
       "size_bytes": 511732,
-      "mtime": "2026-07-30T10:58:12.185Z",
+      "mtime": "2026-07-30T15:02:43.002Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -761,7 +761,7 @@
       "path": "chfa-lihtc.json",
       "kind": "json",
       "size_bytes": 837046,
-      "mtime": "2026-07-30T10:58:12.186Z",
+      "mtime": "2026-07-30T15:02:43.002Z",
       "shape": "object",
       "keys": [
         "type",
@@ -782,7 +782,7 @@
       "path": "chfa-qap-calendar.json",
       "kind": "json",
       "size_bytes": 9569,
-      "mtime": "2026-07-30T10:58:12.186Z",
+      "mtime": "2026-07-30T15:02:43.002Z",
       "shape": "object",
       "keys": [
         "metadata",
@@ -806,7 +806,7 @@
       "path": "co-county-boundaries.json",
       "kind": "json",
       "size_bytes": 126391,
-      "mtime": "2026-07-30T10:58:12.186Z",
+      "mtime": "2026-07-30T15:02:43.002Z",
       "shape": "object",
       "keys": [
         "type",
@@ -826,7 +826,7 @@
       "path": "co-county-demographics.json",
       "kind": "json",
       "size_bytes": 24155,
-      "mtime": "2026-07-30T10:58:12.186Z",
+      "mtime": "2026-07-30T15:02:43.003Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -845,7 +845,7 @@
       "path": "co-county-economic-indicators.json",
       "kind": "json",
       "size_bytes": 15327,
-      "mtime": "2026-07-30T10:58:12.186Z",
+      "mtime": "2026-07-30T15:02:43.003Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -862,7 +862,7 @@
       "path": "co-demographics.json",
       "kind": "json",
       "size_bytes": 875,
-      "mtime": "2026-07-30T10:58:12.186Z",
+      "mtime": "2026-07-30T15:02:43.003Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -889,7 +889,7 @@
       "path": "co-historical-allocations.json",
       "kind": "json",
       "size_bytes": 14708,
-      "mtime": "2026-07-30T10:58:12.186Z",
+      "mtime": "2026-07-30T15:02:43.003Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -925,7 +925,7 @@
       "path": "co-housing-costs/county-trends.json",
       "kind": "json",
       "size_bytes": 51414,
-      "mtime": "2026-07-30T10:58:12.187Z",
+      "mtime": "2026-07-30T15:02:43.003Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -940,7 +940,7 @@
       "path": "co-housing-costs/drivers_ranking.csv",
       "kind": "csv",
       "size_bytes": 243,
-      "mtime": "2026-07-30T10:58:12.187Z",
+      "mtime": "2026-07-30T15:02:43.003Z",
       "shape": "csv",
       "row_count": 5,
       "columns": [
@@ -954,7 +954,7 @@
       "path": "co-place-boundaries.geojson",
       "kind": "geojson",
       "size_bytes": 1367696,
-      "mtime": "2026-07-30T10:58:12.193Z",
+      "mtime": "2026-07-30T15:02:43.007Z",
       "shape": "geojson",
       "feature_count": 484,
       "property_keys": [
@@ -969,7 +969,7 @@
       "path": "co-place-centroids.json",
       "kind": "json",
       "size_bytes": 50501,
-      "mtime": "2026-07-30T10:58:12.193Z",
+      "mtime": "2026-07-30T15:02:43.007Z",
       "shape": "object",
       "keys": [
         "fetchedAt",
@@ -987,7 +987,7 @@
       "path": "co_ami_gap_by_county.json",
       "kind": "json",
       "size_bytes": 87532,
-      "mtime": "2026-07-30T10:58:12.193Z",
+      "mtime": "2026-07-30T15:02:43.008Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -1018,7 +1018,7 @@
       "path": "co_ami_gap_by_place.json",
       "kind": "json",
       "size_bytes": 641520,
-      "mtime": "2026-07-30T10:58:12.194Z",
+      "mtime": "2026-07-30T15:02:43.010Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -1036,7 +1036,7 @@
       "path": "core/educational-content.json",
       "kind": "json",
       "size_bytes": 67585,
-      "mtime": "2026-07-30T10:58:12.196Z",
+      "mtime": "2026-07-30T15:02:43.010Z",
       "shape": "object",
       "keys": [
         "generated",
@@ -1051,7 +1051,7 @@
       "path": "core/neighborhood-context.json",
       "kind": "json",
       "size_bytes": 71321,
-      "mtime": "2026-07-30T10:58:12.196Z",
+      "mtime": "2026-07-30T15:02:43.010Z",
       "shape": "object",
       "keys": [
         "generated",
@@ -1067,7 +1067,7 @@
       "path": "coverage-report.json",
       "kind": "json",
       "size_bytes": 13097,
-      "mtime": "2026-07-30T10:58:12.196Z",
+      "mtime": "2026-07-30T15:02:43.010Z",
       "shape": "object",
       "keys": [
         "generated",
@@ -1088,7 +1088,7 @@
       "path": "dda-colorado.json",
       "kind": "json",
       "size_bytes": 341647,
-      "mtime": "2026-07-30T10:58:12.197Z",
+      "mtime": "2026-07-30T15:02:43.011Z",
       "shape": "object",
       "keys": [
         "type",
@@ -1111,7 +1111,7 @@
       "path": "derived/market-analysis/market_demand.json",
       "kind": "json",
       "size_bytes": 8313,
-      "mtime": "2026-07-30T10:58:12.197Z",
+      "mtime": "2026-07-30T15:02:43.011Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -1133,7 +1133,7 @@
       "path": "derived/market-analysis/neighborhood_access.json",
       "kind": "json",
       "size_bytes": 2855530,
-      "mtime": "2026-07-30T10:58:12.200Z",
+      "mtime": "2026-07-30T15:02:43.014Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -1153,7 +1153,7 @@
       "path": "derived/market-analysis/site_opportunities.json",
       "kind": "json",
       "size_bytes": 9505,
-      "mtime": "2026-07-30T10:58:12.200Z",
+      "mtime": "2026-07-30T15:02:43.014Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -1176,7 +1176,7 @@
       "path": "derived/market-analysis/subsidy_layers.json",
       "kind": "json",
       "size_bytes": 1872,
-      "mtime": "2026-07-30T10:58:12.200Z",
+      "mtime": "2026-07-30T15:02:43.014Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -1192,7 +1192,7 @@
       "path": "discovery-reports/latest.json",
       "kind": "json",
       "size_bytes": 242198,
-      "mtime": "2026-07-30T10:58:12.200Z",
+      "mtime": "2026-07-30T15:02:43.016Z",
       "shape": "object",
       "keys": [
         "scanTimestamp",
@@ -1219,7 +1219,7 @@
       "path": "environmental/epa-superfund-co.json",
       "kind": "json",
       "size_bytes": 2813,
-      "mtime": "2026-07-30T10:58:12.200Z",
+      "mtime": "2026-07-30T15:02:43.017Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -1245,7 +1245,7 @@
       "path": "environmental/fema-flood-co.geojson",
       "kind": "geojson",
       "size_bytes": 2118,
-      "mtime": "2026-07-30T10:58:12.201Z",
+      "mtime": "2026-07-30T15:02:43.018Z",
       "shape": "geojson",
       "feature_count": 4,
       "property_keys": [
@@ -1261,7 +1261,7 @@
       "path": "fred-data.json",
       "kind": "json",
       "size_bytes": 1306613,
-      "mtime": "2026-07-30T10:58:12.202Z",
+      "mtime": "2026-07-30T15:02:43.019Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1276,7 +1276,7 @@
       "path": "glossary.json",
       "kind": "json",
       "size_bytes": 13886,
-      "mtime": "2026-07-30T10:58:12.203Z",
+      "mtime": "2026-07-30T15:02:43.020Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1295,7 +1295,7 @@
       "path": "hmda/co-county-aggregates.json",
       "kind": "json",
       "size_bytes": 246619,
-      "mtime": "2026-07-30T10:58:12.204Z",
+      "mtime": "2026-07-30T15:02:43.020Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -1310,7 +1310,7 @@
       "path": "hmda/co-state-trends.json",
       "kind": "json",
       "size_bytes": 3693,
-      "mtime": "2026-07-30T10:58:12.204Z",
+      "mtime": "2026-07-30T15:02:43.020Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -1325,7 +1325,7 @@
       "path": "hna/benchmarks.json",
       "kind": "json",
       "size_bytes": 9360,
-      "mtime": "2026-07-30T10:58:12.204Z",
+      "mtime": "2026-07-30T15:02:43.020Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -1346,7 +1346,7 @@
       "path": "hna/chas_affordability_gap.json",
       "kind": "json",
       "size_bytes": 166598,
-      "mtime": "2026-07-30T10:58:12.207Z",
+      "mtime": "2026-07-30T15:02:43.023Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -1362,7 +1362,7 @@
       "path": "hna/combined-regions.json",
       "kind": "json",
       "size_bytes": 1483,
-      "mtime": "2026-07-30T10:58:12.207Z",
+      "mtime": "2026-07-30T15:02:43.023Z",
       "shape": "object",
       "keys": [
         "regions"
@@ -1381,7 +1381,7 @@
       "path": "hna/cross-county-places.json",
       "kind": "json",
       "size_bytes": 9931,
-      "mtime": "2026-07-30T10:58:12.207Z",
+      "mtime": "2026-07-30T15:02:43.023Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -1396,7 +1396,7 @@
       "path": "hna/derived/geo-derived.json",
       "kind": "json",
       "size_bytes": 6329,
-      "mtime": "2026-07-30T10:58:12.207Z",
+      "mtime": "2026-07-30T15:02:43.023Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1412,7 +1412,7 @@
       "path": "hna/derived/place_county_lookup.json",
       "kind": "json",
       "size_bytes": 11919,
-      "mtime": "2026-07-30T10:58:12.208Z",
+      "mtime": "2026-07-30T15:02:43.023Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -1427,7 +1427,7 @@
       "path": "hna/dola_sya/08.json",
       "kind": "json",
       "size_bytes": 3753,
-      "mtime": "2026-07-30T10:58:12.208Z",
+      "mtime": "2026-07-30T15:02:43.023Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1448,7 +1448,7 @@
       "path": "hna/dola_sya/08000.json",
       "kind": "json",
       "size_bytes": 2339,
-      "mtime": "2026-07-30T10:58:12.208Z",
+      "mtime": "2026-07-30T15:02:43.023Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1469,7 +1469,7 @@
       "path": "hna/dola_sya/08001.json",
       "kind": "json",
       "size_bytes": 2118,
-      "mtime": "2026-07-30T10:58:12.208Z",
+      "mtime": "2026-07-30T15:02:43.024Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1490,7 +1490,7 @@
       "path": "hna/dola_sya/08003.json",
       "kind": "json",
       "size_bytes": 1813,
-      "mtime": "2026-07-30T10:58:12.208Z",
+      "mtime": "2026-07-30T15:02:43.024Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1511,7 +1511,7 @@
       "path": "hna/dola_sya/08005.json",
       "kind": "json",
       "size_bytes": 2133,
-      "mtime": "2026-07-30T10:58:12.208Z",
+      "mtime": "2026-07-30T15:02:43.024Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1532,7 +1532,7 @@
       "path": "hna/dola_sya/08007.json",
       "kind": "json",
       "size_bytes": 1782,
-      "mtime": "2026-07-30T10:58:12.208Z",
+      "mtime": "2026-07-30T15:02:43.024Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1553,7 +1553,7 @@
       "path": "hna/dola_sya/08009.json",
       "kind": "json",
       "size_bytes": 1717,
-      "mtime": "2026-07-30T10:58:12.208Z",
+      "mtime": "2026-07-30T15:02:43.024Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1574,7 +1574,7 @@
       "path": "hna/dola_sya/08011.json",
       "kind": "json",
       "size_bytes": 1716,
-      "mtime": "2026-07-30T10:58:12.208Z",
+      "mtime": "2026-07-30T15:02:43.024Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1595,7 +1595,7 @@
       "path": "hna/dola_sya/08013.json",
       "kind": "json",
       "size_bytes": 2115,
-      "mtime": "2026-07-30T10:58:12.208Z",
+      "mtime": "2026-07-30T15:02:43.024Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1616,7 +1616,7 @@
       "path": "hna/dola_sya/08014.json",
       "kind": "json",
       "size_bytes": 1933,
-      "mtime": "2026-07-30T10:58:12.208Z",
+      "mtime": "2026-07-30T15:02:43.024Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1637,7 +1637,7 @@
       "path": "hna/dola_sya/08015.json",
       "kind": "json",
       "size_bytes": 1846,
-      "mtime": "2026-07-30T10:58:12.208Z",
+      "mtime": "2026-07-30T15:02:43.024Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1658,7 +1658,7 @@
       "path": "hna/dola_sya/08017.json",
       "kind": "json",
       "size_bytes": 1646,
-      "mtime": "2026-07-30T10:58:12.209Z",
+      "mtime": "2026-07-30T15:02:43.024Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1679,7 +1679,7 @@
       "path": "hna/dola_sya/08019.json",
       "kind": "json",
       "size_bytes": 1733,
-      "mtime": "2026-07-30T10:58:12.211Z",
+      "mtime": "2026-07-30T15:02:43.024Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1700,7 +1700,7 @@
       "path": "hna/dola_sya/08021.json",
       "kind": "json",
       "size_bytes": 1733,
-      "mtime": "2026-07-30T10:58:12.211Z",
+      "mtime": "2026-07-30T15:02:43.024Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1721,7 +1721,7 @@
       "path": "hna/dola_sya/08023.json",
       "kind": "json",
       "size_bytes": 1727,
-      "mtime": "2026-07-30T10:58:12.211Z",
+      "mtime": "2026-07-30T15:02:43.024Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1742,7 +1742,7 @@
       "path": "hna/dola_sya/08025.json",
       "kind": "json",
       "size_bytes": 1721,
-      "mtime": "2026-07-30T10:58:12.211Z",
+      "mtime": "2026-07-30T15:02:43.024Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1763,7 +1763,7 @@
       "path": "hna/dola_sya/08027.json",
       "kind": "json",
       "size_bytes": 1734,
-      "mtime": "2026-07-30T10:58:12.212Z",
+      "mtime": "2026-07-30T15:02:43.024Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1784,7 +1784,7 @@
       "path": "hna/dola_sya/08029.json",
       "kind": "json",
       "size_bytes": 1923,
-      "mtime": "2026-07-30T10:58:12.212Z",
+      "mtime": "2026-07-30T15:02:43.024Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1805,7 +1805,7 @@
       "path": "hna/dola_sya/08031.json",
       "kind": "json",
       "size_bytes": 2133,
-      "mtime": "2026-07-30T10:58:12.212Z",
+      "mtime": "2026-07-30T15:02:43.024Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1826,7 +1826,7 @@
       "path": "hna/dola_sya/08033.json",
       "kind": "json",
       "size_bytes": 1685,
-      "mtime": "2026-07-30T10:58:12.212Z",
+      "mtime": "2026-07-30T15:02:43.024Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1847,7 +1847,7 @@
       "path": "hna/dola_sya/08035.json",
       "kind": "json",
       "size_bytes": 2115,
-      "mtime": "2026-07-30T10:58:12.212Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1868,7 +1868,7 @@
       "path": "hna/dola_sya/08037.json",
       "kind": "json",
       "size_bytes": 1902,
-      "mtime": "2026-07-30T10:58:12.212Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1889,7 +1889,7 @@
       "path": "hna/dola_sya/08039.json",
       "kind": "json",
       "size_bytes": 1895,
-      "mtime": "2026-07-30T10:58:12.212Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1910,7 +1910,7 @@
       "path": "hna/dola_sya/08041.json",
       "kind": "json",
       "size_bytes": 2136,
-      "mtime": "2026-07-30T10:58:12.212Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1931,7 +1931,7 @@
       "path": "hna/dola_sya/08043.json",
       "kind": "json",
       "size_bytes": 1928,
-      "mtime": "2026-07-30T10:58:12.212Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1952,7 +1952,7 @@
       "path": "hna/dola_sya/08045.json",
       "kind": "json",
       "size_bytes": 1922,
-      "mtime": "2026-07-30T10:58:12.212Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1973,7 +1973,7 @@
       "path": "hna/dola_sya/08047.json",
       "kind": "json",
       "size_bytes": 1726,
-      "mtime": "2026-07-30T10:58:12.212Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -1994,7 +1994,7 @@
       "path": "hna/dola_sya/08049.json",
       "kind": "json",
       "size_bytes": 1809,
-      "mtime": "2026-07-30T10:58:12.212Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2015,7 +2015,7 @@
       "path": "hna/dola_sya/08051.json",
       "kind": "json",
       "size_bytes": 1802,
-      "mtime": "2026-07-30T10:58:12.212Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2036,7 +2036,7 @@
       "path": "hna/dola_sya/08053.json",
       "kind": "json",
       "size_bytes": 1563,
-      "mtime": "2026-07-30T10:58:12.212Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2057,7 +2057,7 @@
       "path": "hna/dola_sya/08055.json",
       "kind": "json",
       "size_bytes": 1737,
-      "mtime": "2026-07-30T10:58:12.212Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2078,7 +2078,7 @@
       "path": "hna/dola_sya/08057.json",
       "kind": "json",
       "size_bytes": 1588,
-      "mtime": "2026-07-30T10:58:12.212Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2099,7 +2099,7 @@
       "path": "hna/dola_sya/08059.json",
       "kind": "json",
       "size_bytes": 2135,
-      "mtime": "2026-07-30T10:58:12.212Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2120,7 +2120,7 @@
       "path": "hna/dola_sya/08061.json",
       "kind": "json",
       "size_bytes": 1605,
-      "mtime": "2026-07-30T10:58:12.212Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2141,7 +2141,7 @@
       "path": "hna/dola_sya/08063.json",
       "kind": "json",
       "size_bytes": 1733,
-      "mtime": "2026-07-30T10:58:12.212Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2162,7 +2162,7 @@
       "path": "hna/dola_sya/08065.json",
       "kind": "json",
       "size_bytes": 1719,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2183,7 +2183,7 @@
       "path": "hna/dola_sya/08067.json",
       "kind": "json",
       "size_bytes": 1931,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2204,7 +2204,7 @@
       "path": "hna/dola_sya/08069.json",
       "kind": "json",
       "size_bytes": 2120,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2225,7 +2225,7 @@
       "path": "hna/dola_sya/08071.json",
       "kind": "json",
       "size_bytes": 1790,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2246,7 +2246,7 @@
       "path": "hna/dola_sya/08073.json",
       "kind": "json",
       "size_bytes": 1723,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.025Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2267,7 +2267,7 @@
       "path": "hna/dola_sya/08075.json",
       "kind": "json",
       "size_bytes": 1863,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2288,7 +2288,7 @@
       "path": "hna/dola_sya/08077.json",
       "kind": "json",
       "size_bytes": 2013,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2309,7 +2309,7 @@
       "path": "hna/dola_sya/08079.json",
       "kind": "json",
       "size_bytes": 1572,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2330,7 +2330,7 @@
       "path": "hna/dola_sya/08081.json",
       "kind": "json",
       "size_bytes": 1753,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2351,7 +2351,7 @@
       "path": "hna/dola_sya/08083.json",
       "kind": "json",
       "size_bytes": 1902,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2372,7 +2372,7 @@
       "path": "hna/dola_sya/08085.json",
       "kind": "json",
       "size_bytes": 1933,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2393,7 +2393,7 @@
       "path": "hna/dola_sya/08087.json",
       "kind": "json",
       "size_bytes": 1904,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2414,7 +2414,7 @@
       "path": "hna/dola_sya/08089.json",
       "kind": "json",
       "size_bytes": 1847,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2435,7 +2435,7 @@
       "path": "hna/dola_sya/08091.json",
       "kind": "json",
       "size_bytes": 1728,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2456,7 +2456,7 @@
       "path": "hna/dola_sya/08093.json",
       "kind": "json",
       "size_bytes": 1830,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2477,7 +2477,7 @@
       "path": "hna/dola_sya/08095.json",
       "kind": "json",
       "size_bytes": 1722,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2498,7 +2498,7 @@
       "path": "hna/dola_sya/08097.json",
       "kind": "json",
       "size_bytes": 1825,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2519,7 +2519,7 @@
       "path": "hna/dola_sya/08099.json",
       "kind": "json",
       "size_bytes": 1747,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2540,7 +2540,7 @@
       "path": "hna/dola_sya/08101.json",
       "kind": "json",
       "size_bytes": 2044,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2561,7 +2561,7 @@
       "path": "hna/dola_sya/08103.json",
       "kind": "json",
       "size_bytes": 1731,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2582,7 +2582,7 @@
       "path": "hna/dola_sya/08105.json",
       "kind": "json",
       "size_bytes": 1738,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2603,7 +2603,7 @@
       "path": "hna/dola_sya/08107.json",
       "kind": "json",
       "size_bytes": 1888,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2624,7 +2624,7 @@
       "path": "hna/dola_sya/08109.json",
       "kind": "json",
       "size_bytes": 1733,
-      "mtime": "2026-07-30T10:58:12.213Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2645,7 +2645,7 @@
       "path": "hna/dola_sya/08111.json",
       "kind": "json",
       "size_bytes": 1563,
-      "mtime": "2026-07-30T10:58:12.214Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2666,7 +2666,7 @@
       "path": "hna/dola_sya/08113.json",
       "kind": "json",
       "size_bytes": 1719,
-      "mtime": "2026-07-30T10:58:12.214Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2687,7 +2687,7 @@
       "path": "hna/dola_sya/08115.json",
       "kind": "json",
       "size_bytes": 1672,
-      "mtime": "2026-07-30T10:58:12.214Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2708,7 +2708,7 @@
       "path": "hna/dola_sya/08117.json",
       "kind": "json",
       "size_bytes": 1883,
-      "mtime": "2026-07-30T10:58:12.214Z",
+      "mtime": "2026-07-30T15:02:43.026Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2729,7 +2729,7 @@
       "path": "hna/dola_sya/08119.json",
       "kind": "json",
       "size_bytes": 1880,
-      "mtime": "2026-07-30T10:58:12.214Z",
+      "mtime": "2026-07-30T15:02:43.027Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2750,7 +2750,7 @@
       "path": "hna/dola_sya/08121.json",
       "kind": "json",
       "size_bytes": 1724,
-      "mtime": "2026-07-30T10:58:12.214Z",
+      "mtime": "2026-07-30T15:02:43.027Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2771,7 +2771,7 @@
       "path": "hna/dola_sya/08123.json",
       "kind": "json",
       "size_bytes": 2109,
-      "mtime": "2026-07-30T10:58:12.214Z",
+      "mtime": "2026-07-30T15:02:43.027Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2792,7 +2792,7 @@
       "path": "hna/dola_sya/08125.json",
       "kind": "json",
       "size_bytes": 1737,
-      "mtime": "2026-07-30T10:58:12.214Z",
+      "mtime": "2026-07-30T15:02:43.027Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2813,7 +2813,7 @@
       "path": "hna/geo-config.json",
       "kind": "json",
       "size_bytes": 65584,
-      "mtime": "2026-07-30T10:58:12.214Z",
+      "mtime": "2026-07-30T15:02:43.027Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -2836,7 +2836,7 @@
       "path": "hna/geography-registry.json",
       "kind": "json",
       "size_bytes": 123285,
-      "mtime": "2026-07-30T10:58:12.214Z",
+      "mtime": "2026-07-30T15:02:43.027Z",
       "shape": "object",
       "keys": [
         "generated",
@@ -2860,7 +2860,7 @@
       "path": "hna/home-value-cascade.json",
       "kind": "json",
       "size_bytes": 133277,
-      "mtime": "2026-07-30T10:58:12.215Z",
+      "mtime": "2026-07-30T15:02:43.027Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -2877,7 +2877,7 @@
       "path": "hna/jurisdiction-metrics-digest/08001.json",
       "kind": "json",
       "size_bytes": 29427,
-      "mtime": "2026-07-30T10:58:12.215Z",
+      "mtime": "2026-07-30T15:02:43.028Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -2896,7 +2896,7 @@
       "path": "hna/jurisdiction-metrics-digest/08003.json",
       "kind": "json",
       "size_bytes": 29345,
-      "mtime": "2026-07-30T10:58:12.215Z",
+      "mtime": "2026-07-30T15:02:43.028Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -2915,7 +2915,7 @@
       "path": "hna/jurisdiction-metrics-digest/0800320.json",
       "kind": "json",
       "size_bytes": 29486,
-      "mtime": "2026-07-30T10:58:12.215Z",
+      "mtime": "2026-07-30T15:02:43.029Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -2934,7 +2934,7 @@
       "path": "hna/jurisdiction-metrics-digest/08005.json",
       "kind": "json",
       "size_bytes": 29455,
-      "mtime": "2026-07-30T10:58:12.216Z",
+      "mtime": "2026-07-30T15:02:43.030Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -2953,7 +2953,7 @@
       "path": "hna/jurisdiction-metrics-digest/0800620.json",
       "kind": "json",
       "size_bytes": 29416,
-      "mtime": "2026-07-30T10:58:12.216Z",
+      "mtime": "2026-07-30T15:02:43.030Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -2972,7 +2972,7 @@
       "path": "hna/jurisdiction-metrics-digest/08007.json",
       "kind": "json",
       "size_bytes": 29361,
-      "mtime": "2026-07-30T10:58:12.216Z",
+      "mtime": "2026-07-30T15:02:43.030Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -2991,7 +2991,7 @@
       "path": "hna/jurisdiction-metrics-digest/0800760.json",
       "kind": "json",
       "size_bytes": 29333,
-      "mtime": "2026-07-30T10:58:12.216Z",
+      "mtime": "2026-07-30T15:02:43.030Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3010,7 +3010,7 @@
       "path": "hna/jurisdiction-metrics-digest/0800870.json",
       "kind": "json",
       "size_bytes": 29482,
-      "mtime": "2026-07-30T10:58:12.216Z",
+      "mtime": "2026-07-30T15:02:43.030Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3029,7 +3029,7 @@
       "path": "hna/jurisdiction-metrics-digest/08009.json",
       "kind": "json",
       "size_bytes": 29310,
-      "mtime": "2026-07-30T10:58:12.216Z",
+      "mtime": "2026-07-30T15:02:43.030Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3048,7 +3048,7 @@
       "path": "hna/jurisdiction-metrics-digest/0800925.json",
       "kind": "json",
       "size_bytes": 29506,
-      "mtime": "2026-07-30T10:58:12.217Z",
+      "mtime": "2026-07-30T15:02:43.030Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3067,7 +3067,7 @@
       "path": "hna/jurisdiction-metrics-digest/0801090.json",
       "kind": "json",
       "size_bytes": 29475,
-      "mtime": "2026-07-30T10:58:12.217Z",
+      "mtime": "2026-07-30T15:02:43.031Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3086,7 +3086,7 @@
       "path": "hna/jurisdiction-metrics-digest/08011.json",
       "kind": "json",
       "size_bytes": 29166,
-      "mtime": "2026-07-30T10:58:12.217Z",
+      "mtime": "2026-07-30T15:02:43.031Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3105,7 +3105,7 @@
       "path": "hna/jurisdiction-metrics-digest/0801145.json",
       "kind": "json",
       "size_bytes": 29340,
-      "mtime": "2026-07-30T10:58:12.217Z",
+      "mtime": "2026-07-30T15:02:43.031Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3124,7 +3124,7 @@
       "path": "hna/jurisdiction-metrics-digest/08013.json",
       "kind": "json",
       "size_bytes": 29426,
-      "mtime": "2026-07-30T10:58:12.217Z",
+      "mtime": "2026-07-30T15:02:43.031Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3143,7 +3143,7 @@
       "path": "hna/jurisdiction-metrics-digest/08014.json",
       "kind": "json",
       "size_bytes": 29388,
-      "mtime": "2026-07-30T10:58:12.217Z",
+      "mtime": "2026-07-30T15:02:43.031Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3162,7 +3162,7 @@
       "path": "hna/jurisdiction-metrics-digest/0801420.json",
       "kind": "json",
       "size_bytes": 29444,
-      "mtime": "2026-07-30T10:58:12.218Z",
+      "mtime": "2026-07-30T15:02:43.031Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3181,7 +3181,7 @@
       "path": "hna/jurisdiction-metrics-digest/08015.json",
       "kind": "json",
       "size_bytes": 29355,
-      "mtime": "2026-07-30T10:58:12.218Z",
+      "mtime": "2026-07-30T15:02:43.031Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3200,7 +3200,7 @@
       "path": "hna/jurisdiction-metrics-digest/0801530.json",
       "kind": "json",
       "size_bytes": 29313,
-      "mtime": "2026-07-30T10:58:12.218Z",
+      "mtime": "2026-07-30T15:02:43.032Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3219,7 +3219,7 @@
       "path": "hna/jurisdiction-metrics-digest/0801640.json",
       "kind": "json",
       "size_bytes": 29242,
-      "mtime": "2026-07-30T10:58:12.218Z",
+      "mtime": "2026-07-30T15:02:43.032Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3238,7 +3238,7 @@
       "path": "hna/jurisdiction-metrics-digest/08017.json",
       "kind": "json",
       "size_bytes": 29241,
-      "mtime": "2026-07-30T10:58:12.218Z",
+      "mtime": "2026-07-30T15:02:43.032Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3257,7 +3257,7 @@
       "path": "hna/jurisdiction-metrics-digest/0801740.json",
       "kind": "json",
       "size_bytes": 29454,
-      "mtime": "2026-07-30T10:58:12.218Z",
+      "mtime": "2026-07-30T15:02:43.032Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3276,7 +3276,7 @@
       "path": "hna/jurisdiction-metrics-digest/08019.json",
       "kind": "json",
       "size_bytes": 29349,
-      "mtime": "2026-07-30T10:58:12.219Z",
+      "mtime": "2026-07-30T15:02:43.032Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3295,7 +3295,7 @@
       "path": "hna/jurisdiction-metrics-digest/0801915.json",
       "kind": "json",
       "size_bytes": 29228,
-      "mtime": "2026-07-30T10:58:12.219Z",
+      "mtime": "2026-07-30T15:02:43.033Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3314,7 +3314,7 @@
       "path": "hna/jurisdiction-metrics-digest/08021.json",
       "kind": "json",
       "size_bytes": 29317,
-      "mtime": "2026-07-30T10:58:12.219Z",
+      "mtime": "2026-07-30T15:02:43.033Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3333,7 +3333,7 @@
       "path": "hna/jurisdiction-metrics-digest/08023.json",
       "kind": "json",
       "size_bytes": 29311,
-      "mtime": "2026-07-30T10:58:12.219Z",
+      "mtime": "2026-07-30T15:02:43.033Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3352,7 +3352,7 @@
       "path": "hna/jurisdiction-metrics-digest/0802355.json",
       "kind": "json",
       "size_bytes": 29508,
-      "mtime": "2026-07-30T10:58:12.219Z",
+      "mtime": "2026-07-30T15:02:43.033Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3371,7 +3371,7 @@
       "path": "hna/jurisdiction-metrics-digest/08025.json",
       "kind": "json",
       "size_bytes": 29166,
-      "mtime": "2026-07-30T10:58:12.219Z",
+      "mtime": "2026-07-30T15:02:43.033Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3390,7 +3390,7 @@
       "path": "hna/jurisdiction-metrics-digest/0802575.json",
       "kind": "json",
       "size_bytes": 29485,
-      "mtime": "2026-07-30T10:58:12.220Z",
+      "mtime": "2026-07-30T15:02:43.033Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3409,7 +3409,7 @@
       "path": "hna/jurisdiction-metrics-digest/08027.json",
       "kind": "json",
       "size_bytes": 29141,
-      "mtime": "2026-07-30T10:58:12.220Z",
+      "mtime": "2026-07-30T15:02:43.033Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3428,7 +3428,7 @@
       "path": "hna/jurisdiction-metrics-digest/0802850.json",
       "kind": "json",
       "size_bytes": 29216,
-      "mtime": "2026-07-30T10:58:12.220Z",
+      "mtime": "2026-07-30T15:02:43.034Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3447,7 +3447,7 @@
       "path": "hna/jurisdiction-metrics-digest/08029.json",
       "kind": "json",
       "size_bytes": 29385,
-      "mtime": "2026-07-30T10:58:12.220Z",
+      "mtime": "2026-07-30T15:02:43.034Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3466,7 +3466,7 @@
       "path": "hna/jurisdiction-metrics-digest/0802905.json",
       "kind": "json",
       "size_bytes": 29306,
-      "mtime": "2026-07-30T10:58:12.220Z",
+      "mtime": "2026-07-30T15:02:43.034Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3485,7 +3485,7 @@
       "path": "hna/jurisdiction-metrics-digest/0803015.json",
       "kind": "json",
       "size_bytes": 29517,
-      "mtime": "2026-07-30T10:58:12.221Z",
+      "mtime": "2026-07-30T15:02:43.034Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3504,7 +3504,7 @@
       "path": "hna/jurisdiction-metrics-digest/08031.json",
       "kind": "json",
       "size_bytes": 29437,
-      "mtime": "2026-07-30T10:58:12.221Z",
+      "mtime": "2026-07-30T15:02:43.034Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3523,7 +3523,7 @@
       "path": "hna/jurisdiction-metrics-digest/0803235.json",
       "kind": "json",
       "size_bytes": 29460,
-      "mtime": "2026-07-30T10:58:12.222Z",
+      "mtime": "2026-07-30T15:02:43.034Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3542,7 +3542,7 @@
       "path": "hna/jurisdiction-metrics-digest/08033.json",
       "kind": "json",
       "size_bytes": 29286,
-      "mtime": "2026-07-30T10:58:12.222Z",
+      "mtime": "2026-07-30T15:02:43.034Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3561,7 +3561,7 @@
       "path": "hna/jurisdiction-metrics-digest/0803455.json",
       "kind": "json",
       "size_bytes": 29475,
-      "mtime": "2026-07-30T10:58:12.222Z",
+      "mtime": "2026-07-30T15:02:43.035Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3580,7 +3580,7 @@
       "path": "hna/jurisdiction-metrics-digest/08035.json",
       "kind": "json",
       "size_bytes": 29402,
-      "mtime": "2026-07-30T10:58:12.222Z",
+      "mtime": "2026-07-30T15:02:43.035Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3599,7 +3599,7 @@
       "path": "hna/jurisdiction-metrics-digest/0803620.json",
       "kind": "json",
       "size_bytes": 29447,
-      "mtime": "2026-07-30T10:58:12.223Z",
+      "mtime": "2026-07-30T15:02:43.035Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3618,7 +3618,7 @@
       "path": "hna/jurisdiction-metrics-digest/08037.json",
       "kind": "json",
       "size_bytes": 29396,
-      "mtime": "2026-07-30T10:58:12.223Z",
+      "mtime": "2026-07-30T15:02:43.035Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3637,7 +3637,7 @@
       "path": "hna/jurisdiction-metrics-digest/0803730.json",
       "kind": "json",
       "size_bytes": 29277,
-      "mtime": "2026-07-30T10:58:12.223Z",
+      "mtime": "2026-07-30T15:02:43.036Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3656,7 +3656,7 @@
       "path": "hna/jurisdiction-metrics-digest/0803840.json",
       "kind": "json",
       "size_bytes": 29230,
-      "mtime": "2026-07-30T10:58:12.224Z",
+      "mtime": "2026-07-30T15:02:43.036Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3675,7 +3675,7 @@
       "path": "hna/jurisdiction-metrics-digest/08039.json",
       "kind": "json",
       "size_bytes": 29342,
-      "mtime": "2026-07-30T10:58:12.224Z",
+      "mtime": "2026-07-30T15:02:43.036Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3694,7 +3694,7 @@
       "path": "hna/jurisdiction-metrics-digest/0803950.json",
       "kind": "json",
       "size_bytes": 29549,
-      "mtime": "2026-07-30T10:58:12.224Z",
+      "mtime": "2026-07-30T15:02:43.036Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3713,7 +3713,7 @@
       "path": "hna/jurisdiction-metrics-digest/0804000.json",
       "kind": "json",
       "size_bytes": 29506,
-      "mtime": "2026-07-30T10:58:12.224Z",
+      "mtime": "2026-07-30T15:02:43.036Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3732,7 +3732,7 @@
       "path": "hna/jurisdiction-metrics-digest/08041.json",
       "kind": "json",
       "size_bytes": 29442,
-      "mtime": "2026-07-30T10:58:12.224Z",
+      "mtime": "2026-07-30T15:02:43.037Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3751,7 +3751,7 @@
       "path": "hna/jurisdiction-metrics-digest/0804110.json",
       "kind": "json",
       "size_bytes": 29450,
-      "mtime": "2026-07-30T10:58:12.224Z",
+      "mtime": "2026-07-30T15:02:43.037Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3770,7 +3770,7 @@
       "path": "hna/jurisdiction-metrics-digest/0804165.json",
       "kind": "json",
       "size_bytes": 29255,
-      "mtime": "2026-07-30T10:58:12.225Z",
+      "mtime": "2026-07-30T15:02:43.037Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3789,7 +3789,7 @@
       "path": "hna/jurisdiction-metrics-digest/08043.json",
       "kind": "json",
       "size_bytes": 29370,
-      "mtime": "2026-07-30T10:58:12.225Z",
+      "mtime": "2026-07-30T15:02:43.037Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3808,7 +3808,7 @@
       "path": "hna/jurisdiction-metrics-digest/08045.json",
       "kind": "json",
       "size_bytes": 29394,
-      "mtime": "2026-07-30T10:58:12.225Z",
+      "mtime": "2026-07-30T15:02:43.037Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3827,7 +3827,7 @@
       "path": "hna/jurisdiction-metrics-digest/0804620.json",
       "kind": "json",
       "size_bytes": 29275,
-      "mtime": "2026-07-30T10:58:12.225Z",
+      "mtime": "2026-07-30T15:02:43.038Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3846,7 +3846,7 @@
       "path": "hna/jurisdiction-metrics-digest/08047.json",
       "kind": "json",
       "size_bytes": 29151,
-      "mtime": "2026-07-30T10:58:12.225Z",
+      "mtime": "2026-07-30T15:02:43.039Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3865,7 +3865,7 @@
       "path": "hna/jurisdiction-metrics-digest/08049.json",
       "kind": "json",
       "size_bytes": 29359,
-      "mtime": "2026-07-30T10:58:12.226Z",
+      "mtime": "2026-07-30T15:02:43.039Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3884,7 +3884,7 @@
       "path": "hna/jurisdiction-metrics-digest/0804935.json",
       "kind": "json",
       "size_bytes": 29483,
-      "mtime": "2026-07-30T10:58:12.226Z",
+      "mtime": "2026-07-30T15:02:43.039Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3903,7 +3903,7 @@
       "path": "hna/jurisdiction-metrics-digest/08051.json",
       "kind": "json",
       "size_bytes": 29366,
-      "mtime": "2026-07-30T10:58:12.226Z",
+      "mtime": "2026-07-30T15:02:43.039Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3922,7 +3922,7 @@
       "path": "hna/jurisdiction-metrics-digest/0805120.json",
       "kind": "json",
       "size_bytes": 29412,
-      "mtime": "2026-07-30T10:58:12.226Z",
+      "mtime": "2026-07-30T15:02:43.039Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3941,7 +3941,7 @@
       "path": "hna/jurisdiction-metrics-digest/0805265.json",
       "kind": "json",
       "size_bytes": 29348,
-      "mtime": "2026-07-30T10:58:12.226Z",
+      "mtime": "2026-07-30T15:02:43.039Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3960,7 +3960,7 @@
       "path": "hna/jurisdiction-metrics-digest/08053.json",
       "kind": "json",
       "size_bytes": 29097,
-      "mtime": "2026-07-30T10:58:12.226Z",
+      "mtime": "2026-07-30T15:02:43.039Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3979,7 +3979,7 @@
       "path": "hna/jurisdiction-metrics-digest/08055.json",
       "kind": "json",
       "size_bytes": 29335,
-      "mtime": "2026-07-30T10:58:12.227Z",
+      "mtime": "2026-07-30T15:02:43.040Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -3998,7 +3998,7 @@
       "path": "hna/jurisdiction-metrics-digest/08057.json",
       "kind": "json",
       "size_bytes": 29251,
-      "mtime": "2026-07-30T10:58:12.228Z",
+      "mtime": "2026-07-30T15:02:43.040Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4017,7 +4017,7 @@
       "path": "hna/jurisdiction-metrics-digest/08059.json",
       "kind": "json",
       "size_bytes": 29441,
-      "mtime": "2026-07-30T10:58:12.228Z",
+      "mtime": "2026-07-30T15:02:43.040Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4036,7 +4036,7 @@
       "path": "hna/jurisdiction-metrics-digest/0806090.json",
       "kind": "json",
       "size_bytes": 29495,
-      "mtime": "2026-07-30T10:58:12.228Z",
+      "mtime": "2026-07-30T15:02:43.040Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4055,7 +4055,7 @@
       "path": "hna/jurisdiction-metrics-digest/08061.json",
       "kind": "json",
       "size_bytes": 29254,
-      "mtime": "2026-07-30T10:58:12.228Z",
+      "mtime": "2026-07-30T15:02:43.040Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4074,7 +4074,7 @@
       "path": "hna/jurisdiction-metrics-digest/0806172.json",
       "kind": "json",
       "size_bytes": 29437,
-      "mtime": "2026-07-30T10:58:12.228Z",
+      "mtime": "2026-07-30T15:02:43.040Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4093,7 +4093,7 @@
       "path": "hna/jurisdiction-metrics-digest/0806255.json",
       "kind": "json",
       "size_bytes": 29412,
-      "mtime": "2026-07-30T10:58:12.229Z",
+      "mtime": "2026-07-30T15:02:43.041Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4112,7 +4112,7 @@
       "path": "hna/jurisdiction-metrics-digest/08063.json",
       "kind": "json",
       "size_bytes": 29318,
-      "mtime": "2026-07-30T10:58:12.229Z",
+      "mtime": "2026-07-30T15:02:43.041Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4131,7 +4131,7 @@
       "path": "hna/jurisdiction-metrics-digest/08065.json",
       "kind": "json",
       "size_bytes": 29314,
-      "mtime": "2026-07-30T10:58:12.229Z",
+      "mtime": "2026-07-30T15:02:43.041Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4150,7 +4150,7 @@
       "path": "hna/jurisdiction-metrics-digest/0806530.json",
       "kind": "json",
       "size_bytes": 29282,
-      "mtime": "2026-07-30T10:58:12.229Z",
+      "mtime": "2026-07-30T15:02:43.041Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4169,7 +4169,7 @@
       "path": "hna/jurisdiction-metrics-digest/0806602.json",
       "kind": "json",
       "size_bytes": 29303,
-      "mtime": "2026-07-30T10:58:12.229Z",
+      "mtime": "2026-07-30T15:02:43.041Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4188,7 +4188,7 @@
       "path": "hna/jurisdiction-metrics-digest/08067.json",
       "kind": "json",
       "size_bytes": 29385,
-      "mtime": "2026-07-30T10:58:12.229Z",
+      "mtime": "2026-07-30T15:02:43.041Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4207,7 +4207,7 @@
       "path": "hna/jurisdiction-metrics-digest/08069.json",
       "kind": "json",
       "size_bytes": 29442,
-      "mtime": "2026-07-30T10:58:12.230Z",
+      "mtime": "2026-07-30T15:02:43.041Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4226,7 +4226,7 @@
       "path": "hna/jurisdiction-metrics-digest/0806970.json",
       "kind": "json",
       "size_bytes": 29509,
-      "mtime": "2026-07-30T10:58:12.230Z",
+      "mtime": "2026-07-30T15:02:43.041Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4245,7 +4245,7 @@
       "path": "hna/jurisdiction-metrics-digest/0807025.json",
       "kind": "json",
       "size_bytes": 29289,
-      "mtime": "2026-07-30T10:58:12.230Z",
+      "mtime": "2026-07-30T15:02:43.042Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4264,7 +4264,7 @@
       "path": "hna/jurisdiction-metrics-digest/08071.json",
       "kind": "json",
       "size_bytes": 29356,
-      "mtime": "2026-07-30T10:58:12.230Z",
+      "mtime": "2026-07-30T15:02:43.042Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4283,7 +4283,7 @@
       "path": "hna/jurisdiction-metrics-digest/0807190.json",
       "kind": "json",
       "size_bytes": 29514,
-      "mtime": "2026-07-30T10:58:12.230Z",
+      "mtime": "2026-07-30T15:02:43.042Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4302,7 +4302,7 @@
       "path": "hna/jurisdiction-metrics-digest/0807245.json",
       "kind": "json",
       "size_bytes": 29489,
-      "mtime": "2026-07-30T10:58:12.231Z",
+      "mtime": "2026-07-30T15:02:43.042Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4321,7 +4321,7 @@
       "path": "hna/jurisdiction-metrics-digest/08073.json",
       "kind": "json",
       "size_bytes": 29316,
-      "mtime": "2026-07-30T10:58:12.231Z",
+      "mtime": "2026-07-30T15:02:43.042Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4340,7 +4340,7 @@
       "path": "hna/jurisdiction-metrics-digest/0807410.json",
       "kind": "json",
       "size_bytes": 29394,
-      "mtime": "2026-07-30T10:58:12.231Z",
+      "mtime": "2026-07-30T15:02:43.042Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4359,7 +4359,7 @@
       "path": "hna/jurisdiction-metrics-digest/0807420.json",
       "kind": "json",
       "size_bytes": 29193,
-      "mtime": "2026-07-30T10:58:12.231Z",
+      "mtime": "2026-07-30T15:02:43.042Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4378,7 +4378,7 @@
       "path": "hna/jurisdiction-metrics-digest/0807455.json",
       "kind": "json",
       "size_bytes": 29253,
-      "mtime": "2026-07-30T10:58:12.231Z",
+      "mtime": "2026-07-30T15:02:43.043Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4397,7 +4397,7 @@
       "path": "hna/jurisdiction-metrics-digest/08075.json",
       "kind": "json",
       "size_bytes": 29323,
-      "mtime": "2026-07-30T10:58:12.231Z",
+      "mtime": "2026-07-30T15:02:43.043Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4416,7 +4416,7 @@
       "path": "hna/jurisdiction-metrics-digest/0807571.json",
       "kind": "json",
       "size_bytes": 29255,
-      "mtime": "2026-07-30T10:58:12.232Z",
+      "mtime": "2026-07-30T15:02:43.043Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4435,7 +4435,7 @@
       "path": "hna/jurisdiction-metrics-digest/0807580.json",
       "kind": "json",
       "size_bytes": 29297,
-      "mtime": "2026-07-30T10:58:12.232Z",
+      "mtime": "2026-07-30T15:02:43.043Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4454,7 +4454,7 @@
       "path": "hna/jurisdiction-metrics-digest/08077.json",
       "kind": "json",
       "size_bytes": 29387,
-      "mtime": "2026-07-30T10:58:12.232Z",
+      "mtime": "2026-07-30T15:02:43.043Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4473,7 +4473,7 @@
       "path": "hna/jurisdiction-metrics-digest/0807795.json",
       "kind": "json",
       "size_bytes": 29441,
-      "mtime": "2026-07-30T10:58:12.232Z",
+      "mtime": "2026-07-30T15:02:43.043Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4492,7 +4492,7 @@
       "path": "hna/jurisdiction-metrics-digest/0807850.json",
       "kind": "json",
       "size_bytes": 29505,
-      "mtime": "2026-07-30T10:58:12.232Z",
+      "mtime": "2026-07-30T15:02:43.043Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4511,7 +4511,7 @@
       "path": "hna/jurisdiction-metrics-digest/08079.json",
       "kind": "json",
       "size_bytes": 29100,
-      "mtime": "2026-07-30T10:58:12.232Z",
+      "mtime": "2026-07-30T15:02:43.044Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4530,7 +4530,7 @@
       "path": "hna/jurisdiction-metrics-digest/0808070.json",
       "kind": "json",
       "size_bytes": 29444,
-      "mtime": "2026-07-30T10:58:12.233Z",
+      "mtime": "2026-07-30T15:02:43.044Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4549,7 +4549,7 @@
       "path": "hna/jurisdiction-metrics-digest/08081.json",
       "kind": "json",
       "size_bytes": 29357,
-      "mtime": "2026-07-30T10:58:12.233Z",
+      "mtime": "2026-07-30T15:02:43.044Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4568,7 +4568,7 @@
       "path": "hna/jurisdiction-metrics-digest/0808290.json",
       "kind": "json",
       "size_bytes": 29192,
-      "mtime": "2026-07-30T10:58:12.233Z",
+      "mtime": "2026-07-30T15:02:43.044Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4587,7 +4587,7 @@
       "path": "hna/jurisdiction-metrics-digest/08083.json",
       "kind": "json",
       "size_bytes": 29360,
-      "mtime": "2026-07-30T10:58:12.233Z",
+      "mtime": "2026-07-30T15:02:43.044Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4606,7 +4606,7 @@
       "path": "hna/jurisdiction-metrics-digest/0808345.json",
       "kind": "json",
       "size_bytes": 29322,
-      "mtime": "2026-07-30T10:58:12.233Z",
+      "mtime": "2026-07-30T15:02:43.044Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4625,7 +4625,7 @@
       "path": "hna/jurisdiction-metrics-digest/0808400.json",
       "kind": "json",
       "size_bytes": 29549,
-      "mtime": "2026-07-30T10:58:12.233Z",
+      "mtime": "2026-07-30T15:02:43.044Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4644,7 +4644,7 @@
       "path": "hna/jurisdiction-metrics-digest/08085.json",
       "kind": "json",
       "size_bytes": 29368,
-      "mtime": "2026-07-30T10:58:12.234Z",
+      "mtime": "2026-07-30T15:02:43.045Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4663,7 +4663,7 @@
       "path": "hna/jurisdiction-metrics-digest/0808530.json",
       "kind": "json",
       "size_bytes": 29266,
-      "mtime": "2026-07-30T10:58:12.234Z",
+      "mtime": "2026-07-30T15:02:43.045Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4682,7 +4682,7 @@
       "path": "hna/jurisdiction-metrics-digest/0808620.json",
       "kind": "json",
       "size_bytes": 29245,
-      "mtime": "2026-07-30T10:58:12.234Z",
+      "mtime": "2026-07-30T15:02:43.045Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4701,7 +4701,7 @@
       "path": "hna/jurisdiction-metrics-digest/0808675.json",
       "kind": "json",
       "size_bytes": 29525,
-      "mtime": "2026-07-30T10:58:12.234Z",
+      "mtime": "2026-07-30T15:02:43.045Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4720,7 +4720,7 @@
       "path": "hna/jurisdiction-metrics-digest/08087.json",
       "kind": "json",
       "size_bytes": 29377,
-      "mtime": "2026-07-30T10:58:12.234Z",
+      "mtime": "2026-07-30T15:02:43.045Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4739,7 +4739,7 @@
       "path": "hna/jurisdiction-metrics-digest/08089.json",
       "kind": "json",
       "size_bytes": 29350,
-      "mtime": "2026-07-30T10:58:12.234Z",
+      "mtime": "2026-07-30T15:02:43.046Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4758,7 +4758,7 @@
       "path": "hna/jurisdiction-metrics-digest/0808950.json",
       "kind": "json",
       "size_bytes": 29318,
-      "mtime": "2026-07-30T10:58:12.235Z",
+      "mtime": "2026-07-30T15:02:43.047Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4777,7 +4777,7 @@
       "path": "hna/jurisdiction-metrics-digest/08091.json",
       "kind": "json",
       "size_bytes": 29154,
-      "mtime": "2026-07-30T10:58:12.236Z",
+      "mtime": "2026-07-30T15:02:43.047Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4796,7 +4796,7 @@
       "path": "hna/jurisdiction-metrics-digest/0809115.json",
       "kind": "json",
       "size_bytes": 29433,
-      "mtime": "2026-07-30T10:58:12.236Z",
+      "mtime": "2026-07-30T15:02:43.047Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4815,7 +4815,7 @@
       "path": "hna/jurisdiction-metrics-digest/0809280.json",
       "kind": "json",
       "size_bytes": 29489,
-      "mtime": "2026-07-30T10:58:12.236Z",
+      "mtime": "2026-07-30T15:02:43.047Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4834,7 +4834,7 @@
       "path": "hna/jurisdiction-metrics-digest/08093.json",
       "kind": "json",
       "size_bytes": 29347,
-      "mtime": "2026-07-30T10:58:12.236Z",
+      "mtime": "2026-07-30T15:02:43.047Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4853,7 +4853,7 @@
       "path": "hna/jurisdiction-metrics-digest/08095.json",
       "kind": "json",
       "size_bytes": 29316,
-      "mtime": "2026-07-30T10:58:12.236Z",
+      "mtime": "2026-07-30T15:02:43.047Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4872,7 +4872,7 @@
       "path": "hna/jurisdiction-metrics-digest/0809555.json",
       "kind": "json",
       "size_bytes": 29417,
-      "mtime": "2026-07-30T10:58:12.237Z",
+      "mtime": "2026-07-30T15:02:43.047Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4891,7 +4891,7 @@
       "path": "hna/jurisdiction-metrics-digest/08097.json",
       "kind": "json",
       "size_bytes": 29387,
-      "mtime": "2026-07-30T10:58:12.237Z",
+      "mtime": "2026-07-30T15:02:43.048Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4910,7 +4910,7 @@
       "path": "hna/jurisdiction-metrics-digest/08099.json",
       "kind": "json",
       "size_bytes": 29339,
-      "mtime": "2026-07-30T10:58:12.237Z",
+      "mtime": "2026-07-30T15:02:43.048Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4929,7 +4929,7 @@
       "path": "hna/jurisdiction-metrics-digest/08101.json",
       "kind": "json",
       "size_bytes": 29401,
-      "mtime": "2026-07-30T10:58:12.237Z",
+      "mtime": "2026-07-30T15:02:43.048Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4948,7 +4948,7 @@
       "path": "hna/jurisdiction-metrics-digest/0810105.json",
       "kind": "json",
       "size_bytes": 29423,
-      "mtime": "2026-07-30T10:58:12.237Z",
+      "mtime": "2026-07-30T15:02:43.048Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4967,7 +4967,7 @@
       "path": "hna/jurisdiction-metrics-digest/08103.json",
       "kind": "json",
       "size_bytes": 29311,
-      "mtime": "2026-07-30T10:58:12.237Z",
+      "mtime": "2026-07-30T15:02:43.048Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -4986,7 +4986,7 @@
       "path": "hna/jurisdiction-metrics-digest/08105.json",
       "kind": "json",
       "size_bytes": 29334,
-      "mtime": "2026-07-30T10:58:12.238Z",
+      "mtime": "2026-07-30T15:02:43.048Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5005,7 +5005,7 @@
       "path": "hna/jurisdiction-metrics-digest/0810600.json",
       "kind": "json",
       "size_bytes": 29402,
-      "mtime": "2026-07-30T10:58:12.238Z",
+      "mtime": "2026-07-30T15:02:43.049Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5024,7 +5024,7 @@
       "path": "hna/jurisdiction-metrics-digest/08107.json",
       "kind": "json",
       "size_bytes": 29369,
-      "mtime": "2026-07-30T10:58:12.238Z",
+      "mtime": "2026-07-30T15:02:43.049Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5043,7 +5043,7 @@
       "path": "hna/jurisdiction-metrics-digest/08109.json",
       "kind": "json",
       "size_bytes": 29338,
-      "mtime": "2026-07-30T10:58:12.238Z",
+      "mtime": "2026-07-30T15:02:43.049Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5062,7 +5062,7 @@
       "path": "hna/jurisdiction-metrics-digest/0810985.json",
       "kind": "json",
       "size_bytes": 29465,
-      "mtime": "2026-07-30T10:58:12.238Z",
+      "mtime": "2026-07-30T15:02:43.049Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5081,7 +5081,7 @@
       "path": "hna/jurisdiction-metrics-digest/08111.json",
       "kind": "json",
       "size_bytes": 29275,
-      "mtime": "2026-07-30T10:58:12.239Z",
+      "mtime": "2026-07-30T15:02:43.049Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5100,7 +5100,7 @@
       "path": "hna/jurisdiction-metrics-digest/0811260.json",
       "kind": "json",
       "size_bytes": 29356,
-      "mtime": "2026-07-30T10:58:12.239Z",
+      "mtime": "2026-07-30T15:02:43.049Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5119,7 +5119,7 @@
       "path": "hna/jurisdiction-metrics-digest/08113.json",
       "kind": "json",
       "size_bytes": 29344,
-      "mtime": "2026-07-30T10:58:12.239Z",
+      "mtime": "2026-07-30T15:02:43.049Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5138,7 +5138,7 @@
       "path": "hna/jurisdiction-metrics-digest/08115.json",
       "kind": "json",
       "size_bytes": 29312,
-      "mtime": "2026-07-30T10:58:12.239Z",
+      "mtime": "2026-07-30T15:02:43.050Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5157,7 +5157,7 @@
       "path": "hna/jurisdiction-metrics-digest/0811645.json",
       "kind": "json",
       "size_bytes": 29226,
-      "mtime": "2026-07-30T10:58:12.240Z",
+      "mtime": "2026-07-30T15:02:43.050Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5176,7 +5176,7 @@
       "path": "hna/jurisdiction-metrics-digest/08117.json",
       "kind": "json",
       "size_bytes": 29206,
-      "mtime": "2026-07-30T10:58:12.240Z",
+      "mtime": "2026-07-30T15:02:43.051Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5195,7 +5195,7 @@
       "path": "hna/jurisdiction-metrics-digest/0811810.json",
       "kind": "json",
       "size_bytes": 29425,
-      "mtime": "2026-07-30T10:58:12.240Z",
+      "mtime": "2026-07-30T15:02:43.051Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5214,7 +5214,7 @@
       "path": "hna/jurisdiction-metrics-digest/08119.json",
       "kind": "json",
       "size_bytes": 29358,
-      "mtime": "2026-07-30T10:58:12.240Z",
+      "mtime": "2026-07-30T15:02:43.051Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5233,7 +5233,7 @@
       "path": "hna/jurisdiction-metrics-digest/0811975.json",
       "kind": "json",
       "size_bytes": 29268,
-      "mtime": "2026-07-30T10:58:12.240Z",
+      "mtime": "2026-07-30T15:02:43.051Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5252,7 +5252,7 @@
       "path": "hna/jurisdiction-metrics-digest/0812030.json",
       "kind": "json",
       "size_bytes": 29239,
-      "mtime": "2026-07-30T10:58:12.241Z",
+      "mtime": "2026-07-30T15:02:43.051Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5271,7 +5271,7 @@
       "path": "hna/jurisdiction-metrics-digest/0812045.json",
       "kind": "json",
       "size_bytes": 29450,
-      "mtime": "2026-07-30T10:58:12.241Z",
+      "mtime": "2026-07-30T15:02:43.051Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5290,7 +5290,7 @@
       "path": "hna/jurisdiction-metrics-digest/08121.json",
       "kind": "json",
       "size_bytes": 29309,
-      "mtime": "2026-07-30T10:58:12.241Z",
+      "mtime": "2026-07-30T15:02:43.051Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5309,7 +5309,7 @@
       "path": "hna/jurisdiction-metrics-digest/08123.json",
       "kind": "json",
       "size_bytes": 29399,
-      "mtime": "2026-07-30T10:58:12.241Z",
+      "mtime": "2026-07-30T15:02:43.052Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5328,7 +5328,7 @@
       "path": "hna/jurisdiction-metrics-digest/0812325.json",
       "kind": "json",
       "size_bytes": 29535,
-      "mtime": "2026-07-30T10:58:12.241Z",
+      "mtime": "2026-07-30T15:02:43.052Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5347,7 +5347,7 @@
       "path": "hna/jurisdiction-metrics-digest/0812387.json",
       "kind": "json",
       "size_bytes": 29426,
-      "mtime": "2026-07-30T10:58:12.241Z",
+      "mtime": "2026-07-30T15:02:43.052Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5366,7 +5366,7 @@
       "path": "hna/jurisdiction-metrics-digest/0812393.json",
       "kind": "json",
       "size_bytes": 29480,
-      "mtime": "2026-07-30T10:58:12.242Z",
+      "mtime": "2026-07-30T15:02:43.052Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5385,7 +5385,7 @@
       "path": "hna/jurisdiction-metrics-digest/0812415.json",
       "kind": "json",
       "size_bytes": 29460,
-      "mtime": "2026-07-30T10:58:12.242Z",
+      "mtime": "2026-07-30T15:02:43.052Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5404,7 +5404,7 @@
       "path": "hna/jurisdiction-metrics-digest/0812450.json",
       "kind": "json",
       "size_bytes": 29208,
-      "mtime": "2026-07-30T10:58:12.242Z",
+      "mtime": "2026-07-30T15:02:43.052Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5423,7 +5423,7 @@
       "path": "hna/jurisdiction-metrics-digest/0812460.json",
       "kind": "json",
       "size_bytes": 29291,
-      "mtime": "2026-07-30T10:58:12.242Z",
+      "mtime": "2026-07-30T15:02:43.052Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5442,7 +5442,7 @@
       "path": "hna/jurisdiction-metrics-digest/0812470.json",
       "kind": "json",
       "size_bytes": 29324,
-      "mtime": "2026-07-30T10:58:12.242Z",
+      "mtime": "2026-07-30T15:02:43.053Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5461,7 +5461,7 @@
       "path": "hna/jurisdiction-metrics-digest/08125.json",
       "kind": "json",
       "size_bytes": 29329,
-      "mtime": "2026-07-30T10:58:12.242Z",
+      "mtime": "2026-07-30T15:02:43.053Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5480,7 +5480,7 @@
       "path": "hna/jurisdiction-metrics-digest/0812635.json",
       "kind": "json",
       "size_bytes": 29439,
-      "mtime": "2026-07-30T10:58:12.243Z",
+      "mtime": "2026-07-30T15:02:43.053Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5499,7 +5499,7 @@
       "path": "hna/jurisdiction-metrics-digest/0812815.json",
       "kind": "json",
       "size_bytes": 29463,
-      "mtime": "2026-07-30T10:58:12.243Z",
+      "mtime": "2026-07-30T15:02:43.053Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5518,7 +5518,7 @@
       "path": "hna/jurisdiction-metrics-digest/0812855.json",
       "kind": "json",
       "size_bytes": 29408,
-      "mtime": "2026-07-30T10:58:12.243Z",
+      "mtime": "2026-07-30T15:02:43.053Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5537,7 +5537,7 @@
       "path": "hna/jurisdiction-metrics-digest/0812900.json",
       "kind": "json",
       "size_bytes": 29516,
-      "mtime": "2026-07-30T10:58:12.243Z",
+      "mtime": "2026-07-30T15:02:43.053Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5556,7 +5556,7 @@
       "path": "hna/jurisdiction-metrics-digest/0812945.json",
       "kind": "json",
       "size_bytes": 29324,
-      "mtime": "2026-07-30T10:58:12.243Z",
+      "mtime": "2026-07-30T15:02:43.053Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5575,7 +5575,7 @@
       "path": "hna/jurisdiction-metrics-digest/0813460.json",
       "kind": "json",
       "size_bytes": 29427,
-      "mtime": "2026-07-30T10:58:12.243Z",
+      "mtime": "2026-07-30T15:02:43.054Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5594,7 +5594,7 @@
       "path": "hna/jurisdiction-metrics-digest/0813590.json",
       "kind": "json",
       "size_bytes": 29441,
-      "mtime": "2026-07-30T10:58:12.244Z",
+      "mtime": "2026-07-30T15:02:43.054Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5613,7 +5613,7 @@
       "path": "hna/jurisdiction-metrics-digest/0813845.json",
       "kind": "json",
       "size_bytes": 29398,
-      "mtime": "2026-07-30T10:58:12.244Z",
+      "mtime": "2026-07-30T15:02:43.054Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5632,7 +5632,7 @@
       "path": "hna/jurisdiction-metrics-digest/0814175.json",
       "kind": "json",
       "size_bytes": 29488,
-      "mtime": "2026-07-30T10:58:12.244Z",
+      "mtime": "2026-07-30T15:02:43.054Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5651,7 +5651,7 @@
       "path": "hna/jurisdiction-metrics-digest/0814587.json",
       "kind": "json",
       "size_bytes": 29455,
-      "mtime": "2026-07-30T10:58:12.244Z",
+      "mtime": "2026-07-30T15:02:43.055Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5670,7 +5670,7 @@
       "path": "hna/jurisdiction-metrics-digest/0814765.json",
       "kind": "json",
       "size_bytes": 29533,
-      "mtime": "2026-07-30T10:58:12.244Z",
+      "mtime": "2026-07-30T15:02:43.055Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5689,7 +5689,7 @@
       "path": "hna/jurisdiction-metrics-digest/0815165.json",
       "kind": "json",
       "size_bytes": 29437,
-      "mtime": "2026-07-30T10:58:12.244Z",
+      "mtime": "2026-07-30T15:02:43.056Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5708,7 +5708,7 @@
       "path": "hna/jurisdiction-metrics-digest/0815302.json",
       "kind": "json",
       "size_bytes": 29430,
-      "mtime": "2026-07-30T10:58:12.245Z",
+      "mtime": "2026-07-30T15:02:43.056Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5727,7 +5727,7 @@
       "path": "hna/jurisdiction-metrics-digest/0815330.json",
       "kind": "json",
       "size_bytes": 29470,
-      "mtime": "2026-07-30T10:58:12.245Z",
+      "mtime": "2026-07-30T15:02:43.056Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5746,7 +5746,7 @@
       "path": "hna/jurisdiction-metrics-digest/0815440.json",
       "kind": "json",
       "size_bytes": 29350,
-      "mtime": "2026-07-30T10:58:12.245Z",
+      "mtime": "2026-07-30T15:02:43.056Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5765,7 +5765,7 @@
       "path": "hna/jurisdiction-metrics-digest/0815550.json",
       "kind": "json",
       "size_bytes": 29460,
-      "mtime": "2026-07-30T10:58:12.245Z",
+      "mtime": "2026-07-30T15:02:43.056Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5784,7 +5784,7 @@
       "path": "hna/jurisdiction-metrics-digest/0815605.json",
       "kind": "json",
       "size_bytes": 29293,
-      "mtime": "2026-07-30T10:58:12.245Z",
+      "mtime": "2026-07-30T15:02:43.056Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5803,7 +5803,7 @@
       "path": "hna/jurisdiction-metrics-digest/0815825.json",
       "kind": "json",
       "size_bytes": 29246,
-      "mtime": "2026-07-30T10:58:12.245Z",
+      "mtime": "2026-07-30T15:02:43.057Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5822,7 +5822,7 @@
       "path": "hna/jurisdiction-metrics-digest/0815935.json",
       "kind": "json",
       "size_bytes": 29452,
-      "mtime": "2026-07-30T10:58:12.246Z",
+      "mtime": "2026-07-30T15:02:43.057Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5841,7 +5841,7 @@
       "path": "hna/jurisdiction-metrics-digest/0816000.json",
       "kind": "json",
       "size_bytes": 29574,
-      "mtime": "2026-07-30T10:58:12.246Z",
+      "mtime": "2026-07-30T15:02:43.057Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5860,7 +5860,7 @@
       "path": "hna/jurisdiction-metrics-digest/0816110.json",
       "kind": "json",
       "size_bytes": 29475,
-      "mtime": "2026-07-30T10:58:12.246Z",
+      "mtime": "2026-07-30T15:02:43.057Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5879,7 +5879,7 @@
       "path": "hna/jurisdiction-metrics-digest/0816385.json",
       "kind": "json",
       "size_bytes": 29367,
-      "mtime": "2026-07-30T10:58:12.246Z",
+      "mtime": "2026-07-30T15:02:43.057Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5898,7 +5898,7 @@
       "path": "hna/jurisdiction-metrics-digest/0816465.json",
       "kind": "json",
       "size_bytes": 29288,
-      "mtime": "2026-07-30T10:58:12.246Z",
+      "mtime": "2026-07-30T15:02:43.057Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5917,7 +5917,7 @@
       "path": "hna/jurisdiction-metrics-digest/0816495.json",
       "kind": "json",
       "size_bytes": 29482,
-      "mtime": "2026-07-30T10:58:12.246Z",
+      "mtime": "2026-07-30T15:02:43.057Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5936,7 +5936,7 @@
       "path": "hna/jurisdiction-metrics-digest/0816715.json",
       "kind": "json",
       "size_bytes": 29219,
-      "mtime": "2026-07-30T10:58:12.247Z",
+      "mtime": "2026-07-30T15:02:43.058Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5955,7 +5955,7 @@
       "path": "hna/jurisdiction-metrics-digest/0817100.json",
       "kind": "json",
       "size_bytes": 29225,
-      "mtime": "2026-07-30T10:58:12.247Z",
+      "mtime": "2026-07-30T15:02:43.058Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5974,7 +5974,7 @@
       "path": "hna/jurisdiction-metrics-digest/0817150.json",
       "kind": "json",
       "size_bytes": 29266,
-      "mtime": "2026-07-30T10:58:12.247Z",
+      "mtime": "2026-07-30T15:02:43.058Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -5993,7 +5993,7 @@
       "path": "hna/jurisdiction-metrics-digest/0817375.json",
       "kind": "json",
       "size_bytes": 29436,
-      "mtime": "2026-07-30T10:58:12.247Z",
+      "mtime": "2026-07-30T15:02:43.058Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6012,7 +6012,7 @@
       "path": "hna/jurisdiction-metrics-digest/0817485.json",
       "kind": "json",
       "size_bytes": 29232,
-      "mtime": "2026-07-30T10:58:12.247Z",
+      "mtime": "2026-07-30T15:02:43.058Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6031,7 +6031,7 @@
       "path": "hna/jurisdiction-metrics-digest/0817760.json",
       "kind": "json",
       "size_bytes": 29443,
-      "mtime": "2026-07-30T10:58:12.247Z",
+      "mtime": "2026-07-30T15:02:43.058Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6050,7 +6050,7 @@
       "path": "hna/jurisdiction-metrics-digest/0817925.json",
       "kind": "json",
       "size_bytes": 29399,
-      "mtime": "2026-07-30T10:58:12.248Z",
+      "mtime": "2026-07-30T15:02:43.059Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6069,7 +6069,7 @@
       "path": "hna/jurisdiction-metrics-digest/0818310.json",
       "kind": "json",
       "size_bytes": 29502,
-      "mtime": "2026-07-30T10:58:12.248Z",
+      "mtime": "2026-07-30T15:02:43.059Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6088,7 +6088,7 @@
       "path": "hna/jurisdiction-metrics-digest/0818420.json",
       "kind": "json",
       "size_bytes": 29343,
-      "mtime": "2026-07-30T10:58:12.248Z",
+      "mtime": "2026-07-30T15:02:43.059Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6107,7 +6107,7 @@
       "path": "hna/jurisdiction-metrics-digest/0818530.json",
       "kind": "json",
       "size_bytes": 29592,
-      "mtime": "2026-07-30T10:58:12.248Z",
+      "mtime": "2026-07-30T15:02:43.059Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6126,7 +6126,7 @@
       "path": "hna/jurisdiction-metrics-digest/0818585.json",
       "kind": "json",
       "size_bytes": 29306,
-      "mtime": "2026-07-30T10:58:12.248Z",
+      "mtime": "2026-07-30T15:02:43.059Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6145,7 +6145,7 @@
       "path": "hna/jurisdiction-metrics-digest/0818640.json",
       "kind": "json",
       "size_bytes": 29427,
-      "mtime": "2026-07-30T10:58:12.248Z",
+      "mtime": "2026-07-30T15:02:43.059Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6164,7 +6164,7 @@
       "path": "hna/jurisdiction-metrics-digest/0818750.json",
       "kind": "json",
       "size_bytes": 29386,
-      "mtime": "2026-07-30T10:58:12.249Z",
+      "mtime": "2026-07-30T15:02:43.059Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6183,7 +6183,7 @@
       "path": "hna/jurisdiction-metrics-digest/0819080.json",
       "kind": "json",
       "size_bytes": 29417,
-      "mtime": "2026-07-30T10:58:12.249Z",
+      "mtime": "2026-07-30T15:02:43.060Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6202,7 +6202,7 @@
       "path": "hna/jurisdiction-metrics-digest/0819150.json",
       "kind": "json",
       "size_bytes": 29499,
-      "mtime": "2026-07-30T10:58:12.249Z",
+      "mtime": "2026-07-30T15:02:43.060Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6221,7 +6221,7 @@
       "path": "hna/jurisdiction-metrics-digest/0819355.json",
       "kind": "json",
       "size_bytes": 29513,
-      "mtime": "2026-07-30T10:58:12.249Z",
+      "mtime": "2026-07-30T15:02:43.060Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6240,7 +6240,7 @@
       "path": "hna/jurisdiction-metrics-digest/0819630.json",
       "kind": "json",
       "size_bytes": 29477,
-      "mtime": "2026-07-30T10:58:12.249Z",
+      "mtime": "2026-07-30T15:02:43.060Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6259,7 +6259,7 @@
       "path": "hna/jurisdiction-metrics-digest/0819795.json",
       "kind": "json",
       "size_bytes": 29419,
-      "mtime": "2026-07-30T10:58:12.251Z",
+      "mtime": "2026-07-30T15:02:43.060Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6278,7 +6278,7 @@
       "path": "hna/jurisdiction-metrics-digest/0819850.json",
       "kind": "json",
       "size_bytes": 29434,
-      "mtime": "2026-07-30T10:58:12.251Z",
+      "mtime": "2026-07-30T15:02:43.060Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6297,7 +6297,7 @@
       "path": "hna/jurisdiction-metrics-digest/0820000.json",
       "kind": "json",
       "size_bytes": 29523,
-      "mtime": "2026-07-30T10:58:12.251Z",
+      "mtime": "2026-07-30T15:02:43.060Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6316,7 +6316,7 @@
       "path": "hna/jurisdiction-metrics-digest/0820275.json",
       "kind": "json",
       "size_bytes": 29387,
-      "mtime": "2026-07-30T10:58:12.251Z",
+      "mtime": "2026-07-30T15:02:43.061Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6335,7 +6335,7 @@
       "path": "hna/jurisdiction-metrics-digest/0820440.json",
       "kind": "json",
       "size_bytes": 29322,
-      "mtime": "2026-07-30T10:58:12.251Z",
+      "mtime": "2026-07-30T15:02:43.061Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6354,7 +6354,7 @@
       "path": "hna/jurisdiction-metrics-digest/0820495.json",
       "kind": "json",
       "size_bytes": 29317,
-      "mtime": "2026-07-30T10:58:12.251Z",
+      "mtime": "2026-07-30T15:02:43.061Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6373,7 +6373,7 @@
       "path": "hna/jurisdiction-metrics-digest/0820605.json",
       "kind": "json",
       "size_bytes": 29227,
-      "mtime": "2026-07-30T10:58:12.252Z",
+      "mtime": "2026-07-30T15:02:43.061Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6392,7 +6392,7 @@
       "path": "hna/jurisdiction-metrics-digest/0820770.json",
       "kind": "json",
       "size_bytes": 29554,
-      "mtime": "2026-07-30T10:58:12.252Z",
+      "mtime": "2026-07-30T15:02:43.061Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6411,7 +6411,7 @@
       "path": "hna/jurisdiction-metrics-digest/0821155.json",
       "kind": "json",
       "size_bytes": 29459,
-      "mtime": "2026-07-30T10:58:12.252Z",
+      "mtime": "2026-07-30T15:02:43.061Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6430,7 +6430,7 @@
       "path": "hna/jurisdiction-metrics-digest/0821265.json",
       "kind": "json",
       "size_bytes": 29477,
-      "mtime": "2026-07-30T10:58:12.252Z",
+      "mtime": "2026-07-30T15:02:43.061Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6449,7 +6449,7 @@
       "path": "hna/jurisdiction-metrics-digest/0821330.json",
       "kind": "json",
       "size_bytes": 29488,
-      "mtime": "2026-07-30T10:58:12.252Z",
+      "mtime": "2026-07-30T15:02:43.062Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6468,7 +6468,7 @@
       "path": "hna/jurisdiction-metrics-digest/0821390.json",
       "kind": "json",
       "size_bytes": 29385,
-      "mtime": "2026-07-30T10:58:12.252Z",
+      "mtime": "2026-07-30T15:02:43.062Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6487,7 +6487,7 @@
       "path": "hna/jurisdiction-metrics-digest/0822035.json",
       "kind": "json",
       "size_bytes": 29455,
-      "mtime": "2026-07-30T10:58:12.253Z",
+      "mtime": "2026-07-30T15:02:43.062Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6506,7 +6506,7 @@
       "path": "hna/jurisdiction-metrics-digest/0822145.json",
       "kind": "json",
       "size_bytes": 29456,
-      "mtime": "2026-07-30T10:58:12.253Z",
+      "mtime": "2026-07-30T15:02:43.062Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6525,7 +6525,7 @@
       "path": "hna/jurisdiction-metrics-digest/0822200.json",
       "kind": "json",
       "size_bytes": 29544,
-      "mtime": "2026-07-30T10:58:12.253Z",
+      "mtime": "2026-07-30T15:02:43.062Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6544,7 +6544,7 @@
       "path": "hna/jurisdiction-metrics-digest/0822575.json",
       "kind": "json",
       "size_bytes": 29329,
-      "mtime": "2026-07-30T10:58:12.253Z",
+      "mtime": "2026-07-30T15:02:43.062Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6563,7 +6563,7 @@
       "path": "hna/jurisdiction-metrics-digest/0822860.json",
       "kind": "json",
       "size_bytes": 29503,
-      "mtime": "2026-07-30T10:58:12.253Z",
+      "mtime": "2026-07-30T15:02:43.064Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6582,7 +6582,7 @@
       "path": "hna/jurisdiction-metrics-digest/0822882.json",
       "kind": "json",
       "size_bytes": 29274,
-      "mtime": "2026-07-30T10:58:12.253Z",
+      "mtime": "2026-07-30T15:02:43.064Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6601,7 +6601,7 @@
       "path": "hna/jurisdiction-metrics-digest/0823025.json",
       "kind": "json",
       "size_bytes": 29424,
-      "mtime": "2026-07-30T10:58:12.254Z",
+      "mtime": "2026-07-30T15:02:43.064Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6620,7 +6620,7 @@
       "path": "hna/jurisdiction-metrics-digest/0823135.json",
       "kind": "json",
       "size_bytes": 29417,
-      "mtime": "2026-07-30T10:58:12.254Z",
+      "mtime": "2026-07-30T15:02:43.064Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6639,7 +6639,7 @@
       "path": "hna/jurisdiction-metrics-digest/0823300.json",
       "kind": "json",
       "size_bytes": 29447,
-      "mtime": "2026-07-30T10:58:12.254Z",
+      "mtime": "2026-07-30T15:02:43.064Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6658,7 +6658,7 @@
       "path": "hna/jurisdiction-metrics-digest/0823520.json",
       "kind": "json",
       "size_bytes": 29418,
-      "mtime": "2026-07-30T10:58:12.254Z",
+      "mtime": "2026-07-30T15:02:43.064Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6677,7 +6677,7 @@
       "path": "hna/jurisdiction-metrics-digest/0823575.json",
       "kind": "json",
       "size_bytes": 29341,
-      "mtime": "2026-07-30T10:58:12.254Z",
+      "mtime": "2026-07-30T15:02:43.065Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6696,7 +6696,7 @@
       "path": "hna/jurisdiction-metrics-digest/0823630.json",
       "kind": "json",
       "size_bytes": 29377,
-      "mtime": "2026-07-30T10:58:12.255Z",
+      "mtime": "2026-07-30T15:02:43.065Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6715,7 +6715,7 @@
       "path": "hna/jurisdiction-metrics-digest/0823740.json",
       "kind": "json",
       "size_bytes": 29446,
-      "mtime": "2026-07-30T10:58:12.255Z",
+      "mtime": "2026-07-30T15:02:43.065Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6734,7 +6734,7 @@
       "path": "hna/jurisdiction-metrics-digest/0823795.json",
       "kind": "json",
       "size_bytes": 29557,
-      "mtime": "2026-07-30T10:58:12.255Z",
+      "mtime": "2026-07-30T15:02:43.065Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6753,7 +6753,7 @@
       "path": "hna/jurisdiction-metrics-digest/0824235.json",
       "kind": "json",
       "size_bytes": 29313,
-      "mtime": "2026-07-30T10:58:12.255Z",
+      "mtime": "2026-07-30T15:02:43.065Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6772,7 +6772,7 @@
       "path": "hna/jurisdiction-metrics-digest/0824290.json",
       "kind": "json",
       "size_bytes": 29283,
-      "mtime": "2026-07-30T10:58:12.255Z",
+      "mtime": "2026-07-30T15:02:43.065Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6791,7 +6791,7 @@
       "path": "hna/jurisdiction-metrics-digest/0824620.json",
       "kind": "json",
       "size_bytes": 29475,
-      "mtime": "2026-07-30T10:58:12.255Z",
+      "mtime": "2026-07-30T15:02:43.066Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6810,7 +6810,7 @@
       "path": "hna/jurisdiction-metrics-digest/0824785.json",
       "kind": "json",
       "size_bytes": 29477,
-      "mtime": "2026-07-30T10:58:12.256Z",
+      "mtime": "2026-07-30T15:02:43.066Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6829,7 +6829,7 @@
       "path": "hna/jurisdiction-metrics-digest/0824950.json",
       "kind": "json",
       "size_bytes": 29433,
-      "mtime": "2026-07-30T10:58:12.256Z",
+      "mtime": "2026-07-30T15:02:43.066Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6848,7 +6848,7 @@
       "path": "hna/jurisdiction-metrics-digest/0825115.json",
       "kind": "json",
       "size_bytes": 29468,
-      "mtime": "2026-07-30T10:58:12.256Z",
+      "mtime": "2026-07-30T15:02:43.066Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6867,7 +6867,7 @@
       "path": "hna/jurisdiction-metrics-digest/0825280.json",
       "kind": "json",
       "size_bytes": 29442,
-      "mtime": "2026-07-30T10:58:12.256Z",
+      "mtime": "2026-07-30T15:02:43.066Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6886,7 +6886,7 @@
       "path": "hna/jurisdiction-metrics-digest/0825390.json",
       "kind": "json",
       "size_bytes": 29552,
-      "mtime": "2026-07-30T10:58:12.256Z",
+      "mtime": "2026-07-30T15:02:43.066Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6905,7 +6905,7 @@
       "path": "hna/jurisdiction-metrics-digest/0825550.json",
       "kind": "json",
       "size_bytes": 29562,
-      "mtime": "2026-07-30T10:58:12.256Z",
+      "mtime": "2026-07-30T15:02:43.066Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6924,7 +6924,7 @@
       "path": "hna/jurisdiction-metrics-digest/0825610.json",
       "kind": "json",
       "size_bytes": 29468,
-      "mtime": "2026-07-30T10:58:12.257Z",
+      "mtime": "2026-07-30T15:02:43.067Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6943,7 +6943,7 @@
       "path": "hna/jurisdiction-metrics-digest/0826270.json",
       "kind": "json",
       "size_bytes": 29485,
-      "mtime": "2026-07-30T10:58:12.257Z",
+      "mtime": "2026-07-30T15:02:43.067Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6962,7 +6962,7 @@
       "path": "hna/jurisdiction-metrics-digest/0826600.json",
       "kind": "json",
       "size_bytes": 29410,
-      "mtime": "2026-07-30T10:58:12.257Z",
+      "mtime": "2026-07-30T15:02:43.067Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -6981,7 +6981,7 @@
       "path": "hna/jurisdiction-metrics-digest/0826765.json",
       "kind": "json",
       "size_bytes": 29345,
-      "mtime": "2026-07-30T10:58:12.257Z",
+      "mtime": "2026-07-30T15:02:43.067Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7000,7 +7000,7 @@
       "path": "hna/jurisdiction-metrics-digest/0826875.json",
       "kind": "json",
       "size_bytes": 29444,
-      "mtime": "2026-07-30T10:58:12.257Z",
+      "mtime": "2026-07-30T15:02:43.067Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7019,7 +7019,7 @@
       "path": "hna/jurisdiction-metrics-digest/0827040.json",
       "kind": "json",
       "size_bytes": 29455,
-      "mtime": "2026-07-30T10:58:12.257Z",
+      "mtime": "2026-07-30T15:02:43.067Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7038,7 +7038,7 @@
       "path": "hna/jurisdiction-metrics-digest/0827095.json",
       "kind": "json",
       "size_bytes": 29335,
-      "mtime": "2026-07-30T10:58:12.257Z",
+      "mtime": "2026-07-30T15:02:43.067Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7057,7 +7057,7 @@
       "path": "hna/jurisdiction-metrics-digest/0827175.json",
       "kind": "json",
       "size_bytes": 29333,
-      "mtime": "2026-07-30T10:58:12.258Z",
+      "mtime": "2026-07-30T15:02:43.067Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7076,7 +7076,7 @@
       "path": "hna/jurisdiction-metrics-digest/0827370.json",
       "kind": "json",
       "size_bytes": 29519,
-      "mtime": "2026-07-30T10:58:12.258Z",
+      "mtime": "2026-07-30T15:02:43.068Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7095,7 +7095,7 @@
       "path": "hna/jurisdiction-metrics-digest/0827425.json",
       "kind": "json",
       "size_bytes": 29502,
-      "mtime": "2026-07-30T10:58:12.258Z",
+      "mtime": "2026-07-30T15:02:43.068Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7114,7 +7114,7 @@
       "path": "hna/jurisdiction-metrics-digest/0827535.json",
       "kind": "json",
       "size_bytes": 29374,
-      "mtime": "2026-07-30T10:58:12.258Z",
+      "mtime": "2026-07-30T15:02:43.068Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7133,7 +7133,7 @@
       "path": "hna/jurisdiction-metrics-digest/0827700.json",
       "kind": "json",
       "size_bytes": 29423,
-      "mtime": "2026-07-30T10:58:12.258Z",
+      "mtime": "2026-07-30T15:02:43.068Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7152,7 +7152,7 @@
       "path": "hna/jurisdiction-metrics-digest/0827810.json",
       "kind": "json",
       "size_bytes": 29455,
-      "mtime": "2026-07-30T10:58:12.259Z",
+      "mtime": "2026-07-30T15:02:43.068Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7171,7 +7171,7 @@
       "path": "hna/jurisdiction-metrics-digest/0827865.json",
       "kind": "json",
       "size_bytes": 29449,
-      "mtime": "2026-07-30T10:58:12.260Z",
+      "mtime": "2026-07-30T15:02:43.068Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7190,7 +7190,7 @@
       "path": "hna/jurisdiction-metrics-digest/0827950.json",
       "kind": "json",
       "size_bytes": 29479,
-      "mtime": "2026-07-30T10:58:12.260Z",
+      "mtime": "2026-07-30T15:02:43.068Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7209,7 +7209,7 @@
       "path": "hna/jurisdiction-metrics-digest/0827975.json",
       "kind": "json",
       "size_bytes": 29556,
-      "mtime": "2026-07-30T10:58:12.260Z",
+      "mtime": "2026-07-30T15:02:43.069Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7228,7 +7228,7 @@
       "path": "hna/jurisdiction-metrics-digest/0828105.json",
       "kind": "json",
       "size_bytes": 29304,
-      "mtime": "2026-07-30T10:58:12.260Z",
+      "mtime": "2026-07-30T15:02:43.069Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7247,7 +7247,7 @@
       "path": "hna/jurisdiction-metrics-digest/0828250.json",
       "kind": "json",
       "size_bytes": 29298,
-      "mtime": "2026-07-30T10:58:12.260Z",
+      "mtime": "2026-07-30T15:02:43.069Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7266,7 +7266,7 @@
       "path": "hna/jurisdiction-metrics-digest/0828305.json",
       "kind": "json",
       "size_bytes": 29341,
-      "mtime": "2026-07-30T10:58:12.261Z",
+      "mtime": "2026-07-30T15:02:43.069Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7285,7 +7285,7 @@
       "path": "hna/jurisdiction-metrics-digest/0828360.json",
       "kind": "json",
       "size_bytes": 29505,
-      "mtime": "2026-07-30T10:58:12.261Z",
+      "mtime": "2026-07-30T15:02:43.069Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7304,7 +7304,7 @@
       "path": "hna/jurisdiction-metrics-digest/0828690.json",
       "kind": "json",
       "size_bytes": 29528,
-      "mtime": "2026-07-30T10:58:12.261Z",
+      "mtime": "2026-07-30T15:02:43.070Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7323,7 +7323,7 @@
       "path": "hna/jurisdiction-metrics-digest/0828745.json",
       "kind": "json",
       "size_bytes": 29425,
-      "mtime": "2026-07-30T10:58:12.261Z",
+      "mtime": "2026-07-30T15:02:43.070Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7342,7 +7342,7 @@
       "path": "hna/jurisdiction-metrics-digest/0828800.json",
       "kind": "json",
       "size_bytes": 29553,
-      "mtime": "2026-07-30T10:58:12.261Z",
+      "mtime": "2026-07-30T15:02:43.070Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7361,7 +7361,7 @@
       "path": "hna/jurisdiction-metrics-digest/0828830.json",
       "kind": "json",
       "size_bytes": 29300,
-      "mtime": "2026-07-30T10:58:12.262Z",
+      "mtime": "2026-07-30T15:02:43.070Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7380,7 +7380,7 @@
       "path": "hna/jurisdiction-metrics-digest/0829185.json",
       "kind": "json",
       "size_bytes": 29508,
-      "mtime": "2026-07-30T10:58:12.262Z",
+      "mtime": "2026-07-30T15:02:43.070Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7399,7 +7399,7 @@
       "path": "hna/jurisdiction-metrics-digest/0829240.json",
       "kind": "json",
       "size_bytes": 29277,
-      "mtime": "2026-07-30T10:58:12.262Z",
+      "mtime": "2026-07-30T15:02:43.070Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7418,7 +7418,7 @@
       "path": "hna/jurisdiction-metrics-digest/0829295.json",
       "kind": "json",
       "size_bytes": 29241,
-      "mtime": "2026-07-30T10:58:12.262Z",
+      "mtime": "2026-07-30T15:02:43.070Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7437,7 +7437,7 @@
       "path": "hna/jurisdiction-metrics-digest/0829625.json",
       "kind": "json",
       "size_bytes": 29528,
-      "mtime": "2026-07-30T10:58:12.262Z",
+      "mtime": "2026-07-30T15:02:43.071Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7456,7 +7456,7 @@
       "path": "hna/jurisdiction-metrics-digest/0829680.json",
       "kind": "json",
       "size_bytes": 29286,
-      "mtime": "2026-07-30T10:58:12.262Z",
+      "mtime": "2026-07-30T15:02:43.071Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7475,7 +7475,7 @@
       "path": "hna/jurisdiction-metrics-digest/0829735.json",
       "kind": "json",
       "size_bytes": 29408,
-      "mtime": "2026-07-30T10:58:12.263Z",
+      "mtime": "2026-07-30T15:02:43.072Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7494,7 +7494,7 @@
       "path": "hna/jurisdiction-metrics-digest/0829845.json",
       "kind": "json",
       "size_bytes": 29321,
-      "mtime": "2026-07-30T10:58:12.263Z",
+      "mtime": "2026-07-30T15:02:43.073Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7513,7 +7513,7 @@
       "path": "hna/jurisdiction-metrics-digest/0829955.json",
       "kind": "json",
       "size_bytes": 29313,
-      "mtime": "2026-07-30T10:58:12.263Z",
+      "mtime": "2026-07-30T15:02:43.075Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7532,7 +7532,7 @@
       "path": "hna/jurisdiction-metrics-digest/0830340.json",
       "kind": "json",
       "size_bytes": 29453,
-      "mtime": "2026-07-30T10:58:12.263Z",
+      "mtime": "2026-07-30T15:02:43.075Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7551,7 +7551,7 @@
       "path": "hna/jurisdiction-metrics-digest/0830350.json",
       "kind": "json",
       "size_bytes": 29239,
-      "mtime": "2026-07-30T10:58:12.263Z",
+      "mtime": "2026-07-30T15:02:43.075Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7570,7 +7570,7 @@
       "path": "hna/jurisdiction-metrics-digest/0830420.json",
       "kind": "json",
       "size_bytes": 29513,
-      "mtime": "2026-07-30T10:58:12.263Z",
+      "mtime": "2026-07-30T15:02:43.075Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7589,7 +7589,7 @@
       "path": "hna/jurisdiction-metrics-digest/0830780.json",
       "kind": "json",
       "size_bytes": 29471,
-      "mtime": "2026-07-30T10:58:12.264Z",
+      "mtime": "2026-07-30T15:02:43.075Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7608,7 +7608,7 @@
       "path": "hna/jurisdiction-metrics-digest/0830835.json",
       "kind": "json",
       "size_bytes": 29447,
-      "mtime": "2026-07-30T10:58:12.264Z",
+      "mtime": "2026-07-30T15:02:43.076Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7627,7 +7627,7 @@
       "path": "hna/jurisdiction-metrics-digest/0830890.json",
       "kind": "json",
       "size_bytes": 29308,
-      "mtime": "2026-07-30T10:58:12.264Z",
+      "mtime": "2026-07-30T15:02:43.076Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7646,7 +7646,7 @@
       "path": "hna/jurisdiction-metrics-digest/0830945.json",
       "kind": "json",
       "size_bytes": 29316,
-      "mtime": "2026-07-30T10:58:12.264Z",
+      "mtime": "2026-07-30T15:02:43.076Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7665,7 +7665,7 @@
       "path": "hna/jurisdiction-metrics-digest/0831550.json",
       "kind": "json",
       "size_bytes": 29477,
-      "mtime": "2026-07-30T10:58:12.264Z",
+      "mtime": "2026-07-30T15:02:43.076Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7684,7 +7684,7 @@
       "path": "hna/jurisdiction-metrics-digest/0831605.json",
       "kind": "json",
       "size_bytes": 29509,
-      "mtime": "2026-07-30T10:58:12.264Z",
+      "mtime": "2026-07-30T15:02:43.076Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7703,7 +7703,7 @@
       "path": "hna/jurisdiction-metrics-digest/0831660.json",
       "kind": "json",
       "size_bytes": 29503,
-      "mtime": "2026-07-30T10:58:12.265Z",
+      "mtime": "2026-07-30T15:02:43.076Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7722,7 +7722,7 @@
       "path": "hna/jurisdiction-metrics-digest/0831715.json",
       "kind": "json",
       "size_bytes": 29323,
-      "mtime": "2026-07-30T10:58:12.265Z",
+      "mtime": "2026-07-30T15:02:43.077Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7741,7 +7741,7 @@
       "path": "hna/jurisdiction-metrics-digest/0831935.json",
       "kind": "json",
       "size_bytes": 29299,
-      "mtime": "2026-07-30T10:58:12.265Z",
+      "mtime": "2026-07-30T15:02:43.077Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7760,7 +7760,7 @@
       "path": "hna/jurisdiction-metrics-digest/0832155.json",
       "kind": "json",
       "size_bytes": 29488,
-      "mtime": "2026-07-30T10:58:12.265Z",
+      "mtime": "2026-07-30T15:02:43.077Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7779,7 +7779,7 @@
       "path": "hna/jurisdiction-metrics-digest/0832650.json",
       "kind": "json",
       "size_bytes": 29366,
-      "mtime": "2026-07-30T10:58:12.265Z",
+      "mtime": "2026-07-30T15:02:43.077Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7798,7 +7798,7 @@
       "path": "hna/jurisdiction-metrics-digest/0833035.json",
       "kind": "json",
       "size_bytes": 29453,
-      "mtime": "2026-07-30T10:58:12.265Z",
+      "mtime": "2026-07-30T15:02:43.077Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7817,7 +7817,7 @@
       "path": "hna/jurisdiction-metrics-digest/0833310.json",
       "kind": "json",
       "size_bytes": 29270,
-      "mtime": "2026-07-30T10:58:12.266Z",
+      "mtime": "2026-07-30T15:02:43.078Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7836,7 +7836,7 @@
       "path": "hna/jurisdiction-metrics-digest/0833420.json",
       "kind": "json",
       "size_bytes": 29273,
-      "mtime": "2026-07-30T10:58:12.266Z",
+      "mtime": "2026-07-30T15:02:43.078Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7855,7 +7855,7 @@
       "path": "hna/jurisdiction-metrics-digest/0833502.json",
       "kind": "json",
       "size_bytes": 29442,
-      "mtime": "2026-07-30T10:58:12.266Z",
+      "mtime": "2026-07-30T15:02:43.078Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7874,7 +7874,7 @@
       "path": "hna/jurisdiction-metrics-digest/0833640.json",
       "kind": "json",
       "size_bytes": 29553,
-      "mtime": "2026-07-30T10:58:12.266Z",
+      "mtime": "2026-07-30T15:02:43.078Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7893,7 +7893,7 @@
       "path": "hna/jurisdiction-metrics-digest/0833695.json",
       "kind": "json",
       "size_bytes": 29532,
-      "mtime": "2026-07-30T10:58:12.266Z",
+      "mtime": "2026-07-30T15:02:43.078Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7912,7 +7912,7 @@
       "path": "hna/jurisdiction-metrics-digest/0834520.json",
       "kind": "json",
       "size_bytes": 29217,
-      "mtime": "2026-07-30T10:58:12.266Z",
+      "mtime": "2026-07-30T15:02:43.078Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7931,7 +7931,7 @@
       "path": "hna/jurisdiction-metrics-digest/0834630.json",
       "kind": "json",
       "size_bytes": 29236,
-      "mtime": "2026-07-30T10:58:12.267Z",
+      "mtime": "2026-07-30T15:02:43.078Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7950,7 +7950,7 @@
       "path": "hna/jurisdiction-metrics-digest/0834685.json",
       "kind": "json",
       "size_bytes": 29337,
-      "mtime": "2026-07-30T10:58:12.267Z",
+      "mtime": "2026-07-30T15:02:43.079Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7969,7 +7969,7 @@
       "path": "hna/jurisdiction-metrics-digest/0834740.json",
       "kind": "json",
       "size_bytes": 29251,
-      "mtime": "2026-07-30T10:58:12.267Z",
+      "mtime": "2026-07-30T15:02:43.079Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -7988,7 +7988,7 @@
       "path": "hna/jurisdiction-metrics-digest/0834960.json",
       "kind": "json",
       "size_bytes": 29374,
-      "mtime": "2026-07-30T10:58:12.267Z",
+      "mtime": "2026-07-30T15:02:43.079Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8007,7 +8007,7 @@
       "path": "hna/jurisdiction-metrics-digest/0835070.json",
       "kind": "json",
       "size_bytes": 29490,
-      "mtime": "2026-07-30T10:58:12.267Z",
+      "mtime": "2026-07-30T15:02:43.079Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8026,7 +8026,7 @@
       "path": "hna/jurisdiction-metrics-digest/0835400.json",
       "kind": "json",
       "size_bytes": 29250,
-      "mtime": "2026-07-30T10:58:12.267Z",
+      "mtime": "2026-07-30T15:02:43.079Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8045,7 +8045,7 @@
       "path": "hna/jurisdiction-metrics-digest/0835860.json",
       "kind": "json",
       "size_bytes": 29215,
-      "mtime": "2026-07-30T10:58:12.268Z",
+      "mtime": "2026-07-30T15:02:43.080Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8064,7 +8064,7 @@
       "path": "hna/jurisdiction-metrics-digest/0836410.json",
       "kind": "json",
       "size_bytes": 29485,
-      "mtime": "2026-07-30T10:58:12.268Z",
+      "mtime": "2026-07-30T15:02:43.080Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8083,7 +8083,7 @@
       "path": "hna/jurisdiction-metrics-digest/0836610.json",
       "kind": "json",
       "size_bytes": 29425,
-      "mtime": "2026-07-30T10:58:12.269Z",
+      "mtime": "2026-07-30T15:02:43.080Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8102,7 +8102,7 @@
       "path": "hna/jurisdiction-metrics-digest/0836940.json",
       "kind": "json",
       "size_bytes": 29215,
-      "mtime": "2026-07-30T10:58:12.269Z",
+      "mtime": "2026-07-30T15:02:43.080Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8121,7 +8121,7 @@
       "path": "hna/jurisdiction-metrics-digest/0837215.json",
       "kind": "json",
       "size_bytes": 29493,
-      "mtime": "2026-07-30T10:58:12.269Z",
+      "mtime": "2026-07-30T15:02:43.080Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8140,7 +8140,7 @@
       "path": "hna/jurisdiction-metrics-digest/0837220.json",
       "kind": "json",
       "size_bytes": 29333,
-      "mtime": "2026-07-30T10:58:12.270Z",
+      "mtime": "2026-07-30T15:02:43.080Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8159,7 +8159,7 @@
       "path": "hna/jurisdiction-metrics-digest/0837270.json",
       "kind": "json",
       "size_bytes": 29422,
-      "mtime": "2026-07-30T10:58:12.270Z",
+      "mtime": "2026-07-30T15:02:43.081Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8178,7 +8178,7 @@
       "path": "hna/jurisdiction-metrics-digest/0837380.json",
       "kind": "json",
       "size_bytes": 29299,
-      "mtime": "2026-07-30T10:58:12.270Z",
+      "mtime": "2026-07-30T15:02:43.081Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8197,7 +8197,7 @@
       "path": "hna/jurisdiction-metrics-digest/0837545.json",
       "kind": "json",
       "size_bytes": 29383,
-      "mtime": "2026-07-30T10:58:12.270Z",
+      "mtime": "2026-07-30T15:02:43.081Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8216,7 +8216,7 @@
       "path": "hna/jurisdiction-metrics-digest/0837600.json",
       "kind": "json",
       "size_bytes": 29493,
-      "mtime": "2026-07-30T10:58:12.270Z",
+      "mtime": "2026-07-30T15:02:43.081Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8235,7 +8235,7 @@
       "path": "hna/jurisdiction-metrics-digest/0837655.json",
       "kind": "json",
       "size_bytes": 29368,
-      "mtime": "2026-07-30T10:58:12.270Z",
+      "mtime": "2026-07-30T15:02:43.081Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8254,7 +8254,7 @@
       "path": "hna/jurisdiction-metrics-digest/0837820.json",
       "kind": "json",
       "size_bytes": 29501,
-      "mtime": "2026-07-30T10:58:12.271Z",
+      "mtime": "2026-07-30T15:02:43.082Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8273,7 +8273,7 @@
       "path": "hna/jurisdiction-metrics-digest/0837875.json",
       "kind": "json",
       "size_bytes": 29437,
-      "mtime": "2026-07-30T10:58:12.271Z",
+      "mtime": "2026-07-30T15:02:43.082Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8292,7 +8292,7 @@
       "path": "hna/jurisdiction-metrics-digest/0838370.json",
       "kind": "json",
       "size_bytes": 29457,
-      "mtime": "2026-07-30T10:58:12.271Z",
+      "mtime": "2026-07-30T15:02:43.082Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8311,7 +8311,7 @@
       "path": "hna/jurisdiction-metrics-digest/0838425.json",
       "kind": "json",
       "size_bytes": 29372,
-      "mtime": "2026-07-30T10:58:12.271Z",
+      "mtime": "2026-07-30T15:02:43.082Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8330,7 +8330,7 @@
       "path": "hna/jurisdiction-metrics-digest/0838480.json",
       "kind": "json",
       "size_bytes": 29290,
-      "mtime": "2026-07-30T10:58:12.271Z",
+      "mtime": "2026-07-30T15:02:43.082Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8349,7 +8349,7 @@
       "path": "hna/jurisdiction-metrics-digest/0838535.json",
       "kind": "json",
       "size_bytes": 29471,
-      "mtime": "2026-07-30T10:58:12.271Z",
+      "mtime": "2026-07-30T15:02:43.083Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8368,7 +8368,7 @@
       "path": "hna/jurisdiction-metrics-digest/0838590.json",
       "kind": "json",
       "size_bytes": 29436,
-      "mtime": "2026-07-30T10:58:12.272Z",
+      "mtime": "2026-07-30T15:02:43.083Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8387,7 +8387,7 @@
       "path": "hna/jurisdiction-metrics-digest/0838810.json",
       "kind": "json",
       "size_bytes": 29306,
-      "mtime": "2026-07-30T10:58:12.272Z",
+      "mtime": "2026-07-30T15:02:43.083Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8406,7 +8406,7 @@
       "path": "hna/jurisdiction-metrics-digest/0838910.json",
       "kind": "json",
       "size_bytes": 29478,
-      "mtime": "2026-07-30T10:58:12.272Z",
+      "mtime": "2026-07-30T15:02:43.083Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8425,7 +8425,7 @@
       "path": "hna/jurisdiction-metrics-digest/0839160.json",
       "kind": "json",
       "size_bytes": 29374,
-      "mtime": "2026-07-30T10:58:12.272Z",
+      "mtime": "2026-07-30T15:02:43.083Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8444,7 +8444,7 @@
       "path": "hna/jurisdiction-metrics-digest/0839195.json",
       "kind": "json",
       "size_bytes": 29313,
-      "mtime": "2026-07-30T10:58:12.272Z",
+      "mtime": "2026-07-30T15:02:43.083Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8463,7 +8463,7 @@
       "path": "hna/jurisdiction-metrics-digest/0839250.json",
       "kind": "json",
       "size_bytes": 29266,
-      "mtime": "2026-07-30T10:58:12.273Z",
+      "mtime": "2026-07-30T15:02:43.084Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8482,7 +8482,7 @@
       "path": "hna/jurisdiction-metrics-digest/0839745.json",
       "kind": "json",
       "size_bytes": 29275,
-      "mtime": "2026-07-30T10:58:12.273Z",
+      "mtime": "2026-07-30T15:02:43.084Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8501,7 +8501,7 @@
       "path": "hna/jurisdiction-metrics-digest/0839800.json",
       "kind": "json",
       "size_bytes": 29257,
-      "mtime": "2026-07-30T10:58:12.273Z",
+      "mtime": "2026-07-30T15:02:43.085Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8520,7 +8520,7 @@
       "path": "hna/jurisdiction-metrics-digest/0839855.json",
       "kind": "json",
       "size_bytes": 29391,
-      "mtime": "2026-07-30T10:58:12.273Z",
+      "mtime": "2026-07-30T15:02:43.085Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8539,7 +8539,7 @@
       "path": "hna/jurisdiction-metrics-digest/0839965.json",
       "kind": "json",
       "size_bytes": 29381,
-      "mtime": "2026-07-30T10:58:12.273Z",
+      "mtime": "2026-07-30T15:02:43.085Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8558,7 +8558,7 @@
       "path": "hna/jurisdiction-metrics-digest/0840185.json",
       "kind": "json",
       "size_bytes": 29468,
-      "mtime": "2026-07-30T10:58:12.273Z",
+      "mtime": "2026-07-30T15:02:43.086Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8577,7 +8577,7 @@
       "path": "hna/jurisdiction-metrics-digest/0840377.json",
       "kind": "json",
       "size_bytes": 29439,
-      "mtime": "2026-07-30T10:58:12.274Z",
+      "mtime": "2026-07-30T15:02:43.086Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8596,7 +8596,7 @@
       "path": "hna/jurisdiction-metrics-digest/0840515.json",
       "kind": "json",
       "size_bytes": 29386,
-      "mtime": "2026-07-30T10:58:12.274Z",
+      "mtime": "2026-07-30T15:02:43.086Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8615,7 +8615,7 @@
       "path": "hna/jurisdiction-metrics-digest/0840550.json",
       "kind": "json",
       "size_bytes": 29557,
-      "mtime": "2026-07-30T10:58:12.274Z",
+      "mtime": "2026-07-30T15:02:43.086Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8634,7 +8634,7 @@
       "path": "hna/jurisdiction-metrics-digest/0840570.json",
       "kind": "json",
       "size_bytes": 29265,
-      "mtime": "2026-07-30T10:58:12.274Z",
+      "mtime": "2026-07-30T15:02:43.086Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8653,7 +8653,7 @@
       "path": "hna/jurisdiction-metrics-digest/0840790.json",
       "kind": "json",
       "size_bytes": 29507,
-      "mtime": "2026-07-30T10:58:12.274Z",
+      "mtime": "2026-07-30T15:02:43.087Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8672,7 +8672,7 @@
       "path": "hna/jurisdiction-metrics-digest/0840900.json",
       "kind": "json",
       "size_bytes": 29201,
-      "mtime": "2026-07-30T10:58:12.274Z",
+      "mtime": "2026-07-30T15:02:43.087Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8691,7 +8691,7 @@
       "path": "hna/jurisdiction-metrics-digest/0841010.json",
       "kind": "json",
       "size_bytes": 29438,
-      "mtime": "2026-07-30T10:58:12.275Z",
+      "mtime": "2026-07-30T15:02:43.087Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8710,7 +8710,7 @@
       "path": "hna/jurisdiction-metrics-digest/0841065.json",
       "kind": "json",
       "size_bytes": 29300,
-      "mtime": "2026-07-30T10:58:12.275Z",
+      "mtime": "2026-07-30T15:02:43.087Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8729,7 +8729,7 @@
       "path": "hna/jurisdiction-metrics-digest/0841560.json",
       "kind": "json",
       "size_bytes": 29544,
-      "mtime": "2026-07-30T10:58:12.275Z",
+      "mtime": "2026-07-30T15:02:43.087Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8748,7 +8748,7 @@
       "path": "hna/jurisdiction-metrics-digest/0841835.json",
       "kind": "json",
       "size_bytes": 29483,
-      "mtime": "2026-07-30T10:58:12.275Z",
+      "mtime": "2026-07-30T15:02:43.088Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8767,7 +8767,7 @@
       "path": "hna/jurisdiction-metrics-digest/0842000.json",
       "kind": "json",
       "size_bytes": 29178,
-      "mtime": "2026-07-30T10:58:12.275Z",
+      "mtime": "2026-07-30T15:02:43.088Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8786,7 +8786,7 @@
       "path": "hna/jurisdiction-metrics-digest/0842055.json",
       "kind": "json",
       "size_bytes": 29368,
-      "mtime": "2026-07-30T10:58:12.275Z",
+      "mtime": "2026-07-30T15:02:43.088Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8805,7 +8805,7 @@
       "path": "hna/jurisdiction-metrics-digest/0842110.json",
       "kind": "json",
       "size_bytes": 29401,
-      "mtime": "2026-07-30T10:58:12.276Z",
+      "mtime": "2026-07-30T15:02:43.088Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8824,7 +8824,7 @@
       "path": "hna/jurisdiction-metrics-digest/0842165.json",
       "kind": "json",
       "size_bytes": 29310,
-      "mtime": "2026-07-30T10:58:12.276Z",
+      "mtime": "2026-07-30T15:02:43.088Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8843,7 +8843,7 @@
       "path": "hna/jurisdiction-metrics-digest/0842330.json",
       "kind": "json",
       "size_bytes": 29472,
-      "mtime": "2026-07-30T10:58:12.276Z",
+      "mtime": "2026-07-30T15:02:43.088Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8862,7 +8862,7 @@
       "path": "hna/jurisdiction-metrics-digest/0842495.json",
       "kind": "json",
       "size_bytes": 29239,
-      "mtime": "2026-07-30T10:58:12.276Z",
+      "mtime": "2026-07-30T15:02:43.088Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8881,7 +8881,7 @@
       "path": "hna/jurisdiction-metrics-digest/0843000.json",
       "kind": "json",
       "size_bytes": 29492,
-      "mtime": "2026-07-30T10:58:12.276Z",
+      "mtime": "2026-07-30T15:02:43.089Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8900,7 +8900,7 @@
       "path": "hna/jurisdiction-metrics-digest/0843110.json",
       "kind": "json",
       "size_bytes": 29418,
-      "mtime": "2026-07-30T10:58:12.276Z",
+      "mtime": "2026-07-30T15:02:43.089Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8919,7 +8919,7 @@
       "path": "hna/jurisdiction-metrics-digest/0843220.json",
       "kind": "json",
       "size_bytes": 29385,
-      "mtime": "2026-07-30T10:58:12.277Z",
+      "mtime": "2026-07-30T15:02:43.089Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8938,7 +8938,7 @@
       "path": "hna/jurisdiction-metrics-digest/0843550.json",
       "kind": "json",
       "size_bytes": 29260,
-      "mtime": "2026-07-30T10:58:12.277Z",
+      "mtime": "2026-07-30T15:02:43.089Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8957,7 +8957,7 @@
       "path": "hna/jurisdiction-metrics-digest/0843605.json",
       "kind": "json",
       "size_bytes": 29487,
-      "mtime": "2026-07-30T10:58:12.277Z",
+      "mtime": "2026-07-30T15:02:43.089Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8976,7 +8976,7 @@
       "path": "hna/jurisdiction-metrics-digest/0843660.json",
       "kind": "json",
       "size_bytes": 29588,
-      "mtime": "2026-07-30T10:58:12.277Z",
+      "mtime": "2026-07-30T15:02:43.090Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -8995,7 +8995,7 @@
       "path": "hna/jurisdiction-metrics-digest/0844100.json",
       "kind": "json",
       "size_bytes": 29557,
-      "mtime": "2026-07-30T10:58:12.278Z",
+      "mtime": "2026-07-30T15:02:43.090Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9014,7 +9014,7 @@
       "path": "hna/jurisdiction-metrics-digest/0844265.json",
       "kind": "json",
       "size_bytes": 29268,
-      "mtime": "2026-07-30T10:58:12.279Z",
+      "mtime": "2026-07-30T15:02:43.090Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9033,7 +9033,7 @@
       "path": "hna/jurisdiction-metrics-digest/0844270.json",
       "kind": "json",
       "size_bytes": 29324,
-      "mtime": "2026-07-30T10:58:12.279Z",
+      "mtime": "2026-07-30T15:02:43.090Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9052,7 +9052,7 @@
       "path": "hna/jurisdiction-metrics-digest/0844320.json",
       "kind": "json",
       "size_bytes": 29546,
-      "mtime": "2026-07-30T10:58:12.279Z",
+      "mtime": "2026-07-30T15:02:43.090Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9071,7 +9071,7 @@
       "path": "hna/jurisdiction-metrics-digest/0844375.json",
       "kind": "json",
       "size_bytes": 29333,
-      "mtime": "2026-07-30T10:58:12.279Z",
+      "mtime": "2026-07-30T15:02:43.090Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9090,7 +9090,7 @@
       "path": "hna/jurisdiction-metrics-digest/0844595.json",
       "kind": "json",
       "size_bytes": 29275,
-      "mtime": "2026-07-30T10:58:12.279Z",
+      "mtime": "2026-07-30T15:02:43.091Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9109,7 +9109,7 @@
       "path": "hna/jurisdiction-metrics-digest/0844695.json",
       "kind": "json",
       "size_bytes": 29257,
-      "mtime": "2026-07-30T10:58:12.280Z",
+      "mtime": "2026-07-30T15:02:43.091Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9128,7 +9128,7 @@
       "path": "hna/jurisdiction-metrics-digest/0844980.json",
       "kind": "json",
       "size_bytes": 29480,
-      "mtime": "2026-07-30T10:58:12.280Z",
+      "mtime": "2026-07-30T15:02:43.091Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9147,7 +9147,7 @@
       "path": "hna/jurisdiction-metrics-digest/0845145.json",
       "kind": "json",
       "size_bytes": 29530,
-      "mtime": "2026-07-30T10:58:12.280Z",
+      "mtime": "2026-07-30T15:02:43.091Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9166,7 +9166,7 @@
       "path": "hna/jurisdiction-metrics-digest/0845255.json",
       "kind": "json",
       "size_bytes": 29488,
-      "mtime": "2026-07-30T10:58:12.280Z",
+      "mtime": "2026-07-30T15:02:43.091Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9185,7 +9185,7 @@
       "path": "hna/jurisdiction-metrics-digest/0845530.json",
       "kind": "json",
       "size_bytes": 29534,
-      "mtime": "2026-07-30T10:58:12.280Z",
+      "mtime": "2026-07-30T15:02:43.091Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9204,7 +9204,7 @@
       "path": "hna/jurisdiction-metrics-digest/0845680.json",
       "kind": "json",
       "size_bytes": 29331,
-      "mtime": "2026-07-30T10:58:12.280Z",
+      "mtime": "2026-07-30T15:02:43.092Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9223,7 +9223,7 @@
       "path": "hna/jurisdiction-metrics-digest/0845695.json",
       "kind": "json",
       "size_bytes": 29527,
-      "mtime": "2026-07-30T10:58:12.281Z",
+      "mtime": "2026-07-30T15:02:43.092Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9242,7 +9242,7 @@
       "path": "hna/jurisdiction-metrics-digest/0845750.json",
       "kind": "json",
       "size_bytes": 29299,
-      "mtime": "2026-07-30T10:58:12.281Z",
+      "mtime": "2026-07-30T15:02:43.092Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9261,7 +9261,7 @@
       "path": "hna/jurisdiction-metrics-digest/0845955.json",
       "kind": "json",
       "size_bytes": 29432,
-      "mtime": "2026-07-30T10:58:12.281Z",
+      "mtime": "2026-07-30T15:02:43.092Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9280,7 +9280,7 @@
       "path": "hna/jurisdiction-metrics-digest/0845970.json",
       "kind": "json",
       "size_bytes": 29501,
-      "mtime": "2026-07-30T10:58:12.281Z",
+      "mtime": "2026-07-30T15:02:43.092Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9299,7 +9299,7 @@
       "path": "hna/jurisdiction-metrics-digest/0846355.json",
       "kind": "json",
       "size_bytes": 29430,
-      "mtime": "2026-07-30T10:58:12.281Z",
+      "mtime": "2026-07-30T15:02:43.092Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9318,7 +9318,7 @@
       "path": "hna/jurisdiction-metrics-digest/0846410.json",
       "kind": "json",
       "size_bytes": 29296,
-      "mtime": "2026-07-30T10:58:12.281Z",
+      "mtime": "2026-07-30T15:02:43.093Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9337,7 +9337,7 @@
       "path": "hna/jurisdiction-metrics-digest/0846465.json",
       "kind": "json",
       "size_bytes": 29493,
-      "mtime": "2026-07-30T10:58:12.281Z",
+      "mtime": "2026-07-30T15:02:43.093Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9356,7 +9356,7 @@
       "path": "hna/jurisdiction-metrics-digest/0847015.json",
       "kind": "json",
       "size_bytes": 29291,
-      "mtime": "2026-07-30T10:58:12.282Z",
+      "mtime": "2026-07-30T15:02:43.093Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9375,7 +9375,7 @@
       "path": "hna/jurisdiction-metrics-digest/0847070.json",
       "kind": "json",
       "size_bytes": 29465,
-      "mtime": "2026-07-30T10:58:12.282Z",
+      "mtime": "2026-07-30T15:02:43.093Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9394,7 +9394,7 @@
       "path": "hna/jurisdiction-metrics-digest/0847235.json",
       "kind": "json",
       "size_bytes": 29244,
-      "mtime": "2026-07-30T10:58:12.282Z",
+      "mtime": "2026-07-30T15:02:43.093Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9413,7 +9413,7 @@
       "path": "hna/jurisdiction-metrics-digest/0847345.json",
       "kind": "json",
       "size_bytes": 29223,
-      "mtime": "2026-07-30T10:58:12.282Z",
+      "mtime": "2026-07-30T15:02:43.095Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9432,7 +9432,7 @@
       "path": "hna/jurisdiction-metrics-digest/0848060.json",
       "kind": "json",
       "size_bytes": 29463,
-      "mtime": "2026-07-30T10:58:12.282Z",
+      "mtime": "2026-07-30T15:02:43.095Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9451,7 +9451,7 @@
       "path": "hna/jurisdiction-metrics-digest/0848115.json",
       "kind": "json",
       "size_bytes": 29555,
-      "mtime": "2026-07-30T10:58:12.282Z",
+      "mtime": "2026-07-30T15:02:43.095Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9470,7 +9470,7 @@
       "path": "hna/jurisdiction-metrics-digest/0848445.json",
       "kind": "json",
       "size_bytes": 29546,
-      "mtime": "2026-07-30T10:58:12.282Z",
+      "mtime": "2026-07-30T15:02:43.095Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9489,7 +9489,7 @@
       "path": "hna/jurisdiction-metrics-digest/0848500.json",
       "kind": "json",
       "size_bytes": 29459,
-      "mtime": "2026-07-30T10:58:12.283Z",
+      "mtime": "2026-07-30T15:02:43.095Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9508,7 +9508,7 @@
       "path": "hna/jurisdiction-metrics-digest/0848555.json",
       "kind": "json",
       "size_bytes": 29311,
-      "mtime": "2026-07-30T10:58:12.283Z",
+      "mtime": "2026-07-30T15:02:43.096Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9527,7 +9527,7 @@
       "path": "hna/jurisdiction-metrics-digest/0848940.json",
       "kind": "json",
       "size_bytes": 29216,
-      "mtime": "2026-07-30T10:58:12.283Z",
+      "mtime": "2026-07-30T15:02:43.096Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9546,7 +9546,7 @@
       "path": "hna/jurisdiction-metrics-digest/0849215.json",
       "kind": "json",
       "size_bytes": 29297,
-      "mtime": "2026-07-30T10:58:12.283Z",
+      "mtime": "2026-07-30T15:02:43.096Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9565,7 +9565,7 @@
       "path": "hna/jurisdiction-metrics-digest/0849325.json",
       "kind": "json",
       "size_bytes": 29216,
-      "mtime": "2026-07-30T10:58:12.283Z",
+      "mtime": "2026-07-30T15:02:43.096Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9584,7 +9584,7 @@
       "path": "hna/jurisdiction-metrics-digest/0849490.json",
       "kind": "json",
       "size_bytes": 29287,
-      "mtime": "2026-07-30T10:58:12.283Z",
+      "mtime": "2026-07-30T15:02:43.096Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9603,7 +9603,7 @@
       "path": "hna/jurisdiction-metrics-digest/0849600.json",
       "kind": "json",
       "size_bytes": 29543,
-      "mtime": "2026-07-30T10:58:12.284Z",
+      "mtime": "2026-07-30T15:02:43.097Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9622,7 +9622,7 @@
       "path": "hna/jurisdiction-metrics-digest/0849875.json",
       "kind": "json",
       "size_bytes": 29488,
-      "mtime": "2026-07-30T10:58:12.284Z",
+      "mtime": "2026-07-30T15:02:43.097Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9641,7 +9641,7 @@
       "path": "hna/jurisdiction-metrics-digest/0850012.json",
       "kind": "json",
       "size_bytes": 29421,
-      "mtime": "2026-07-30T10:58:12.284Z",
+      "mtime": "2026-07-30T15:02:43.097Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9660,7 +9660,7 @@
       "path": "hna/jurisdiction-metrics-digest/0850026.json",
       "kind": "json",
       "size_bytes": 29485,
-      "mtime": "2026-07-30T10:58:12.284Z",
+      "mtime": "2026-07-30T15:02:43.097Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9679,7 +9679,7 @@
       "path": "hna/jurisdiction-metrics-digest/0850040.json",
       "kind": "json",
       "size_bytes": 29446,
-      "mtime": "2026-07-30T10:58:12.284Z",
+      "mtime": "2026-07-30T15:02:43.097Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9698,7 +9698,7 @@
       "path": "hna/jurisdiction-metrics-digest/0850380.json",
       "kind": "json",
       "size_bytes": 29279,
-      "mtime": "2026-07-30T10:58:12.284Z",
+      "mtime": "2026-07-30T15:02:43.097Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9717,7 +9717,7 @@
       "path": "hna/jurisdiction-metrics-digest/0850480.json",
       "kind": "json",
       "size_bytes": 29545,
-      "mtime": "2026-07-30T10:58:12.284Z",
+      "mtime": "2026-07-30T15:02:43.098Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9736,7 +9736,7 @@
       "path": "hna/jurisdiction-metrics-digest/0850920.json",
       "kind": "json",
       "size_bytes": 29508,
-      "mtime": "2026-07-30T10:58:12.285Z",
+      "mtime": "2026-07-30T15:02:43.098Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9755,7 +9755,7 @@
       "path": "hna/jurisdiction-metrics-digest/0851250.json",
       "kind": "json",
       "size_bytes": 29254,
-      "mtime": "2026-07-30T10:58:12.285Z",
+      "mtime": "2026-07-30T15:02:43.098Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9774,7 +9774,7 @@
       "path": "hna/jurisdiction-metrics-digest/0851635.json",
       "kind": "json",
       "size_bytes": 29414,
-      "mtime": "2026-07-30T10:58:12.285Z",
+      "mtime": "2026-07-30T15:02:43.098Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9793,7 +9793,7 @@
       "path": "hna/jurisdiction-metrics-digest/0851690.json",
       "kind": "json",
       "size_bytes": 29252,
-      "mtime": "2026-07-30T10:58:12.285Z",
+      "mtime": "2026-07-30T15:02:43.098Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9812,7 +9812,7 @@
       "path": "hna/jurisdiction-metrics-digest/0851745.json",
       "kind": "json",
       "size_bytes": 29490,
-      "mtime": "2026-07-30T10:58:12.285Z",
+      "mtime": "2026-07-30T15:02:43.098Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9831,7 +9831,7 @@
       "path": "hna/jurisdiction-metrics-digest/0851800.json",
       "kind": "json",
       "size_bytes": 29520,
-      "mtime": "2026-07-30T10:58:12.285Z",
+      "mtime": "2026-07-30T15:02:43.099Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9850,7 +9850,7 @@
       "path": "hna/jurisdiction-metrics-digest/0851975.json",
       "kind": "json",
       "size_bytes": 29288,
-      "mtime": "2026-07-30T10:58:12.286Z",
+      "mtime": "2026-07-30T15:02:43.099Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9869,7 +9869,7 @@
       "path": "hna/jurisdiction-metrics-digest/0852075.json",
       "kind": "json",
       "size_bytes": 29444,
-      "mtime": "2026-07-30T10:58:12.286Z",
+      "mtime": "2026-07-30T15:02:43.099Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9888,7 +9888,7 @@
       "path": "hna/jurisdiction-metrics-digest/0852210.json",
       "kind": "json",
       "size_bytes": 29295,
-      "mtime": "2026-07-30T10:58:12.286Z",
+      "mtime": "2026-07-30T15:02:43.099Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9907,7 +9907,7 @@
       "path": "hna/jurisdiction-metrics-digest/0852350.json",
       "kind": "json",
       "size_bytes": 29460,
-      "mtime": "2026-07-30T10:58:12.287Z",
+      "mtime": "2026-07-30T15:02:43.099Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9926,7 +9926,7 @@
       "path": "hna/jurisdiction-metrics-digest/0852550.json",
       "kind": "json",
       "size_bytes": 29438,
-      "mtime": "2026-07-30T10:58:12.287Z",
+      "mtime": "2026-07-30T15:02:43.100Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9945,7 +9945,7 @@
       "path": "hna/jurisdiction-metrics-digest/0852570.json",
       "kind": "json",
       "size_bytes": 29476,
-      "mtime": "2026-07-30T10:58:12.288Z",
+      "mtime": "2026-07-30T15:02:43.100Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9964,7 +9964,7 @@
       "path": "hna/jurisdiction-metrics-digest/0852820.json",
       "kind": "json",
       "size_bytes": 29299,
-      "mtime": "2026-07-30T10:58:12.288Z",
+      "mtime": "2026-07-30T15:02:43.100Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -9983,7 +9983,7 @@
       "path": "hna/jurisdiction-metrics-digest/0853010.json",
       "kind": "json",
       "size_bytes": 29267,
-      "mtime": "2026-07-30T10:58:12.288Z",
+      "mtime": "2026-07-30T15:02:43.101Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10002,7 +10002,7 @@
       "path": "hna/jurisdiction-metrics-digest/0853120.json",
       "kind": "json",
       "size_bytes": 29455,
-      "mtime": "2026-07-30T10:58:12.288Z",
+      "mtime": "2026-07-30T15:02:43.101Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10021,7 +10021,7 @@
       "path": "hna/jurisdiction-metrics-digest/0853175.json",
       "kind": "json",
       "size_bytes": 29384,
-      "mtime": "2026-07-30T10:58:12.288Z",
+      "mtime": "2026-07-30T15:02:43.101Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10040,7 +10040,7 @@
       "path": "hna/jurisdiction-metrics-digest/0853395.json",
       "kind": "json",
       "size_bytes": 29417,
-      "mtime": "2026-07-30T10:58:12.288Z",
+      "mtime": "2026-07-30T15:02:43.101Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10059,7 +10059,7 @@
       "path": "hna/jurisdiction-metrics-digest/0853780.json",
       "kind": "json",
       "size_bytes": 29399,
-      "mtime": "2026-07-30T10:58:12.289Z",
+      "mtime": "2026-07-30T15:02:43.101Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10078,7 +10078,7 @@
       "path": "hna/jurisdiction-metrics-digest/0853875.json",
       "kind": "json",
       "size_bytes": 29277,
-      "mtime": "2026-07-30T10:58:12.289Z",
+      "mtime": "2026-07-30T15:02:43.101Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10097,7 +10097,7 @@
       "path": "hna/jurisdiction-metrics-digest/0853945.json",
       "kind": "json",
       "size_bytes": 29292,
-      "mtime": "2026-07-30T10:58:12.289Z",
+      "mtime": "2026-07-30T15:02:43.102Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10116,7 +10116,7 @@
       "path": "hna/jurisdiction-metrics-digest/0854330.json",
       "kind": "json",
       "size_bytes": 29486,
-      "mtime": "2026-07-30T10:58:12.289Z",
+      "mtime": "2026-07-30T15:02:43.102Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10135,7 +10135,7 @@
       "path": "hna/jurisdiction-metrics-digest/0854495.json",
       "kind": "json",
       "size_bytes": 29511,
-      "mtime": "2026-07-30T10:58:12.289Z",
+      "mtime": "2026-07-30T15:02:43.102Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10154,7 +10154,7 @@
       "path": "hna/jurisdiction-metrics-digest/0854750.json",
       "kind": "json",
       "size_bytes": 29322,
-      "mtime": "2026-07-30T10:58:12.289Z",
+      "mtime": "2026-07-30T15:02:43.102Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10173,7 +10173,7 @@
       "path": "hna/jurisdiction-metrics-digest/0854880.json",
       "kind": "json",
       "size_bytes": 29464,
-      "mtime": "2026-07-30T10:58:12.290Z",
+      "mtime": "2026-07-30T15:02:43.102Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10192,7 +10192,7 @@
       "path": "hna/jurisdiction-metrics-digest/0854935.json",
       "kind": "json",
       "size_bytes": 29461,
-      "mtime": "2026-07-30T10:58:12.290Z",
+      "mtime": "2026-07-30T15:02:43.102Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10211,7 +10211,7 @@
       "path": "hna/jurisdiction-metrics-digest/0855045.json",
       "kind": "json",
       "size_bytes": 29307,
-      "mtime": "2026-07-30T10:58:12.290Z",
+      "mtime": "2026-07-30T15:02:43.103Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10230,7 +10230,7 @@
       "path": "hna/jurisdiction-metrics-digest/0855155.json",
       "kind": "json",
       "size_bytes": 29452,
-      "mtime": "2026-07-30T10:58:12.290Z",
+      "mtime": "2026-07-30T15:02:43.103Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10249,7 +10249,7 @@
       "path": "hna/jurisdiction-metrics-digest/0855540.json",
       "kind": "json",
       "size_bytes": 29394,
-      "mtime": "2026-07-30T10:58:12.290Z",
+      "mtime": "2026-07-30T15:02:43.103Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10268,7 +10268,7 @@
       "path": "hna/jurisdiction-metrics-digest/0855705.json",
       "kind": "json",
       "size_bytes": 29384,
-      "mtime": "2026-07-30T10:58:12.290Z",
+      "mtime": "2026-07-30T15:02:43.103Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10287,7 +10287,7 @@
       "path": "hna/jurisdiction-metrics-digest/0855870.json",
       "kind": "json",
       "size_bytes": 29290,
-      "mtime": "2026-07-30T10:58:12.290Z",
+      "mtime": "2026-07-30T15:02:43.103Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10306,7 +10306,7 @@
       "path": "hna/jurisdiction-metrics-digest/0855925.json",
       "kind": "json",
       "size_bytes": 29325,
-      "mtime": "2026-07-30T10:58:12.291Z",
+      "mtime": "2026-07-30T15:02:43.103Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10325,7 +10325,7 @@
       "path": "hna/jurisdiction-metrics-digest/0855980.json",
       "kind": "json",
       "size_bytes": 29438,
-      "mtime": "2026-07-30T10:58:12.291Z",
+      "mtime": "2026-07-30T15:02:43.105Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10344,7 +10344,7 @@
       "path": "hna/jurisdiction-metrics-digest/0856035.json",
       "kind": "json",
       "size_bytes": 29583,
-      "mtime": "2026-07-30T10:58:12.291Z",
+      "mtime": "2026-07-30T15:02:43.105Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10363,7 +10363,7 @@
       "path": "hna/jurisdiction-metrics-digest/0856145.json",
       "kind": "json",
       "size_bytes": 29510,
-      "mtime": "2026-07-30T10:58:12.292Z",
+      "mtime": "2026-07-30T15:02:43.105Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10382,7 +10382,7 @@
       "path": "hna/jurisdiction-metrics-digest/0856365.json",
       "kind": "json",
       "size_bytes": 29435,
-      "mtime": "2026-07-30T10:58:12.292Z",
+      "mtime": "2026-07-30T15:02:43.105Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10401,7 +10401,7 @@
       "path": "hna/jurisdiction-metrics-digest/0856420.json",
       "kind": "json",
       "size_bytes": 29330,
-      "mtime": "2026-07-30T10:58:12.292Z",
+      "mtime": "2026-07-30T15:02:43.105Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10420,7 +10420,7 @@
       "path": "hna/jurisdiction-metrics-digest/0856475.json",
       "kind": "json",
       "size_bytes": 29456,
-      "mtime": "2026-07-30T10:58:12.292Z",
+      "mtime": "2026-07-30T15:02:43.105Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10439,7 +10439,7 @@
       "path": "hna/jurisdiction-metrics-digest/0856695.json",
       "kind": "json",
       "size_bytes": 29175,
-      "mtime": "2026-07-30T10:58:12.292Z",
+      "mtime": "2026-07-30T15:02:43.105Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10458,7 +10458,7 @@
       "path": "hna/jurisdiction-metrics-digest/0856860.json",
       "kind": "json",
       "size_bytes": 29461,
-      "mtime": "2026-07-30T10:58:12.292Z",
+      "mtime": "2026-07-30T15:02:43.106Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10477,7 +10477,7 @@
       "path": "hna/jurisdiction-metrics-digest/0856970.json",
       "kind": "json",
       "size_bytes": 29409,
-      "mtime": "2026-07-30T10:58:12.293Z",
+      "mtime": "2026-07-30T15:02:43.106Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10496,7 +10496,7 @@
       "path": "hna/jurisdiction-metrics-digest/0857025.json",
       "kind": "json",
       "size_bytes": 29353,
-      "mtime": "2026-07-30T10:58:12.293Z",
+      "mtime": "2026-07-30T15:02:43.106Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10515,7 +10515,7 @@
       "path": "hna/jurisdiction-metrics-digest/0857245.json",
       "kind": "json",
       "size_bytes": 29225,
-      "mtime": "2026-07-30T10:58:12.293Z",
+      "mtime": "2026-07-30T15:02:43.106Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10534,7 +10534,7 @@
       "path": "hna/jurisdiction-metrics-digest/0857300.json",
       "kind": "json",
       "size_bytes": 29402,
-      "mtime": "2026-07-30T10:58:12.293Z",
+      "mtime": "2026-07-30T15:02:43.106Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10553,7 +10553,7 @@
       "path": "hna/jurisdiction-metrics-digest/0857400.json",
       "kind": "json",
       "size_bytes": 29406,
-      "mtime": "2026-07-30T10:58:12.293Z",
+      "mtime": "2026-07-30T15:02:43.106Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10572,7 +10572,7 @@
       "path": "hna/jurisdiction-metrics-digest/0857445.json",
       "kind": "json",
       "size_bytes": 29296,
-      "mtime": "2026-07-30T10:58:12.294Z",
+      "mtime": "2026-07-30T15:02:43.107Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10591,7 +10591,7 @@
       "path": "hna/jurisdiction-metrics-digest/0857465.json",
       "kind": "json",
       "size_bytes": 29581,
-      "mtime": "2026-07-30T10:58:12.294Z",
+      "mtime": "2026-07-30T15:02:43.107Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10610,7 +10610,7 @@
       "path": "hna/jurisdiction-metrics-digest/0857630.json",
       "kind": "json",
       "size_bytes": 29460,
-      "mtime": "2026-07-30T10:58:12.294Z",
+      "mtime": "2026-07-30T15:02:43.107Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10629,7 +10629,7 @@
       "path": "hna/jurisdiction-metrics-digest/0857850.json",
       "kind": "json",
       "size_bytes": 29233,
-      "mtime": "2026-07-30T10:58:12.295Z",
+      "mtime": "2026-07-30T15:02:43.107Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10648,7 +10648,7 @@
       "path": "hna/jurisdiction-metrics-digest/0858235.json",
       "kind": "json",
       "size_bytes": 29457,
-      "mtime": "2026-07-30T10:58:12.295Z",
+      "mtime": "2026-07-30T15:02:43.107Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10667,7 +10667,7 @@
       "path": "hna/jurisdiction-metrics-digest/0858400.json",
       "kind": "json",
       "size_bytes": 29382,
-      "mtime": "2026-07-30T10:58:12.295Z",
+      "mtime": "2026-07-30T15:02:43.107Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10686,7 +10686,7 @@
       "path": "hna/jurisdiction-metrics-digest/0858510.json",
       "kind": "json",
       "size_bytes": 29259,
-      "mtime": "2026-07-30T10:58:12.295Z",
+      "mtime": "2026-07-30T15:02:43.107Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10705,7 +10705,7 @@
       "path": "hna/jurisdiction-metrics-digest/0858592.json",
       "kind": "json",
       "size_bytes": 29295,
-      "mtime": "2026-07-30T10:58:12.296Z",
+      "mtime": "2026-07-30T15:02:43.108Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10724,7 +10724,7 @@
       "path": "hna/jurisdiction-metrics-digest/0858675.json",
       "kind": "json",
       "size_bytes": 29243,
-      "mtime": "2026-07-30T10:58:12.296Z",
+      "mtime": "2026-07-30T15:02:43.108Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10743,7 +10743,7 @@
       "path": "hna/jurisdiction-metrics-digest/0858785.json",
       "kind": "json",
       "size_bytes": 29293,
-      "mtime": "2026-07-30T10:58:12.296Z",
+      "mtime": "2026-07-30T15:02:43.108Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10762,7 +10762,7 @@
       "path": "hna/jurisdiction-metrics-digest/0858960.json",
       "kind": "json",
       "size_bytes": 29236,
-      "mtime": "2026-07-30T10:58:12.296Z",
+      "mtime": "2026-07-30T15:02:43.108Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10781,7 +10781,7 @@
       "path": "hna/jurisdiction-metrics-digest/0859005.json",
       "kind": "json",
       "size_bytes": 29474,
-      "mtime": "2026-07-30T10:58:12.297Z",
+      "mtime": "2026-07-30T15:02:43.108Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10800,7 +10800,7 @@
       "path": "hna/jurisdiction-metrics-digest/0859240.json",
       "kind": "json",
       "size_bytes": 29322,
-      "mtime": "2026-07-30T10:58:12.297Z",
+      "mtime": "2026-07-30T15:02:43.108Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10819,7 +10819,7 @@
       "path": "hna/jurisdiction-metrics-digest/0859520.json",
       "kind": "json",
       "size_bytes": 29283,
-      "mtime": "2026-07-30T10:58:12.298Z",
+      "mtime": "2026-07-30T15:02:43.108Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10838,7 +10838,7 @@
       "path": "hna/jurisdiction-metrics-digest/0859830.json",
       "kind": "json",
       "size_bytes": 29268,
-      "mtime": "2026-07-30T10:58:12.298Z",
+      "mtime": "2026-07-30T15:02:43.109Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10857,7 +10857,7 @@
       "path": "hna/jurisdiction-metrics-digest/0859885.json",
       "kind": "json",
       "size_bytes": 29474,
-      "mtime": "2026-07-30T10:58:12.298Z",
+      "mtime": "2026-07-30T15:02:43.109Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10876,7 +10876,7 @@
       "path": "hna/jurisdiction-metrics-digest/0860160.json",
       "kind": "json",
       "size_bytes": 29487,
-      "mtime": "2026-07-30T10:58:12.299Z",
+      "mtime": "2026-07-30T15:02:43.109Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10895,7 +10895,7 @@
       "path": "hna/jurisdiction-metrics-digest/0860600.json",
       "kind": "json",
       "size_bytes": 29451,
-      "mtime": "2026-07-30T10:58:12.299Z",
+      "mtime": "2026-07-30T15:02:43.109Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10914,7 +10914,7 @@
       "path": "hna/jurisdiction-metrics-digest/0860655.json",
       "kind": "json",
       "size_bytes": 29303,
-      "mtime": "2026-07-30T10:58:12.299Z",
+      "mtime": "2026-07-30T15:02:43.109Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10933,7 +10933,7 @@
       "path": "hna/jurisdiction-metrics-digest/0860765.json",
       "kind": "json",
       "size_bytes": 29266,
-      "mtime": "2026-07-30T10:58:12.299Z",
+      "mtime": "2026-07-30T15:02:43.109Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10952,7 +10952,7 @@
       "path": "hna/jurisdiction-metrics-digest/0861315.json",
       "kind": "json",
       "size_bytes": 29264,
-      "mtime": "2026-07-30T10:58:12.299Z",
+      "mtime": "2026-07-30T15:02:43.109Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10971,7 +10971,7 @@
       "path": "hna/jurisdiction-metrics-digest/0862000.json",
       "kind": "json",
       "size_bytes": 29519,
-      "mtime": "2026-07-30T10:58:12.300Z",
+      "mtime": "2026-07-30T15:02:43.110Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -10990,7 +10990,7 @@
       "path": "hna/jurisdiction-metrics-digest/0862220.json",
       "kind": "json",
       "size_bytes": 29458,
-      "mtime": "2026-07-30T10:58:12.300Z",
+      "mtime": "2026-07-30T15:02:43.110Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11009,7 +11009,7 @@
       "path": "hna/jurisdiction-metrics-digest/0862660.json",
       "kind": "json",
       "size_bytes": 29279,
-      "mtime": "2026-07-30T10:58:12.300Z",
+      "mtime": "2026-07-30T15:02:43.110Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11028,7 +11028,7 @@
       "path": "hna/jurisdiction-metrics-digest/0862880.json",
       "kind": "json",
       "size_bytes": 29382,
-      "mtime": "2026-07-30T10:58:12.300Z",
+      "mtime": "2026-07-30T15:02:43.110Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11047,7 +11047,7 @@
       "path": "hna/jurisdiction-metrics-digest/0863045.json",
       "kind": "json",
       "size_bytes": 29243,
-      "mtime": "2026-07-30T10:58:12.300Z",
+      "mtime": "2026-07-30T15:02:43.110Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11066,7 +11066,7 @@
       "path": "hna/jurisdiction-metrics-digest/0863265.json",
       "kind": "json",
       "size_bytes": 29464,
-      "mtime": "2026-07-30T10:58:12.300Z",
+      "mtime": "2026-07-30T15:02:43.110Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11085,7 +11085,7 @@
       "path": "hna/jurisdiction-metrics-digest/0863320.json",
       "kind": "json",
       "size_bytes": 29278,
-      "mtime": "2026-07-30T10:58:12.301Z",
+      "mtime": "2026-07-30T15:02:43.111Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11104,7 +11104,7 @@
       "path": "hna/jurisdiction-metrics-digest/0863375.json",
       "kind": "json",
       "size_bytes": 29570,
-      "mtime": "2026-07-30T10:58:12.301Z",
+      "mtime": "2026-07-30T15:02:43.111Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11123,7 +11123,7 @@
       "path": "hna/jurisdiction-metrics-digest/0863650.json",
       "kind": "json",
       "size_bytes": 29257,
-      "mtime": "2026-07-30T10:58:12.301Z",
+      "mtime": "2026-07-30T15:02:43.111Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11142,7 +11142,7 @@
       "path": "hna/jurisdiction-metrics-digest/0863705.json",
       "kind": "json",
       "size_bytes": 29276,
-      "mtime": "2026-07-30T10:58:12.301Z",
+      "mtime": "2026-07-30T15:02:43.111Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11161,7 +11161,7 @@
       "path": "hna/jurisdiction-metrics-digest/0864090.json",
       "kind": "json",
       "size_bytes": 29478,
-      "mtime": "2026-07-30T10:58:12.301Z",
+      "mtime": "2026-07-30T15:02:43.111Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11180,7 +11180,7 @@
       "path": "hna/jurisdiction-metrics-digest/0864200.json",
       "kind": "json",
       "size_bytes": 29343,
-      "mtime": "2026-07-30T10:58:12.302Z",
+      "mtime": "2026-07-30T15:02:43.111Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11199,7 +11199,7 @@
       "path": "hna/jurisdiction-metrics-digest/0864255.json",
       "kind": "json",
       "size_bytes": 29454,
-      "mtime": "2026-07-30T10:58:12.302Z",
+      "mtime": "2026-07-30T15:02:43.111Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11218,7 +11218,7 @@
       "path": "hna/jurisdiction-metrics-digest/0864870.json",
       "kind": "json",
       "size_bytes": 29250,
-      "mtime": "2026-07-30T10:58:12.302Z",
+      "mtime": "2026-07-30T15:02:43.112Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11237,7 +11237,7 @@
       "path": "hna/jurisdiction-metrics-digest/0864970.json",
       "kind": "json",
       "size_bytes": 29472,
-      "mtime": "2026-07-30T10:58:12.302Z",
+      "mtime": "2026-07-30T15:02:43.113Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11256,7 +11256,7 @@
       "path": "hna/jurisdiction-metrics-digest/0865190.json",
       "kind": "json",
       "size_bytes": 29413,
-      "mtime": "2026-07-30T10:58:12.302Z",
+      "mtime": "2026-07-30T15:02:43.113Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11275,7 +11275,7 @@
       "path": "hna/jurisdiction-metrics-digest/0865685.json",
       "kind": "json",
       "size_bytes": 29286,
-      "mtime": "2026-07-30T10:58:12.303Z",
+      "mtime": "2026-07-30T15:02:43.113Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11294,7 +11294,7 @@
       "path": "hna/jurisdiction-metrics-digest/0865740.json",
       "kind": "json",
       "size_bytes": 29464,
-      "mtime": "2026-07-30T10:58:12.303Z",
+      "mtime": "2026-07-30T15:02:43.113Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11313,7 +11313,7 @@
       "path": "hna/jurisdiction-metrics-digest/0866197.json",
       "kind": "json",
       "size_bytes": 29537,
-      "mtime": "2026-07-30T10:58:12.303Z",
+      "mtime": "2026-07-30T15:02:43.114Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11332,7 +11332,7 @@
       "path": "hna/jurisdiction-metrics-digest/0866895.json",
       "kind": "json",
       "size_bytes": 29348,
-      "mtime": "2026-07-30T10:58:12.303Z",
+      "mtime": "2026-07-30T15:02:43.114Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11351,7 +11351,7 @@
       "path": "hna/jurisdiction-metrics-digest/0866995.json",
       "kind": "json",
       "size_bytes": 29179,
-      "mtime": "2026-07-30T10:58:12.303Z",
+      "mtime": "2026-07-30T15:02:43.114Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11370,7 +11370,7 @@
       "path": "hna/jurisdiction-metrics-digest/0867005.json",
       "kind": "json",
       "size_bytes": 29523,
-      "mtime": "2026-07-30T10:58:12.303Z",
+      "mtime": "2026-07-30T15:02:43.114Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11389,7 +11389,7 @@
       "path": "hna/jurisdiction-metrics-digest/0867040.json",
       "kind": "json",
       "size_bytes": 29322,
-      "mtime": "2026-07-30T10:58:12.304Z",
+      "mtime": "2026-07-30T15:02:43.114Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11408,7 +11408,7 @@
       "path": "hna/jurisdiction-metrics-digest/0867142.json",
       "kind": "json",
       "size_bytes": 29255,
-      "mtime": "2026-07-30T10:58:12.304Z",
+      "mtime": "2026-07-30T15:02:43.114Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11427,7 +11427,7 @@
       "path": "hna/jurisdiction-metrics-digest/0867280.json",
       "kind": "json",
       "size_bytes": 29427,
-      "mtime": "2026-07-30T10:58:12.304Z",
+      "mtime": "2026-07-30T15:02:43.114Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11446,7 +11446,7 @@
       "path": "hna/jurisdiction-metrics-digest/0867445.json",
       "kind": "json",
       "size_bytes": 29489,
-      "mtime": "2026-07-30T10:58:12.304Z",
+      "mtime": "2026-07-30T15:02:43.115Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11465,7 +11465,7 @@
       "path": "hna/jurisdiction-metrics-digest/0867500.json",
       "kind": "json",
       "size_bytes": 29232,
-      "mtime": "2026-07-30T10:58:12.304Z",
+      "mtime": "2026-07-30T15:02:43.115Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11484,7 +11484,7 @@
       "path": "hna/jurisdiction-metrics-digest/0867830.json",
       "kind": "json",
       "size_bytes": 29517,
-      "mtime": "2026-07-30T10:58:12.305Z",
+      "mtime": "2026-07-30T15:02:43.115Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11503,7 +11503,7 @@
       "path": "hna/jurisdiction-metrics-digest/0868105.json",
       "kind": "json",
       "size_bytes": 29464,
-      "mtime": "2026-07-30T10:58:12.305Z",
+      "mtime": "2026-07-30T15:02:43.115Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11522,7 +11522,7 @@
       "path": "hna/jurisdiction-metrics-digest/0868655.json",
       "kind": "json",
       "size_bytes": 29186,
-      "mtime": "2026-07-30T10:58:12.305Z",
+      "mtime": "2026-07-30T15:02:43.115Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11541,7 +11541,7 @@
       "path": "hna/jurisdiction-metrics-digest/0868847.json",
       "kind": "json",
       "size_bytes": 29460,
-      "mtime": "2026-07-30T10:58:12.305Z",
+      "mtime": "2026-07-30T15:02:43.115Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11560,7 +11560,7 @@
       "path": "hna/jurisdiction-metrics-digest/0868875.json",
       "kind": "json",
       "size_bytes": 29219,
-      "mtime": "2026-07-30T10:58:12.305Z",
+      "mtime": "2026-07-30T15:02:43.115Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11579,7 +11579,7 @@
       "path": "hna/jurisdiction-metrics-digest/0868930.json",
       "kind": "json",
       "size_bytes": 29266,
-      "mtime": "2026-07-30T10:58:12.306Z",
+      "mtime": "2026-07-30T15:02:43.116Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11598,7 +11598,7 @@
       "path": "hna/jurisdiction-metrics-digest/0868985.json",
       "kind": "json",
       "size_bytes": 29291,
-      "mtime": "2026-07-30T10:58:12.306Z",
+      "mtime": "2026-07-30T15:02:43.116Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11617,7 +11617,7 @@
       "path": "hna/jurisdiction-metrics-digest/0869040.json",
       "kind": "json",
       "size_bytes": 29341,
-      "mtime": "2026-07-30T10:58:12.306Z",
+      "mtime": "2026-07-30T15:02:43.116Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11636,7 +11636,7 @@
       "path": "hna/jurisdiction-metrics-digest/0869110.json",
       "kind": "json",
       "size_bytes": 29288,
-      "mtime": "2026-07-30T10:58:12.306Z",
+      "mtime": "2026-07-30T15:02:43.116Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11655,7 +11655,7 @@
       "path": "hna/jurisdiction-metrics-digest/0869150.json",
       "kind": "json",
       "size_bytes": 29492,
-      "mtime": "2026-07-30T10:58:12.306Z",
+      "mtime": "2026-07-30T15:02:43.116Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11674,7 +11674,7 @@
       "path": "hna/jurisdiction-metrics-digest/0869480.json",
       "kind": "json",
       "size_bytes": 29535,
-      "mtime": "2026-07-30T10:58:12.307Z",
+      "mtime": "2026-07-30T15:02:43.116Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11693,7 +11693,7 @@
       "path": "hna/jurisdiction-metrics-digest/0869645.json",
       "kind": "json",
       "size_bytes": 29436,
-      "mtime": "2026-07-30T10:58:12.307Z",
+      "mtime": "2026-07-30T15:02:43.116Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11712,7 +11712,7 @@
       "path": "hna/jurisdiction-metrics-digest/0869700.json",
       "kind": "json",
       "size_bytes": 29255,
-      "mtime": "2026-07-30T10:58:12.307Z",
+      "mtime": "2026-07-30T15:02:43.117Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11731,7 +11731,7 @@
       "path": "hna/jurisdiction-metrics-digest/0869810.json",
       "kind": "json",
       "size_bytes": 29443,
-      "mtime": "2026-07-30T10:58:12.308Z",
+      "mtime": "2026-07-30T15:02:43.117Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11750,7 +11750,7 @@
       "path": "hna/jurisdiction-metrics-digest/0870112.json",
       "kind": "json",
       "size_bytes": 29571,
-      "mtime": "2026-07-30T10:58:12.308Z",
+      "mtime": "2026-07-30T15:02:43.117Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11769,7 +11769,7 @@
       "path": "hna/jurisdiction-metrics-digest/0870195.json",
       "kind": "json",
       "size_bytes": 29427,
-      "mtime": "2026-07-30T10:58:12.309Z",
+      "mtime": "2026-07-30T15:02:43.117Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11788,7 +11788,7 @@
       "path": "hna/jurisdiction-metrics-digest/0870250.json",
       "kind": "json",
       "size_bytes": 29508,
-      "mtime": "2026-07-30T10:58:12.309Z",
+      "mtime": "2026-07-30T15:02:43.117Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11807,7 +11807,7 @@
       "path": "hna/jurisdiction-metrics-digest/0870360.json",
       "kind": "json",
       "size_bytes": 29428,
-      "mtime": "2026-07-30T10:58:12.309Z",
+      "mtime": "2026-07-30T15:02:43.117Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11826,7 +11826,7 @@
       "path": "hna/jurisdiction-metrics-digest/0870525.json",
       "kind": "json",
       "size_bytes": 29530,
-      "mtime": "2026-07-30T10:58:12.309Z",
+      "mtime": "2026-07-30T15:02:43.118Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11845,7 +11845,7 @@
       "path": "hna/jurisdiction-metrics-digest/0870580.json",
       "kind": "json",
       "size_bytes": 29378,
-      "mtime": "2026-07-30T10:58:12.309Z",
+      "mtime": "2026-07-30T15:02:43.118Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11864,7 +11864,7 @@
       "path": "hna/jurisdiction-metrics-digest/0870635.json",
       "kind": "json",
       "size_bytes": 29491,
-      "mtime": "2026-07-30T10:58:12.309Z",
+      "mtime": "2026-07-30T15:02:43.118Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11883,7 +11883,7 @@
       "path": "hna/jurisdiction-metrics-digest/0871625.json",
       "kind": "json",
       "size_bytes": 29296,
-      "mtime": "2026-07-30T10:58:12.310Z",
+      "mtime": "2026-07-30T15:02:43.118Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11902,7 +11902,7 @@
       "path": "hna/jurisdiction-metrics-digest/0871755.json",
       "kind": "json",
       "size_bytes": 29592,
-      "mtime": "2026-07-30T10:58:12.310Z",
+      "mtime": "2026-07-30T15:02:43.118Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11921,7 +11921,7 @@
       "path": "hna/jurisdiction-metrics-digest/0871790.json",
       "kind": "json",
       "size_bytes": 29222,
-      "mtime": "2026-07-30T10:58:12.310Z",
+      "mtime": "2026-07-30T15:02:43.118Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11940,7 +11940,7 @@
       "path": "hna/jurisdiction-metrics-digest/0871845.json",
       "kind": "json",
       "size_bytes": 29227,
-      "mtime": "2026-07-30T10:58:12.310Z",
+      "mtime": "2026-07-30T15:02:43.119Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11959,7 +11959,7 @@
       "path": "hna/jurisdiction-metrics-digest/0872320.json",
       "kind": "json",
       "size_bytes": 29244,
-      "mtime": "2026-07-30T10:58:12.310Z",
+      "mtime": "2026-07-30T15:02:43.119Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11978,7 +11978,7 @@
       "path": "hna/jurisdiction-metrics-digest/0872395.json",
       "kind": "json",
       "size_bytes": 29356,
-      "mtime": "2026-07-30T10:58:12.310Z",
+      "mtime": "2026-07-30T15:02:43.119Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -11997,7 +11997,7 @@
       "path": "hna/jurisdiction-metrics-digest/0873330.json",
       "kind": "json",
       "size_bytes": 29506,
-      "mtime": "2026-07-30T10:58:12.311Z",
+      "mtime": "2026-07-30T15:02:43.119Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12016,7 +12016,7 @@
       "path": "hna/jurisdiction-metrics-digest/0873715.json",
       "kind": "json",
       "size_bytes": 29480,
-      "mtime": "2026-07-30T10:58:12.311Z",
+      "mtime": "2026-07-30T15:02:43.119Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12035,7 +12035,7 @@
       "path": "hna/jurisdiction-metrics-digest/0873825.json",
       "kind": "json",
       "size_bytes": 29465,
-      "mtime": "2026-07-30T10:58:12.311Z",
+      "mtime": "2026-07-30T15:02:43.119Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12054,7 +12054,7 @@
       "path": "hna/jurisdiction-metrics-digest/0873925.json",
       "kind": "json",
       "size_bytes": 29319,
-      "mtime": "2026-07-30T10:58:12.311Z",
+      "mtime": "2026-07-30T15:02:43.119Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12073,7 +12073,7 @@
       "path": "hna/jurisdiction-metrics-digest/0873935.json",
       "kind": "json",
       "size_bytes": 29404,
-      "mtime": "2026-07-30T10:58:12.311Z",
+      "mtime": "2026-07-30T15:02:43.120Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12092,7 +12092,7 @@
       "path": "hna/jurisdiction-metrics-digest/0873943.json",
       "kind": "json",
       "size_bytes": 29354,
-      "mtime": "2026-07-30T10:58:12.311Z",
+      "mtime": "2026-07-30T15:02:43.120Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12111,7 +12111,7 @@
       "path": "hna/jurisdiction-metrics-digest/0874080.json",
       "kind": "json",
       "size_bytes": 29580,
-      "mtime": "2026-07-30T10:58:12.312Z",
+      "mtime": "2026-07-30T15:02:43.120Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12130,7 +12130,7 @@
       "path": "hna/jurisdiction-metrics-digest/0874275.json",
       "kind": "json",
       "size_bytes": 29259,
-      "mtime": "2026-07-30T10:58:12.312Z",
+      "mtime": "2026-07-30T15:02:43.120Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12149,7 +12149,7 @@
       "path": "hna/jurisdiction-metrics-digest/0874375.json",
       "kind": "json",
       "size_bytes": 29479,
-      "mtime": "2026-07-30T10:58:12.312Z",
+      "mtime": "2026-07-30T15:02:43.121Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12168,7 +12168,7 @@
       "path": "hna/jurisdiction-metrics-digest/0874430.json",
       "kind": "json",
       "size_bytes": 29403,
-      "mtime": "2026-07-30T10:58:12.312Z",
+      "mtime": "2026-07-30T15:02:43.122Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12187,7 +12187,7 @@
       "path": "hna/jurisdiction-metrics-digest/0874485.json",
       "kind": "json",
       "size_bytes": 29324,
-      "mtime": "2026-07-30T10:58:12.312Z",
+      "mtime": "2026-07-30T15:02:43.122Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12206,7 +12206,7 @@
       "path": "hna/jurisdiction-metrics-digest/0874815.json",
       "kind": "json",
       "size_bytes": 29324,
-      "mtime": "2026-07-30T10:58:12.312Z",
+      "mtime": "2026-07-30T15:02:43.122Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12225,7 +12225,7 @@
       "path": "hna/jurisdiction-metrics-digest/0874980.json",
       "kind": "json",
       "size_bytes": 29302,
-      "mtime": "2026-07-30T10:58:12.313Z",
+      "mtime": "2026-07-30T15:02:43.122Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12244,7 +12244,7 @@
       "path": "hna/jurisdiction-metrics-digest/0875585.json",
       "kind": "json",
       "size_bytes": 29313,
-      "mtime": "2026-07-30T10:58:12.313Z",
+      "mtime": "2026-07-30T15:02:43.122Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12263,7 +12263,7 @@
       "path": "hna/jurisdiction-metrics-digest/0875640.json",
       "kind": "json",
       "size_bytes": 29408,
-      "mtime": "2026-07-30T10:58:12.313Z",
+      "mtime": "2026-07-30T15:02:43.122Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12282,7 +12282,7 @@
       "path": "hna/jurisdiction-metrics-digest/0875970.json",
       "kind": "json",
       "size_bytes": 29313,
-      "mtime": "2026-07-30T10:58:12.313Z",
+      "mtime": "2026-07-30T15:02:43.123Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12301,7 +12301,7 @@
       "path": "hna/jurisdiction-metrics-digest/0876190.json",
       "kind": "json",
       "size_bytes": 29330,
-      "mtime": "2026-07-30T10:58:12.313Z",
+      "mtime": "2026-07-30T15:02:43.123Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12320,7 +12320,7 @@
       "path": "hna/jurisdiction-metrics-digest/0876325.json",
       "kind": "json",
       "size_bytes": 29359,
-      "mtime": "2026-07-30T10:58:12.313Z",
+      "mtime": "2026-07-30T15:02:43.123Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12339,7 +12339,7 @@
       "path": "hna/jurisdiction-metrics-digest/0876795.json",
       "kind": "json",
       "size_bytes": 29514,
-      "mtime": "2026-07-30T10:58:12.314Z",
+      "mtime": "2026-07-30T15:02:43.123Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12358,7 +12358,7 @@
       "path": "hna/jurisdiction-metrics-digest/0877235.json",
       "kind": "json",
       "size_bytes": 29518,
-      "mtime": "2026-07-30T10:58:12.314Z",
+      "mtime": "2026-07-30T15:02:43.123Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12377,7 +12377,7 @@
       "path": "hna/jurisdiction-metrics-digest/0877290.json",
       "kind": "json",
       "size_bytes": 29534,
-      "mtime": "2026-07-30T10:58:12.314Z",
+      "mtime": "2026-07-30T15:02:43.123Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12396,7 +12396,7 @@
       "path": "hna/jurisdiction-metrics-digest/0877510.json",
       "kind": "json",
       "size_bytes": 29458,
-      "mtime": "2026-07-30T10:58:12.314Z",
+      "mtime": "2026-07-30T15:02:43.123Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12415,7 +12415,7 @@
       "path": "hna/jurisdiction-metrics-digest/0877757.json",
       "kind": "json",
       "size_bytes": 29321,
-      "mtime": "2026-07-30T10:58:12.314Z",
+      "mtime": "2026-07-30T15:02:43.124Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12434,7 +12434,7 @@
       "path": "hna/jurisdiction-metrics-digest/0878280.json",
       "kind": "json",
       "size_bytes": 29496,
-      "mtime": "2026-07-30T10:58:12.314Z",
+      "mtime": "2026-07-30T15:02:43.124Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12453,7 +12453,7 @@
       "path": "hna/jurisdiction-metrics-digest/0878335.json",
       "kind": "json",
       "size_bytes": 29201,
-      "mtime": "2026-07-30T10:58:12.314Z",
+      "mtime": "2026-07-30T15:02:43.125Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12472,7 +12472,7 @@
       "path": "hna/jurisdiction-metrics-digest/0878345.json",
       "kind": "json",
       "size_bytes": 29266,
-      "mtime": "2026-07-30T10:58:12.315Z",
+      "mtime": "2026-07-30T15:02:43.125Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12491,7 +12491,7 @@
       "path": "hna/jurisdiction-metrics-digest/0878610.json",
       "kind": "json",
       "size_bytes": 29483,
-      "mtime": "2026-07-30T10:58:12.315Z",
+      "mtime": "2026-07-30T15:02:43.125Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12510,7 +12510,7 @@
       "path": "hna/jurisdiction-metrics-digest/0879100.json",
       "kind": "json",
       "size_bytes": 29493,
-      "mtime": "2026-07-30T10:58:12.315Z",
+      "mtime": "2026-07-30T15:02:43.125Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12529,7 +12529,7 @@
       "path": "hna/jurisdiction-metrics-digest/0879105.json",
       "kind": "json",
       "size_bytes": 29293,
-      "mtime": "2026-07-30T10:58:12.315Z",
+      "mtime": "2026-07-30T15:02:43.126Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12548,7 +12548,7 @@
       "path": "hna/jurisdiction-metrics-digest/0879270.json",
       "kind": "json",
       "size_bytes": 29269,
-      "mtime": "2026-07-30T10:58:12.315Z",
+      "mtime": "2026-07-30T15:02:43.126Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12567,7 +12567,7 @@
       "path": "hna/jurisdiction-metrics-digest/0879785.json",
       "kind": "json",
       "size_bytes": 29321,
-      "mtime": "2026-07-30T10:58:12.316Z",
+      "mtime": "2026-07-30T15:02:43.126Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12586,7 +12586,7 @@
       "path": "hna/jurisdiction-metrics-digest/0879800.json",
       "kind": "json",
       "size_bytes": 29298,
-      "mtime": "2026-07-30T10:58:12.316Z",
+      "mtime": "2026-07-30T15:02:43.126Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12605,7 +12605,7 @@
       "path": "hna/jurisdiction-metrics-digest/0880040.json",
       "kind": "json",
       "size_bytes": 29432,
-      "mtime": "2026-07-30T10:58:12.316Z",
+      "mtime": "2026-07-30T15:02:43.126Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12624,7 +12624,7 @@
       "path": "hna/jurisdiction-metrics-digest/0880095.json",
       "kind": "json",
       "size_bytes": 29230,
-      "mtime": "2026-07-30T10:58:12.316Z",
+      "mtime": "2026-07-30T15:02:43.126Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12643,7 +12643,7 @@
       "path": "hna/jurisdiction-metrics-digest/0880370.json",
       "kind": "json",
       "size_bytes": 29221,
-      "mtime": "2026-07-30T10:58:12.317Z",
+      "mtime": "2026-07-30T15:02:43.127Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12662,7 +12662,7 @@
       "path": "hna/jurisdiction-metrics-digest/0880755.json",
       "kind": "json",
       "size_bytes": 29230,
-      "mtime": "2026-07-30T10:58:12.317Z",
+      "mtime": "2026-07-30T15:02:43.127Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12681,7 +12681,7 @@
       "path": "hna/jurisdiction-metrics-digest/0880865.json",
       "kind": "json",
       "size_bytes": 29394,
-      "mtime": "2026-07-30T10:58:12.318Z",
+      "mtime": "2026-07-30T15:02:43.127Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12700,7 +12700,7 @@
       "path": "hna/jurisdiction-metrics-digest/0881030.json",
       "kind": "json",
       "size_bytes": 29270,
-      "mtime": "2026-07-30T10:58:12.318Z",
+      "mtime": "2026-07-30T15:02:43.127Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12719,7 +12719,7 @@
       "path": "hna/jurisdiction-metrics-digest/0881305.json",
       "kind": "json",
       "size_bytes": 29291,
-      "mtime": "2026-07-30T10:58:12.318Z",
+      "mtime": "2026-07-30T15:02:43.127Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12738,7 +12738,7 @@
       "path": "hna/jurisdiction-metrics-digest/0881690.json",
       "kind": "json",
       "size_bytes": 29301,
-      "mtime": "2026-07-30T10:58:12.318Z",
+      "mtime": "2026-07-30T15:02:43.127Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12757,7 +12757,7 @@
       "path": "hna/jurisdiction-metrics-digest/0882130.json",
       "kind": "json",
       "size_bytes": 29492,
-      "mtime": "2026-07-30T10:58:12.318Z",
+      "mtime": "2026-07-30T15:02:43.127Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12776,7 +12776,7 @@
       "path": "hna/jurisdiction-metrics-digest/0882350.json",
       "kind": "json",
       "size_bytes": 29417,
-      "mtime": "2026-07-30T10:58:12.318Z",
+      "mtime": "2026-07-30T15:02:43.128Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12795,7 +12795,7 @@
       "path": "hna/jurisdiction-metrics-digest/0882460.json",
       "kind": "json",
       "size_bytes": 29511,
-      "mtime": "2026-07-30T10:58:12.319Z",
+      "mtime": "2026-07-30T15:02:43.128Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12814,7 +12814,7 @@
       "path": "hna/jurisdiction-metrics-digest/0882735.json",
       "kind": "json",
       "size_bytes": 29269,
-      "mtime": "2026-07-30T10:58:12.319Z",
+      "mtime": "2026-07-30T15:02:43.128Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12833,7 +12833,7 @@
       "path": "hna/jurisdiction-metrics-digest/0882900.json",
       "kind": "json",
       "size_bytes": 29290,
-      "mtime": "2026-07-30T10:58:12.319Z",
+      "mtime": "2026-07-30T15:02:43.128Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12852,7 +12852,7 @@
       "path": "hna/jurisdiction-metrics-digest/0883120.json",
       "kind": "json",
       "size_bytes": 29413,
-      "mtime": "2026-07-30T10:58:12.319Z",
+      "mtime": "2026-07-30T15:02:43.128Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12871,7 +12871,7 @@
       "path": "hna/jurisdiction-metrics-digest/0883175.json",
       "kind": "json",
       "size_bytes": 29280,
-      "mtime": "2026-07-30T10:58:12.319Z",
+      "mtime": "2026-07-30T15:02:43.128Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12890,7 +12890,7 @@
       "path": "hna/jurisdiction-metrics-digest/0883230.json",
       "kind": "json",
       "size_bytes": 29541,
-      "mtime": "2026-07-30T10:58:12.320Z",
+      "mtime": "2026-07-30T15:02:43.129Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12909,7 +12909,7 @@
       "path": "hna/jurisdiction-metrics-digest/0883450.json",
       "kind": "json",
       "size_bytes": 29331,
-      "mtime": "2026-07-30T10:58:12.320Z",
+      "mtime": "2026-07-30T15:02:43.129Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12928,7 +12928,7 @@
       "path": "hna/jurisdiction-metrics-digest/0883500.json",
       "kind": "json",
       "size_bytes": 29325,
-      "mtime": "2026-07-30T10:58:12.320Z",
+      "mtime": "2026-07-30T15:02:43.129Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12947,7 +12947,7 @@
       "path": "hna/jurisdiction-metrics-digest/0883835.json",
       "kind": "json",
       "size_bytes": 29501,
-      "mtime": "2026-07-30T10:58:12.320Z",
+      "mtime": "2026-07-30T15:02:43.129Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12966,7 +12966,7 @@
       "path": "hna/jurisdiction-metrics-digest/0884000.json",
       "kind": "json",
       "size_bytes": 29221,
-      "mtime": "2026-07-30T10:58:12.320Z",
+      "mtime": "2026-07-30T15:02:43.129Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -12985,7 +12985,7 @@
       "path": "hna/jurisdiction-metrics-digest/0884042.json",
       "kind": "json",
       "size_bytes": 29411,
-      "mtime": "2026-07-30T10:58:12.321Z",
+      "mtime": "2026-07-30T15:02:43.129Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -13004,7 +13004,7 @@
       "path": "hna/jurisdiction-metrics-digest/0884440.json",
       "kind": "json",
       "size_bytes": 29524,
-      "mtime": "2026-07-30T10:58:12.321Z",
+      "mtime": "2026-07-30T15:02:43.129Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -13023,7 +13023,7 @@
       "path": "hna/jurisdiction-metrics-digest/0884770.json",
       "kind": "json",
       "size_bytes": 29481,
-      "mtime": "2026-07-30T10:58:12.321Z",
+      "mtime": "2026-07-30T15:02:43.130Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -13042,7 +13042,7 @@
       "path": "hna/jurisdiction-metrics-digest/0885045.json",
       "kind": "json",
       "size_bytes": 29435,
-      "mtime": "2026-07-30T10:58:12.321Z",
+      "mtime": "2026-07-30T15:02:43.130Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -13061,7 +13061,7 @@
       "path": "hna/jurisdiction-metrics-digest/0885155.json",
       "kind": "json",
       "size_bytes": 29462,
-      "mtime": "2026-07-30T10:58:12.321Z",
+      "mtime": "2026-07-30T15:02:43.130Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -13080,7 +13080,7 @@
       "path": "hna/jurisdiction-metrics-digest/0885485.json",
       "kind": "json",
       "size_bytes": 29459,
-      "mtime": "2026-07-30T10:58:12.321Z",
+      "mtime": "2026-07-30T15:02:43.130Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -13099,7 +13099,7 @@
       "path": "hna/jurisdiction-metrics-digest/0885705.json",
       "kind": "json",
       "size_bytes": 29339,
-      "mtime": "2026-07-30T10:58:12.322Z",
+      "mtime": "2026-07-30T15:02:43.130Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -13118,7 +13118,7 @@
       "path": "hna/jurisdiction-metrics-digest/0885760.json",
       "kind": "json",
       "size_bytes": 29315,
-      "mtime": "2026-07-30T10:58:12.322Z",
+      "mtime": "2026-07-30T15:02:43.130Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -13137,7 +13137,7 @@
       "path": "hna/jurisdiction-metrics-digest/0886090.json",
       "kind": "json",
       "size_bytes": 29473,
-      "mtime": "2026-07-30T10:58:12.322Z",
+      "mtime": "2026-07-30T15:02:43.130Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -13156,7 +13156,7 @@
       "path": "hna/jurisdiction-metrics-digest/0886117.json",
       "kind": "json",
       "size_bytes": 29363,
-      "mtime": "2026-07-30T10:58:12.322Z",
+      "mtime": "2026-07-30T15:02:43.131Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -13175,7 +13175,7 @@
       "path": "hna/jurisdiction-metrics-digest/0886200.json",
       "kind": "json",
       "size_bytes": 29256,
-      "mtime": "2026-07-30T10:58:12.322Z",
+      "mtime": "2026-07-30T15:02:43.131Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -13194,7 +13194,7 @@
       "path": "hna/jurisdiction-metrics-digest/0886310.json",
       "kind": "json",
       "size_bytes": 29392,
-      "mtime": "2026-07-30T10:58:12.322Z",
+      "mtime": "2026-07-30T15:02:43.131Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -13213,7 +13213,7 @@
       "path": "hna/jurisdiction-metrics-digest/0886475.json",
       "kind": "json",
       "size_bytes": 29464,
-      "mtime": "2026-07-30T10:58:12.323Z",
+      "mtime": "2026-07-30T15:02:43.131Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -13232,7 +13232,7 @@
       "path": "hna/jurisdiction-metrics-digest/0886750.json",
       "kind": "json",
       "size_bytes": 29444,
-      "mtime": "2026-07-30T10:58:12.323Z",
+      "mtime": "2026-07-30T15:02:43.131Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -13251,7 +13251,7 @@
       "path": "hna/lehd/08.json",
       "kind": "json",
       "size_bytes": 2173,
-      "mtime": "2026-07-30T10:58:12.323Z",
+      "mtime": "2026-07-30T15:02:43.131Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13281,7 +13281,7 @@
       "path": "hna/lehd/08001.json",
       "kind": "json",
       "size_bytes": 2730,
-      "mtime": "2026-07-30T10:58:12.323Z",
+      "mtime": "2026-07-30T15:02:43.131Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13313,7 +13313,7 @@
       "path": "hna/lehd/08003.json",
       "kind": "json",
       "size_bytes": 2625,
-      "mtime": "2026-07-30T10:58:12.323Z",
+      "mtime": "2026-07-30T15:02:43.131Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13345,7 +13345,7 @@
       "path": "hna/lehd/08005.json",
       "kind": "json",
       "size_bytes": 2730,
-      "mtime": "2026-07-30T10:58:12.323Z",
+      "mtime": "2026-07-30T15:02:43.131Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13377,7 +13377,7 @@
       "path": "hna/lehd/08007.json",
       "kind": "json",
       "size_bytes": 2615,
-      "mtime": "2026-07-30T10:58:12.323Z",
+      "mtime": "2026-07-30T15:02:43.131Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13409,7 +13409,7 @@
       "path": "hna/lehd/08009.json",
       "kind": "json",
       "size_bytes": 2362,
-      "mtime": "2026-07-30T10:58:12.323Z",
+      "mtime": "2026-07-30T15:02:43.132Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13441,7 +13441,7 @@
       "path": "hna/lehd/08011.json",
       "kind": "json",
       "size_bytes": 2392,
-      "mtime": "2026-07-30T10:58:12.323Z",
+      "mtime": "2026-07-30T15:02:43.132Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13473,7 +13473,7 @@
       "path": "hna/lehd/08013.json",
       "kind": "json",
       "size_bytes": 2716,
-      "mtime": "2026-07-30T10:58:12.323Z",
+      "mtime": "2026-07-30T15:02:43.132Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13505,7 +13505,7 @@
       "path": "hna/lehd/08014.json",
       "kind": "json",
       "size_bytes": 2657,
-      "mtime": "2026-07-30T10:58:12.323Z",
+      "mtime": "2026-07-30T15:02:43.132Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13537,7 +13537,7 @@
       "path": "hna/lehd/08015.json",
       "kind": "json",
       "size_bytes": 2622,
-      "mtime": "2026-07-30T10:58:12.324Z",
+      "mtime": "2026-07-30T15:02:43.132Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13569,7 +13569,7 @@
       "path": "hna/lehd/08017.json",
       "kind": "json",
       "size_bytes": 2478,
-      "mtime": "2026-07-30T10:58:12.324Z",
+      "mtime": "2026-07-30T15:02:43.132Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13601,7 +13601,7 @@
       "path": "hna/lehd/08019.json",
       "kind": "json",
       "size_bytes": 2598,
-      "mtime": "2026-07-30T10:58:12.324Z",
+      "mtime": "2026-07-30T15:02:43.132Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13633,7 +13633,7 @@
       "path": "hna/lehd/08021.json",
       "kind": "json",
       "size_bytes": 2437,
-      "mtime": "2026-07-30T10:58:12.324Z",
+      "mtime": "2026-07-30T15:02:43.132Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13665,7 +13665,7 @@
       "path": "hna/lehd/08023.json",
       "kind": "json",
       "size_bytes": 2260,
-      "mtime": "2026-07-30T10:58:12.324Z",
+      "mtime": "2026-07-30T15:02:43.132Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13697,7 +13697,7 @@
       "path": "hna/lehd/08025.json",
       "kind": "json",
       "size_bytes": 2110,
-      "mtime": "2026-07-30T10:58:12.324Z",
+      "mtime": "2026-07-30T15:02:43.132Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13729,7 +13729,7 @@
       "path": "hna/lehd/08027.json",
       "kind": "json",
       "size_bytes": 2495,
-      "mtime": "2026-07-30T10:58:12.324Z",
+      "mtime": "2026-07-30T15:02:43.132Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13761,7 +13761,7 @@
       "path": "hna/lehd/08029.json",
       "kind": "json",
       "size_bytes": 2621,
-      "mtime": "2026-07-30T10:58:12.324Z",
+      "mtime": "2026-07-30T15:02:43.132Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13793,7 +13793,7 @@
       "path": "hna/lehd/08031.json",
       "kind": "json",
       "size_bytes": 2748,
-      "mtime": "2026-07-30T10:58:12.324Z",
+      "mtime": "2026-07-30T15:02:43.132Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13825,7 +13825,7 @@
       "path": "hna/lehd/08033.json",
       "kind": "json",
       "size_bytes": 2344,
-      "mtime": "2026-07-30T10:58:12.324Z",
+      "mtime": "2026-07-30T15:02:43.132Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13857,7 +13857,7 @@
       "path": "hna/lehd/08035.json",
       "kind": "json",
       "size_bytes": 2709,
-      "mtime": "2026-07-30T10:58:12.324Z",
+      "mtime": "2026-07-30T15:02:43.132Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13889,7 +13889,7 @@
       "path": "hna/lehd/08037.json",
       "kind": "json",
       "size_bytes": 2663,
-      "mtime": "2026-07-30T10:58:12.324Z",
+      "mtime": "2026-07-30T15:02:43.132Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13921,7 +13921,7 @@
       "path": "hna/lehd/08039.json",
       "kind": "json",
       "size_bytes": 2607,
-      "mtime": "2026-07-30T10:58:12.324Z",
+      "mtime": "2026-07-30T15:02:43.132Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13953,7 +13953,7 @@
       "path": "hna/lehd/08041.json",
       "kind": "json",
       "size_bytes": 2724,
-      "mtime": "2026-07-30T10:58:12.324Z",
+      "mtime": "2026-07-30T15:02:43.132Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -13985,7 +13985,7 @@
       "path": "hna/lehd/08043.json",
       "kind": "json",
       "size_bytes": 2635,
-      "mtime": "2026-07-30T10:58:12.324Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14017,7 +14017,7 @@
       "path": "hna/lehd/08045.json",
       "kind": "json",
       "size_bytes": 2658,
-      "mtime": "2026-07-30T10:58:12.324Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14049,7 +14049,7 @@
       "path": "hna/lehd/08047.json",
       "kind": "json",
       "size_bytes": 2503,
-      "mtime": "2026-07-30T10:58:12.324Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14081,7 +14081,7 @@
       "path": "hna/lehd/08049.json",
       "kind": "json",
       "size_bytes": 2620,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14113,7 +14113,7 @@
       "path": "hna/lehd/08051.json",
       "kind": "json",
       "size_bytes": 2623,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14145,7 +14145,7 @@
       "path": "hna/lehd/08053.json",
       "kind": "json",
       "size_bytes": 2322,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14177,7 +14177,7 @@
       "path": "hna/lehd/08055.json",
       "kind": "json",
       "size_bytes": 2494,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14209,7 +14209,7 @@
       "path": "hna/lehd/08057.json",
       "kind": "json",
       "size_bytes": 2196,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14241,7 +14241,7 @@
       "path": "hna/lehd/08059.json",
       "kind": "json",
       "size_bytes": 2725,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14273,7 +14273,7 @@
       "path": "hna/lehd/08061.json",
       "kind": "json",
       "size_bytes": 2181,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14305,7 +14305,7 @@
       "path": "hna/lehd/08063.json",
       "kind": "json",
       "size_bytes": 2526,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14337,7 +14337,7 @@
       "path": "hna/lehd/08065.json",
       "kind": "json",
       "size_bytes": 2583,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14369,7 +14369,7 @@
       "path": "hna/lehd/08067.json",
       "kind": "json",
       "size_bytes": 2652,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14401,7 +14401,7 @@
       "path": "hna/lehd/08069.json",
       "kind": "json",
       "size_bytes": 2711,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14433,7 +14433,7 @@
       "path": "hna/lehd/08071.json",
       "kind": "json",
       "size_bytes": 2603,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14465,7 +14465,7 @@
       "path": "hna/lehd/08073.json",
       "kind": "json",
       "size_bytes": 2502,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14497,7 +14497,7 @@
       "path": "hna/lehd/08075.json",
       "kind": "json",
       "size_bytes": 2626,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14529,7 +14529,7 @@
       "path": "hna/lehd/08077.json",
       "kind": "json",
       "size_bytes": 2689,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14561,7 +14561,7 @@
       "path": "hna/lehd/08079.json",
       "kind": "json",
       "size_bytes": 2241,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14593,7 +14593,7 @@
       "path": "hna/lehd/08081.json",
       "kind": "json",
       "size_bytes": 2609,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14625,7 +14625,7 @@
       "path": "hna/lehd/08083.json",
       "kind": "json",
       "size_bytes": 2631,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14657,7 +14657,7 @@
       "path": "hna/lehd/08085.json",
       "kind": "json",
       "size_bytes": 2644,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.133Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14689,7 +14689,7 @@
       "path": "hna/lehd/08087.json",
       "kind": "json",
       "size_bytes": 2631,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14721,7 +14721,7 @@
       "path": "hna/lehd/08089.json",
       "kind": "json",
       "size_bytes": 2473,
-      "mtime": "2026-07-30T10:58:12.325Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14753,7 +14753,7 @@
       "path": "hna/lehd/08091.json",
       "kind": "json",
       "size_bytes": 2582,
-      "mtime": "2026-07-30T10:58:12.326Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14785,7 +14785,7 @@
       "path": "hna/lehd/08093.json",
       "kind": "json",
       "size_bytes": 2592,
-      "mtime": "2026-07-30T10:58:12.326Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14817,7 +14817,7 @@
       "path": "hna/lehd/08095.json",
       "kind": "json",
       "size_bytes": 2503,
-      "mtime": "2026-07-30T10:58:12.326Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14849,7 +14849,7 @@
       "path": "hna/lehd/08097.json",
       "kind": "json",
       "size_bytes": 2638,
-      "mtime": "2026-07-30T10:58:12.326Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14881,7 +14881,7 @@
       "path": "hna/lehd/08099.json",
       "kind": "json",
       "size_bytes": 2603,
-      "mtime": "2026-07-30T10:58:12.326Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14913,7 +14913,7 @@
       "path": "hna/lehd/08101.json",
       "kind": "json",
       "size_bytes": 2682,
-      "mtime": "2026-07-30T10:58:12.326Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14945,7 +14945,7 @@
       "path": "hna/lehd/08103.json",
       "kind": "json",
       "size_bytes": 2523,
-      "mtime": "2026-07-30T10:58:12.326Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -14977,7 +14977,7 @@
       "path": "hna/lehd/08105.json",
       "kind": "json",
       "size_bytes": 2527,
-      "mtime": "2026-07-30T10:58:12.326Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -15009,7 +15009,7 @@
       "path": "hna/lehd/08107.json",
       "kind": "json",
       "size_bytes": 2645,
-      "mtime": "2026-07-30T10:58:12.326Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -15041,7 +15041,7 @@
       "path": "hna/lehd/08109.json",
       "kind": "json",
       "size_bytes": 2424,
-      "mtime": "2026-07-30T10:58:12.326Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -15073,7 +15073,7 @@
       "path": "hna/lehd/08111.json",
       "kind": "json",
       "size_bytes": 2228,
-      "mtime": "2026-07-30T10:58:12.326Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -15105,7 +15105,7 @@
       "path": "hna/lehd/08113.json",
       "kind": "json",
       "size_bytes": 2614,
-      "mtime": "2026-07-30T10:58:12.326Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -15137,7 +15137,7 @@
       "path": "hna/lehd/08115.json",
       "kind": "json",
       "size_bytes": 2338,
-      "mtime": "2026-07-30T10:58:12.326Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -15169,7 +15169,7 @@
       "path": "hna/lehd/08117.json",
       "kind": "json",
       "size_bytes": 2644,
-      "mtime": "2026-07-30T10:58:12.326Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -15201,7 +15201,7 @@
       "path": "hna/lehd/08119.json",
       "kind": "json",
       "size_bytes": 2618,
-      "mtime": "2026-07-30T10:58:12.326Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -15233,7 +15233,7 @@
       "path": "hna/lehd/08121.json",
       "kind": "json",
       "size_bytes": 2422,
-      "mtime": "2026-07-30T10:58:12.326Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -15265,7 +15265,7 @@
       "path": "hna/lehd/08123.json",
       "kind": "json",
       "size_bytes": 2706,
-      "mtime": "2026-07-30T10:58:12.326Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -15297,7 +15297,7 @@
       "path": "hna/lehd/08125.json",
       "kind": "json",
       "size_bytes": 2608,
-      "mtime": "2026-07-30T10:58:12.326Z",
+      "mtime": "2026-07-30T15:02:43.134Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -15329,7 +15329,7 @@
       "path": "hna/lihtc/08001.json",
       "kind": "json",
       "size_bytes": 65200,
-      "mtime": "2026-07-30T10:58:12.327Z",
+      "mtime": "2026-07-30T15:02:43.135Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15349,7 +15349,7 @@
       "path": "hna/lihtc/08003.json",
       "kind": "json",
       "size_bytes": 6307,
-      "mtime": "2026-07-30T10:58:12.327Z",
+      "mtime": "2026-07-30T15:02:43.135Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15369,7 +15369,7 @@
       "path": "hna/lihtc/08005.json",
       "kind": "json",
       "size_bytes": 62847,
-      "mtime": "2026-07-30T10:58:12.327Z",
+      "mtime": "2026-07-30T15:02:43.135Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15389,7 +15389,7 @@
       "path": "hna/lihtc/08007.json",
       "kind": "json",
       "size_bytes": 2832,
-      "mtime": "2026-07-30T10:58:12.327Z",
+      "mtime": "2026-07-30T15:02:43.135Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15409,7 +15409,7 @@
       "path": "hna/lihtc/08009.json",
       "kind": "json",
       "size_bytes": 81,
-      "mtime": "2026-07-30T10:58:12.327Z",
+      "mtime": "2026-07-30T15:02:43.135Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15425,7 +15425,7 @@
       "path": "hna/lihtc/08011.json",
       "kind": "json",
       "size_bytes": 984,
-      "mtime": "2026-07-30T10:58:12.327Z",
+      "mtime": "2026-07-30T15:02:43.135Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15445,7 +15445,7 @@
       "path": "hna/lihtc/08013.json",
       "kind": "json",
       "size_bytes": 80290,
-      "mtime": "2026-07-30T10:58:12.327Z",
+      "mtime": "2026-07-30T15:02:43.135Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15465,7 +15465,7 @@
       "path": "hna/lihtc/08014.json",
       "kind": "json",
       "size_bytes": 8231,
-      "mtime": "2026-07-30T10:58:12.328Z",
+      "mtime": "2026-07-30T15:02:43.135Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15485,7 +15485,7 @@
       "path": "hna/lihtc/08015.json",
       "kind": "json",
       "size_bytes": 5535,
-      "mtime": "2026-07-30T10:58:12.328Z",
+      "mtime": "2026-07-30T15:02:43.135Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15505,7 +15505,7 @@
       "path": "hna/lihtc/08017.json",
       "kind": "json",
       "size_bytes": 81,
-      "mtime": "2026-07-30T10:58:12.328Z",
+      "mtime": "2026-07-30T15:02:43.135Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15521,7 +15521,7 @@
       "path": "hna/lihtc/08019.json",
       "kind": "json",
       "size_bytes": 990,
-      "mtime": "2026-07-30T10:58:12.328Z",
+      "mtime": "2026-07-30T15:02:43.135Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15541,7 +15541,7 @@
       "path": "hna/lihtc/08021.json",
       "kind": "json",
       "size_bytes": 1911,
-      "mtime": "2026-07-30T10:58:12.328Z",
+      "mtime": "2026-07-30T15:02:43.136Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15561,7 +15561,7 @@
       "path": "hna/lihtc/08023.json",
       "kind": "json",
       "size_bytes": 81,
-      "mtime": "2026-07-30T10:58:12.328Z",
+      "mtime": "2026-07-30T15:02:43.136Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15577,7 +15577,7 @@
       "path": "hna/lihtc/08025.json",
       "kind": "json",
       "size_bytes": 81,
-      "mtime": "2026-07-30T10:58:12.328Z",
+      "mtime": "2026-07-30T15:02:43.136Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15593,7 +15593,7 @@
       "path": "hna/lihtc/08027.json",
       "kind": "json",
       "size_bytes": 1893,
-      "mtime": "2026-07-30T10:58:12.328Z",
+      "mtime": "2026-07-30T15:02:43.136Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15613,7 +15613,7 @@
       "path": "hna/lihtc/08029.json",
       "kind": "json",
       "size_bytes": 5444,
-      "mtime": "2026-07-30T10:58:12.328Z",
+      "mtime": "2026-07-30T15:02:43.136Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15633,7 +15633,7 @@
       "path": "hna/lihtc/08031.json",
       "kind": "json",
       "size_bytes": 216412,
-      "mtime": "2026-07-30T10:58:12.329Z",
+      "mtime": "2026-07-30T15:02:43.136Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15653,7 +15653,7 @@
       "path": "hna/lihtc/08033.json",
       "kind": "json",
       "size_bytes": 81,
-      "mtime": "2026-07-30T10:58:12.329Z",
+      "mtime": "2026-07-30T15:02:43.136Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15669,7 +15669,7 @@
       "path": "hna/lihtc/08035.json",
       "kind": "json",
       "size_bytes": 19068,
-      "mtime": "2026-07-30T10:58:12.329Z",
+      "mtime": "2026-07-30T15:02:43.136Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15689,7 +15689,7 @@
       "path": "hna/lihtc/08037.json",
       "kind": "json",
       "size_bytes": 8206,
-      "mtime": "2026-07-30T10:58:12.329Z",
+      "mtime": "2026-07-30T15:02:43.136Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15709,7 +15709,7 @@
       "path": "hna/lihtc/08039.json",
       "kind": "json",
       "size_bytes": 81,
-      "mtime": "2026-07-30T10:58:12.329Z",
+      "mtime": "2026-07-30T15:02:43.136Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15725,7 +15725,7 @@
       "path": "hna/lihtc/08041.json",
       "kind": "json",
       "size_bytes": 50517,
-      "mtime": "2026-07-30T10:58:12.329Z",
+      "mtime": "2026-07-30T15:02:43.136Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15745,7 +15745,7 @@
       "path": "hna/lihtc/08043.json",
       "kind": "json",
       "size_bytes": 11945,
-      "mtime": "2026-07-30T10:58:12.329Z",
+      "mtime": "2026-07-30T15:02:43.136Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15765,7 +15765,7 @@
       "path": "hna/lihtc/08045.json",
       "kind": "json",
       "size_bytes": 10860,
-      "mtime": "2026-07-30T10:58:12.329Z",
+      "mtime": "2026-07-30T15:02:43.136Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15785,7 +15785,7 @@
       "path": "hna/lihtc/08047.json",
       "kind": "json",
       "size_bytes": 988,
-      "mtime": "2026-07-30T10:58:12.330Z",
+      "mtime": "2026-07-30T15:02:43.137Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15805,7 +15805,7 @@
       "path": "hna/lihtc/08049.json",
       "kind": "json",
       "size_bytes": 3678,
-      "mtime": "2026-07-30T10:58:12.330Z",
+      "mtime": "2026-07-30T15:02:43.137Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15825,7 +15825,7 @@
       "path": "hna/lihtc/08051.json",
       "kind": "json",
       "size_bytes": 2793,
-      "mtime": "2026-07-30T10:58:12.330Z",
+      "mtime": "2026-07-30T15:02:43.137Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15845,7 +15845,7 @@
       "path": "hna/lihtc/08053.json",
       "kind": "json",
       "size_bytes": 81,
-      "mtime": "2026-07-30T10:58:12.330Z",
+      "mtime": "2026-07-30T15:02:43.137Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15861,7 +15861,7 @@
       "path": "hna/lihtc/08055.json",
       "kind": "json",
       "size_bytes": 1002,
-      "mtime": "2026-07-30T10:58:12.330Z",
+      "mtime": "2026-07-30T15:02:43.137Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15881,7 +15881,7 @@
       "path": "hna/lihtc/08057.json",
       "kind": "json",
       "size_bytes": 81,
-      "mtime": "2026-07-30T10:58:12.330Z",
+      "mtime": "2026-07-30T15:02:43.137Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15897,7 +15897,7 @@
       "path": "hna/lihtc/08059.json",
       "kind": "json",
       "size_bytes": 60915,
-      "mtime": "2026-07-30T10:58:12.330Z",
+      "mtime": "2026-07-30T15:02:43.137Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15917,7 +15917,7 @@
       "path": "hna/lihtc/08061.json",
       "kind": "json",
       "size_bytes": 81,
-      "mtime": "2026-07-30T10:58:12.330Z",
+      "mtime": "2026-07-30T15:02:43.137Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15933,7 +15933,7 @@
       "path": "hna/lihtc/08063.json",
       "kind": "json",
       "size_bytes": 986,
-      "mtime": "2026-07-30T10:58:12.330Z",
+      "mtime": "2026-07-30T15:02:43.137Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15953,7 +15953,7 @@
       "path": "hna/lihtc/08065.json",
       "kind": "json",
       "size_bytes": 983,
-      "mtime": "2026-07-30T10:58:12.330Z",
+      "mtime": "2026-07-30T15:02:43.137Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15973,7 +15973,7 @@
       "path": "hna/lihtc/08067.json",
       "kind": "json",
       "size_bytes": 13660,
-      "mtime": "2026-07-30T10:58:12.330Z",
+      "mtime": "2026-07-30T15:02:43.137Z",
       "shape": "object",
       "keys": [
         "type",
@@ -15993,7 +15993,7 @@
       "path": "hna/lihtc/08069.json",
       "kind": "json",
       "size_bytes": 57912,
-      "mtime": "2026-07-30T10:58:12.330Z",
+      "mtime": "2026-07-30T15:02:43.137Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16013,7 +16013,7 @@
       "path": "hna/lihtc/08071.json",
       "kind": "json",
       "size_bytes": 3681,
-      "mtime": "2026-07-30T10:58:12.330Z",
+      "mtime": "2026-07-30T15:02:43.137Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16033,7 +16033,7 @@
       "path": "hna/lihtc/08073.json",
       "kind": "json",
       "size_bytes": 1010,
-      "mtime": "2026-07-30T10:58:12.330Z",
+      "mtime": "2026-07-30T15:02:43.137Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16053,7 +16053,7 @@
       "path": "hna/lihtc/08075.json",
       "kind": "json",
       "size_bytes": 3652,
-      "mtime": "2026-07-30T10:58:12.331Z",
+      "mtime": "2026-07-30T15:02:43.137Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16073,7 +16073,7 @@
       "path": "hna/lihtc/08077.json",
       "kind": "json",
       "size_bytes": 15271,
-      "mtime": "2026-07-30T10:58:12.331Z",
+      "mtime": "2026-07-30T15:02:43.137Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16093,7 +16093,7 @@
       "path": "hna/lihtc/08079.json",
       "kind": "json",
       "size_bytes": 81,
-      "mtime": "2026-07-30T10:58:12.331Z",
+      "mtime": "2026-07-30T15:02:43.137Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16109,7 +16109,7 @@
       "path": "hna/lihtc/08081.json",
       "kind": "json",
       "size_bytes": 81,
-      "mtime": "2026-07-30T10:58:12.331Z",
+      "mtime": "2026-07-30T15:02:43.138Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16125,7 +16125,7 @@
       "path": "hna/lihtc/08083.json",
       "kind": "json",
       "size_bytes": 8164,
-      "mtime": "2026-07-30T10:58:12.331Z",
+      "mtime": "2026-07-30T15:02:43.138Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16145,7 +16145,7 @@
       "path": "hna/lihtc/08085.json",
       "kind": "json",
       "size_bytes": 9148,
-      "mtime": "2026-07-30T10:58:12.331Z",
+      "mtime": "2026-07-30T15:02:43.138Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16165,7 +16165,7 @@
       "path": "hna/lihtc/08087.json",
       "kind": "json",
       "size_bytes": 4572,
-      "mtime": "2026-07-30T10:58:12.331Z",
+      "mtime": "2026-07-30T15:02:43.138Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16185,7 +16185,7 @@
       "path": "hna/lihtc/08089.json",
       "kind": "json",
       "size_bytes": 2752,
-      "mtime": "2026-07-30T10:58:12.331Z",
+      "mtime": "2026-07-30T15:02:43.138Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16205,7 +16205,7 @@
       "path": "hna/lihtc/08091.json",
       "kind": "json",
       "size_bytes": 979,
-      "mtime": "2026-07-30T10:58:12.331Z",
+      "mtime": "2026-07-30T15:02:43.138Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16225,7 +16225,7 @@
       "path": "hna/lihtc/08093.json",
       "kind": "json",
       "size_bytes": 955,
-      "mtime": "2026-07-30T10:58:12.331Z",
+      "mtime": "2026-07-30T15:02:43.138Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16245,7 +16245,7 @@
       "path": "hna/lihtc/08095.json",
       "kind": "json",
       "size_bytes": 81,
-      "mtime": "2026-07-30T10:58:12.331Z",
+      "mtime": "2026-07-30T15:02:43.138Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16261,7 +16261,7 @@
       "path": "hna/lihtc/08097.json",
       "kind": "json",
       "size_bytes": 5516,
-      "mtime": "2026-07-30T10:58:12.331Z",
+      "mtime": "2026-07-30T15:02:43.138Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16281,7 +16281,7 @@
       "path": "hna/lihtc/08099.json",
       "kind": "json",
       "size_bytes": 981,
-      "mtime": "2026-07-30T10:58:12.331Z",
+      "mtime": "2026-07-30T15:02:43.138Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16301,7 +16301,7 @@
       "path": "hna/lihtc/08101.json",
       "kind": "json",
       "size_bytes": 29434,
-      "mtime": "2026-07-30T10:58:12.331Z",
+      "mtime": "2026-07-30T15:02:43.138Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16321,7 +16321,7 @@
       "path": "hna/lihtc/08103.json",
       "kind": "json",
       "size_bytes": 81,
-      "mtime": "2026-07-30T10:58:12.331Z",
+      "mtime": "2026-07-30T15:02:43.138Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16337,7 +16337,7 @@
       "path": "hna/lihtc/08105.json",
       "kind": "json",
       "size_bytes": 3763,
-      "mtime": "2026-07-30T10:58:12.332Z",
+      "mtime": "2026-07-30T15:02:43.138Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16357,7 +16357,7 @@
       "path": "hna/lihtc/08107.json",
       "kind": "json",
       "size_bytes": 4703,
-      "mtime": "2026-07-30T10:58:12.332Z",
+      "mtime": "2026-07-30T15:02:43.138Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16377,7 +16377,7 @@
       "path": "hna/lihtc/08109.json",
       "kind": "json",
       "size_bytes": 4584,
-      "mtime": "2026-07-30T10:58:12.332Z",
+      "mtime": "2026-07-30T15:02:43.138Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16397,7 +16397,7 @@
       "path": "hna/lihtc/08111.json",
       "kind": "json",
       "size_bytes": 81,
-      "mtime": "2026-07-30T10:58:12.332Z",
+      "mtime": "2026-07-30T15:02:43.139Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16413,7 +16413,7 @@
       "path": "hna/lihtc/08113.json",
       "kind": "json",
       "size_bytes": 1894,
-      "mtime": "2026-07-30T10:58:12.332Z",
+      "mtime": "2026-07-30T15:02:43.139Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16433,7 +16433,7 @@
       "path": "hna/lihtc/08115.json",
       "kind": "json",
       "size_bytes": 81,
-      "mtime": "2026-07-30T10:58:12.332Z",
+      "mtime": "2026-07-30T15:02:43.139Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16449,7 +16449,7 @@
       "path": "hna/lihtc/08117.json",
       "kind": "json",
       "size_bytes": 7350,
-      "mtime": "2026-07-30T10:58:12.332Z",
+      "mtime": "2026-07-30T15:02:43.139Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16469,7 +16469,7 @@
       "path": "hna/lihtc/08119.json",
       "kind": "json",
       "size_bytes": 2788,
-      "mtime": "2026-07-30T10:58:12.332Z",
+      "mtime": "2026-07-30T15:02:43.139Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16489,7 +16489,7 @@
       "path": "hna/lihtc/08121.json",
       "kind": "json",
       "size_bytes": 81,
-      "mtime": "2026-07-30T10:58:12.332Z",
+      "mtime": "2026-07-30T15:02:43.139Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16505,7 +16505,7 @@
       "path": "hna/lihtc/08123.json",
       "kind": "json",
       "size_bytes": 26138,
-      "mtime": "2026-07-30T10:58:12.332Z",
+      "mtime": "2026-07-30T15:02:43.139Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16525,7 +16525,7 @@
       "path": "hna/lihtc/08125.json",
       "kind": "json",
       "size_bytes": 951,
-      "mtime": "2026-07-30T10:58:12.332Z",
+      "mtime": "2026-07-30T15:02:43.139Z",
       "shape": "object",
       "keys": [
         "type",
@@ -16545,7 +16545,7 @@
       "path": "hna/local-notes.json",
       "kind": "json",
       "size_bytes": 751,
-      "mtime": "2026-07-30T10:58:12.332Z",
+      "mtime": "2026-07-30T15:02:43.140Z",
       "shape": "object",
       "keys": [
         "08077"
@@ -16559,7 +16559,7 @@
       "path": "hna/local-resources-candidates.json",
       "kind": "json",
       "size_bytes": 25730,
-      "mtime": "2026-07-30T10:58:12.332Z",
+      "mtime": "2026-07-30T15:02:43.140Z",
       "shape": "object",
       "keys": [
         "generatedAt",
@@ -16583,7 +16583,7 @@
       "path": "hna/local-resources.json",
       "kind": "json",
       "size_bytes": 176383,
-      "mtime": "2026-07-30T10:58:12.333Z",
+      "mtime": "2026-07-30T15:02:43.140Z",
       "shape": "object",
       "keys": [
         "state:08",
@@ -16610,7 +16610,7 @@
       "path": "hna/ownership-need.json",
       "kind": "json",
       "size_bytes": 720001,
-      "mtime": "2026-07-30T10:58:12.334Z",
+      "mtime": "2026-07-30T15:02:43.141Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -16626,7 +16626,7 @@
       "path": "hna/permits.json",
       "kind": "json",
       "size_bytes": 249061,
-      "mtime": "2026-07-30T10:58:12.336Z",
+      "mtime": "2026-07-30T15:02:43.143Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -16643,7 +16643,7 @@
       "path": "hna/place-chas-coverage-stats.json",
       "kind": "json",
       "size_bytes": 11846,
-      "mtime": "2026-07-30T10:58:12.336Z",
+      "mtime": "2026-07-30T15:02:43.143Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -16660,7 +16660,7 @@
       "path": "hna/place-chas.json",
       "kind": "json",
       "size_bytes": 1629845,
-      "mtime": "2026-07-30T10:58:12.340Z",
+      "mtime": "2026-07-30T15:02:43.147Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -16675,7 +16675,7 @@
       "path": "hna/place-lehd.json",
       "kind": "json",
       "size_bytes": 1912794,
-      "mtime": "2026-07-30T10:58:12.344Z",
+      "mtime": "2026-07-30T15:02:43.159Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -16690,7 +16690,7 @@
       "path": "hna/place-od-flows.json",
       "kind": "json",
       "size_bytes": 82696,
-      "mtime": "2026-07-30T10:58:12.346Z",
+      "mtime": "2026-07-30T15:02:43.159Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -16705,7 +16705,7 @@
       "path": "hna/place-phantom-aliases.json",
       "kind": "json",
       "size_bytes": 1771,
-      "mtime": "2026-07-30T10:58:12.346Z",
+      "mtime": "2026-07-30T15:02:43.159Z",
       "shape": "object",
       "keys": [
         "aliases",
@@ -16720,7 +16720,7 @@
       "path": "hna/place-tract-membership.json",
       "kind": "json",
       "size_bytes": 426048,
-      "mtime": "2026-07-30T10:58:12.346Z",
+      "mtime": "2026-07-30T15:02:43.160Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -16735,7 +16735,7 @@
       "path": "hna/projections/08.json",
       "kind": "json",
       "size_bytes": 2670,
-      "mtime": "2026-07-30T10:58:12.347Z",
+      "mtime": "2026-07-30T15:02:43.161Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -16762,7 +16762,7 @@
       "path": "hna/projections/08001.json",
       "kind": "json",
       "size_bytes": 4900,
-      "mtime": "2026-07-30T10:58:12.347Z",
+      "mtime": "2026-07-30T15:02:43.161Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -16787,7 +16787,7 @@
       "path": "hna/projections/08003.json",
       "kind": "json",
       "size_bytes": 4767,
-      "mtime": "2026-07-30T10:58:12.347Z",
+      "mtime": "2026-07-30T15:02:43.161Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -16812,7 +16812,7 @@
       "path": "hna/projections/08005.json",
       "kind": "json",
       "size_bytes": 4826,
-      "mtime": "2026-07-30T10:58:12.347Z",
+      "mtime": "2026-07-30T15:02:43.161Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -16837,7 +16837,7 @@
       "path": "hna/projections/08007.json",
       "kind": "json",
       "size_bytes": 4801,
-      "mtime": "2026-07-30T10:58:12.347Z",
+      "mtime": "2026-07-30T15:02:43.161Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -16862,7 +16862,7 @@
       "path": "hna/projections/08009.json",
       "kind": "json",
       "size_bytes": 4755,
-      "mtime": "2026-07-30T10:58:12.347Z",
+      "mtime": "2026-07-30T15:02:43.161Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -16887,7 +16887,7 @@
       "path": "hna/projections/08011.json",
       "kind": "json",
       "size_bytes": 4692,
-      "mtime": "2026-07-30T10:58:12.347Z",
+      "mtime": "2026-07-30T15:02:43.161Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -16912,7 +16912,7 @@
       "path": "hna/projections/08013.json",
       "kind": "json",
       "size_bytes": 4816,
-      "mtime": "2026-07-30T10:58:12.347Z",
+      "mtime": "2026-07-30T15:02:43.161Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -16937,7 +16937,7 @@
       "path": "hna/projections/08014.json",
       "kind": "json",
       "size_bytes": 4742,
-      "mtime": "2026-07-30T10:58:12.347Z",
+      "mtime": "2026-07-30T15:02:43.161Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -16962,7 +16962,7 @@
       "path": "hna/projections/08015.json",
       "kind": "json",
       "size_bytes": 4722,
-      "mtime": "2026-07-30T10:58:12.347Z",
+      "mtime": "2026-07-30T15:02:43.161Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -16987,7 +16987,7 @@
       "path": "hna/projections/08017.json",
       "kind": "json",
       "size_bytes": 4765,
-      "mtime": "2026-07-30T10:58:12.347Z",
+      "mtime": "2026-07-30T15:02:43.161Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17012,7 +17012,7 @@
       "path": "hna/projections/08019.json",
       "kind": "json",
       "size_bytes": 4819,
-      "mtime": "2026-07-30T10:58:12.347Z",
+      "mtime": "2026-07-30T15:02:43.161Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17037,7 +17037,7 @@
       "path": "hna/projections/08021.json",
       "kind": "json",
       "size_bytes": 4650,
-      "mtime": "2026-07-30T10:58:12.347Z",
+      "mtime": "2026-07-30T15:02:43.162Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17062,7 +17062,7 @@
       "path": "hna/projections/08023.json",
       "kind": "json",
       "size_bytes": 4772,
-      "mtime": "2026-07-30T10:58:12.348Z",
+      "mtime": "2026-07-30T15:02:43.162Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17087,7 +17087,7 @@
       "path": "hna/projections/08025.json",
       "kind": "json",
       "size_bytes": 4829,
-      "mtime": "2026-07-30T10:58:12.348Z",
+      "mtime": "2026-07-30T15:02:43.162Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17112,7 +17112,7 @@
       "path": "hna/projections/08027.json",
       "kind": "json",
       "size_bytes": 4683,
-      "mtime": "2026-07-30T10:58:12.348Z",
+      "mtime": "2026-07-30T15:02:43.162Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17137,7 +17137,7 @@
       "path": "hna/projections/08029.json",
       "kind": "json",
       "size_bytes": 4843,
-      "mtime": "2026-07-30T10:58:12.348Z",
+      "mtime": "2026-07-30T15:02:43.162Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17162,7 +17162,7 @@
       "path": "hna/projections/08031.json",
       "kind": "json",
       "size_bytes": 4842,
-      "mtime": "2026-07-30T10:58:12.348Z",
+      "mtime": "2026-07-30T15:02:43.162Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17187,7 +17187,7 @@
       "path": "hna/projections/08033.json",
       "kind": "json",
       "size_bytes": 4659,
-      "mtime": "2026-07-30T10:58:12.348Z",
+      "mtime": "2026-07-30T15:02:43.162Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17212,7 +17212,7 @@
       "path": "hna/projections/08035.json",
       "kind": "json",
       "size_bytes": 4880,
-      "mtime": "2026-07-30T10:58:12.348Z",
+      "mtime": "2026-07-30T15:02:43.162Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17237,7 +17237,7 @@
       "path": "hna/projections/08037.json",
       "kind": "json",
       "size_bytes": 4795,
-      "mtime": "2026-07-30T10:58:12.348Z",
+      "mtime": "2026-07-30T15:02:43.162Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17262,7 +17262,7 @@
       "path": "hna/projections/08039.json",
       "kind": "json",
       "size_bytes": 4745,
-      "mtime": "2026-07-30T10:58:12.348Z",
+      "mtime": "2026-07-30T15:02:43.162Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17287,7 +17287,7 @@
       "path": "hna/projections/08041.json",
       "kind": "json",
       "size_bytes": 4803,
-      "mtime": "2026-07-30T10:58:12.349Z",
+      "mtime": "2026-07-30T15:02:43.162Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17312,7 +17312,7 @@
       "path": "hna/projections/08043.json",
       "kind": "json",
       "size_bytes": 4788,
-      "mtime": "2026-07-30T10:58:12.349Z",
+      "mtime": "2026-07-30T15:02:43.162Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17337,7 +17337,7 @@
       "path": "hna/projections/08045.json",
       "kind": "json",
       "size_bytes": 4857,
-      "mtime": "2026-07-30T10:58:12.349Z",
+      "mtime": "2026-07-30T15:02:43.162Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17362,7 +17362,7 @@
       "path": "hna/projections/08047.json",
       "kind": "json",
       "size_bytes": 4663,
-      "mtime": "2026-07-30T10:58:12.349Z",
+      "mtime": "2026-07-30T15:02:43.162Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17387,7 +17387,7 @@
       "path": "hna/projections/08049.json",
       "kind": "json",
       "size_bytes": 4748,
-      "mtime": "2026-07-30T10:58:12.349Z",
+      "mtime": "2026-07-30T15:02:43.162Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17412,7 +17412,7 @@
       "path": "hna/projections/08051.json",
       "kind": "json",
       "size_bytes": 4710,
-      "mtime": "2026-07-30T10:58:12.349Z",
+      "mtime": "2026-07-30T15:02:43.162Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17437,7 +17437,7 @@
       "path": "hna/projections/08053.json",
       "kind": "json",
       "size_bytes": 4719,
-      "mtime": "2026-07-30T10:58:12.349Z",
+      "mtime": "2026-07-30T15:02:43.163Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17462,7 +17462,7 @@
       "path": "hna/projections/08055.json",
       "kind": "json",
       "size_bytes": 4704,
-      "mtime": "2026-07-30T10:58:12.349Z",
+      "mtime": "2026-07-30T15:02:43.163Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17487,7 +17487,7 @@
       "path": "hna/projections/08057.json",
       "kind": "json",
       "size_bytes": 4849,
-      "mtime": "2026-07-30T10:58:12.349Z",
+      "mtime": "2026-07-30T15:02:43.163Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17512,7 +17512,7 @@
       "path": "hna/projections/08059.json",
       "kind": "json",
       "size_bytes": 4797,
-      "mtime": "2026-07-30T10:58:12.350Z",
+      "mtime": "2026-07-30T15:02:43.163Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17537,7 +17537,7 @@
       "path": "hna/projections/08061.json",
       "kind": "json",
       "size_bytes": 4718,
-      "mtime": "2026-07-30T10:58:12.350Z",
+      "mtime": "2026-07-30T15:02:43.163Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17562,7 +17562,7 @@
       "path": "hna/projections/08063.json",
       "kind": "json",
       "size_bytes": 4879,
-      "mtime": "2026-07-30T10:58:12.350Z",
+      "mtime": "2026-07-30T15:02:43.163Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17587,7 +17587,7 @@
       "path": "hna/projections/08065.json",
       "kind": "json",
       "size_bytes": 4697,
-      "mtime": "2026-07-30T10:58:12.350Z",
+      "mtime": "2026-07-30T15:02:43.163Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17612,7 +17612,7 @@
       "path": "hna/projections/08067.json",
       "kind": "json",
       "size_bytes": 4829,
-      "mtime": "2026-07-30T10:58:12.350Z",
+      "mtime": "2026-07-30T15:02:43.163Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17637,7 +17637,7 @@
       "path": "hna/projections/08069.json",
       "kind": "json",
       "size_bytes": 4805,
-      "mtime": "2026-07-30T10:58:12.351Z",
+      "mtime": "2026-07-30T15:02:43.163Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17662,7 +17662,7 @@
       "path": "hna/projections/08071.json",
       "kind": "json",
       "size_bytes": 4762,
-      "mtime": "2026-07-30T10:58:12.351Z",
+      "mtime": "2026-07-30T15:02:43.163Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17687,7 +17687,7 @@
       "path": "hna/projections/08073.json",
       "kind": "json",
       "size_bytes": 4707,
-      "mtime": "2026-07-30T10:58:12.351Z",
+      "mtime": "2026-07-30T15:02:43.163Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17712,7 +17712,7 @@
       "path": "hna/projections/08075.json",
       "kind": "json",
       "size_bytes": 4691,
-      "mtime": "2026-07-30T10:58:12.351Z",
+      "mtime": "2026-07-30T15:02:43.163Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17737,7 +17737,7 @@
       "path": "hna/projections/08077.json",
       "kind": "json",
       "size_bytes": 4735,
-      "mtime": "2026-07-30T10:58:12.351Z",
+      "mtime": "2026-07-30T15:02:43.163Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17762,7 +17762,7 @@
       "path": "hna/projections/08079.json",
       "kind": "json",
       "size_bytes": 4615,
-      "mtime": "2026-07-30T10:58:12.351Z",
+      "mtime": "2026-07-30T15:02:43.163Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17787,7 +17787,7 @@
       "path": "hna/projections/08081.json",
       "kind": "json",
       "size_bytes": 4730,
-      "mtime": "2026-07-30T10:58:12.351Z",
+      "mtime": "2026-07-30T15:02:43.163Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17812,7 +17812,7 @@
       "path": "hna/projections/08083.json",
       "kind": "json",
       "size_bytes": 4834,
-      "mtime": "2026-07-30T10:58:12.351Z",
+      "mtime": "2026-07-30T15:02:43.163Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17837,7 +17837,7 @@
       "path": "hna/projections/08085.json",
       "kind": "json",
       "size_bytes": 4757,
-      "mtime": "2026-07-30T10:58:12.352Z",
+      "mtime": "2026-07-30T15:02:43.164Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17862,7 +17862,7 @@
       "path": "hna/projections/08087.json",
       "kind": "json",
       "size_bytes": 4748,
-      "mtime": "2026-07-30T10:58:12.352Z",
+      "mtime": "2026-07-30T15:02:43.164Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17887,7 +17887,7 @@
       "path": "hna/projections/08089.json",
       "kind": "json",
       "size_bytes": 4756,
-      "mtime": "2026-07-30T10:58:12.352Z",
+      "mtime": "2026-07-30T15:02:43.164Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17912,7 +17912,7 @@
       "path": "hna/projections/08091.json",
       "kind": "json",
       "size_bytes": 4623,
-      "mtime": "2026-07-30T10:58:12.352Z",
+      "mtime": "2026-07-30T15:02:43.164Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17937,7 +17937,7 @@
       "path": "hna/projections/08093.json",
       "kind": "json",
       "size_bytes": 4766,
-      "mtime": "2026-07-30T10:58:12.352Z",
+      "mtime": "2026-07-30T15:02:43.164Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17962,7 +17962,7 @@
       "path": "hna/projections/08095.json",
       "kind": "json",
       "size_bytes": 4726,
-      "mtime": "2026-07-30T10:58:12.352Z",
+      "mtime": "2026-07-30T15:02:43.164Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -17987,7 +17987,7 @@
       "path": "hna/projections/08097.json",
       "kind": "json",
       "size_bytes": 4784,
-      "mtime": "2026-07-30T10:58:12.352Z",
+      "mtime": "2026-07-30T15:02:43.164Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18012,7 +18012,7 @@
       "path": "hna/projections/08099.json",
       "kind": "json",
       "size_bytes": 4741,
-      "mtime": "2026-07-30T10:58:12.352Z",
+      "mtime": "2026-07-30T15:02:43.164Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18037,7 +18037,7 @@
       "path": "hna/projections/08101.json",
       "kind": "json",
       "size_bytes": 4813,
-      "mtime": "2026-07-30T10:58:12.352Z",
+      "mtime": "2026-07-30T15:02:43.164Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18062,7 +18062,7 @@
       "path": "hna/projections/08103.json",
       "kind": "json",
       "size_bytes": 4794,
-      "mtime": "2026-07-30T10:58:12.353Z",
+      "mtime": "2026-07-30T15:02:43.164Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18087,7 +18087,7 @@
       "path": "hna/projections/08105.json",
       "kind": "json",
       "size_bytes": 4811,
-      "mtime": "2026-07-30T10:58:12.353Z",
+      "mtime": "2026-07-30T15:02:43.164Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18112,7 +18112,7 @@
       "path": "hna/projections/08107.json",
       "kind": "json",
       "size_bytes": 4751,
-      "mtime": "2026-07-30T10:58:12.353Z",
+      "mtime": "2026-07-30T15:02:43.164Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18137,7 +18137,7 @@
       "path": "hna/projections/08109.json",
       "kind": "json",
       "size_bytes": 4699,
-      "mtime": "2026-07-30T10:58:12.353Z",
+      "mtime": "2026-07-30T15:02:43.164Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18162,7 +18162,7 @@
       "path": "hna/projections/08111.json",
       "kind": "json",
       "size_bytes": 4704,
-      "mtime": "2026-07-30T10:58:12.353Z",
+      "mtime": "2026-07-30T15:02:43.164Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18187,7 +18187,7 @@
       "path": "hna/projections/08113.json",
       "kind": "json",
       "size_bytes": 4713,
-      "mtime": "2026-07-30T10:58:12.353Z",
+      "mtime": "2026-07-30T15:02:43.165Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18212,7 +18212,7 @@
       "path": "hna/projections/08115.json",
       "kind": "json",
       "size_bytes": 4829,
-      "mtime": "2026-07-30T10:58:12.353Z",
+      "mtime": "2026-07-30T15:02:43.165Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18237,7 +18237,7 @@
       "path": "hna/projections/08117.json",
       "kind": "json",
       "size_bytes": 4756,
-      "mtime": "2026-07-30T10:58:12.353Z",
+      "mtime": "2026-07-30T15:02:43.165Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18262,7 +18262,7 @@
       "path": "hna/projections/08119.json",
       "kind": "json",
       "size_bytes": 4752,
-      "mtime": "2026-07-30T10:58:12.353Z",
+      "mtime": "2026-07-30T15:02:43.165Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18287,7 +18287,7 @@
       "path": "hna/projections/08121.json",
       "kind": "json",
       "size_bytes": 4817,
-      "mtime": "2026-07-30T10:58:12.353Z",
+      "mtime": "2026-07-30T15:02:43.165Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18312,7 +18312,7 @@
       "path": "hna/projections/08123.json",
       "kind": "json",
       "size_bytes": 4844,
-      "mtime": "2026-07-30T10:58:12.354Z",
+      "mtime": "2026-07-30T15:02:43.165Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18337,7 +18337,7 @@
       "path": "hna/projections/08125.json",
       "kind": "json",
       "size_bytes": 4845,
-      "mtime": "2026-07-30T10:58:12.354Z",
+      "mtime": "2026-07-30T15:02:43.165Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18362,7 +18362,7 @@
       "path": "hna/projections/places.json",
       "kind": "json",
       "size_bytes": 846226,
-      "mtime": "2026-07-30T10:58:12.358Z",
+      "mtime": "2026-07-30T15:02:43.166Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -18377,7 +18377,7 @@
       "path": "hna/ranking-index.json",
       "kind": "json",
       "size_bytes": 1718294,
-      "mtime": "2026-07-30T10:58:12.363Z",
+      "mtime": "2026-07-30T15:02:43.169Z",
       "shape": "object",
       "keys": [
         "metadata",
@@ -18406,7 +18406,7 @@
       "path": "hna/ranking-scenarios/balanced.json",
       "kind": "json",
       "size_bytes": 49963,
-      "mtime": "2026-07-30T10:58:12.364Z",
+      "mtime": "2026-07-30T15:02:43.170Z",
       "shape": "object",
       "keys": [
         "metadata",
@@ -18425,7 +18425,7 @@
       "path": "hna/ranking-scenarios/commuter-pressure.json",
       "kind": "json",
       "size_bytes": 49983,
-      "mtime": "2026-07-30T10:58:12.365Z",
+      "mtime": "2026-07-30T15:02:43.170Z",
       "shape": "object",
       "keys": [
         "metadata",
@@ -18444,7 +18444,7 @@
       "path": "hna/ranking-scenarios/large-gap.json",
       "kind": "json",
       "size_bytes": 49974,
-      "mtime": "2026-07-30T10:58:12.365Z",
+      "mtime": "2026-07-30T15:02:43.170Z",
       "shape": "object",
       "keys": [
         "metadata",
@@ -18463,7 +18463,7 @@
       "path": "hna/ranking-scenarios/rate-sensitive.json",
       "kind": "json",
       "size_bytes": 49983,
-      "mtime": "2026-07-30T10:58:12.366Z",
+      "mtime": "2026-07-30T15:02:43.170Z",
       "shape": "object",
       "keys": [
         "metadata",
@@ -18482,7 +18482,7 @@
       "path": "hna/ranking-scenarios/rural-lens.json",
       "kind": "json",
       "size_bytes": 49985,
-      "mtime": "2026-07-30T10:58:12.366Z",
+      "mtime": "2026-07-30T15:02:43.170Z",
       "shape": "object",
       "keys": [
         "metadata",
@@ -18501,7 +18501,7 @@
       "path": "hna/scenarios/baseline.json",
       "kind": "json",
       "size_bytes": 1288,
-      "mtime": "2026-07-30T10:58:12.366Z",
+      "mtime": "2026-07-30T15:02:43.171Z",
       "shape": "object",
       "keys": [
         "id",
@@ -18527,7 +18527,7 @@
       "path": "hna/scenarios/high-growth.json",
       "kind": "json",
       "size_bytes": 1294,
-      "mtime": "2026-07-30T10:58:12.366Z",
+      "mtime": "2026-07-30T15:02:43.171Z",
       "shape": "object",
       "keys": [
         "id",
@@ -18553,7 +18553,7 @@
       "path": "hna/scenarios/low-growth.json",
       "kind": "json",
       "size_bytes": 1282,
-      "mtime": "2026-07-30T10:58:12.366Z",
+      "mtime": "2026-07-30T15:02:43.171Z",
       "shape": "object",
       "keys": [
         "id",
@@ -18579,7 +18579,7 @@
       "path": "hna/source/dola_components_county.csv",
       "kind": "csv",
       "size_bytes": 316471,
-      "mtime": "2026-07-30T10:58:12.369Z",
+      "mtime": "2026-07-30T15:02:43.175Z",
       "shape": "csv",
       "row_count": 5886,
       "columns": [
@@ -18600,7 +18600,7 @@
       "path": "hna/source/dola_profiles_county.csv",
       "kind": "csv",
       "size_bytes": 223591,
-      "mtime": "2026-07-30T10:58:12.370Z",
+      "mtime": "2026-07-30T15:02:43.176Z",
       "shape": "csv",
       "row_count": 2601,
       "columns": [
@@ -18627,7 +18627,7 @@
       "path": "hna/source/dola_sya_county.csv",
       "kind": "csv",
       "size_bytes": 20924469,
-      "mtime": "2026-07-30T10:58:12.404Z",
+      "mtime": "2026-07-30T15:02:43.204Z",
       "shape": "csv",
       "row_count": 453116,
       "columns": [
@@ -18647,7 +18647,7 @@
       "path": "hna/summary/08.json",
       "kind": "json",
       "size_bytes": 2914,
-      "mtime": "2026-07-30T10:58:12.405Z",
+      "mtime": "2026-07-30T15:02:43.204Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18665,7 +18665,7 @@
       "path": "hna/summary/08001.json",
       "kind": "json",
       "size_bytes": 4182,
-      "mtime": "2026-07-30T10:58:12.405Z",
+      "mtime": "2026-07-30T15:02:43.205Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18684,7 +18684,7 @@
       "path": "hna/summary/08003.json",
       "kind": "json",
       "size_bytes": 4027,
-      "mtime": "2026-07-30T10:58:12.405Z",
+      "mtime": "2026-07-30T15:02:43.205Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18703,7 +18703,7 @@
       "path": "hna/summary/0800320.json",
       "kind": "json",
       "size_bytes": 4066,
-      "mtime": "2026-07-30T10:58:12.405Z",
+      "mtime": "2026-07-30T15:02:43.205Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18722,7 +18722,7 @@
       "path": "hna/summary/08005.json",
       "kind": "json",
       "size_bytes": 4249,
-      "mtime": "2026-07-30T10:58:12.405Z",
+      "mtime": "2026-07-30T15:02:43.205Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18741,7 +18741,7 @@
       "path": "hna/summary/0800620.json",
       "kind": "json",
       "size_bytes": 4432,
-      "mtime": "2026-07-30T10:58:12.405Z",
+      "mtime": "2026-07-30T15:02:43.205Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18760,7 +18760,7 @@
       "path": "hna/summary/08007.json",
       "kind": "json",
       "size_bytes": 4020,
-      "mtime": "2026-07-30T10:58:12.405Z",
+      "mtime": "2026-07-30T15:02:43.205Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18779,7 +18779,7 @@
       "path": "hna/summary/0800760.json",
       "kind": "json",
       "size_bytes": 3978,
-      "mtime": "2026-07-30T10:58:12.405Z",
+      "mtime": "2026-07-30T15:02:43.205Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18798,7 +18798,7 @@
       "path": "hna/summary/0800870.json",
       "kind": "json",
       "size_bytes": 4025,
-      "mtime": "2026-07-30T10:58:12.405Z",
+      "mtime": "2026-07-30T15:02:43.205Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18817,7 +18817,7 @@
       "path": "hna/summary/08009.json",
       "kind": "json",
       "size_bytes": 3949,
-      "mtime": "2026-07-30T10:58:12.405Z",
+      "mtime": "2026-07-30T15:02:43.205Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18836,7 +18836,7 @@
       "path": "hna/summary/0800925.json",
       "kind": "json",
       "size_bytes": 4087,
-      "mtime": "2026-07-30T10:58:12.405Z",
+      "mtime": "2026-07-30T15:02:43.205Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18855,7 +18855,7 @@
       "path": "hna/summary/0801090.json",
       "kind": "json",
       "size_bytes": 4193,
-      "mtime": "2026-07-30T10:58:12.405Z",
+      "mtime": "2026-07-30T15:02:43.205Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18874,7 +18874,7 @@
       "path": "hna/summary/08011.json",
       "kind": "json",
       "size_bytes": 3961,
-      "mtime": "2026-07-30T10:58:12.405Z",
+      "mtime": "2026-07-30T15:02:43.205Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18893,7 +18893,7 @@
       "path": "hna/summary/0801145.json",
       "kind": "json",
       "size_bytes": 4020,
-      "mtime": "2026-07-30T10:58:12.405Z",
+      "mtime": "2026-07-30T15:02:43.205Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18912,7 +18912,7 @@
       "path": "hna/summary/08013.json",
       "kind": "json",
       "size_bytes": 4152,
-      "mtime": "2026-07-30T10:58:12.405Z",
+      "mtime": "2026-07-30T15:02:43.206Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18931,7 +18931,7 @@
       "path": "hna/summary/08014.json",
       "kind": "json",
       "size_bytes": 4031,
-      "mtime": "2026-07-30T10:58:12.406Z",
+      "mtime": "2026-07-30T15:02:43.206Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18950,7 +18950,7 @@
       "path": "hna/summary/0801420.json",
       "kind": "json",
       "size_bytes": 4030,
-      "mtime": "2026-07-30T10:58:12.406Z",
+      "mtime": "2026-07-30T15:02:43.206Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18969,7 +18969,7 @@
       "path": "hna/summary/08015.json",
       "kind": "json",
       "size_bytes": 4037,
-      "mtime": "2026-07-30T10:58:12.406Z",
+      "mtime": "2026-07-30T15:02:43.206Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -18988,7 +18988,7 @@
       "path": "hna/summary/0801530.json",
       "kind": "json",
       "size_bytes": 4001,
-      "mtime": "2026-07-30T10:58:12.406Z",
+      "mtime": "2026-07-30T15:02:43.206Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19007,7 +19007,7 @@
       "path": "hna/summary/0801640.json",
       "kind": "json",
       "size_bytes": 3907,
-      "mtime": "2026-07-30T10:58:12.406Z",
+      "mtime": "2026-07-30T15:02:43.206Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19026,7 +19026,7 @@
       "path": "hna/summary/08017.json",
       "kind": "json",
       "size_bytes": 3897,
-      "mtime": "2026-07-30T10:58:12.406Z",
+      "mtime": "2026-07-30T15:02:43.206Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19045,7 +19045,7 @@
       "path": "hna/summary/0801740.json",
       "kind": "json",
       "size_bytes": 3948,
-      "mtime": "2026-07-30T10:58:12.406Z",
+      "mtime": "2026-07-30T15:02:43.207Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19064,7 +19064,7 @@
       "path": "hna/summary/08019.json",
       "kind": "json",
       "size_bytes": 4001,
-      "mtime": "2026-07-30T10:58:12.406Z",
+      "mtime": "2026-07-30T15:02:43.207Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19083,7 +19083,7 @@
       "path": "hna/summary/0801915.json",
       "kind": "json",
       "size_bytes": 3884,
-      "mtime": "2026-07-30T10:58:12.406Z",
+      "mtime": "2026-07-30T15:02:43.207Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19102,7 +19102,7 @@
       "path": "hna/summary/08021.json",
       "kind": "json",
       "size_bytes": 3992,
-      "mtime": "2026-07-30T10:58:12.406Z",
+      "mtime": "2026-07-30T15:02:43.207Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19121,7 +19121,7 @@
       "path": "hna/summary/08023.json",
       "kind": "json",
       "size_bytes": 3955,
-      "mtime": "2026-07-30T10:58:12.406Z",
+      "mtime": "2026-07-30T15:02:43.207Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19140,7 +19140,7 @@
       "path": "hna/summary/0802355.json",
       "kind": "json",
       "size_bytes": 4034,
-      "mtime": "2026-07-30T10:58:12.406Z",
+      "mtime": "2026-07-30T15:02:43.207Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19159,7 +19159,7 @@
       "path": "hna/summary/08025.json",
       "kind": "json",
       "size_bytes": 3950,
-      "mtime": "2026-07-30T10:58:12.406Z",
+      "mtime": "2026-07-30T15:02:43.207Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19178,7 +19178,7 @@
       "path": "hna/summary/0802575.json",
       "kind": "json",
       "size_bytes": 4106,
-      "mtime": "2026-07-30T10:58:12.406Z",
+      "mtime": "2026-07-30T15:02:43.207Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19197,7 +19197,7 @@
       "path": "hna/summary/08027.json",
       "kind": "json",
       "size_bytes": 3968,
-      "mtime": "2026-07-30T10:58:12.406Z",
+      "mtime": "2026-07-30T15:02:43.207Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19216,7 +19216,7 @@
       "path": "hna/summary/0802850.json",
       "kind": "json",
       "size_bytes": 3882,
-      "mtime": "2026-07-30T10:58:12.406Z",
+      "mtime": "2026-07-30T15:02:43.207Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19235,7 +19235,7 @@
       "path": "hna/summary/08029.json",
       "kind": "json",
       "size_bytes": 4079,
-      "mtime": "2026-07-30T10:58:12.406Z",
+      "mtime": "2026-07-30T15:02:43.207Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19254,7 +19254,7 @@
       "path": "hna/summary/0802905.json",
       "kind": "json",
       "size_bytes": 3942,
-      "mtime": "2026-07-30T10:58:12.406Z",
+      "mtime": "2026-07-30T15:02:43.207Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19273,7 +19273,7 @@
       "path": "hna/summary/0803015.json",
       "kind": "json",
       "size_bytes": 4015,
-      "mtime": "2026-07-30T10:58:12.407Z",
+      "mtime": "2026-07-30T15:02:43.207Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19292,7 +19292,7 @@
       "path": "hna/summary/08031.json",
       "kind": "json",
       "size_bytes": 4225,
-      "mtime": "2026-07-30T10:58:12.407Z",
+      "mtime": "2026-07-30T15:02:43.208Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19311,7 +19311,7 @@
       "path": "hna/summary/0803235.json",
       "kind": "json",
       "size_bytes": 3942,
-      "mtime": "2026-07-30T10:58:12.407Z",
+      "mtime": "2026-07-30T15:02:43.208Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19330,7 +19330,7 @@
       "path": "hna/summary/08033.json",
       "kind": "json",
       "size_bytes": 3928,
-      "mtime": "2026-07-30T10:58:12.407Z",
+      "mtime": "2026-07-30T15:02:43.208Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19349,7 +19349,7 @@
       "path": "hna/summary/0803455.json",
       "kind": "json",
       "size_bytes": 4261,
-      "mtime": "2026-07-30T10:58:12.407Z",
+      "mtime": "2026-07-30T15:02:43.208Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19368,7 +19368,7 @@
       "path": "hna/summary/08035.json",
       "kind": "json",
       "size_bytes": 4108,
-      "mtime": "2026-07-30T10:58:12.407Z",
+      "mtime": "2026-07-30T15:02:43.208Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19387,7 +19387,7 @@
       "path": "hna/summary/0803620.json",
       "kind": "json",
       "size_bytes": 4177,
-      "mtime": "2026-07-30T10:58:12.407Z",
+      "mtime": "2026-07-30T15:02:43.208Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19406,7 +19406,7 @@
       "path": "hna/summary/08037.json",
       "kind": "json",
       "size_bytes": 4083,
-      "mtime": "2026-07-30T10:58:12.407Z",
+      "mtime": "2026-07-30T15:02:43.208Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19425,7 +19425,7 @@
       "path": "hna/summary/0803730.json",
       "kind": "json",
       "size_bytes": 3948,
-      "mtime": "2026-07-30T10:58:12.407Z",
+      "mtime": "2026-07-30T15:02:43.208Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19444,7 +19444,7 @@
       "path": "hna/summary/0803840.json",
       "kind": "json",
       "size_bytes": 3927,
-      "mtime": "2026-07-30T10:58:12.407Z",
+      "mtime": "2026-07-30T15:02:43.208Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19463,7 +19463,7 @@
       "path": "hna/summary/08039.json",
       "kind": "json",
       "size_bytes": 4030,
-      "mtime": "2026-07-30T10:58:12.407Z",
+      "mtime": "2026-07-30T15:02:43.208Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19482,7 +19482,7 @@
       "path": "hna/summary/0803950.json",
       "kind": "json",
       "size_bytes": 4079,
-      "mtime": "2026-07-30T10:58:12.407Z",
+      "mtime": "2026-07-30T15:02:43.208Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19501,7 +19501,7 @@
       "path": "hna/summary/0804000.json",
       "kind": "json",
       "size_bytes": 4370,
-      "mtime": "2026-07-30T10:58:12.408Z",
+      "mtime": "2026-07-30T15:02:43.209Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19520,7 +19520,7 @@
       "path": "hna/summary/08041.json",
       "kind": "json",
       "size_bytes": 4264,
-      "mtime": "2026-07-30T10:58:12.408Z",
+      "mtime": "2026-07-30T15:02:43.209Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19539,7 +19539,7 @@
       "path": "hna/summary/0804110.json",
       "kind": "json",
       "size_bytes": 4140,
-      "mtime": "2026-07-30T10:58:12.408Z",
+      "mtime": "2026-07-30T15:02:43.209Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19558,7 +19558,7 @@
       "path": "hna/summary/0804165.json",
       "kind": "json",
       "size_bytes": 3957,
-      "mtime": "2026-07-30T10:58:12.408Z",
+      "mtime": "2026-07-30T15:02:43.209Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19577,7 +19577,7 @@
       "path": "hna/summary/08043.json",
       "kind": "json",
       "size_bytes": 4108,
-      "mtime": "2026-07-30T10:58:12.408Z",
+      "mtime": "2026-07-30T15:02:43.209Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19596,7 +19596,7 @@
       "path": "hna/summary/08045.json",
       "kind": "json",
       "size_bytes": 4111,
-      "mtime": "2026-07-30T10:58:12.408Z",
+      "mtime": "2026-07-30T15:02:43.209Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19615,7 +19615,7 @@
       "path": "hna/summary/0804620.json",
       "kind": "json",
       "size_bytes": 3912,
-      "mtime": "2026-07-30T10:58:12.408Z",
+      "mtime": "2026-07-30T15:02:43.209Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19634,7 +19634,7 @@
       "path": "hna/summary/08047.json",
       "kind": "json",
       "size_bytes": 3969,
-      "mtime": "2026-07-30T10:58:12.408Z",
+      "mtime": "2026-07-30T15:02:43.209Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19653,7 +19653,7 @@
       "path": "hna/summary/08049.json",
       "kind": "json",
       "size_bytes": 4036,
-      "mtime": "2026-07-30T10:58:12.408Z",
+      "mtime": "2026-07-30T15:02:43.209Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19672,7 +19672,7 @@
       "path": "hna/summary/0804935.json",
       "kind": "json",
       "size_bytes": 4074,
-      "mtime": "2026-07-30T10:58:12.408Z",
+      "mtime": "2026-07-30T15:02:43.209Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19691,7 +19691,7 @@
       "path": "hna/summary/08051.json",
       "kind": "json",
       "size_bytes": 4047,
-      "mtime": "2026-07-30T10:58:12.408Z",
+      "mtime": "2026-07-30T15:02:43.209Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19710,7 +19710,7 @@
       "path": "hna/summary/0805120.json",
       "kind": "json",
       "size_bytes": 4095,
-      "mtime": "2026-07-30T10:58:12.408Z",
+      "mtime": "2026-07-30T15:02:43.209Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19729,7 +19729,7 @@
       "path": "hna/summary/0805265.json",
       "kind": "json",
       "size_bytes": 4104,
-      "mtime": "2026-07-30T10:58:12.409Z",
+      "mtime": "2026-07-30T15:02:43.210Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19748,7 +19748,7 @@
       "path": "hna/summary/08053.json",
       "kind": "json",
       "size_bytes": 3864,
-      "mtime": "2026-07-30T10:58:12.409Z",
+      "mtime": "2026-07-30T15:02:43.210Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19767,7 +19767,7 @@
       "path": "hna/summary/08055.json",
       "kind": "json",
       "size_bytes": 3989,
-      "mtime": "2026-07-30T10:58:12.409Z",
+      "mtime": "2026-07-30T15:02:43.210Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19786,7 +19786,7 @@
       "path": "hna/summary/08057.json",
       "kind": "json",
       "size_bytes": 3895,
-      "mtime": "2026-07-30T10:58:12.409Z",
+      "mtime": "2026-07-30T15:02:43.210Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19805,7 +19805,7 @@
       "path": "hna/summary/08059.json",
       "kind": "json",
       "size_bytes": 4180,
-      "mtime": "2026-07-30T10:58:12.409Z",
+      "mtime": "2026-07-30T15:02:43.210Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19824,7 +19824,7 @@
       "path": "hna/summary/0806090.json",
       "kind": "json",
       "size_bytes": 4112,
-      "mtime": "2026-07-30T10:58:12.409Z",
+      "mtime": "2026-07-30T15:02:43.210Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19843,7 +19843,7 @@
       "path": "hna/summary/08061.json",
       "kind": "json",
       "size_bytes": 3889,
-      "mtime": "2026-07-30T10:58:12.409Z",
+      "mtime": "2026-07-30T15:02:43.210Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19862,7 +19862,7 @@
       "path": "hna/summary/0806172.json",
       "kind": "json",
       "size_bytes": 4145,
-      "mtime": "2026-07-30T10:58:12.409Z",
+      "mtime": "2026-07-30T15:02:43.210Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19881,7 +19881,7 @@
       "path": "hna/summary/0806255.json",
       "kind": "json",
       "size_bytes": 3733,
-      "mtime": "2026-07-30T10:58:12.410Z",
+      "mtime": "2026-07-30T15:02:43.211Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19900,7 +19900,7 @@
       "path": "hna/summary/08063.json",
       "kind": "json",
       "size_bytes": 3990,
-      "mtime": "2026-07-30T10:58:12.410Z",
+      "mtime": "2026-07-30T15:02:43.211Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19919,7 +19919,7 @@
       "path": "hna/summary/08065.json",
       "kind": "json",
       "size_bytes": 3974,
-      "mtime": "2026-07-30T10:58:12.410Z",
+      "mtime": "2026-07-30T15:02:43.211Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19938,7 +19938,7 @@
       "path": "hna/summary/0806530.json",
       "kind": "json",
       "size_bytes": 3915,
-      "mtime": "2026-07-30T10:58:12.410Z",
+      "mtime": "2026-07-30T15:02:43.211Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19957,7 +19957,7 @@
       "path": "hna/summary/0806602.json",
       "kind": "json",
       "size_bytes": 3970,
-      "mtime": "2026-07-30T10:58:12.410Z",
+      "mtime": "2026-07-30T15:02:43.211Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19976,7 +19976,7 @@
       "path": "hna/summary/08067.json",
       "kind": "json",
       "size_bytes": 4110,
-      "mtime": "2026-07-30T10:58:12.410Z",
+      "mtime": "2026-07-30T15:02:43.211Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -19995,7 +19995,7 @@
       "path": "hna/summary/08069.json",
       "kind": "json",
       "size_bytes": 4167,
-      "mtime": "2026-07-30T10:58:12.411Z",
+      "mtime": "2026-07-30T15:02:43.212Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20014,7 +20014,7 @@
       "path": "hna/summary/0806970.json",
       "kind": "json",
       "size_bytes": 4131,
-      "mtime": "2026-07-30T10:58:12.411Z",
+      "mtime": "2026-07-30T15:02:43.212Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20033,7 +20033,7 @@
       "path": "hna/summary/0807025.json",
       "kind": "json",
       "size_bytes": 3916,
-      "mtime": "2026-07-30T10:58:12.411Z",
+      "mtime": "2026-07-30T15:02:43.212Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20052,7 +20052,7 @@
       "path": "hna/summary/08071.json",
       "kind": "json",
       "size_bytes": 4038,
-      "mtime": "2026-07-30T10:58:12.411Z",
+      "mtime": "2026-07-30T15:02:43.212Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20071,7 +20071,7 @@
       "path": "hna/summary/0807190.json",
       "kind": "json",
       "size_bytes": 3968,
-      "mtime": "2026-07-30T10:58:12.412Z",
+      "mtime": "2026-07-30T15:02:43.212Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20090,7 +20090,7 @@
       "path": "hna/summary/0807245.json",
       "kind": "json",
       "size_bytes": 3981,
-      "mtime": "2026-07-30T10:58:12.412Z",
+      "mtime": "2026-07-30T15:02:43.212Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20109,7 +20109,7 @@
       "path": "hna/summary/08073.json",
       "kind": "json",
       "size_bytes": 3957,
-      "mtime": "2026-07-30T10:58:12.412Z",
+      "mtime": "2026-07-30T15:02:43.212Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20128,7 +20128,7 @@
       "path": "hna/summary/0807410.json",
       "kind": "json",
       "size_bytes": 4019,
-      "mtime": "2026-07-30T10:58:12.412Z",
+      "mtime": "2026-07-30T15:02:43.212Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20147,7 +20147,7 @@
       "path": "hna/summary/0807420.json",
       "kind": "json",
       "size_bytes": 3869,
-      "mtime": "2026-07-30T10:58:12.412Z",
+      "mtime": "2026-07-30T15:02:43.213Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20166,7 +20166,7 @@
       "path": "hna/summary/0807455.json",
       "kind": "json",
       "size_bytes": 3907,
-      "mtime": "2026-07-30T10:58:12.412Z",
+      "mtime": "2026-07-30T15:02:43.213Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20185,7 +20185,7 @@
       "path": "hna/summary/08075.json",
       "kind": "json",
       "size_bytes": 4047,
-      "mtime": "2026-07-30T10:58:12.412Z",
+      "mtime": "2026-07-30T15:02:43.213Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20204,7 +20204,7 @@
       "path": "hna/summary/0807571.json",
       "kind": "json",
       "size_bytes": 3878,
-      "mtime": "2026-07-30T10:58:12.412Z",
+      "mtime": "2026-07-30T15:02:43.213Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20223,7 +20223,7 @@
       "path": "hna/summary/0807580.json",
       "kind": "json",
       "size_bytes": 3902,
-      "mtime": "2026-07-30T10:58:12.412Z",
+      "mtime": "2026-07-30T15:02:43.213Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20242,7 +20242,7 @@
       "path": "hna/summary/08077.json",
       "kind": "json",
       "size_bytes": 4099,
-      "mtime": "2026-07-30T10:58:12.412Z",
+      "mtime": "2026-07-30T15:02:43.213Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20261,7 +20261,7 @@
       "path": "hna/summary/0807795.json",
       "kind": "json",
       "size_bytes": 3956,
-      "mtime": "2026-07-30T10:58:12.413Z",
+      "mtime": "2026-07-30T15:02:43.213Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20280,7 +20280,7 @@
       "path": "hna/summary/0807850.json",
       "kind": "json",
       "size_bytes": 4240,
-      "mtime": "2026-07-30T10:58:12.413Z",
+      "mtime": "2026-07-30T15:02:43.213Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20299,7 +20299,7 @@
       "path": "hna/summary/08079.json",
       "kind": "json",
       "size_bytes": 3857,
-      "mtime": "2026-07-30T10:58:12.413Z",
+      "mtime": "2026-07-30T15:02:43.213Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20318,7 +20318,7 @@
       "path": "hna/summary/0808070.json",
       "kind": "json",
       "size_bytes": 4018,
-      "mtime": "2026-07-30T10:58:12.413Z",
+      "mtime": "2026-07-30T15:02:43.214Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20337,7 +20337,7 @@
       "path": "hna/summary/08081.json",
       "kind": "json",
       "size_bytes": 4020,
-      "mtime": "2026-07-30T10:58:12.413Z",
+      "mtime": "2026-07-30T15:02:43.214Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20356,7 +20356,7 @@
       "path": "hna/summary/0808290.json",
       "kind": "json",
       "size_bytes": 3838,
-      "mtime": "2026-07-30T10:58:12.413Z",
+      "mtime": "2026-07-30T15:02:43.214Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20375,7 +20375,7 @@
       "path": "hna/summary/08083.json",
       "kind": "json",
       "size_bytes": 4070,
-      "mtime": "2026-07-30T10:58:12.413Z",
+      "mtime": "2026-07-30T15:02:43.214Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20394,7 +20394,7 @@
       "path": "hna/summary/0808345.json",
       "kind": "json",
       "size_bytes": 3874,
-      "mtime": "2026-07-30T10:58:12.413Z",
+      "mtime": "2026-07-30T15:02:43.214Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20413,7 +20413,7 @@
       "path": "hna/summary/0808400.json",
       "kind": "json",
       "size_bytes": 4155,
-      "mtime": "2026-07-30T10:58:12.413Z",
+      "mtime": "2026-07-30T15:02:43.214Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20432,7 +20432,7 @@
       "path": "hna/summary/08085.json",
       "kind": "json",
       "size_bytes": 4092,
-      "mtime": "2026-07-30T10:58:12.413Z",
+      "mtime": "2026-07-30T15:02:43.214Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20451,7 +20451,7 @@
       "path": "hna/summary/0808530.json",
       "kind": "json",
       "size_bytes": 3901,
-      "mtime": "2026-07-30T10:58:12.413Z",
+      "mtime": "2026-07-30T15:02:43.214Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20470,7 +20470,7 @@
       "path": "hna/summary/0808620.json",
       "kind": "json",
       "size_bytes": 3919,
-      "mtime": "2026-07-30T10:58:12.413Z",
+      "mtime": "2026-07-30T15:02:43.214Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20489,7 +20489,7 @@
       "path": "hna/summary/0808675.json",
       "kind": "json",
       "size_bytes": 4261,
-      "mtime": "2026-07-30T10:58:12.413Z",
+      "mtime": "2026-07-30T15:02:43.214Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20508,7 +20508,7 @@
       "path": "hna/summary/08087.json",
       "kind": "json",
       "size_bytes": 4073,
-      "mtime": "2026-07-30T10:58:12.413Z",
+      "mtime": "2026-07-30T15:02:43.214Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20527,7 +20527,7 @@
       "path": "hna/summary/08089.json",
       "kind": "json",
       "size_bytes": 4038,
-      "mtime": "2026-07-30T10:58:12.413Z",
+      "mtime": "2026-07-30T15:02:43.214Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20546,7 +20546,7 @@
       "path": "hna/summary/0808950.json",
       "kind": "json",
       "size_bytes": 3938,
-      "mtime": "2026-07-30T10:58:12.413Z",
+      "mtime": "2026-07-30T15:02:43.214Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20565,7 +20565,7 @@
       "path": "hna/summary/08091.json",
       "kind": "json",
       "size_bytes": 3959,
-      "mtime": "2026-07-30T10:58:12.413Z",
+      "mtime": "2026-07-30T15:02:43.214Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20584,7 +20584,7 @@
       "path": "hna/summary/0809115.json",
       "kind": "json",
       "size_bytes": 3954,
-      "mtime": "2026-07-30T10:58:12.413Z",
+      "mtime": "2026-07-30T15:02:43.214Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20603,7 +20603,7 @@
       "path": "hna/summary/0809280.json",
       "kind": "json",
       "size_bytes": 4220,
-      "mtime": "2026-07-30T10:58:12.413Z",
+      "mtime": "2026-07-30T15:02:43.214Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20622,7 +20622,7 @@
       "path": "hna/summary/08093.json",
       "kind": "json",
       "size_bytes": 4030,
-      "mtime": "2026-07-30T10:58:12.414Z",
+      "mtime": "2026-07-30T15:02:43.214Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20641,7 +20641,7 @@
       "path": "hna/summary/08095.json",
       "kind": "json",
       "size_bytes": 3962,
-      "mtime": "2026-07-30T10:58:12.414Z",
+      "mtime": "2026-07-30T15:02:43.215Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20660,7 +20660,7 @@
       "path": "hna/summary/0809555.json",
       "kind": "json",
       "size_bytes": 3685,
-      "mtime": "2026-07-30T10:58:12.415Z",
+      "mtime": "2026-07-30T15:02:43.215Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20679,7 +20679,7 @@
       "path": "hna/summary/08097.json",
       "kind": "json",
       "size_bytes": 4043,
-      "mtime": "2026-07-30T10:58:12.415Z",
+      "mtime": "2026-07-30T15:02:43.215Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20698,7 +20698,7 @@
       "path": "hna/summary/08099.json",
       "kind": "json",
       "size_bytes": 4013,
-      "mtime": "2026-07-30T10:58:12.416Z",
+      "mtime": "2026-07-30T15:02:43.215Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20717,7 +20717,7 @@
       "path": "hna/summary/08101.json",
       "kind": "json",
       "size_bytes": 4101,
-      "mtime": "2026-07-30T10:58:12.416Z",
+      "mtime": "2026-07-30T15:02:43.215Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20736,7 +20736,7 @@
       "path": "hna/summary/0810105.json",
       "kind": "json",
       "size_bytes": 4095,
-      "mtime": "2026-07-30T10:58:12.416Z",
+      "mtime": "2026-07-30T15:02:43.215Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20755,7 +20755,7 @@
       "path": "hna/summary/08103.json",
       "kind": "json",
       "size_bytes": 3978,
-      "mtime": "2026-07-30T10:58:12.416Z",
+      "mtime": "2026-07-30T15:02:43.215Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20774,7 +20774,7 @@
       "path": "hna/summary/08105.json",
       "kind": "json",
       "size_bytes": 4021,
-      "mtime": "2026-07-30T10:58:12.416Z",
+      "mtime": "2026-07-30T15:02:43.215Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20793,7 +20793,7 @@
       "path": "hna/summary/0810600.json",
       "kind": "json",
       "size_bytes": 4122,
-      "mtime": "2026-07-30T10:58:12.416Z",
+      "mtime": "2026-07-30T15:02:43.215Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20812,7 +20812,7 @@
       "path": "hna/summary/08107.json",
       "kind": "json",
       "size_bytes": 4063,
-      "mtime": "2026-07-30T10:58:12.416Z",
+      "mtime": "2026-07-30T15:02:43.215Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20831,7 +20831,7 @@
       "path": "hna/summary/08109.json",
       "kind": "json",
       "size_bytes": 3991,
-      "mtime": "2026-07-30T10:58:12.416Z",
+      "mtime": "2026-07-30T15:02:43.215Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20850,7 +20850,7 @@
       "path": "hna/summary/0810985.json",
       "kind": "json",
       "size_bytes": 4014,
-      "mtime": "2026-07-30T10:58:12.416Z",
+      "mtime": "2026-07-30T15:02:43.215Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20869,7 +20869,7 @@
       "path": "hna/summary/08111.json",
       "kind": "json",
       "size_bytes": 3857,
-      "mtime": "2026-07-30T10:58:12.416Z",
+      "mtime": "2026-07-30T15:02:43.215Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20888,7 +20888,7 @@
       "path": "hna/summary/0811260.json",
       "kind": "json",
       "size_bytes": 4020,
-      "mtime": "2026-07-30T10:58:12.416Z",
+      "mtime": "2026-07-30T15:02:43.216Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20907,7 +20907,7 @@
       "path": "hna/summary/08113.json",
       "kind": "json",
       "size_bytes": 3998,
-      "mtime": "2026-07-30T10:58:12.417Z",
+      "mtime": "2026-07-30T15:02:43.216Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20926,7 +20926,7 @@
       "path": "hna/summary/08115.json",
       "kind": "json",
       "size_bytes": 3929,
-      "mtime": "2026-07-30T10:58:12.417Z",
+      "mtime": "2026-07-30T15:02:43.216Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20945,7 +20945,7 @@
       "path": "hna/summary/0811645.json",
       "kind": "json",
       "size_bytes": 3871,
-      "mtime": "2026-07-30T10:58:12.417Z",
+      "mtime": "2026-07-30T15:02:43.216Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20964,7 +20964,7 @@
       "path": "hna/summary/08117.json",
       "kind": "json",
       "size_bytes": 4070,
-      "mtime": "2026-07-30T10:58:12.417Z",
+      "mtime": "2026-07-30T15:02:43.216Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -20983,7 +20983,7 @@
       "path": "hna/summary/0811810.json",
       "kind": "json",
       "size_bytes": 4187,
-      "mtime": "2026-07-30T10:58:12.417Z",
+      "mtime": "2026-07-30T15:02:43.216Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21002,7 +21002,7 @@
       "path": "hna/summary/08119.json",
       "kind": "json",
       "size_bytes": 4059,
-      "mtime": "2026-07-30T10:58:12.417Z",
+      "mtime": "2026-07-30T15:02:43.216Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21021,7 +21021,7 @@
       "path": "hna/summary/0811975.json",
       "kind": "json",
       "size_bytes": 3907,
-      "mtime": "2026-07-30T10:58:12.417Z",
+      "mtime": "2026-07-30T15:02:43.216Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21040,7 +21040,7 @@
       "path": "hna/summary/0812030.json",
       "kind": "json",
       "size_bytes": 3883,
-      "mtime": "2026-07-30T10:58:12.417Z",
+      "mtime": "2026-07-30T15:02:43.216Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21059,7 +21059,7 @@
       "path": "hna/summary/0812045.json",
       "kind": "json",
       "size_bytes": 4114,
-      "mtime": "2026-07-30T10:58:12.417Z",
+      "mtime": "2026-07-30T15:02:43.216Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21078,7 +21078,7 @@
       "path": "hna/summary/08121.json",
       "kind": "json",
       "size_bytes": 3972,
-      "mtime": "2026-07-30T10:58:12.417Z",
+      "mtime": "2026-07-30T15:02:43.216Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21097,7 +21097,7 @@
       "path": "hna/summary/08123.json",
       "kind": "json",
       "size_bytes": 4163,
-      "mtime": "2026-07-30T10:58:12.417Z",
+      "mtime": "2026-07-30T15:02:43.216Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21116,7 +21116,7 @@
       "path": "hna/summary/0812325.json",
       "kind": "json",
       "size_bytes": 4030,
-      "mtime": "2026-07-30T10:58:12.417Z",
+      "mtime": "2026-07-30T15:02:43.216Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21135,7 +21135,7 @@
       "path": "hna/summary/0812387.json",
       "kind": "json",
       "size_bytes": 4165,
-      "mtime": "2026-07-30T10:58:12.417Z",
+      "mtime": "2026-07-30T15:02:43.216Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21154,7 +21154,7 @@
       "path": "hna/summary/0812393.json",
       "kind": "json",
       "size_bytes": 4100,
-      "mtime": "2026-07-30T10:58:12.417Z",
+      "mtime": "2026-07-30T15:02:43.216Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21173,7 +21173,7 @@
       "path": "hna/summary/0812415.json",
       "kind": "json",
       "size_bytes": 4211,
-      "mtime": "2026-07-30T10:58:12.418Z",
+      "mtime": "2026-07-30T15:02:43.217Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21192,7 +21192,7 @@
       "path": "hna/summary/0812450.json",
       "kind": "json",
       "size_bytes": 3870,
-      "mtime": "2026-07-30T10:58:12.418Z",
+      "mtime": "2026-07-30T15:02:43.217Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21211,7 +21211,7 @@
       "path": "hna/summary/0812460.json",
       "kind": "json",
       "size_bytes": 3910,
-      "mtime": "2026-07-30T10:58:12.418Z",
+      "mtime": "2026-07-30T15:02:43.217Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21230,7 +21230,7 @@
       "path": "hna/summary/0812470.json",
       "kind": "json",
       "size_bytes": 3944,
-      "mtime": "2026-07-30T10:58:12.418Z",
+      "mtime": "2026-07-30T15:02:43.217Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21249,7 +21249,7 @@
       "path": "hna/summary/08125.json",
       "kind": "json",
       "size_bytes": 3990,
-      "mtime": "2026-07-30T10:58:12.418Z",
+      "mtime": "2026-07-30T15:02:43.217Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21268,7 +21268,7 @@
       "path": "hna/summary/0812635.json",
       "kind": "json",
       "size_bytes": 4098,
-      "mtime": "2026-07-30T10:58:12.418Z",
+      "mtime": "2026-07-30T15:02:43.217Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21287,7 +21287,7 @@
       "path": "hna/summary/0812815.json",
       "kind": "json",
       "size_bytes": 4226,
-      "mtime": "2026-07-30T10:58:12.418Z",
+      "mtime": "2026-07-30T15:02:43.217Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21306,7 +21306,7 @@
       "path": "hna/summary/0812855.json",
       "kind": "json",
       "size_bytes": 4095,
-      "mtime": "2026-07-30T10:58:12.418Z",
+      "mtime": "2026-07-30T15:02:43.217Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21325,7 +21325,7 @@
       "path": "hna/summary/0812900.json",
       "kind": "json",
       "size_bytes": 4033,
-      "mtime": "2026-07-30T10:58:12.418Z",
+      "mtime": "2026-07-30T15:02:43.217Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21344,7 +21344,7 @@
       "path": "hna/summary/0812945.json",
       "kind": "json",
       "size_bytes": 3963,
-      "mtime": "2026-07-30T10:58:12.418Z",
+      "mtime": "2026-07-30T15:02:43.217Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21363,7 +21363,7 @@
       "path": "hna/summary/0813460.json",
       "kind": "json",
       "size_bytes": 3936,
-      "mtime": "2026-07-30T10:58:12.418Z",
+      "mtime": "2026-07-30T15:02:43.217Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21382,7 +21382,7 @@
       "path": "hna/summary/0813590.json",
       "kind": "json",
       "size_bytes": 4166,
-      "mtime": "2026-07-30T10:58:12.418Z",
+      "mtime": "2026-07-30T15:02:43.217Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21401,7 +21401,7 @@
       "path": "hna/summary/0813845.json",
       "kind": "json",
       "size_bytes": 4112,
-      "mtime": "2026-07-30T10:58:12.418Z",
+      "mtime": "2026-07-30T15:02:43.218Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21420,7 +21420,7 @@
       "path": "hna/summary/0814175.json",
       "kind": "json",
       "size_bytes": 4064,
-      "mtime": "2026-07-30T10:58:12.418Z",
+      "mtime": "2026-07-30T15:02:43.218Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21439,7 +21439,7 @@
       "path": "hna/summary/0814587.json",
       "kind": "json",
       "size_bytes": 4182,
-      "mtime": "2026-07-30T10:58:12.418Z",
+      "mtime": "2026-07-30T15:02:43.218Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21458,7 +21458,7 @@
       "path": "hna/summary/0814765.json",
       "kind": "json",
       "size_bytes": 3946,
-      "mtime": "2026-07-30T10:58:12.419Z",
+      "mtime": "2026-07-30T15:02:43.218Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21477,7 +21477,7 @@
       "path": "hna/summary/0815165.json",
       "kind": "json",
       "size_bytes": 4222,
-      "mtime": "2026-07-30T10:58:12.419Z",
+      "mtime": "2026-07-30T15:02:43.218Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21496,7 +21496,7 @@
       "path": "hna/summary/0815302.json",
       "kind": "json",
       "size_bytes": 4089,
-      "mtime": "2026-07-30T10:58:12.419Z",
+      "mtime": "2026-07-30T15:02:43.218Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21515,7 +21515,7 @@
       "path": "hna/summary/0815330.json",
       "kind": "json",
       "size_bytes": 3963,
-      "mtime": "2026-07-30T10:58:12.419Z",
+      "mtime": "2026-07-30T15:02:43.218Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21534,7 +21534,7 @@
       "path": "hna/summary/0815440.json",
       "kind": "json",
       "size_bytes": 3944,
-      "mtime": "2026-07-30T10:58:12.419Z",
+      "mtime": "2026-07-30T15:02:43.218Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21553,7 +21553,7 @@
       "path": "hna/summary/0815550.json",
       "kind": "json",
       "size_bytes": 3903,
-      "mtime": "2026-07-30T10:58:12.419Z",
+      "mtime": "2026-07-30T15:02:43.218Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21572,7 +21572,7 @@
       "path": "hna/summary/0815605.json",
       "kind": "json",
       "size_bytes": 3978,
-      "mtime": "2026-07-30T10:58:12.419Z",
+      "mtime": "2026-07-30T15:02:43.218Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21591,7 +21591,7 @@
       "path": "hna/summary/0815825.json",
       "kind": "json",
       "size_bytes": 3893,
-      "mtime": "2026-07-30T10:58:12.419Z",
+      "mtime": "2026-07-30T15:02:43.218Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21610,7 +21610,7 @@
       "path": "hna/summary/0815935.json",
       "kind": "json",
       "size_bytes": 4050,
-      "mtime": "2026-07-30T10:58:12.419Z",
+      "mtime": "2026-07-30T15:02:43.218Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21629,7 +21629,7 @@
       "path": "hna/summary/0816000.json",
       "kind": "json",
       "size_bytes": 4369,
-      "mtime": "2026-07-30T10:58:12.419Z",
+      "mtime": "2026-07-30T15:02:43.218Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21648,7 +21648,7 @@
       "path": "hna/summary/0816110.json",
       "kind": "json",
       "size_bytes": 4175,
-      "mtime": "2026-07-30T10:58:12.419Z",
+      "mtime": "2026-07-30T15:02:43.218Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21667,7 +21667,7 @@
       "path": "hna/summary/0816385.json",
       "kind": "json",
       "size_bytes": 4053,
-      "mtime": "2026-07-30T10:58:12.419Z",
+      "mtime": "2026-07-30T15:02:43.218Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21686,7 +21686,7 @@
       "path": "hna/summary/0816465.json",
       "kind": "json",
       "size_bytes": 3907,
-      "mtime": "2026-07-30T10:58:12.419Z",
+      "mtime": "2026-07-30T15:02:43.218Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21705,7 +21705,7 @@
       "path": "hna/summary/0816495.json",
       "kind": "json",
       "size_bytes": 4239,
-      "mtime": "2026-07-30T10:58:12.420Z",
+      "mtime": "2026-07-30T15:02:43.218Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21724,7 +21724,7 @@
       "path": "hna/summary/0816715.json",
       "kind": "json",
       "size_bytes": 3878,
-      "mtime": "2026-07-30T10:58:12.420Z",
+      "mtime": "2026-07-30T15:02:43.218Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21743,7 +21743,7 @@
       "path": "hna/summary/0817100.json",
       "kind": "json",
       "size_bytes": 3875,
-      "mtime": "2026-07-30T10:58:12.420Z",
+      "mtime": "2026-07-30T15:02:43.219Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21762,7 +21762,7 @@
       "path": "hna/summary/0817150.json",
       "kind": "json",
       "size_bytes": 3944,
-      "mtime": "2026-07-30T10:58:12.420Z",
+      "mtime": "2026-07-30T15:02:43.219Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21781,7 +21781,7 @@
       "path": "hna/summary/0817375.json",
       "kind": "json",
       "size_bytes": 4179,
-      "mtime": "2026-07-30T10:58:12.420Z",
+      "mtime": "2026-07-30T15:02:43.219Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21800,7 +21800,7 @@
       "path": "hna/summary/0817485.json",
       "kind": "json",
       "size_bytes": 3891,
-      "mtime": "2026-07-30T10:58:12.420Z",
+      "mtime": "2026-07-30T15:02:43.219Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21819,7 +21819,7 @@
       "path": "hna/summary/0817760.json",
       "kind": "json",
       "size_bytes": 4179,
-      "mtime": "2026-07-30T10:58:12.420Z",
+      "mtime": "2026-07-30T15:02:43.219Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21838,7 +21838,7 @@
       "path": "hna/summary/0817925.json",
       "kind": "json",
       "size_bytes": 3971,
-      "mtime": "2026-07-30T10:58:12.420Z",
+      "mtime": "2026-07-30T15:02:43.219Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21857,7 +21857,7 @@
       "path": "hna/summary/0818310.json",
       "kind": "json",
       "size_bytes": 4066,
-      "mtime": "2026-07-30T10:58:12.420Z",
+      "mtime": "2026-07-30T15:02:43.219Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21876,7 +21876,7 @@
       "path": "hna/summary/0818420.json",
       "kind": "json",
       "size_bytes": 3913,
-      "mtime": "2026-07-30T10:58:12.420Z",
+      "mtime": "2026-07-30T15:02:43.219Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21895,7 +21895,7 @@
       "path": "hna/summary/0818530.json",
       "kind": "json",
       "size_bytes": 4060,
-      "mtime": "2026-07-30T10:58:12.420Z",
+      "mtime": "2026-07-30T15:02:43.219Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21914,7 +21914,7 @@
       "path": "hna/summary/0818585.json",
       "kind": "json",
       "size_bytes": 3918,
-      "mtime": "2026-07-30T10:58:12.420Z",
+      "mtime": "2026-07-30T15:02:43.219Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21933,7 +21933,7 @@
       "path": "hna/summary/0818640.json",
       "kind": "json",
       "size_bytes": 3958,
-      "mtime": "2026-07-30T10:58:12.420Z",
+      "mtime": "2026-07-30T15:02:43.219Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21952,7 +21952,7 @@
       "path": "hna/summary/0818750.json",
       "kind": "json",
       "size_bytes": 4159,
-      "mtime": "2026-07-30T10:58:12.421Z",
+      "mtime": "2026-07-30T15:02:43.219Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21971,7 +21971,7 @@
       "path": "hna/summary/0819080.json",
       "kind": "json",
       "size_bytes": 4130,
-      "mtime": "2026-07-30T10:58:12.421Z",
+      "mtime": "2026-07-30T15:02:43.219Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -21990,7 +21990,7 @@
       "path": "hna/summary/0819150.json",
       "kind": "json",
       "size_bytes": 4199,
-      "mtime": "2026-07-30T10:58:12.421Z",
+      "mtime": "2026-07-30T15:02:43.220Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22009,7 +22009,7 @@
       "path": "hna/summary/0819355.json",
       "kind": "json",
       "size_bytes": 3968,
-      "mtime": "2026-07-30T10:58:12.421Z",
+      "mtime": "2026-07-30T15:02:43.220Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22028,7 +22028,7 @@
       "path": "hna/summary/0819630.json",
       "kind": "json",
       "size_bytes": 4055,
-      "mtime": "2026-07-30T10:58:12.421Z",
+      "mtime": "2026-07-30T15:02:43.220Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22047,7 +22047,7 @@
       "path": "hna/summary/0819795.json",
       "kind": "json",
       "size_bytes": 4096,
-      "mtime": "2026-07-30T10:58:12.421Z",
+      "mtime": "2026-07-30T15:02:43.220Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22066,7 +22066,7 @@
       "path": "hna/summary/0819850.json",
       "kind": "json",
       "size_bytes": 4177,
-      "mtime": "2026-07-30T10:58:12.421Z",
+      "mtime": "2026-07-30T15:02:43.220Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22085,7 +22085,7 @@
       "path": "hna/summary/0820000.json",
       "kind": "json",
       "size_bytes": 4416,
-      "mtime": "2026-07-30T10:58:12.421Z",
+      "mtime": "2026-07-30T15:02:43.220Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22104,7 +22104,7 @@
       "path": "hna/summary/0820275.json",
       "kind": "json",
       "size_bytes": 4152,
-      "mtime": "2026-07-30T10:58:12.421Z",
+      "mtime": "2026-07-30T15:02:43.220Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22123,7 +22123,7 @@
       "path": "hna/summary/0820440.json",
       "kind": "json",
       "size_bytes": 4045,
-      "mtime": "2026-07-30T10:58:12.421Z",
+      "mtime": "2026-07-30T15:02:43.220Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22142,7 +22142,7 @@
       "path": "hna/summary/0820495.json",
       "kind": "json",
       "size_bytes": 3935,
-      "mtime": "2026-07-30T10:58:12.421Z",
+      "mtime": "2026-07-30T15:02:43.220Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22161,7 +22161,7 @@
       "path": "hna/summary/0820605.json",
       "kind": "json",
       "size_bytes": 3893,
-      "mtime": "2026-07-30T10:58:12.421Z",
+      "mtime": "2026-07-30T15:02:43.220Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22180,7 +22180,7 @@
       "path": "hna/summary/0820770.json",
       "kind": "json",
       "size_bytes": 4000,
-      "mtime": "2026-07-30T10:58:12.421Z",
+      "mtime": "2026-07-30T15:02:43.220Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22199,7 +22199,7 @@
       "path": "hna/summary/0821155.json",
       "kind": "json",
       "size_bytes": 3987,
-      "mtime": "2026-07-30T10:58:12.421Z",
+      "mtime": "2026-07-30T15:02:43.220Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22218,7 +22218,7 @@
       "path": "hna/summary/0821265.json",
       "kind": "json",
       "size_bytes": 4018,
-      "mtime": "2026-07-30T10:58:12.422Z",
+      "mtime": "2026-07-30T15:02:43.220Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22237,7 +22237,7 @@
       "path": "hna/summary/0821330.json",
       "kind": "json",
       "size_bytes": 4062,
-      "mtime": "2026-07-30T10:58:12.422Z",
+      "mtime": "2026-07-30T15:02:43.221Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22256,7 +22256,7 @@
       "path": "hna/summary/0821390.json",
       "kind": "json",
       "size_bytes": 4007,
-      "mtime": "2026-07-30T10:58:12.422Z",
+      "mtime": "2026-07-30T15:02:43.221Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22275,7 +22275,7 @@
       "path": "hna/summary/0822035.json",
       "kind": "json",
       "size_bytes": 4229,
-      "mtime": "2026-07-30T10:58:12.422Z",
+      "mtime": "2026-07-30T15:02:43.221Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22294,7 +22294,7 @@
       "path": "hna/summary/0822145.json",
       "kind": "json",
       "size_bytes": 4035,
-      "mtime": "2026-07-30T10:58:12.422Z",
+      "mtime": "2026-07-30T15:02:43.221Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22313,7 +22313,7 @@
       "path": "hna/summary/0822200.json",
       "kind": "json",
       "size_bytes": 4129,
-      "mtime": "2026-07-30T10:58:12.422Z",
+      "mtime": "2026-07-30T15:02:43.221Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22332,7 +22332,7 @@
       "path": "hna/summary/0822575.json",
       "kind": "json",
       "size_bytes": 3957,
-      "mtime": "2026-07-30T10:58:12.422Z",
+      "mtime": "2026-07-30T15:02:43.221Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22351,7 +22351,7 @@
       "path": "hna/summary/0822860.json",
       "kind": "json",
       "size_bytes": 4124,
-      "mtime": "2026-07-30T10:58:12.422Z",
+      "mtime": "2026-07-30T15:02:43.221Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22370,7 +22370,7 @@
       "path": "hna/summary/0822882.json",
       "kind": "json",
       "size_bytes": 3921,
-      "mtime": "2026-07-30T10:58:12.422Z",
+      "mtime": "2026-07-30T15:02:43.221Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22389,7 +22389,7 @@
       "path": "hna/summary/0823025.json",
       "kind": "json",
       "size_bytes": 3995,
-      "mtime": "2026-07-30T10:58:12.422Z",
+      "mtime": "2026-07-30T15:02:43.221Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22408,7 +22408,7 @@
       "path": "hna/summary/0823135.json",
       "kind": "json",
       "size_bytes": 4128,
-      "mtime": "2026-07-30T10:58:12.422Z",
+      "mtime": "2026-07-30T15:02:43.221Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22427,7 +22427,7 @@
       "path": "hna/summary/0823300.json",
       "kind": "json",
       "size_bytes": 4177,
-      "mtime": "2026-07-30T10:58:12.422Z",
+      "mtime": "2026-07-30T15:02:43.221Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22446,7 +22446,7 @@
       "path": "hna/summary/0823520.json",
       "kind": "json",
       "size_bytes": 3949,
-      "mtime": "2026-07-30T10:58:12.422Z",
+      "mtime": "2026-07-30T15:02:43.221Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22465,7 +22465,7 @@
       "path": "hna/summary/0823575.json",
       "kind": "json",
       "size_bytes": 3938,
-      "mtime": "2026-07-30T10:58:12.422Z",
+      "mtime": "2026-07-30T15:02:43.221Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22484,7 +22484,7 @@
       "path": "hna/summary/0823630.json",
       "kind": "json",
       "size_bytes": 3965,
-      "mtime": "2026-07-30T10:58:12.422Z",
+      "mtime": "2026-07-30T15:02:43.221Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22503,7 +22503,7 @@
       "path": "hna/summary/0823740.json",
       "kind": "json",
       "size_bytes": 4075,
-      "mtime": "2026-07-30T10:58:12.422Z",
+      "mtime": "2026-07-30T15:02:43.221Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22522,7 +22522,7 @@
       "path": "hna/summary/0823795.json",
       "kind": "json",
       "size_bytes": 4045,
-      "mtime": "2026-07-30T10:58:12.422Z",
+      "mtime": "2026-07-30T15:02:43.221Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22541,7 +22541,7 @@
       "path": "hna/summary/0824235.json",
       "kind": "json",
       "size_bytes": 3991,
-      "mtime": "2026-07-30T10:58:12.423Z",
+      "mtime": "2026-07-30T15:02:43.222Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22560,7 +22560,7 @@
       "path": "hna/summary/0824290.json",
       "kind": "json",
       "size_bytes": 3923,
-      "mtime": "2026-07-30T10:58:12.423Z",
+      "mtime": "2026-07-30T15:02:43.222Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22579,7 +22579,7 @@
       "path": "hna/summary/0824620.json",
       "kind": "json",
       "size_bytes": 4037,
-      "mtime": "2026-07-30T10:58:12.423Z",
+      "mtime": "2026-07-30T15:02:43.222Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22598,7 +22598,7 @@
       "path": "hna/summary/0824785.json",
       "kind": "json",
       "size_bytes": 4266,
-      "mtime": "2026-07-30T10:58:12.423Z",
+      "mtime": "2026-07-30T15:02:43.222Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22617,7 +22617,7 @@
       "path": "hna/summary/0824950.json",
       "kind": "json",
       "size_bytes": 4228,
-      "mtime": "2026-07-30T10:58:12.423Z",
+      "mtime": "2026-07-30T15:02:43.222Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22636,7 +22636,7 @@
       "path": "hna/summary/0825115.json",
       "kind": "json",
       "size_bytes": 4145,
-      "mtime": "2026-07-30T10:58:12.423Z",
+      "mtime": "2026-07-30T15:02:43.222Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22655,7 +22655,7 @@
       "path": "hna/summary/0825280.json",
       "kind": "json",
       "size_bytes": 4226,
-      "mtime": "2026-07-30T10:58:12.423Z",
+      "mtime": "2026-07-30T15:02:43.222Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22674,7 +22674,7 @@
       "path": "hna/summary/0825390.json",
       "kind": "json",
       "size_bytes": 4114,
-      "mtime": "2026-07-30T10:58:12.423Z",
+      "mtime": "2026-07-30T15:02:43.222Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22693,7 +22693,7 @@
       "path": "hna/summary/0825550.json",
       "kind": "json",
       "size_bytes": 4101,
-      "mtime": "2026-07-30T10:58:12.423Z",
+      "mtime": "2026-07-30T15:02:43.222Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22712,7 +22712,7 @@
       "path": "hna/summary/0825610.json",
       "kind": "json",
       "size_bytes": 4055,
-      "mtime": "2026-07-30T10:58:12.423Z",
+      "mtime": "2026-07-30T15:02:43.222Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22731,7 +22731,7 @@
       "path": "hna/summary/0826270.json",
       "kind": "json",
       "size_bytes": 4215,
-      "mtime": "2026-07-30T10:58:12.423Z",
+      "mtime": "2026-07-30T15:02:43.222Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22750,7 +22750,7 @@
       "path": "hna/summary/0826600.json",
       "kind": "json",
       "size_bytes": 4207,
-      "mtime": "2026-07-30T10:58:12.423Z",
+      "mtime": "2026-07-30T15:02:43.222Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22769,7 +22769,7 @@
       "path": "hna/summary/0826765.json",
       "kind": "json",
       "size_bytes": 4037,
-      "mtime": "2026-07-30T10:58:12.423Z",
+      "mtime": "2026-07-30T15:02:43.222Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22788,7 +22788,7 @@
       "path": "hna/summary/0826875.json",
       "kind": "json",
       "size_bytes": 4032,
-      "mtime": "2026-07-30T10:58:12.423Z",
+      "mtime": "2026-07-30T15:02:43.222Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22807,7 +22807,7 @@
       "path": "hna/summary/0827040.json",
       "kind": "json",
       "size_bytes": 4127,
-      "mtime": "2026-07-30T10:58:12.423Z",
+      "mtime": "2026-07-30T15:02:43.223Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22826,7 +22826,7 @@
       "path": "hna/summary/0827095.json",
       "kind": "json",
       "size_bytes": 3895,
-      "mtime": "2026-07-30T10:58:12.424Z",
+      "mtime": "2026-07-30T15:02:43.223Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22845,7 +22845,7 @@
       "path": "hna/summary/0827175.json",
       "kind": "json",
       "size_bytes": 3972,
-      "mtime": "2026-07-30T10:58:12.424Z",
+      "mtime": "2026-07-30T15:02:43.223Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22864,7 +22864,7 @@
       "path": "hna/summary/0827370.json",
       "kind": "json",
       "size_bytes": 4076,
-      "mtime": "2026-07-30T10:58:12.424Z",
+      "mtime": "2026-07-30T15:02:43.223Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22883,7 +22883,7 @@
       "path": "hna/summary/0827425.json",
       "kind": "json",
       "size_bytes": 4272,
-      "mtime": "2026-07-30T10:58:12.424Z",
+      "mtime": "2026-07-30T15:02:43.223Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22902,7 +22902,7 @@
       "path": "hna/summary/0827535.json",
       "kind": "json",
       "size_bytes": 3983,
-      "mtime": "2026-07-30T10:58:12.424Z",
+      "mtime": "2026-07-30T15:02:43.223Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22921,7 +22921,7 @@
       "path": "hna/summary/0827700.json",
       "kind": "json",
       "size_bytes": 4162,
-      "mtime": "2026-07-30T10:58:12.424Z",
+      "mtime": "2026-07-30T15:02:43.223Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22940,7 +22940,7 @@
       "path": "hna/summary/0827810.json",
       "kind": "json",
       "size_bytes": 3750,
-      "mtime": "2026-07-30T10:58:12.424Z",
+      "mtime": "2026-07-30T15:02:43.223Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22959,7 +22959,7 @@
       "path": "hna/summary/0827865.json",
       "kind": "json",
       "size_bytes": 4244,
-      "mtime": "2026-07-30T10:58:12.424Z",
+      "mtime": "2026-07-30T15:02:43.223Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22978,7 +22978,7 @@
       "path": "hna/summary/0827950.json",
       "kind": "json",
       "size_bytes": 4194,
-      "mtime": "2026-07-30T10:58:12.424Z",
+      "mtime": "2026-07-30T15:02:43.223Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -22997,7 +22997,7 @@
       "path": "hna/summary/0827975.json",
       "kind": "json",
       "size_bytes": 4015,
-      "mtime": "2026-07-30T10:58:12.424Z",
+      "mtime": "2026-07-30T15:02:43.223Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23016,7 +23016,7 @@
       "path": "hna/summary/0828105.json",
       "kind": "json",
       "size_bytes": 4007,
-      "mtime": "2026-07-30T10:58:12.424Z",
+      "mtime": "2026-07-30T15:02:43.223Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23035,7 +23035,7 @@
       "path": "hna/summary/0828250.json",
       "kind": "json",
       "size_bytes": 3995,
-      "mtime": "2026-07-30T10:58:12.424Z",
+      "mtime": "2026-07-30T15:02:43.223Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23054,7 +23054,7 @@
       "path": "hna/summary/0828305.json",
       "kind": "json",
       "size_bytes": 4064,
-      "mtime": "2026-07-30T10:58:12.424Z",
+      "mtime": "2026-07-30T15:02:43.223Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23073,7 +23073,7 @@
       "path": "hna/summary/0828360.json",
       "kind": "json",
       "size_bytes": 4174,
-      "mtime": "2026-07-30T10:58:12.424Z",
+      "mtime": "2026-07-30T15:02:43.223Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23092,7 +23092,7 @@
       "path": "hna/summary/0828690.json",
       "kind": "json",
       "size_bytes": 4096,
-      "mtime": "2026-07-30T10:58:12.425Z",
+      "mtime": "2026-07-30T15:02:43.223Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23111,7 +23111,7 @@
       "path": "hna/summary/0828745.json",
       "kind": "json",
       "size_bytes": 4179,
-      "mtime": "2026-07-30T10:58:12.425Z",
+      "mtime": "2026-07-30T15:02:43.224Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23130,7 +23130,7 @@
       "path": "hna/summary/0828800.json",
       "kind": "json",
       "size_bytes": 4108,
-      "mtime": "2026-07-30T10:58:12.425Z",
+      "mtime": "2026-07-30T15:02:43.224Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23149,7 +23149,7 @@
       "path": "hna/summary/0828830.json",
       "kind": "json",
       "size_bytes": 3877,
-      "mtime": "2026-07-30T10:58:12.425Z",
+      "mtime": "2026-07-30T15:02:43.224Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23168,7 +23168,7 @@
       "path": "hna/summary/0829185.json",
       "kind": "json",
       "size_bytes": 3958,
-      "mtime": "2026-07-30T10:58:12.425Z",
+      "mtime": "2026-07-30T15:02:43.224Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23187,7 +23187,7 @@
       "path": "hna/summary/0829240.json",
       "kind": "json",
       "size_bytes": 3933,
-      "mtime": "2026-07-30T10:58:12.425Z",
+      "mtime": "2026-07-30T15:02:43.224Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23206,7 +23206,7 @@
       "path": "hna/summary/0829295.json",
       "kind": "json",
       "size_bytes": 3879,
-      "mtime": "2026-07-30T10:58:12.425Z",
+      "mtime": "2026-07-30T15:02:43.224Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23225,7 +23225,7 @@
       "path": "hna/summary/0829625.json",
       "kind": "json",
       "size_bytes": 4096,
-      "mtime": "2026-07-30T10:58:12.425Z",
+      "mtime": "2026-07-30T15:02:43.224Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23244,7 +23244,7 @@
       "path": "hna/summary/0829680.json",
       "kind": "json",
       "size_bytes": 3928,
-      "mtime": "2026-07-30T10:58:12.425Z",
+      "mtime": "2026-07-30T15:02:43.224Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23263,7 +23263,7 @@
       "path": "hna/summary/0829735.json",
       "kind": "json",
       "size_bytes": 4061,
-      "mtime": "2026-07-30T10:58:12.425Z",
+      "mtime": "2026-07-30T15:02:43.224Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23282,7 +23282,7 @@
       "path": "hna/summary/0829845.json",
       "kind": "json",
       "size_bytes": 3928,
-      "mtime": "2026-07-30T10:58:12.425Z",
+      "mtime": "2026-07-30T15:02:43.224Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23301,7 +23301,7 @@
       "path": "hna/summary/0829955.json",
       "kind": "json",
       "size_bytes": 3987,
-      "mtime": "2026-07-30T10:58:12.425Z",
+      "mtime": "2026-07-30T15:02:43.224Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23320,7 +23320,7 @@
       "path": "hna/summary/0830340.json",
       "kind": "json",
       "size_bytes": 4115,
-      "mtime": "2026-07-30T10:58:12.425Z",
+      "mtime": "2026-07-30T15:02:43.224Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23339,7 +23339,7 @@
       "path": "hna/summary/0830350.json",
       "kind": "json",
       "size_bytes": 3885,
-      "mtime": "2026-07-30T10:58:12.425Z",
+      "mtime": "2026-07-30T15:02:43.224Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23358,7 +23358,7 @@
       "path": "hna/summary/0830420.json",
       "kind": "json",
       "size_bytes": 4077,
-      "mtime": "2026-07-30T10:58:12.425Z",
+      "mtime": "2026-07-30T15:02:43.224Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23377,7 +23377,7 @@
       "path": "hna/summary/0830780.json",
       "kind": "json",
       "size_bytes": 4203,
-      "mtime": "2026-07-30T10:58:12.425Z",
+      "mtime": "2026-07-30T15:02:43.224Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23396,7 +23396,7 @@
       "path": "hna/summary/0830835.json",
       "kind": "json",
       "size_bytes": 4224,
-      "mtime": "2026-07-30T10:58:12.425Z",
+      "mtime": "2026-07-30T15:02:43.224Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23415,7 +23415,7 @@
       "path": "hna/summary/0830890.json",
       "kind": "json",
       "size_bytes": 3901,
-      "mtime": "2026-07-30T10:58:12.426Z",
+      "mtime": "2026-07-30T15:02:43.225Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23434,7 +23434,7 @@
       "path": "hna/summary/0830945.json",
       "kind": "json",
       "size_bytes": 3949,
-      "mtime": "2026-07-30T10:58:12.426Z",
+      "mtime": "2026-07-30T15:02:43.225Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23453,7 +23453,7 @@
       "path": "hna/summary/0831550.json",
       "kind": "json",
       "size_bytes": 3972,
-      "mtime": "2026-07-30T10:58:12.426Z",
+      "mtime": "2026-07-30T15:02:43.225Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23472,7 +23472,7 @@
       "path": "hna/summary/0831605.json",
       "kind": "json",
       "size_bytes": 4102,
-      "mtime": "2026-07-30T10:58:12.426Z",
+      "mtime": "2026-07-30T15:02:43.225Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23491,7 +23491,7 @@
       "path": "hna/summary/0831660.json",
       "kind": "json",
       "size_bytes": 4230,
-      "mtime": "2026-07-30T10:58:12.426Z",
+      "mtime": "2026-07-30T15:02:43.225Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23510,7 +23510,7 @@
       "path": "hna/summary/0831715.json",
       "kind": "json",
       "size_bytes": 4027,
-      "mtime": "2026-07-30T10:58:12.426Z",
+      "mtime": "2026-07-30T15:02:43.225Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23529,7 +23529,7 @@
       "path": "hna/summary/0831935.json",
       "kind": "json",
       "size_bytes": 3962,
-      "mtime": "2026-07-30T10:58:12.426Z",
+      "mtime": "2026-07-30T15:02:43.225Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23548,7 +23548,7 @@
       "path": "hna/summary/0832155.json",
       "kind": "json",
       "size_bytes": 4260,
-      "mtime": "2026-07-30T10:58:12.426Z",
+      "mtime": "2026-07-30T15:02:43.225Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23567,7 +23567,7 @@
       "path": "hna/summary/0832650.json",
       "kind": "json",
       "size_bytes": 4023,
-      "mtime": "2026-07-30T10:58:12.426Z",
+      "mtime": "2026-07-30T15:02:43.225Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23586,7 +23586,7 @@
       "path": "hna/summary/0833035.json",
       "kind": "json",
       "size_bytes": 4211,
-      "mtime": "2026-07-30T10:58:12.426Z",
+      "mtime": "2026-07-30T15:02:43.225Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23605,7 +23605,7 @@
       "path": "hna/summary/0833310.json",
       "kind": "json",
       "size_bytes": 3907,
-      "mtime": "2026-07-30T10:58:12.426Z",
+      "mtime": "2026-07-30T15:02:43.225Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23624,7 +23624,7 @@
       "path": "hna/summary/0833420.json",
       "kind": "json",
       "size_bytes": 3891,
-      "mtime": "2026-07-30T10:58:12.426Z",
+      "mtime": "2026-07-30T15:02:43.225Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23643,7 +23643,7 @@
       "path": "hna/summary/0833502.json",
       "kind": "json",
       "size_bytes": 4124,
-      "mtime": "2026-07-30T10:58:12.426Z",
+      "mtime": "2026-07-30T15:02:43.225Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23662,7 +23662,7 @@
       "path": "hna/summary/0833640.json",
       "kind": "json",
       "size_bytes": 4157,
-      "mtime": "2026-07-30T10:58:12.426Z",
+      "mtime": "2026-07-30T15:02:43.225Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23681,7 +23681,7 @@
       "path": "hna/summary/0833695.json",
       "kind": "json",
       "size_bytes": 4073,
-      "mtime": "2026-07-30T10:58:12.426Z",
+      "mtime": "2026-07-30T15:02:43.225Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23700,7 +23700,7 @@
       "path": "hna/summary/0834520.json",
       "kind": "json",
       "size_bytes": 3892,
-      "mtime": "2026-07-30T10:58:12.426Z",
+      "mtime": "2026-07-30T15:02:43.225Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23719,7 +23719,7 @@
       "path": "hna/summary/0834630.json",
       "kind": "json",
       "size_bytes": 3893,
-      "mtime": "2026-07-30T10:58:12.427Z",
+      "mtime": "2026-07-30T15:02:43.225Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23738,7 +23738,7 @@
       "path": "hna/summary/0834685.json",
       "kind": "json",
       "size_bytes": 3928,
-      "mtime": "2026-07-30T10:58:12.427Z",
+      "mtime": "2026-07-30T15:02:43.225Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23757,7 +23757,7 @@
       "path": "hna/summary/0834740.json",
       "kind": "json",
       "size_bytes": 3887,
-      "mtime": "2026-07-30T10:58:12.427Z",
+      "mtime": "2026-07-30T15:02:43.225Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23776,7 +23776,7 @@
       "path": "hna/summary/0834960.json",
       "kind": "json",
       "size_bytes": 4048,
-      "mtime": "2026-07-30T10:58:12.427Z",
+      "mtime": "2026-07-30T15:02:43.226Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23795,7 +23795,7 @@
       "path": "hna/summary/0835070.json",
       "kind": "json",
       "size_bytes": 4084,
-      "mtime": "2026-07-30T10:58:12.427Z",
+      "mtime": "2026-07-30T15:02:43.226Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23814,7 +23814,7 @@
       "path": "hna/summary/0835400.json",
       "kind": "json",
       "size_bytes": 3900,
-      "mtime": "2026-07-30T10:58:12.427Z",
+      "mtime": "2026-07-30T15:02:43.226Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23833,7 +23833,7 @@
       "path": "hna/summary/0835860.json",
       "kind": "json",
       "size_bytes": 3878,
-      "mtime": "2026-07-30T10:58:12.427Z",
+      "mtime": "2026-07-30T15:02:43.226Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23852,7 +23852,7 @@
       "path": "hna/summary/0836410.json",
       "kind": "json",
       "size_bytes": 4212,
-      "mtime": "2026-07-30T10:58:12.427Z",
+      "mtime": "2026-07-30T15:02:43.226Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23871,7 +23871,7 @@
       "path": "hna/summary/0836610.json",
       "kind": "json",
       "size_bytes": 3997,
-      "mtime": "2026-07-30T10:58:12.427Z",
+      "mtime": "2026-07-30T15:02:43.226Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23890,7 +23890,7 @@
       "path": "hna/summary/0836940.json",
       "kind": "json",
       "size_bytes": 3857,
-      "mtime": "2026-07-30T10:58:12.427Z",
+      "mtime": "2026-07-30T15:02:43.226Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23909,7 +23909,7 @@
       "path": "hna/summary/0837215.json",
       "kind": "json",
       "size_bytes": 3992,
-      "mtime": "2026-07-30T10:58:12.427Z",
+      "mtime": "2026-07-30T15:02:43.226Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23928,7 +23928,7 @@
       "path": "hna/summary/0837220.json",
       "kind": "json",
       "size_bytes": 4037,
-      "mtime": "2026-07-30T10:58:12.427Z",
+      "mtime": "2026-07-30T15:02:43.226Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23947,7 +23947,7 @@
       "path": "hna/summary/0837270.json",
       "kind": "json",
       "size_bytes": 4106,
-      "mtime": "2026-07-30T10:58:12.427Z",
+      "mtime": "2026-07-30T15:02:43.226Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23966,7 +23966,7 @@
       "path": "hna/summary/0837380.json",
       "kind": "json",
       "size_bytes": 3906,
-      "mtime": "2026-07-30T10:58:12.427Z",
+      "mtime": "2026-07-30T15:02:43.226Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -23985,7 +23985,7 @@
       "path": "hna/summary/0837545.json",
       "kind": "json",
       "size_bytes": 4051,
-      "mtime": "2026-07-30T10:58:12.427Z",
+      "mtime": "2026-07-30T15:02:43.226Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24004,7 +24004,7 @@
       "path": "hna/summary/0837600.json",
       "kind": "json",
       "size_bytes": 4053,
-      "mtime": "2026-07-30T10:58:12.427Z",
+      "mtime": "2026-07-30T15:02:43.226Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24023,7 +24023,7 @@
       "path": "hna/summary/0837655.json",
       "kind": "json",
       "size_bytes": 4024,
-      "mtime": "2026-07-30T10:58:12.428Z",
+      "mtime": "2026-07-30T15:02:43.226Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24042,7 +24042,7 @@
       "path": "hna/summary/0837820.json",
       "kind": "json",
       "size_bytes": 4075,
-      "mtime": "2026-07-30T10:58:12.428Z",
+      "mtime": "2026-07-30T15:02:43.226Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24061,7 +24061,7 @@
       "path": "hna/summary/0837875.json",
       "kind": "json",
       "size_bytes": 4042,
-      "mtime": "2026-07-30T10:58:12.428Z",
+      "mtime": "2026-07-30T15:02:43.226Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24080,7 +24080,7 @@
       "path": "hna/summary/0838370.json",
       "kind": "json",
       "size_bytes": 4090,
-      "mtime": "2026-07-30T10:58:12.428Z",
+      "mtime": "2026-07-30T15:02:43.226Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24099,7 +24099,7 @@
       "path": "hna/summary/0838425.json",
       "kind": "json",
       "size_bytes": 3899,
-      "mtime": "2026-07-30T10:58:12.428Z",
+      "mtime": "2026-07-30T15:02:43.226Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24118,7 +24118,7 @@
       "path": "hna/summary/0838480.json",
       "kind": "json",
       "size_bytes": 3924,
-      "mtime": "2026-07-30T10:58:12.428Z",
+      "mtime": "2026-07-30T15:02:43.227Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24137,7 +24137,7 @@
       "path": "hna/summary/0838535.json",
       "kind": "json",
       "size_bytes": 4064,
-      "mtime": "2026-07-30T10:58:12.428Z",
+      "mtime": "2026-07-30T15:02:43.227Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24156,7 +24156,7 @@
       "path": "hna/summary/0838590.json",
       "kind": "json",
       "size_bytes": 3996,
-      "mtime": "2026-07-30T10:58:12.428Z",
+      "mtime": "2026-07-30T15:02:43.227Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24175,7 +24175,7 @@
       "path": "hna/summary/0838810.json",
       "kind": "json",
       "size_bytes": 4018,
-      "mtime": "2026-07-30T10:58:12.428Z",
+      "mtime": "2026-07-30T15:02:43.227Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24194,7 +24194,7 @@
       "path": "hna/summary/0838910.json",
       "kind": "json",
       "size_bytes": 4044,
-      "mtime": "2026-07-30T10:58:12.428Z",
+      "mtime": "2026-07-30T15:02:43.227Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24213,7 +24213,7 @@
       "path": "hna/summary/0839160.json",
       "kind": "json",
       "size_bytes": 3928,
-      "mtime": "2026-07-30T10:58:12.428Z",
+      "mtime": "2026-07-30T15:02:43.227Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24232,7 +24232,7 @@
       "path": "hna/summary/0839195.json",
       "kind": "json",
       "size_bytes": 3988,
-      "mtime": "2026-07-30T10:58:12.428Z",
+      "mtime": "2026-07-30T15:02:43.227Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24251,7 +24251,7 @@
       "path": "hna/summary/0839250.json",
       "kind": "json",
       "size_bytes": 3905,
-      "mtime": "2026-07-30T10:58:12.428Z",
+      "mtime": "2026-07-30T15:02:43.227Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24270,7 +24270,7 @@
       "path": "hna/summary/0839745.json",
       "kind": "json",
       "size_bytes": 3924,
-      "mtime": "2026-07-30T10:58:12.428Z",
+      "mtime": "2026-07-30T15:02:43.227Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24289,7 +24289,7 @@
       "path": "hna/summary/0839800.json",
       "kind": "json",
       "size_bytes": 3912,
-      "mtime": "2026-07-30T10:58:12.428Z",
+      "mtime": "2026-07-30T15:02:43.227Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24308,7 +24308,7 @@
       "path": "hna/summary/0839855.json",
       "kind": "json",
       "size_bytes": 4193,
-      "mtime": "2026-07-30T10:58:12.428Z",
+      "mtime": "2026-07-30T15:02:43.227Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24327,7 +24327,7 @@
       "path": "hna/summary/0839965.json",
       "kind": "json",
       "size_bytes": 4062,
-      "mtime": "2026-07-30T10:58:12.428Z",
+      "mtime": "2026-07-30T15:02:43.227Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24346,7 +24346,7 @@
       "path": "hna/summary/0840185.json",
       "kind": "json",
       "size_bytes": 4080,
-      "mtime": "2026-07-30T10:58:12.428Z",
+      "mtime": "2026-07-30T15:02:43.227Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24365,7 +24365,7 @@
       "path": "hna/summary/0840377.json",
       "kind": "json",
       "size_bytes": 4185,
-      "mtime": "2026-07-30T10:58:12.429Z",
+      "mtime": "2026-07-30T15:02:43.227Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24384,7 +24384,7 @@
       "path": "hna/summary/0840515.json",
       "kind": "json",
       "size_bytes": 4045,
-      "mtime": "2026-07-30T10:58:12.429Z",
+      "mtime": "2026-07-30T15:02:43.227Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24403,7 +24403,7 @@
       "path": "hna/summary/0840550.json",
       "kind": "json",
       "size_bytes": 4006,
-      "mtime": "2026-07-30T10:58:12.429Z",
+      "mtime": "2026-07-30T15:02:43.227Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24422,7 +24422,7 @@
       "path": "hna/summary/0840570.json",
       "kind": "json",
       "size_bytes": 3897,
-      "mtime": "2026-07-30T10:58:12.429Z",
+      "mtime": "2026-07-30T15:02:43.228Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24441,7 +24441,7 @@
       "path": "hna/summary/0840790.json",
       "kind": "json",
       "size_bytes": 4011,
-      "mtime": "2026-07-30T10:58:12.429Z",
+      "mtime": "2026-07-30T15:02:43.228Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24460,7 +24460,7 @@
       "path": "hna/summary/0840900.json",
       "kind": "json",
       "size_bytes": 3894,
-      "mtime": "2026-07-30T10:58:12.429Z",
+      "mtime": "2026-07-30T15:02:43.228Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24479,7 +24479,7 @@
       "path": "hna/summary/0841010.json",
       "kind": "json",
       "size_bytes": 4004,
-      "mtime": "2026-07-30T10:58:12.429Z",
+      "mtime": "2026-07-30T15:02:43.228Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24498,7 +24498,7 @@
       "path": "hna/summary/0841065.json",
       "kind": "json",
       "size_bytes": 3965,
-      "mtime": "2026-07-30T10:58:12.429Z",
+      "mtime": "2026-07-30T15:02:43.228Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24517,7 +24517,7 @@
       "path": "hna/summary/0841560.json",
       "kind": "json",
       "size_bytes": 4075,
-      "mtime": "2026-07-30T10:58:12.429Z",
+      "mtime": "2026-07-30T15:02:43.228Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24536,7 +24536,7 @@
       "path": "hna/summary/0841835.json",
       "kind": "json",
       "size_bytes": 4260,
-      "mtime": "2026-07-30T10:58:12.429Z",
+      "mtime": "2026-07-30T15:02:43.228Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24555,7 +24555,7 @@
       "path": "hna/summary/0842000.json",
       "kind": "json",
       "size_bytes": 3841,
-      "mtime": "2026-07-30T10:58:12.429Z",
+      "mtime": "2026-07-30T15:02:43.228Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24574,7 +24574,7 @@
       "path": "hna/summary/0842055.json",
       "kind": "json",
       "size_bytes": 4025,
-      "mtime": "2026-07-30T10:58:12.429Z",
+      "mtime": "2026-07-30T15:02:43.228Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24593,7 +24593,7 @@
       "path": "hna/summary/0842110.json",
       "kind": "json",
       "size_bytes": 4165,
-      "mtime": "2026-07-30T10:58:12.429Z",
+      "mtime": "2026-07-30T15:02:43.228Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24612,7 +24612,7 @@
       "path": "hna/summary/0842165.json",
       "kind": "json",
       "size_bytes": 3900,
-      "mtime": "2026-07-30T10:58:12.429Z",
+      "mtime": "2026-07-30T15:02:43.228Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24631,7 +24631,7 @@
       "path": "hna/summary/0842330.json",
       "kind": "json",
       "size_bytes": 4022,
-      "mtime": "2026-07-30T10:58:12.430Z",
+      "mtime": "2026-07-30T15:02:43.228Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24650,7 +24650,7 @@
       "path": "hna/summary/0842495.json",
       "kind": "json",
       "size_bytes": 3836,
-      "mtime": "2026-07-30T10:58:12.430Z",
+      "mtime": "2026-07-30T15:02:43.228Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24669,7 +24669,7 @@
       "path": "hna/summary/0843000.json",
       "kind": "json",
       "size_bytes": 4302,
-      "mtime": "2026-07-30T10:58:12.430Z",
+      "mtime": "2026-07-30T15:02:43.228Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24688,7 +24688,7 @@
       "path": "hna/summary/0843110.json",
       "kind": "json",
       "size_bytes": 3733,
-      "mtime": "2026-07-30T10:58:12.430Z",
+      "mtime": "2026-07-30T15:02:43.229Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24707,7 +24707,7 @@
       "path": "hna/summary/0843220.json",
       "kind": "json",
       "size_bytes": 4078,
-      "mtime": "2026-07-30T10:58:12.430Z",
+      "mtime": "2026-07-30T15:02:43.229Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24726,7 +24726,7 @@
       "path": "hna/summary/0843550.json",
       "kind": "json",
       "size_bytes": 3957,
-      "mtime": "2026-07-30T10:58:12.430Z",
+      "mtime": "2026-07-30T15:02:43.229Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24745,7 +24745,7 @@
       "path": "hna/summary/0843605.json",
       "kind": "json",
       "size_bytes": 4099,
-      "mtime": "2026-07-30T10:58:12.430Z",
+      "mtime": "2026-07-30T15:02:43.229Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24764,7 +24764,7 @@
       "path": "hna/summary/0843660.json",
       "kind": "json",
       "size_bytes": 4111,
-      "mtime": "2026-07-30T10:58:12.430Z",
+      "mtime": "2026-07-30T15:02:43.229Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24783,7 +24783,7 @@
       "path": "hna/summary/0844100.json",
       "kind": "json",
       "size_bytes": 4034,
-      "mtime": "2026-07-30T10:58:12.430Z",
+      "mtime": "2026-07-30T15:02:43.229Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24802,7 +24802,7 @@
       "path": "hna/summary/0844265.json",
       "kind": "json",
       "size_bytes": 3900,
-      "mtime": "2026-07-30T10:58:12.430Z",
+      "mtime": "2026-07-30T15:02:43.229Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24821,7 +24821,7 @@
       "path": "hna/summary/0844270.json",
       "kind": "json",
       "size_bytes": 3975,
-      "mtime": "2026-07-30T10:58:12.430Z",
+      "mtime": "2026-07-30T15:02:43.229Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24840,7 +24840,7 @@
       "path": "hna/summary/0844320.json",
       "kind": "json",
       "size_bytes": 4110,
-      "mtime": "2026-07-30T10:58:12.430Z",
+      "mtime": "2026-07-30T15:02:43.229Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24859,7 +24859,7 @@
       "path": "hna/summary/0844375.json",
       "kind": "json",
       "size_bytes": 4033,
-      "mtime": "2026-07-30T10:58:12.430Z",
+      "mtime": "2026-07-30T15:02:43.229Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24878,7 +24878,7 @@
       "path": "hna/summary/0844595.json",
       "kind": "json",
       "size_bytes": 3973,
-      "mtime": "2026-07-30T10:58:12.430Z",
+      "mtime": "2026-07-30T15:02:43.229Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24897,7 +24897,7 @@
       "path": "hna/summary/0844695.json",
       "kind": "json",
       "size_bytes": 3877,
-      "mtime": "2026-07-30T10:58:12.431Z",
+      "mtime": "2026-07-30T15:02:43.229Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24916,7 +24916,7 @@
       "path": "hna/summary/0844980.json",
       "kind": "json",
       "size_bytes": 4036,
-      "mtime": "2026-07-30T10:58:12.431Z",
+      "mtime": "2026-07-30T15:02:43.229Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24935,7 +24935,7 @@
       "path": "hna/summary/0845145.json",
       "kind": "json",
       "size_bytes": 4088,
-      "mtime": "2026-07-30T10:58:12.431Z",
+      "mtime": "2026-07-30T15:02:43.229Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24954,7 +24954,7 @@
       "path": "hna/summary/0845255.json",
       "kind": "json",
       "size_bytes": 4240,
-      "mtime": "2026-07-30T10:58:12.431Z",
+      "mtime": "2026-07-30T15:02:43.229Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24973,7 +24973,7 @@
       "path": "hna/summary/0845530.json",
       "kind": "json",
       "size_bytes": 4119,
-      "mtime": "2026-07-30T10:58:12.431Z",
+      "mtime": "2026-07-30T15:02:43.229Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -24992,7 +24992,7 @@
       "path": "hna/summary/0845680.json",
       "kind": "json",
       "size_bytes": 3988,
-      "mtime": "2026-07-30T10:58:12.431Z",
+      "mtime": "2026-07-30T15:02:43.229Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25011,7 +25011,7 @@
       "path": "hna/summary/0845695.json",
       "kind": "json",
       "size_bytes": 4058,
-      "mtime": "2026-07-30T10:58:12.431Z",
+      "mtime": "2026-07-30T15:02:43.229Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25030,7 +25030,7 @@
       "path": "hna/summary/0845750.json",
       "kind": "json",
       "size_bytes": 4005,
-      "mtime": "2026-07-30T10:58:12.431Z",
+      "mtime": "2026-07-30T15:02:43.230Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25049,7 +25049,7 @@
       "path": "hna/summary/0845955.json",
       "kind": "json",
       "size_bytes": 4187,
-      "mtime": "2026-07-30T10:58:12.431Z",
+      "mtime": "2026-07-30T15:02:43.230Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25068,7 +25068,7 @@
       "path": "hna/summary/0845970.json",
       "kind": "json",
       "size_bytes": 4245,
-      "mtime": "2026-07-30T10:58:12.431Z",
+      "mtime": "2026-07-30T15:02:43.230Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25087,7 +25087,7 @@
       "path": "hna/summary/0846355.json",
       "kind": "json",
       "size_bytes": 4211,
-      "mtime": "2026-07-30T10:58:12.431Z",
+      "mtime": "2026-07-30T15:02:43.230Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25106,7 +25106,7 @@
       "path": "hna/summary/0846410.json",
       "kind": "json",
       "size_bytes": 3974,
-      "mtime": "2026-07-30T10:58:12.431Z",
+      "mtime": "2026-07-30T15:02:43.230Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25125,7 +25125,7 @@
       "path": "hna/summary/0846465.json",
       "kind": "json",
       "size_bytes": 4228,
-      "mtime": "2026-07-30T10:58:12.431Z",
+      "mtime": "2026-07-30T15:02:43.230Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25144,7 +25144,7 @@
       "path": "hna/summary/0847015.json",
       "kind": "json",
       "size_bytes": 3875,
-      "mtime": "2026-07-30T10:58:12.431Z",
+      "mtime": "2026-07-30T15:02:43.230Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25163,7 +25163,7 @@
       "path": "hna/summary/0847070.json",
       "kind": "json",
       "size_bytes": 4067,
-      "mtime": "2026-07-30T10:58:12.431Z",
+      "mtime": "2026-07-30T15:02:43.230Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25182,7 +25182,7 @@
       "path": "hna/summary/0847235.json",
       "kind": "json",
       "size_bytes": 3944,
-      "mtime": "2026-07-30T10:58:12.431Z",
+      "mtime": "2026-07-30T15:02:43.230Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25201,7 +25201,7 @@
       "path": "hna/summary/0847345.json",
       "kind": "json",
       "size_bytes": 3876,
-      "mtime": "2026-07-30T10:58:12.431Z",
+      "mtime": "2026-07-30T15:02:43.230Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25220,7 +25220,7 @@
       "path": "hna/summary/0848060.json",
       "kind": "json",
       "size_bytes": 3998,
-      "mtime": "2026-07-30T10:58:12.431Z",
+      "mtime": "2026-07-30T15:02:43.230Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25239,7 +25239,7 @@
       "path": "hna/summary/0848115.json",
       "kind": "json",
       "size_bytes": 4070,
-      "mtime": "2026-07-30T10:58:12.432Z",
+      "mtime": "2026-07-30T15:02:43.230Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25258,7 +25258,7 @@
       "path": "hna/summary/0848445.json",
       "kind": "json",
       "size_bytes": 4107,
-      "mtime": "2026-07-30T10:58:12.432Z",
+      "mtime": "2026-07-30T15:02:43.230Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25277,7 +25277,7 @@
       "path": "hna/summary/0848500.json",
       "kind": "json",
       "size_bytes": 4011,
-      "mtime": "2026-07-30T10:58:12.432Z",
+      "mtime": "2026-07-30T15:02:43.230Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25296,7 +25296,7 @@
       "path": "hna/summary/0848555.json",
       "kind": "json",
       "size_bytes": 3981,
-      "mtime": "2026-07-30T10:58:12.432Z",
+      "mtime": "2026-07-30T15:02:43.230Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25315,7 +25315,7 @@
       "path": "hna/summary/0848940.json",
       "kind": "json",
       "size_bytes": 3887,
-      "mtime": "2026-07-30T10:58:12.432Z",
+      "mtime": "2026-07-30T15:02:43.230Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25334,7 +25334,7 @@
       "path": "hna/summary/0849215.json",
       "kind": "json",
       "size_bytes": 3882,
-      "mtime": "2026-07-30T10:58:12.432Z",
+      "mtime": "2026-07-30T15:02:43.230Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25353,7 +25353,7 @@
       "path": "hna/summary/0849325.json",
       "kind": "json",
       "size_bytes": 3847,
-      "mtime": "2026-07-30T10:58:12.432Z",
+      "mtime": "2026-07-30T15:02:43.230Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25372,7 +25372,7 @@
       "path": "hna/summary/0849490.json",
       "kind": "json",
       "size_bytes": 3940,
-      "mtime": "2026-07-30T10:58:12.432Z",
+      "mtime": "2026-07-30T15:02:43.231Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25391,7 +25391,7 @@
       "path": "hna/summary/0849600.json",
       "kind": "json",
       "size_bytes": 4117,
-      "mtime": "2026-07-30T10:58:12.432Z",
+      "mtime": "2026-07-30T15:02:43.231Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25410,7 +25410,7 @@
       "path": "hna/summary/0849875.json",
       "kind": "json",
       "size_bytes": 4109,
-      "mtime": "2026-07-30T10:58:12.432Z",
+      "mtime": "2026-07-30T15:02:43.231Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25429,7 +25429,7 @@
       "path": "hna/summary/0850012.json",
       "kind": "json",
       "size_bytes": 4116,
-      "mtime": "2026-07-30T10:58:12.432Z",
+      "mtime": "2026-07-30T15:02:43.231Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25448,7 +25448,7 @@
       "path": "hna/summary/0850026.json",
       "kind": "json",
       "size_bytes": 4068,
-      "mtime": "2026-07-30T10:58:12.432Z",
+      "mtime": "2026-07-30T15:02:43.231Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25467,7 +25467,7 @@
       "path": "hna/summary/0850040.json",
       "kind": "json",
       "size_bytes": 3995,
-      "mtime": "2026-07-30T10:58:12.432Z",
+      "mtime": "2026-07-30T15:02:43.231Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25486,7 +25486,7 @@
       "path": "hna/summary/0850380.json",
       "kind": "json",
       "size_bytes": 3919,
-      "mtime": "2026-07-30T10:58:12.432Z",
+      "mtime": "2026-07-30T15:02:43.231Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25505,7 +25505,7 @@
       "path": "hna/summary/0850480.json",
       "kind": "json",
       "size_bytes": 4125,
-      "mtime": "2026-07-30T10:58:12.433Z",
+      "mtime": "2026-07-30T15:02:43.231Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25524,7 +25524,7 @@
       "path": "hna/summary/0850920.json",
       "kind": "json",
       "size_bytes": 3999,
-      "mtime": "2026-07-30T10:58:12.433Z",
+      "mtime": "2026-07-30T15:02:43.231Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25543,7 +25543,7 @@
       "path": "hna/summary/0851250.json",
       "kind": "json",
       "size_bytes": 3920,
-      "mtime": "2026-07-30T10:58:12.433Z",
+      "mtime": "2026-07-30T15:02:43.231Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25562,7 +25562,7 @@
       "path": "hna/summary/0851635.json",
       "kind": "json",
       "size_bytes": 4128,
-      "mtime": "2026-07-30T10:58:12.433Z",
+      "mtime": "2026-07-30T15:02:43.231Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25581,7 +25581,7 @@
       "path": "hna/summary/0851690.json",
       "kind": "json",
       "size_bytes": 3907,
-      "mtime": "2026-07-30T10:58:12.433Z",
+      "mtime": "2026-07-30T15:02:43.231Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25600,7 +25600,7 @@
       "path": "hna/summary/0851745.json",
       "kind": "json",
       "size_bytes": 4230,
-      "mtime": "2026-07-30T10:58:12.433Z",
+      "mtime": "2026-07-30T15:02:43.231Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25619,7 +25619,7 @@
       "path": "hna/summary/0851800.json",
       "kind": "json",
       "size_bytes": 4165,
-      "mtime": "2026-07-30T10:58:12.433Z",
+      "mtime": "2026-07-30T15:02:43.231Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25638,7 +25638,7 @@
       "path": "hna/summary/0851975.json",
       "kind": "json",
       "size_bytes": 3918,
-      "mtime": "2026-07-30T10:58:12.433Z",
+      "mtime": "2026-07-30T15:02:43.231Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25657,7 +25657,7 @@
       "path": "hna/summary/0852075.json",
       "kind": "json",
       "size_bytes": 4006,
-      "mtime": "2026-07-30T10:58:12.433Z",
+      "mtime": "2026-07-30T15:02:43.231Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25676,7 +25676,7 @@
       "path": "hna/summary/0852210.json",
       "kind": "json",
       "size_bytes": 3933,
-      "mtime": "2026-07-30T10:58:12.433Z",
+      "mtime": "2026-07-30T15:02:43.231Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25695,7 +25695,7 @@
       "path": "hna/summary/0852350.json",
       "kind": "json",
       "size_bytes": 4036,
-      "mtime": "2026-07-30T10:58:12.433Z",
+      "mtime": "2026-07-30T15:02:43.231Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25714,7 +25714,7 @@
       "path": "hna/summary/0852550.json",
       "kind": "json",
       "size_bytes": 4106,
-      "mtime": "2026-07-30T10:58:12.433Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25733,7 +25733,7 @@
       "path": "hna/summary/0852570.json",
       "kind": "json",
       "size_bytes": 4061,
-      "mtime": "2026-07-30T10:58:12.433Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25752,7 +25752,7 @@
       "path": "hna/summary/0852820.json",
       "kind": "json",
       "size_bytes": 3934,
-      "mtime": "2026-07-30T10:58:12.433Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25771,7 +25771,7 @@
       "path": "hna/summary/0853010.json",
       "kind": "json",
       "size_bytes": 3971,
-      "mtime": "2026-07-30T10:58:12.433Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25790,7 +25790,7 @@
       "path": "hna/summary/0853120.json",
       "kind": "json",
       "size_bytes": 4010,
-      "mtime": "2026-07-30T10:58:12.433Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25809,7 +25809,7 @@
       "path": "hna/summary/0853175.json",
       "kind": "json",
       "size_bytes": 4072,
-      "mtime": "2026-07-30T10:58:12.433Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25828,7 +25828,7 @@
       "path": "hna/summary/0853395.json",
       "kind": "json",
       "size_bytes": 4117,
-      "mtime": "2026-07-30T10:58:12.433Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25847,7 +25847,7 @@
       "path": "hna/summary/0853780.json",
       "kind": "json",
       "size_bytes": 4097,
-      "mtime": "2026-07-30T10:58:12.433Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25866,7 +25866,7 @@
       "path": "hna/summary/0853875.json",
       "kind": "json",
       "size_bytes": 3906,
-      "mtime": "2026-07-30T10:58:12.434Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25885,7 +25885,7 @@
       "path": "hna/summary/0853945.json",
       "kind": "json",
       "size_bytes": 3877,
-      "mtime": "2026-07-30T10:58:12.434Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25904,7 +25904,7 @@
       "path": "hna/summary/0854330.json",
       "kind": "json",
       "size_bytes": 4245,
-      "mtime": "2026-07-30T10:58:12.434Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25923,7 +25923,7 @@
       "path": "hna/summary/0854495.json",
       "kind": "json",
       "size_bytes": 4449,
-      "mtime": "2026-07-30T10:58:12.434Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25942,7 +25942,7 @@
       "path": "hna/summary/0854750.json",
       "kind": "json",
       "size_bytes": 3989,
-      "mtime": "2026-07-30T10:58:12.434Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25961,7 +25961,7 @@
       "path": "hna/summary/0854880.json",
       "kind": "json",
       "size_bytes": 4007,
-      "mtime": "2026-07-30T10:58:12.434Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25980,7 +25980,7 @@
       "path": "hna/summary/0854935.json",
       "kind": "json",
       "size_bytes": 4023,
-      "mtime": "2026-07-30T10:58:12.434Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -25999,7 +25999,7 @@
       "path": "hna/summary/0855045.json",
       "kind": "json",
       "size_bytes": 3994,
-      "mtime": "2026-07-30T10:58:12.434Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26018,7 +26018,7 @@
       "path": "hna/summary/0855155.json",
       "kind": "json",
       "size_bytes": 4029,
-      "mtime": "2026-07-30T10:58:12.434Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26037,7 +26037,7 @@
       "path": "hna/summary/0855540.json",
       "kind": "json",
       "size_bytes": 4058,
-      "mtime": "2026-07-30T10:58:12.434Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26056,7 +26056,7 @@
       "path": "hna/summary/0855705.json",
       "kind": "json",
       "size_bytes": 4006,
-      "mtime": "2026-07-30T10:58:12.434Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26075,7 +26075,7 @@
       "path": "hna/summary/0855870.json",
       "kind": "json",
       "size_bytes": 3947,
-      "mtime": "2026-07-30T10:58:12.434Z",
+      "mtime": "2026-07-30T15:02:43.232Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26094,7 +26094,7 @@
       "path": "hna/summary/0855925.json",
       "kind": "json",
       "size_bytes": 3876,
-      "mtime": "2026-07-30T10:58:12.434Z",
+      "mtime": "2026-07-30T15:02:43.233Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26113,7 +26113,7 @@
       "path": "hna/summary/0855980.json",
       "kind": "json",
       "size_bytes": 4127,
-      "mtime": "2026-07-30T10:58:12.434Z",
+      "mtime": "2026-07-30T15:02:43.233Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26132,7 +26132,7 @@
       "path": "hna/summary/0856035.json",
       "kind": "json",
       "size_bytes": 4111,
-      "mtime": "2026-07-30T10:58:12.434Z",
+      "mtime": "2026-07-30T15:02:43.233Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26151,7 +26151,7 @@
       "path": "hna/summary/0856145.json",
       "kind": "json",
       "size_bytes": 4070,
-      "mtime": "2026-07-30T10:58:12.434Z",
+      "mtime": "2026-07-30T15:02:43.233Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26170,7 +26170,7 @@
       "path": "hna/summary/0856365.json",
       "kind": "json",
       "size_bytes": 4023,
-      "mtime": "2026-07-30T10:58:12.434Z",
+      "mtime": "2026-07-30T15:02:43.233Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26189,7 +26189,7 @@
       "path": "hna/summary/0856420.json",
       "kind": "json",
       "size_bytes": 4063,
-      "mtime": "2026-07-30T10:58:12.435Z",
+      "mtime": "2026-07-30T15:02:43.233Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26208,7 +26208,7 @@
       "path": "hna/summary/0856475.json",
       "kind": "json",
       "size_bytes": 3999,
-      "mtime": "2026-07-30T10:58:12.435Z",
+      "mtime": "2026-07-30T15:02:43.233Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26227,7 +26227,7 @@
       "path": "hna/summary/0856695.json",
       "kind": "json",
       "size_bytes": 3850,
-      "mtime": "2026-07-30T10:58:12.435Z",
+      "mtime": "2026-07-30T15:02:43.233Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26246,7 +26246,7 @@
       "path": "hna/summary/0856860.json",
       "kind": "json",
       "size_bytes": 4099,
-      "mtime": "2026-07-30T10:58:12.435Z",
+      "mtime": "2026-07-30T15:02:43.233Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26265,7 +26265,7 @@
       "path": "hna/summary/0856970.json",
       "kind": "json",
       "size_bytes": 4118,
-      "mtime": "2026-07-30T10:58:12.435Z",
+      "mtime": "2026-07-30T15:02:43.233Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26284,7 +26284,7 @@
       "path": "hna/summary/0857025.json",
       "kind": "json",
       "size_bytes": 4106,
-      "mtime": "2026-07-30T10:58:12.435Z",
+      "mtime": "2026-07-30T15:02:43.233Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26303,7 +26303,7 @@
       "path": "hna/summary/0857245.json",
       "kind": "json",
       "size_bytes": 3864,
-      "mtime": "2026-07-30T10:58:12.435Z",
+      "mtime": "2026-07-30T15:02:43.233Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26322,7 +26322,7 @@
       "path": "hna/summary/0857300.json",
       "kind": "json",
       "size_bytes": 4078,
-      "mtime": "2026-07-30T10:58:12.435Z",
+      "mtime": "2026-07-30T15:02:43.233Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26341,7 +26341,7 @@
       "path": "hna/summary/0857400.json",
       "kind": "json",
       "size_bytes": 4058,
-      "mtime": "2026-07-30T10:58:12.435Z",
+      "mtime": "2026-07-30T15:02:43.233Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26360,7 +26360,7 @@
       "path": "hna/summary/0857445.json",
       "kind": "json",
       "size_bytes": 3976,
-      "mtime": "2026-07-30T10:58:12.435Z",
+      "mtime": "2026-07-30T15:02:43.233Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26379,7 +26379,7 @@
       "path": "hna/summary/0857465.json",
       "kind": "json",
       "size_bytes": 4043,
-      "mtime": "2026-07-30T10:58:12.435Z",
+      "mtime": "2026-07-30T15:02:43.233Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26398,7 +26398,7 @@
       "path": "hna/summary/0857630.json",
       "kind": "json",
       "size_bytes": 4191,
-      "mtime": "2026-07-30T10:58:12.435Z",
+      "mtime": "2026-07-30T15:02:43.233Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26417,7 +26417,7 @@
       "path": "hna/summary/0857850.json",
       "kind": "json",
       "size_bytes": 3876,
-      "mtime": "2026-07-30T10:58:12.435Z",
+      "mtime": "2026-07-30T15:02:43.233Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26436,7 +26436,7 @@
       "path": "hna/summary/0858235.json",
       "kind": "json",
       "size_bytes": 3995,
-      "mtime": "2026-07-30T10:58:12.435Z",
+      "mtime": "2026-07-30T15:02:43.234Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26455,7 +26455,7 @@
       "path": "hna/summary/0858400.json",
       "kind": "json",
       "size_bytes": 4115,
-      "mtime": "2026-07-30T10:58:12.435Z",
+      "mtime": "2026-07-30T15:02:43.234Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26474,7 +26474,7 @@
       "path": "hna/summary/0858510.json",
       "kind": "json",
       "size_bytes": 3860,
-      "mtime": "2026-07-30T10:58:12.435Z",
+      "mtime": "2026-07-30T15:02:43.234Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26493,7 +26493,7 @@
       "path": "hna/summary/0858592.json",
       "kind": "json",
       "size_bytes": 4015,
-      "mtime": "2026-07-30T10:58:12.435Z",
+      "mtime": "2026-07-30T15:02:43.234Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26512,7 +26512,7 @@
       "path": "hna/summary/0858675.json",
       "kind": "json",
       "size_bytes": 3903,
-      "mtime": "2026-07-30T10:58:12.435Z",
+      "mtime": "2026-07-30T15:02:43.234Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26531,7 +26531,7 @@
       "path": "hna/summary/0858785.json",
       "kind": "json",
       "size_bytes": 3968,
-      "mtime": "2026-07-30T10:58:12.436Z",
+      "mtime": "2026-07-30T15:02:43.234Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26550,7 +26550,7 @@
       "path": "hna/summary/0858960.json",
       "kind": "json",
       "size_bytes": 3872,
-      "mtime": "2026-07-30T10:58:12.436Z",
+      "mtime": "2026-07-30T15:02:43.234Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26569,7 +26569,7 @@
       "path": "hna/summary/0859005.json",
       "kind": "json",
       "size_bytes": 4054,
-      "mtime": "2026-07-30T10:58:12.436Z",
+      "mtime": "2026-07-30T15:02:43.234Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26588,7 +26588,7 @@
       "path": "hna/summary/0859240.json",
       "kind": "json",
       "size_bytes": 3973,
-      "mtime": "2026-07-30T10:58:12.436Z",
+      "mtime": "2026-07-30T15:02:43.234Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26607,7 +26607,7 @@
       "path": "hna/summary/0859520.json",
       "kind": "json",
       "size_bytes": 3964,
-      "mtime": "2026-07-30T10:58:12.436Z",
+      "mtime": "2026-07-30T15:02:43.234Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26626,7 +26626,7 @@
       "path": "hna/summary/0859830.json",
       "kind": "json",
       "size_bytes": 3952,
-      "mtime": "2026-07-30T10:58:12.436Z",
+      "mtime": "2026-07-30T15:02:43.234Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26645,7 +26645,7 @@
       "path": "hna/summary/0859885.json",
       "kind": "json",
       "size_bytes": 3995,
-      "mtime": "2026-07-30T10:58:12.436Z",
+      "mtime": "2026-07-30T15:02:43.234Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26664,7 +26664,7 @@
       "path": "hna/summary/0860160.json",
       "kind": "json",
       "size_bytes": 4114,
-      "mtime": "2026-07-30T10:58:12.436Z",
+      "mtime": "2026-07-30T15:02:43.234Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26683,7 +26683,7 @@
       "path": "hna/summary/0860600.json",
       "kind": "json",
       "size_bytes": 4039,
-      "mtime": "2026-07-30T10:58:12.436Z",
+      "mtime": "2026-07-30T15:02:43.234Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26702,7 +26702,7 @@
       "path": "hna/summary/0860655.json",
       "kind": "json",
       "size_bytes": 4032,
-      "mtime": "2026-07-30T10:58:12.436Z",
+      "mtime": "2026-07-30T15:02:43.234Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26721,7 +26721,7 @@
       "path": "hna/summary/0860765.json",
       "kind": "json",
       "size_bytes": 3911,
-      "mtime": "2026-07-30T10:58:12.436Z",
+      "mtime": "2026-07-30T15:02:43.234Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26740,7 +26740,7 @@
       "path": "hna/summary/0861315.json",
       "kind": "json",
       "size_bytes": 3900,
-      "mtime": "2026-07-30T10:58:12.436Z",
+      "mtime": "2026-07-30T15:02:43.234Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26759,7 +26759,7 @@
       "path": "hna/summary/0862000.json",
       "kind": "json",
       "size_bytes": 4268,
-      "mtime": "2026-07-30T10:58:12.436Z",
+      "mtime": "2026-07-30T15:02:43.234Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26778,7 +26778,7 @@
       "path": "hna/summary/0862220.json",
       "kind": "json",
       "size_bytes": 4218,
-      "mtime": "2026-07-30T10:58:12.436Z",
+      "mtime": "2026-07-30T15:02:43.235Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26797,7 +26797,7 @@
       "path": "hna/summary/0862660.json",
       "kind": "json",
       "size_bytes": 3906,
-      "mtime": "2026-07-30T10:58:12.436Z",
+      "mtime": "2026-07-30T15:02:43.235Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26816,7 +26816,7 @@
       "path": "hna/summary/0862880.json",
       "kind": "json",
       "size_bytes": 4094,
-      "mtime": "2026-07-30T10:58:12.436Z",
+      "mtime": "2026-07-30T15:02:43.235Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26835,7 +26835,7 @@
       "path": "hna/summary/0863045.json",
       "kind": "json",
       "size_bytes": 3898,
-      "mtime": "2026-07-30T10:58:12.436Z",
+      "mtime": "2026-07-30T15:02:43.235Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26854,7 +26854,7 @@
       "path": "hna/summary/0863265.json",
       "kind": "json",
       "size_bytes": 3953,
-      "mtime": "2026-07-30T10:58:12.437Z",
+      "mtime": "2026-07-30T15:02:43.235Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26873,7 +26873,7 @@
       "path": "hna/summary/0863320.json",
       "kind": "json",
       "size_bytes": 4027,
-      "mtime": "2026-07-30T10:58:12.437Z",
+      "mtime": "2026-07-30T15:02:43.235Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26892,7 +26892,7 @@
       "path": "hna/summary/0863375.json",
       "kind": "json",
       "size_bytes": 4105,
-      "mtime": "2026-07-30T10:58:12.437Z",
+      "mtime": "2026-07-30T15:02:43.235Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26911,7 +26911,7 @@
       "path": "hna/summary/0863650.json",
       "kind": "json",
       "size_bytes": 3954,
-      "mtime": "2026-07-30T10:58:12.437Z",
+      "mtime": "2026-07-30T15:02:43.235Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26930,7 +26930,7 @@
       "path": "hna/summary/0863705.json",
       "kind": "json",
       "size_bytes": 3941,
-      "mtime": "2026-07-30T10:58:12.437Z",
+      "mtime": "2026-07-30T15:02:43.235Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26949,7 +26949,7 @@
       "path": "hna/summary/0864090.json",
       "kind": "json",
       "size_bytes": 4009,
-      "mtime": "2026-07-30T10:58:12.437Z",
+      "mtime": "2026-07-30T15:02:43.235Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26968,7 +26968,7 @@
       "path": "hna/summary/0864200.json",
       "kind": "json",
       "size_bytes": 4061,
-      "mtime": "2026-07-30T10:58:12.437Z",
+      "mtime": "2026-07-30T15:02:43.235Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -26987,7 +26987,7 @@
       "path": "hna/summary/0864255.json",
       "kind": "json",
       "size_bytes": 4138,
-      "mtime": "2026-07-30T10:58:12.437Z",
+      "mtime": "2026-07-30T15:02:43.235Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27006,7 +27006,7 @@
       "path": "hna/summary/0864870.json",
       "kind": "json",
       "size_bytes": 3897,
-      "mtime": "2026-07-30T10:58:12.437Z",
+      "mtime": "2026-07-30T15:02:43.235Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27025,7 +27025,7 @@
       "path": "hna/summary/0864970.json",
       "kind": "json",
       "size_bytes": 4018,
-      "mtime": "2026-07-30T10:58:12.437Z",
+      "mtime": "2026-07-30T15:02:43.235Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27044,7 +27044,7 @@
       "path": "hna/summary/0865190.json",
       "kind": "json",
       "size_bytes": 4132,
-      "mtime": "2026-07-30T10:58:12.437Z",
+      "mtime": "2026-07-30T15:02:43.235Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27063,7 +27063,7 @@
       "path": "hna/summary/0865685.json",
       "kind": "json",
       "size_bytes": 3928,
-      "mtime": "2026-07-30T10:58:12.437Z",
+      "mtime": "2026-07-30T15:02:43.235Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27082,7 +27082,7 @@
       "path": "hna/summary/0865740.json",
       "kind": "json",
       "size_bytes": 3970,
-      "mtime": "2026-07-30T10:58:12.437Z",
+      "mtime": "2026-07-30T15:02:43.235Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27101,7 +27101,7 @@
       "path": "hna/summary/0866197.json",
       "kind": "json",
       "size_bytes": 4081,
-      "mtime": "2026-07-30T10:58:12.437Z",
+      "mtime": "2026-07-30T15:02:43.235Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27120,7 +27120,7 @@
       "path": "hna/summary/0866895.json",
       "kind": "json",
       "size_bytes": 3942,
-      "mtime": "2026-07-30T10:58:12.438Z",
+      "mtime": "2026-07-30T15:02:43.235Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27139,7 +27139,7 @@
       "path": "hna/summary/0866995.json",
       "kind": "json",
       "size_bytes": 3859,
-      "mtime": "2026-07-30T10:58:12.438Z",
+      "mtime": "2026-07-30T15:02:43.236Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27158,7 +27158,7 @@
       "path": "hna/summary/0867005.json",
       "kind": "json",
       "size_bytes": 3987,
-      "mtime": "2026-07-30T10:58:12.438Z",
+      "mtime": "2026-07-30T15:02:43.236Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27177,7 +27177,7 @@
       "path": "hna/summary/0867040.json",
       "kind": "json",
       "size_bytes": 3934,
-      "mtime": "2026-07-30T10:58:12.438Z",
+      "mtime": "2026-07-30T15:02:43.236Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27196,7 +27196,7 @@
       "path": "hna/summary/0867142.json",
       "kind": "json",
       "size_bytes": 3889,
-      "mtime": "2026-07-30T10:58:12.438Z",
+      "mtime": "2026-07-30T15:02:43.236Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27215,7 +27215,7 @@
       "path": "hna/summary/0867280.json",
       "kind": "json",
       "size_bytes": 4157,
-      "mtime": "2026-07-30T10:58:12.438Z",
+      "mtime": "2026-07-30T15:02:43.236Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27234,7 +27234,7 @@
       "path": "hna/summary/0867445.json",
       "kind": "json",
       "size_bytes": 3988,
-      "mtime": "2026-07-30T10:58:12.438Z",
+      "mtime": "2026-07-30T15:02:43.236Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27253,7 +27253,7 @@
       "path": "hna/summary/0867500.json",
       "kind": "json",
       "size_bytes": 3889,
-      "mtime": "2026-07-30T10:58:12.438Z",
+      "mtime": "2026-07-30T15:02:43.236Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27272,7 +27272,7 @@
       "path": "hna/summary/0867830.json",
       "kind": "json",
       "size_bytes": 4019,
-      "mtime": "2026-07-30T10:58:12.438Z",
+      "mtime": "2026-07-30T15:02:43.236Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27291,7 +27291,7 @@
       "path": "hna/summary/0868105.json",
       "kind": "json",
       "size_bytes": 4035,
-      "mtime": "2026-07-30T10:58:12.438Z",
+      "mtime": "2026-07-30T15:02:43.236Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27310,7 +27310,7 @@
       "path": "hna/summary/0868655.json",
       "kind": "json",
       "size_bytes": 3844,
-      "mtime": "2026-07-30T10:58:12.438Z",
+      "mtime": "2026-07-30T15:02:43.236Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27329,7 +27329,7 @@
       "path": "hna/summary/0868847.json",
       "kind": "json",
       "size_bytes": 4260,
-      "mtime": "2026-07-30T10:58:12.438Z",
+      "mtime": "2026-07-30T15:02:43.236Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27348,7 +27348,7 @@
       "path": "hna/summary/0868875.json",
       "kind": "json",
       "size_bytes": 3889,
-      "mtime": "2026-07-30T10:58:12.438Z",
+      "mtime": "2026-07-30T15:02:43.236Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27367,7 +27367,7 @@
       "path": "hna/summary/0868930.json",
       "kind": "json",
       "size_bytes": 3925,
-      "mtime": "2026-07-30T10:58:12.438Z",
+      "mtime": "2026-07-30T15:02:43.236Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27386,7 +27386,7 @@
       "path": "hna/summary/0868985.json",
       "kind": "json",
       "size_bytes": 3913,
-      "mtime": "2026-07-30T10:58:12.438Z",
+      "mtime": "2026-07-30T15:02:43.236Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27405,7 +27405,7 @@
       "path": "hna/summary/0869040.json",
       "kind": "json",
       "size_bytes": 4154,
-      "mtime": "2026-07-30T10:58:12.438Z",
+      "mtime": "2026-07-30T15:02:43.236Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27424,7 +27424,7 @@
       "path": "hna/summary/0869110.json",
       "kind": "json",
       "size_bytes": 3891,
-      "mtime": "2026-07-30T10:58:12.438Z",
+      "mtime": "2026-07-30T15:02:43.236Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27443,7 +27443,7 @@
       "path": "hna/summary/0869150.json",
       "kind": "json",
       "size_bytes": 4122,
-      "mtime": "2026-07-30T10:58:12.438Z",
+      "mtime": "2026-07-30T15:02:43.236Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27462,7 +27462,7 @@
       "path": "hna/summary/0869480.json",
       "kind": "json",
       "size_bytes": 4061,
-      "mtime": "2026-07-30T10:58:12.438Z",
+      "mtime": "2026-07-30T15:02:43.236Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27481,7 +27481,7 @@
       "path": "hna/summary/0869645.json",
       "kind": "json",
       "size_bytes": 4163,
-      "mtime": "2026-07-30T10:58:12.439Z",
+      "mtime": "2026-07-30T15:02:43.236Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27500,7 +27500,7 @@
       "path": "hna/summary/0869700.json",
       "kind": "json",
       "size_bytes": 3883,
-      "mtime": "2026-07-30T10:58:12.439Z",
+      "mtime": "2026-07-30T15:02:43.237Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27519,7 +27519,7 @@
       "path": "hna/summary/0869810.json",
       "kind": "json",
       "size_bytes": 4168,
-      "mtime": "2026-07-30T10:58:12.439Z",
+      "mtime": "2026-07-30T15:02:43.237Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27538,7 +27538,7 @@
       "path": "hna/summary/0870112.json",
       "kind": "json",
       "size_bytes": 4026,
-      "mtime": "2026-07-30T10:58:12.439Z",
+      "mtime": "2026-07-30T15:02:43.237Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27557,7 +27557,7 @@
       "path": "hna/summary/0870195.json",
       "kind": "json",
       "size_bytes": 4100,
-      "mtime": "2026-07-30T10:58:12.439Z",
+      "mtime": "2026-07-30T15:02:43.237Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27576,7 +27576,7 @@
       "path": "hna/summary/0870250.json",
       "kind": "json",
       "size_bytes": 4040,
-      "mtime": "2026-07-30T10:58:12.439Z",
+      "mtime": "2026-07-30T15:02:43.237Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27595,7 +27595,7 @@
       "path": "hna/summary/0870360.json",
       "kind": "json",
       "size_bytes": 3963,
-      "mtime": "2026-07-30T10:58:12.439Z",
+      "mtime": "2026-07-30T15:02:43.237Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27614,7 +27614,7 @@
       "path": "hna/summary/0870525.json",
       "kind": "json",
       "size_bytes": 4115,
-      "mtime": "2026-07-30T10:58:12.439Z",
+      "mtime": "2026-07-30T15:02:43.237Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27633,7 +27633,7 @@
       "path": "hna/summary/0870580.json",
       "kind": "json",
       "size_bytes": 4032,
-      "mtime": "2026-07-30T10:58:12.439Z",
+      "mtime": "2026-07-30T15:02:43.237Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27652,7 +27652,7 @@
       "path": "hna/summary/0870635.json",
       "kind": "json",
       "size_bytes": 4008,
-      "mtime": "2026-07-30T10:58:12.439Z",
+      "mtime": "2026-07-30T15:02:43.237Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27671,7 +27671,7 @@
       "path": "hna/summary/0871625.json",
       "kind": "json",
       "size_bytes": 3901,
-      "mtime": "2026-07-30T10:58:12.439Z",
+      "mtime": "2026-07-30T15:02:43.237Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27690,7 +27690,7 @@
       "path": "hna/summary/0871755.json",
       "kind": "json",
       "size_bytes": 4106,
-      "mtime": "2026-07-30T10:58:12.439Z",
+      "mtime": "2026-07-30T15:02:43.237Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27709,7 +27709,7 @@
       "path": "hna/summary/0871790.json",
       "kind": "json",
       "size_bytes": 3892,
-      "mtime": "2026-07-30T10:58:12.439Z",
+      "mtime": "2026-07-30T15:02:43.237Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27728,7 +27728,7 @@
       "path": "hna/summary/0871845.json",
       "kind": "json",
       "size_bytes": 3884,
-      "mtime": "2026-07-30T10:58:12.439Z",
+      "mtime": "2026-07-30T15:02:43.237Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27747,7 +27747,7 @@
       "path": "hna/summary/0872320.json",
       "kind": "json",
       "size_bytes": 3909,
-      "mtime": "2026-07-30T10:58:12.439Z",
+      "mtime": "2026-07-30T15:02:43.237Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27766,7 +27766,7 @@
       "path": "hna/summary/0872395.json",
       "kind": "json",
       "size_bytes": 4046,
-      "mtime": "2026-07-30T10:58:12.439Z",
+      "mtime": "2026-07-30T15:02:43.237Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27785,7 +27785,7 @@
       "path": "hna/summary/0873330.json",
       "kind": "json",
       "size_bytes": 4035,
-      "mtime": "2026-07-30T10:58:12.439Z",
+      "mtime": "2026-07-30T15:02:43.237Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27804,7 +27804,7 @@
       "path": "hna/summary/0873715.json",
       "kind": "json",
       "size_bytes": 4373,
-      "mtime": "2026-07-30T10:58:12.439Z",
+      "mtime": "2026-07-30T15:02:43.237Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27823,7 +27823,7 @@
       "path": "hna/summary/0873825.json",
       "kind": "json",
       "size_bytes": 4224,
-      "mtime": "2026-07-30T10:58:12.440Z",
+      "mtime": "2026-07-30T15:02:43.237Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27842,7 +27842,7 @@
       "path": "hna/summary/0873925.json",
       "kind": "json",
       "size_bytes": 4016,
-      "mtime": "2026-07-30T10:58:12.440Z",
+      "mtime": "2026-07-30T15:02:43.237Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27861,7 +27861,7 @@
       "path": "hna/summary/0873935.json",
       "kind": "json",
       "size_bytes": 3802,
-      "mtime": "2026-07-30T10:58:12.440Z",
+      "mtime": "2026-07-30T15:02:43.238Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27880,7 +27880,7 @@
       "path": "hna/summary/0873943.json",
       "kind": "json",
       "size_bytes": 4031,
-      "mtime": "2026-07-30T10:58:12.440Z",
+      "mtime": "2026-07-30T15:02:43.238Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27899,7 +27899,7 @@
       "path": "hna/summary/0874080.json",
       "kind": "json",
       "size_bytes": 4078,
-      "mtime": "2026-07-30T10:58:12.440Z",
+      "mtime": "2026-07-30T15:02:43.238Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27918,7 +27918,7 @@
       "path": "hna/summary/0874275.json",
       "kind": "json",
       "size_bytes": 3874,
-      "mtime": "2026-07-30T10:58:12.440Z",
+      "mtime": "2026-07-30T15:02:43.238Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27937,7 +27937,7 @@
       "path": "hna/summary/0874375.json",
       "kind": "json",
       "size_bytes": 4095,
-      "mtime": "2026-07-30T10:58:12.440Z",
+      "mtime": "2026-07-30T15:02:43.238Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27956,7 +27956,7 @@
       "path": "hna/summary/0874430.json",
       "kind": "json",
       "size_bytes": 4132,
-      "mtime": "2026-07-30T10:58:12.440Z",
+      "mtime": "2026-07-30T15:02:43.238Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27975,7 +27975,7 @@
       "path": "hna/summary/0874485.json",
       "kind": "json",
       "size_bytes": 4041,
-      "mtime": "2026-07-30T10:58:12.440Z",
+      "mtime": "2026-07-30T15:02:43.238Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -27994,7 +27994,7 @@
       "path": "hna/summary/0874815.json",
       "kind": "json",
       "size_bytes": 3997,
-      "mtime": "2026-07-30T10:58:12.440Z",
+      "mtime": "2026-07-30T15:02:43.238Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28013,7 +28013,7 @@
       "path": "hna/summary/0874980.json",
       "kind": "json",
       "size_bytes": 3933,
-      "mtime": "2026-07-30T10:58:12.440Z",
+      "mtime": "2026-07-30T15:02:43.238Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28032,7 +28032,7 @@
       "path": "hna/summary/0875585.json",
       "kind": "json",
       "size_bytes": 3929,
-      "mtime": "2026-07-30T10:58:12.440Z",
+      "mtime": "2026-07-30T15:02:43.238Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28051,7 +28051,7 @@
       "path": "hna/summary/0875640.json",
       "kind": "json",
       "size_bytes": 4171,
-      "mtime": "2026-07-30T10:58:12.440Z",
+      "mtime": "2026-07-30T15:02:43.238Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28070,7 +28070,7 @@
       "path": "hna/summary/0875970.json",
       "kind": "json",
       "size_bytes": 3961,
-      "mtime": "2026-07-30T10:58:12.440Z",
+      "mtime": "2026-07-30T15:02:43.238Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28089,7 +28089,7 @@
       "path": "hna/summary/0876190.json",
       "kind": "json",
       "size_bytes": 3965,
-      "mtime": "2026-07-30T10:58:12.440Z",
+      "mtime": "2026-07-30T15:02:43.238Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28108,7 +28108,7 @@
       "path": "hna/summary/0876325.json",
       "kind": "json",
       "size_bytes": 3934,
-      "mtime": "2026-07-30T10:58:12.441Z",
+      "mtime": "2026-07-30T15:02:43.238Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28127,7 +28127,7 @@
       "path": "hna/summary/0876795.json",
       "kind": "json",
       "size_bytes": 4063,
-      "mtime": "2026-07-30T10:58:12.441Z",
+      "mtime": "2026-07-30T15:02:43.238Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28146,7 +28146,7 @@
       "path": "hna/summary/0877235.json",
       "kind": "json",
       "size_bytes": 4103,
-      "mtime": "2026-07-30T10:58:12.441Z",
+      "mtime": "2026-07-30T15:02:43.238Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28165,7 +28165,7 @@
       "path": "hna/summary/0877290.json",
       "kind": "json",
       "size_bytes": 4289,
-      "mtime": "2026-07-30T10:58:12.441Z",
+      "mtime": "2026-07-30T15:02:43.238Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28184,7 +28184,7 @@
       "path": "hna/summary/0877510.json",
       "kind": "json",
       "size_bytes": 4120,
-      "mtime": "2026-07-30T10:58:12.441Z",
+      "mtime": "2026-07-30T15:02:43.238Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28203,7 +28203,7 @@
       "path": "hna/summary/0877757.json",
       "kind": "json",
       "size_bytes": 4087,
-      "mtime": "2026-07-30T10:58:12.441Z",
+      "mtime": "2026-07-30T15:02:43.239Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28222,7 +28222,7 @@
       "path": "hna/summary/0878280.json",
       "kind": "json",
       "size_bytes": 3974,
-      "mtime": "2026-07-30T10:58:12.441Z",
+      "mtime": "2026-07-30T15:02:43.239Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28241,7 +28241,7 @@
       "path": "hna/summary/0878335.json",
       "kind": "json",
       "size_bytes": 3856,
-      "mtime": "2026-07-30T10:58:12.441Z",
+      "mtime": "2026-07-30T15:02:43.239Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28260,7 +28260,7 @@
       "path": "hna/summary/0878345.json",
       "kind": "json",
       "size_bytes": 3877,
-      "mtime": "2026-07-30T10:58:12.441Z",
+      "mtime": "2026-07-30T15:02:43.239Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28279,7 +28279,7 @@
       "path": "hna/summary/0878610.json",
       "kind": "json",
       "size_bytes": 4196,
-      "mtime": "2026-07-30T10:58:12.441Z",
+      "mtime": "2026-07-30T15:02:43.239Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28298,7 +28298,7 @@
       "path": "hna/summary/0879100.json",
       "kind": "json",
       "size_bytes": 4130,
-      "mtime": "2026-07-30T10:58:12.441Z",
+      "mtime": "2026-07-30T15:02:43.239Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28317,7 +28317,7 @@
       "path": "hna/summary/0879105.json",
       "kind": "json",
       "size_bytes": 4017,
-      "mtime": "2026-07-30T10:58:12.441Z",
+      "mtime": "2026-07-30T15:02:43.239Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28336,7 +28336,7 @@
       "path": "hna/summary/0879270.json",
       "kind": "json",
       "size_bytes": 3885,
-      "mtime": "2026-07-30T10:58:12.441Z",
+      "mtime": "2026-07-30T15:02:43.239Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28355,7 +28355,7 @@
       "path": "hna/summary/0879785.json",
       "kind": "json",
       "size_bytes": 3973,
-      "mtime": "2026-07-30T10:58:12.441Z",
+      "mtime": "2026-07-30T15:02:43.239Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28374,7 +28374,7 @@
       "path": "hna/summary/0879800.json",
       "kind": "json",
       "size_bytes": 3969,
-      "mtime": "2026-07-30T10:58:12.441Z",
+      "mtime": "2026-07-30T15:02:43.239Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28393,7 +28393,7 @@
       "path": "hna/summary/0880040.json",
       "kind": "json",
       "size_bytes": 4140,
-      "mtime": "2026-07-30T10:58:12.441Z",
+      "mtime": "2026-07-30T15:02:43.239Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28412,7 +28412,7 @@
       "path": "hna/summary/0880095.json",
       "kind": "json",
       "size_bytes": 3858,
-      "mtime": "2026-07-30T10:58:12.441Z",
+      "mtime": "2026-07-30T15:02:43.239Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28431,7 +28431,7 @@
       "path": "hna/summary/0880370.json",
       "kind": "json",
       "size_bytes": 3878,
-      "mtime": "2026-07-30T10:58:12.442Z",
+      "mtime": "2026-07-30T15:02:43.239Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28450,7 +28450,7 @@
       "path": "hna/summary/0880755.json",
       "kind": "json",
       "size_bytes": 3877,
-      "mtime": "2026-07-30T10:58:12.442Z",
+      "mtime": "2026-07-30T15:02:43.239Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28469,7 +28469,7 @@
       "path": "hna/summary/0880865.json",
       "kind": "json",
       "size_bytes": 4004,
-      "mtime": "2026-07-30T10:58:12.442Z",
+      "mtime": "2026-07-30T15:02:43.239Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28488,7 +28488,7 @@
       "path": "hna/summary/0881030.json",
       "kind": "json",
       "size_bytes": 3914,
-      "mtime": "2026-07-30T10:58:12.442Z",
+      "mtime": "2026-07-30T15:02:43.239Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28507,7 +28507,7 @@
       "path": "hna/summary/0881305.json",
       "kind": "json",
       "size_bytes": 3949,
-      "mtime": "2026-07-30T10:58:12.442Z",
+      "mtime": "2026-07-30T15:02:43.239Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28526,7 +28526,7 @@
       "path": "hna/summary/0881690.json",
       "kind": "json",
       "size_bytes": 3922,
-      "mtime": "2026-07-30T10:58:12.442Z",
+      "mtime": "2026-07-30T15:02:43.239Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28545,7 +28545,7 @@
       "path": "hna/summary/0882130.json",
       "kind": "json",
       "size_bytes": 4208,
-      "mtime": "2026-07-30T10:58:12.442Z",
+      "mtime": "2026-07-30T15:02:43.240Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28564,7 +28564,7 @@
       "path": "hna/summary/0882350.json",
       "kind": "json",
       "size_bytes": 4118,
-      "mtime": "2026-07-30T10:58:12.442Z",
+      "mtime": "2026-07-30T15:02:43.240Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28583,7 +28583,7 @@
       "path": "hna/summary/0882460.json",
       "kind": "json",
       "size_bytes": 3969,
-      "mtime": "2026-07-30T10:58:12.442Z",
+      "mtime": "2026-07-30T15:02:43.240Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28602,7 +28602,7 @@
       "path": "hna/summary/0882735.json",
       "kind": "json",
       "size_bytes": 3948,
-      "mtime": "2026-07-30T10:58:12.442Z",
+      "mtime": "2026-07-30T15:02:43.240Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28621,7 +28621,7 @@
       "path": "hna/summary/0882900.json",
       "kind": "json",
       "size_bytes": 4024,
-      "mtime": "2026-07-30T10:58:12.442Z",
+      "mtime": "2026-07-30T15:02:43.240Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28640,7 +28640,7 @@
       "path": "hna/summary/0883120.json",
       "kind": "json",
       "size_bytes": 4159,
-      "mtime": "2026-07-30T10:58:12.442Z",
+      "mtime": "2026-07-30T15:02:43.240Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28659,7 +28659,7 @@
       "path": "hna/summary/0883175.json",
       "kind": "json",
       "size_bytes": 3952,
-      "mtime": "2026-07-30T10:58:12.442Z",
+      "mtime": "2026-07-30T15:02:43.240Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28678,7 +28678,7 @@
       "path": "hna/summary/0883230.json",
       "kind": "json",
       "size_bytes": 4152,
-      "mtime": "2026-07-30T10:58:12.442Z",
+      "mtime": "2026-07-30T15:02:43.240Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28697,7 +28697,7 @@
       "path": "hna/summary/0883450.json",
       "kind": "json",
       "size_bytes": 4035,
-      "mtime": "2026-07-30T10:58:12.442Z",
+      "mtime": "2026-07-30T15:02:43.240Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28716,7 +28716,7 @@
       "path": "hna/summary/0883500.json",
       "kind": "json",
       "size_bytes": 3920,
-      "mtime": "2026-07-30T10:58:12.442Z",
+      "mtime": "2026-07-30T15:02:43.240Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28735,7 +28735,7 @@
       "path": "hna/summary/0883835.json",
       "kind": "json",
       "size_bytes": 3811,
-      "mtime": "2026-07-30T10:58:12.443Z",
+      "mtime": "2026-07-30T15:02:43.240Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28754,7 +28754,7 @@
       "path": "hna/summary/0884000.json",
       "kind": "json",
       "size_bytes": 3890,
-      "mtime": "2026-07-30T10:58:12.443Z",
+      "mtime": "2026-07-30T15:02:43.240Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28773,7 +28773,7 @@
       "path": "hna/summary/0884042.json",
       "kind": "json",
       "size_bytes": 4105,
-      "mtime": "2026-07-30T10:58:12.443Z",
+      "mtime": "2026-07-30T15:02:43.240Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28792,7 +28792,7 @@
       "path": "hna/summary/0884440.json",
       "kind": "json",
       "size_bytes": 4257,
-      "mtime": "2026-07-30T10:58:12.443Z",
+      "mtime": "2026-07-30T15:02:43.240Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28811,7 +28811,7 @@
       "path": "hna/summary/0884770.json",
       "kind": "json",
       "size_bytes": 4063,
-      "mtime": "2026-07-30T10:58:12.443Z",
+      "mtime": "2026-07-30T15:02:43.240Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28830,7 +28830,7 @@
       "path": "hna/summary/0885045.json",
       "kind": "json",
       "size_bytes": 3976,
-      "mtime": "2026-07-30T10:58:12.443Z",
+      "mtime": "2026-07-30T15:02:43.240Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28849,7 +28849,7 @@
       "path": "hna/summary/0885155.json",
       "kind": "json",
       "size_bytes": 4041,
-      "mtime": "2026-07-30T10:58:12.443Z",
+      "mtime": "2026-07-30T15:02:43.241Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28868,7 +28868,7 @@
       "path": "hna/summary/0885485.json",
       "kind": "json",
       "size_bytes": 4244,
-      "mtime": "2026-07-30T10:58:12.443Z",
+      "mtime": "2026-07-30T15:02:43.241Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28887,7 +28887,7 @@
       "path": "hna/summary/0885705.json",
       "kind": "json",
       "size_bytes": 4057,
-      "mtime": "2026-07-30T10:58:12.443Z",
+      "mtime": "2026-07-30T15:02:43.241Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28906,7 +28906,7 @@
       "path": "hna/summary/0885760.json",
       "kind": "json",
       "size_bytes": 3878,
-      "mtime": "2026-07-30T10:58:12.443Z",
+      "mtime": "2026-07-30T15:02:43.241Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28925,7 +28925,7 @@
       "path": "hna/summary/0886090.json",
       "kind": "json",
       "size_bytes": 4161,
-      "mtime": "2026-07-30T10:58:12.443Z",
+      "mtime": "2026-07-30T15:02:43.241Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28944,7 +28944,7 @@
       "path": "hna/summary/0886117.json",
       "kind": "json",
       "size_bytes": 4075,
-      "mtime": "2026-07-30T10:58:12.443Z",
+      "mtime": "2026-07-30T15:02:43.241Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28963,7 +28963,7 @@
       "path": "hna/summary/0886200.json",
       "kind": "json",
       "size_bytes": 3922,
-      "mtime": "2026-07-30T10:58:12.443Z",
+      "mtime": "2026-07-30T15:02:43.241Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -28982,7 +28982,7 @@
       "path": "hna/summary/0886310.json",
       "kind": "json",
       "size_bytes": 4092,
-      "mtime": "2026-07-30T10:58:12.443Z",
+      "mtime": "2026-07-30T15:02:43.241Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -29001,7 +29001,7 @@
       "path": "hna/summary/0886475.json",
       "kind": "json",
       "size_bytes": 3997,
-      "mtime": "2026-07-30T10:58:12.443Z",
+      "mtime": "2026-07-30T15:02:43.241Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -29020,7 +29020,7 @@
       "path": "hna/summary/0886750.json",
       "kind": "json",
       "size_bytes": 4108,
-      "mtime": "2026-07-30T10:58:12.443Z",
+      "mtime": "2026-07-30T15:02:43.241Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -29039,7 +29039,7 @@
       "path": "hna/vacancy-status.json",
       "kind": "json",
       "size_bytes": 469032,
-      "mtime": "2026-07-30T10:58:12.444Z",
+      "mtime": "2026-07-30T15:02:43.242Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -29054,7 +29054,7 @@
       "path": "hna/zhvi-place-crosswalk.json",
       "kind": "json",
       "size_bytes": 46219,
-      "mtime": "2026-07-30T10:58:12.444Z",
+      "mtime": "2026-07-30T15:02:43.242Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -29069,7 +29069,7 @@
       "path": "hud-fmr-income-limits.json",
       "kind": "json",
       "size_bytes": 102647,
-      "mtime": "2026-07-30T10:58:12.445Z",
+      "mtime": "2026-07-30T15:02:43.242Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -29092,7 +29092,7 @@
       "path": "insights-meta.json",
       "kind": "json",
       "size_bytes": 970,
-      "mtime": "2026-07-30T10:58:12.445Z",
+      "mtime": "2026-07-30T15:02:43.242Z",
       "shape": "object",
       "keys": [
         "lastVerified",
@@ -29109,7 +29109,7 @@
       "path": "jurisdiction-briefs/0803620.json",
       "kind": "json",
       "size_bytes": 27266,
-      "mtime": "2026-07-30T10:58:12.445Z",
+      "mtime": "2026-07-30T15:02:43.242Z",
       "shape": "object",
       "keys": [
         "geoid",
@@ -29138,7 +29138,7 @@
       "path": "jurisdiction-briefs/08045.json",
       "kind": "json",
       "size_bytes": 29648,
-      "mtime": "2026-07-30T10:58:12.445Z",
+      "mtime": "2026-07-30T15:02:43.243Z",
       "shape": "object",
       "keys": [
         "geoid",
@@ -29168,7 +29168,7 @@
       "path": "jurisdiction-briefs/08097.json",
       "kind": "json",
       "size_bytes": 28667,
-      "mtime": "2026-07-30T10:58:12.446Z",
+      "mtime": "2026-07-30T15:02:43.243Z",
       "shape": "object",
       "keys": [
         "geoid",
@@ -29197,7 +29197,7 @@
       "path": "jurisdiction-briefs/0810105.json",
       "kind": "json",
       "size_bytes": 2967,
-      "mtime": "2026-07-30T13:54:38.506Z",
+      "mtime": "2026-07-30T15:02:43.243Z",
       "shape": "object",
       "keys": [
         "geoid",
@@ -29225,7 +29225,7 @@
       "path": "jurisdiction-briefs/0812045.json",
       "kind": "json",
       "size_bytes": 27804,
-      "mtime": "2026-07-30T10:58:12.446Z",
+      "mtime": "2026-07-30T15:02:43.243Z",
       "shape": "object",
       "keys": [
         "geoid",
@@ -29254,7 +29254,7 @@
       "path": "jurisdiction-briefs/0816000.json",
       "kind": "json",
       "size_bytes": 24827,
-      "mtime": "2026-07-30T10:58:12.446Z",
+      "mtime": "2026-07-30T15:02:43.243Z",
       "shape": "object",
       "keys": [
         "geoid",
@@ -29282,8 +29282,8 @@
     {
       "path": "jurisdiction-briefs/0817375.json",
       "kind": "json",
-      "size_bytes": 23087,
-      "mtime": "2026-07-30T10:58:12.447Z",
+      "size_bytes": 23129,
+      "mtime": "2026-07-30T15:02:43.244Z",
       "shape": "object",
       "keys": [
         "geoid",
@@ -29312,7 +29312,7 @@
       "path": "jurisdiction-briefs/0818310.json",
       "kind": "json",
       "size_bytes": 2989,
-      "mtime": "2026-07-30T13:54:38.506Z",
+      "mtime": "2026-07-30T15:02:43.244Z",
       "shape": "object",
       "keys": [
         "geoid",
@@ -29340,7 +29340,7 @@
       "path": "jurisdiction-briefs/0820000.json",
       "kind": "json",
       "size_bytes": 29980,
-      "mtime": "2026-07-30T10:58:12.448Z",
+      "mtime": "2026-07-30T15:02:43.244Z",
       "shape": "object",
       "keys": [
         "geoid",
@@ -29366,10 +29366,40 @@
       ]
     },
     {
+      "path": "jurisdiction-briefs/0822035.json",
+      "kind": "json",
+      "size_bytes": 19217,
+      "mtime": "2026-07-30T15:02:43.911Z",
+      "shape": "object",
+      "keys": [
+        "geoid",
+        "jurisdiction",
+        "scope",
+        "containing_county_fips",
+        "last_curated",
+        "curator",
+        "published",
+        "summary",
+        "sections",
+        "sources",
+        "_meta_population_at_draft"
+      ],
+      "key_count": 11,
+      "primary_array_key": "sources",
+      "primary_array_length": 35,
+      "primary_array_first_keys": [
+        "id",
+        "label",
+        "url",
+        "kind",
+        "accessed"
+      ]
+    },
+    {
       "path": "jurisdiction-briefs/0827425.json",
       "kind": "json",
       "size_bytes": 29957,
-      "mtime": "2026-07-30T10:58:12.448Z",
+      "mtime": "2026-07-30T15:02:43.244Z",
       "shape": "object",
       "keys": [
         "geoid",
@@ -29398,7 +29428,7 @@
       "path": "jurisdiction-briefs/0828745.json",
       "kind": "json",
       "size_bytes": 16038,
-      "mtime": "2026-07-30T10:58:12.448Z",
+      "mtime": "2026-07-30T15:02:43.244Z",
       "shape": "object",
       "keys": [
         "geoid",
@@ -29427,7 +29457,7 @@
       "path": "jurisdiction-briefs/0830780.json",
       "kind": "json",
       "size_bytes": 29169,
-      "mtime": "2026-07-30T10:58:12.449Z",
+      "mtime": "2026-07-30T15:02:43.245Z",
       "shape": "object",
       "keys": [
         "geoid",
@@ -29456,7 +29486,7 @@
       "path": "jurisdiction-briefs/0864255.json",
       "kind": "json",
       "size_bytes": 18949,
-      "mtime": "2026-07-30T10:58:12.449Z",
+      "mtime": "2026-07-30T15:02:43.245Z",
       "shape": "object",
       "keys": [
         "geoid",
@@ -29484,7 +29514,7 @@
       "path": "jurisdiction-briefs/0867280.json",
       "kind": "json",
       "size_bytes": 25418,
-      "mtime": "2026-07-30T10:58:12.449Z",
+      "mtime": "2026-07-30T15:02:43.245Z",
       "shape": "object",
       "keys": [
         "geoid",
@@ -29513,7 +29543,7 @@
       "path": "jurisdiction-briefs/0870195.json",
       "kind": "json",
       "size_bytes": 30673,
-      "mtime": "2026-07-30T10:58:12.449Z",
+      "mtime": "2026-07-30T15:02:43.245Z",
       "shape": "object",
       "keys": [
         "geoid",
@@ -29542,7 +29572,7 @@
       "path": "jurisdiction-briefs/0873825.json",
       "kind": "json",
       "size_bytes": 3034,
-      "mtime": "2026-07-30T13:54:38.506Z",
+      "mtime": "2026-07-30T15:02:43.245Z",
       "shape": "object",
       "keys": [
         "geoid",
@@ -29570,7 +29600,7 @@
       "path": "jurisdiction-briefs/0876795.json",
       "kind": "json",
       "size_bytes": 2945,
-      "mtime": "2026-07-30T13:54:38.506Z",
+      "mtime": "2026-07-30T15:02:43.245Z",
       "shape": "object",
       "keys": [
         "geoid",
@@ -29598,7 +29628,7 @@
       "path": "jurisdiction-briefs/_candidates.json",
       "kind": "json",
       "size_bytes": 25243,
-      "mtime": "2026-07-30T10:58:12.450Z",
+      "mtime": "2026-07-30T15:02:43.246Z",
       "shape": "object",
       "keys": [
         "generated",
@@ -29620,7 +29650,7 @@
       "path": "jurisdiction-briefs/_liveness.json",
       "kind": "json",
       "size_bytes": 222713,
-      "mtime": "2026-07-30T10:58:12.450Z",
+      "mtime": "2026-07-30T15:02:43.247Z",
       "shape": "object",
       "keys": [
         "summary",
@@ -29644,7 +29674,7 @@
       "path": "jurisdiction-briefs/_schema.json",
       "kind": "json",
       "size_bytes": 3550,
-      "mtime": "2026-07-30T10:58:12.450Z",
+      "mtime": "2026-07-30T15:02:43.247Z",
       "shape": "object",
       "keys": [
         "$schema",
@@ -29662,7 +29692,7 @@
       "path": "jurisdiction-briefs/_stale.json",
       "kind": "json",
       "size_bytes": 70,
-      "mtime": "2026-07-30T10:58:12.450Z",
+      "mtime": "2026-07-30T15:02:43.248Z",
       "shape": "object",
       "keys": [
         "generated",
@@ -29678,7 +29708,7 @@
       "path": "jurisdiction-briefs/_verification-plan.json",
       "kind": "json",
       "size_bytes": 180888,
-      "mtime": "2026-07-30T10:58:12.451Z",
+      "mtime": "2026-07-30T15:02:43.248Z",
       "shape": "object",
       "keys": [
         "rows",
@@ -29705,7 +29735,7 @@
       "path": "jurisdiction-briefs/_verified/0803620.json",
       "kind": "json",
       "size_bytes": 20809,
-      "mtime": "2026-07-30T10:58:12.451Z",
+      "mtime": "2026-07-30T15:02:43.248Z",
       "shape": "object",
       "keys": [
         "brief_geoid",
@@ -29734,7 +29764,7 @@
       "path": "jurisdiction-briefs/_verified/08045.json",
       "kind": "json",
       "size_bytes": 13540,
-      "mtime": "2026-07-30T10:58:12.451Z",
+      "mtime": "2026-07-30T15:02:43.248Z",
       "shape": "object",
       "keys": [
         "brief_geoid",
@@ -29762,7 +29792,7 @@
       "path": "jurisdiction-briefs/_verified/08097.json",
       "kind": "json",
       "size_bytes": 21456,
-      "mtime": "2026-07-30T10:58:12.451Z",
+      "mtime": "2026-07-30T15:02:43.248Z",
       "shape": "object",
       "keys": [
         "brief_geoid",
@@ -29791,7 +29821,7 @@
       "path": "jurisdiction-briefs/_verified/0812045.json",
       "kind": "json",
       "size_bytes": 14366,
-      "mtime": "2026-07-30T10:58:12.451Z",
+      "mtime": "2026-07-30T15:02:43.248Z",
       "shape": "object",
       "keys": [
         "brief_geoid",
@@ -29818,7 +29848,7 @@
       "path": "jurisdiction-briefs/_verified/0816000.json",
       "kind": "json",
       "size_bytes": 14419,
-      "mtime": "2026-07-30T10:58:12.451Z",
+      "mtime": "2026-07-30T15:02:43.249Z",
       "shape": "object",
       "keys": [
         "brief_geoid",
@@ -29845,8 +29875,8 @@
     {
       "path": "jurisdiction-briefs/_verified/0817375.json",
       "kind": "json",
-      "size_bytes": 13975,
-      "mtime": "2026-07-30T10:58:12.451Z",
+      "size_bytes": 14257,
+      "mtime": "2026-07-30T15:02:43.249Z",
       "shape": "object",
       "keys": [
         "brief_geoid",
@@ -29875,7 +29905,7 @@
       "path": "jurisdiction-briefs/_verified/0820000.json",
       "kind": "json",
       "size_bytes": 20297,
-      "mtime": "2026-07-30T10:58:12.451Z",
+      "mtime": "2026-07-30T15:02:43.249Z",
       "shape": "object",
       "keys": [
         "brief_geoid",
@@ -29900,10 +29930,39 @@
       ]
     },
     {
+      "path": "jurisdiction-briefs/_verified/0822035.json",
+      "kind": "json",
+      "size_bytes": 6809,
+      "mtime": "2026-07-30T15:02:43.914Z",
+      "shape": "object",
+      "keys": [
+        "brief_geoid",
+        "brief_jurisdiction",
+        "audited_at",
+        "audit_method",
+        "rows",
+        "dropped_rows",
+        "summary",
+        "strip_summary"
+      ],
+      "key_count": 8,
+      "primary_array_key": "rows",
+      "primary_array_length": 9,
+      "primary_array_first_keys": [
+        "section_id",
+        "paragraph_index",
+        "source_id",
+        "source_url",
+        "verdict",
+        "supporting_quote",
+        "notes"
+      ]
+    },
+    {
       "path": "jurisdiction-briefs/_verified/0827425.json",
       "kind": "json",
       "size_bytes": 20637,
-      "mtime": "2026-07-30T10:58:12.452Z",
+      "mtime": "2026-07-30T15:02:43.249Z",
       "shape": "object",
       "keys": [
         "brief_geoid",
@@ -29931,7 +29990,7 @@
       "path": "jurisdiction-briefs/_verified/0828745.json",
       "kind": "json",
       "size_bytes": 3792,
-      "mtime": "2026-07-30T10:58:12.452Z",
+      "mtime": "2026-07-30T15:02:43.249Z",
       "shape": "object",
       "keys": [
         "brief_geoid",
@@ -29957,7 +30016,7 @@
       "path": "jurisdiction-briefs/_verified/0830780.json",
       "kind": "json",
       "size_bytes": 20453,
-      "mtime": "2026-07-30T10:58:12.452Z",
+      "mtime": "2026-07-30T15:02:43.249Z",
       "shape": "object",
       "keys": [
         "brief_geoid",
@@ -29985,7 +30044,7 @@
       "path": "jurisdiction-briefs/_verified/0864255.json",
       "kind": "json",
       "size_bytes": 13422,
-      "mtime": "2026-07-30T10:58:12.452Z",
+      "mtime": "2026-07-30T15:02:43.249Z",
       "shape": "object",
       "keys": [
         "brief_geoid",
@@ -30013,7 +30072,7 @@
       "path": "jurisdiction-briefs/_verified/0867280.json",
       "kind": "json",
       "size_bytes": 16942,
-      "mtime": "2026-07-30T10:58:12.452Z",
+      "mtime": "2026-07-30T15:02:43.249Z",
       "shape": "object",
       "keys": [
         "brief_geoid",
@@ -30041,7 +30100,7 @@
       "path": "jurisdiction-briefs/_verified/0870195.json",
       "kind": "json",
       "size_bytes": 18763,
-      "mtime": "2026-07-30T10:58:12.452Z",
+      "mtime": "2026-07-30T15:02:43.249Z",
       "shape": "object",
       "keys": [
         "brief_geoid",
@@ -30067,7 +30126,7 @@
       "path": "kalshi/prediction-market.json",
       "kind": "json",
       "size_bytes": 2716,
-      "mtime": "2026-07-30T10:58:12.453Z",
+      "mtime": "2026-07-30T15:02:43.250Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -30090,7 +30149,7 @@
       "path": "lihtc-trends-by-county.json",
       "kind": "json",
       "size_bytes": 14265,
-      "mtime": "2026-07-30T10:58:12.453Z",
+      "mtime": "2026-07-30T15:02:43.250Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -30110,7 +30169,7 @@
       "path": "manifest.json",
       "kind": "json",
       "size_bytes": 202407,
-      "mtime": "2026-07-30T10:58:12.453Z",
+      "mtime": "2026-07-30T15:02:43.250Z",
       "shape": "object",
       "keys": [
         "generated",
@@ -30125,7 +30184,7 @@
       "path": "market/acs_median_rent_co.json",
       "kind": "json",
       "size_bytes": 84901,
-      "mtime": "2026-07-30T10:58:12.453Z",
+      "mtime": "2026-07-30T15:02:43.250Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30141,7 +30200,7 @@
       "path": "market/acs_tract_metrics_co.json",
       "kind": "json",
       "size_bytes": 1346881,
-      "mtime": "2026-07-30T10:58:12.455Z",
+      "mtime": "2026-07-30T15:02:43.252Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30169,7 +30228,7 @@
       "path": "market/apartment_list_co.json",
       "kind": "json",
       "size_bytes": 5646,
-      "mtime": "2026-07-30T10:58:12.456Z",
+      "mtime": "2026-07-30T15:02:43.252Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30185,7 +30244,7 @@
       "path": "market/bridge_co_market_summary.json",
       "kind": "json",
       "size_bytes": 253,
-      "mtime": "2026-07-30T10:58:12.456Z",
+      "mtime": "2026-07-30T15:02:43.252Z",
       "shape": "object",
       "keys": [
         "_note",
@@ -30201,7 +30260,7 @@
       "path": "market/cde_schools_co.json",
       "kind": "json",
       "size_bytes": 10620,
-      "mtime": "2026-07-30T10:58:12.456Z",
+      "mtime": "2026-07-30T15:02:43.253Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30229,7 +30288,7 @@
       "path": "market/cdle_job_postings_co.json",
       "kind": "json",
       "size_bytes": 23720,
-      "mtime": "2026-07-30T10:58:12.456Z",
+      "mtime": "2026-07-30T15:02:43.253Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30254,7 +30313,7 @@
       "path": "market/cdot_traffic_co.json",
       "kind": "json",
       "size_bytes": 8388,
-      "mtime": "2026-07-30T10:58:12.457Z",
+      "mtime": "2026-07-30T15:02:43.253Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30280,7 +30339,7 @@
       "path": "market/cdphe_county_boundaries_co.geojson",
       "kind": "geojson",
       "size_bytes": 5999267,
-      "mtime": "2026-07-30T10:58:12.469Z",
+      "mtime": "2026-07-30T15:02:43.264Z",
       "shape": "geojson",
       "feature_count": 64,
       "property_keys": [
@@ -30302,7 +30361,7 @@
       "path": "market/chas_co.json",
       "kind": "json",
       "size_bytes": 162848,
-      "mtime": "2026-07-30T10:58:12.469Z",
+      "mtime": "2026-07-30T15:02:43.265Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30323,7 +30382,7 @@
       "path": "market/chas_tract_co.json",
       "kind": "json",
       "size_bytes": 3597503,
-      "mtime": "2026-07-30T10:58:12.473Z",
+      "mtime": "2026-07-30T15:02:43.273Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30344,7 +30403,7 @@
       "path": "market/chfa_programs_co.json",
       "kind": "json",
       "size_bytes": 3918,
-      "mtime": "2026-07-30T10:58:12.475Z",
+      "mtime": "2026-07-30T15:02:43.273Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30372,7 +30431,7 @@
       "path": "market/childcare_co.geojson",
       "kind": "geojson",
       "size_bytes": 1944792,
-      "mtime": "2026-07-30T10:58:12.477Z",
+      "mtime": "2026-07-30T15:02:43.277Z",
       "shape": "geojson",
       "feature_count": 2860,
       "property_keys": [
@@ -30397,7 +30456,7 @@
       "path": "market/climate_hazards_co.json",
       "kind": "json",
       "size_bytes": 2648,
-      "mtime": "2026-07-30T10:58:12.478Z",
+      "mtime": "2026-07-30T15:02:43.277Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30414,7 +30473,7 @@
       "path": "market/co-adaptive-reuse-references.json",
       "kind": "json",
       "size_bytes": 13961,
-      "mtime": "2026-07-30T10:58:12.478Z",
+      "mtime": "2026-07-30T15:02:43.277Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30431,7 +30490,7 @@
       "path": "market/co-urban-renewal-authorities.json",
       "kind": "json",
       "size_bytes": 12214,
-      "mtime": "2026-07-30T10:58:12.478Z",
+      "mtime": "2026-07-30T15:02:43.277Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30457,7 +30516,7 @@
       "path": "market/colorado-equity-pricing-factors.json",
       "kind": "json",
       "size_bytes": 5360,
-      "mtime": "2026-07-30T10:58:12.478Z",
+      "mtime": "2026-07-30T15:02:43.277Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -30473,7 +30532,7 @@
       "path": "market/colorado-foreclosure-performance.json",
       "kind": "json",
       "size_bytes": 49077,
-      "mtime": "2026-07-30T10:58:12.478Z",
+      "mtime": "2026-07-30T15:02:43.277Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -30490,7 +30549,7 @@
       "path": "market/commuting_co.geojson",
       "kind": "geojson",
       "size_bytes": 582520,
-      "mtime": "2026-07-30T10:58:12.478Z",
+      "mtime": "2026-07-30T15:02:43.278Z",
       "shape": "geojson",
       "feature_count": 1447,
       "property_keys": [
@@ -30508,7 +30567,7 @@
       "path": "market/data_quality_report.json",
       "kind": "json",
       "size_bytes": 10836,
-      "mtime": "2026-07-30T10:58:12.479Z",
+      "mtime": "2026-07-30T15:02:43.279Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30537,7 +30596,7 @@
       "path": "market/developable_land_context_co.json",
       "kind": "json",
       "size_bytes": 1434048,
-      "mtime": "2026-07-30T10:58:12.481Z",
+      "mtime": "2026-07-30T15:02:43.280Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30552,7 +30611,7 @@
       "path": "market/dola_demographics_co.json",
       "kind": "json",
       "size_bytes": 24844,
-      "mtime": "2026-07-30T10:58:12.481Z",
+      "mtime": "2026-07-30T15:02:43.280Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30567,7 +30626,7 @@
       "path": "market/dola_rent_survey_co.json",
       "kind": "json",
       "size_bytes": 730,
-      "mtime": "2026-07-30T10:58:12.481Z",
+      "mtime": "2026-07-30T15:02:43.280Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30583,7 +30642,7 @@
       "path": "market/employment_centers_co.geojson",
       "kind": "geojson",
       "size_bytes": 774302,
-      "mtime": "2026-07-30T10:58:12.482Z",
+      "mtime": "2026-07-30T15:02:43.283Z",
       "shape": "geojson",
       "feature_count": 1447,
       "property_keys": [
@@ -30605,7 +30664,7 @@
       "path": "market/environmental_constraints_co.geojson",
       "kind": "geojson",
       "size_bytes": 511275,
-      "mtime": "2026-07-30T10:58:12.482Z",
+      "mtime": "2026-07-30T15:02:43.284Z",
       "shape": "geojson",
       "feature_count": 1070,
       "property_keys": [
@@ -30625,7 +30684,7 @@
       "path": "market/epa_sld_co.json",
       "kind": "json",
       "size_bytes": 733069,
-      "mtime": "2026-07-30T10:58:12.484Z",
+      "mtime": "2026-07-30T15:02:43.285Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30640,7 +30699,7 @@
       "path": "market/fhfa_hpi_subcounty_co.json",
       "kind": "json",
       "size_bytes": 526405,
-      "mtime": "2026-07-30T10:58:12.485Z",
+      "mtime": "2026-07-30T15:02:43.286Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30657,14 +30716,14 @@
       "path": "market/flood_zones_co.geojson",
       "kind": "geojson",
       "size_bytes": 28563340,
-      "mtime": "2026-07-30T10:58:12.517Z",
+      "mtime": "2026-07-30T15:02:43.309Z",
       "note": "too-large-to-parse"
     },
     {
       "path": "market/flood_zones_co.json",
       "kind": "json",
       "size_bytes": 619727,
-      "mtime": "2026-07-30T10:58:12.517Z",
+      "mtime": "2026-07-30T15:02:43.309Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30679,7 +30738,7 @@
       "path": "market/fmr_co.json",
       "kind": "json",
       "size_bytes": 22697,
-      "mtime": "2026-07-30T10:58:12.518Z",
+      "mtime": "2026-07-30T15:02:43.309Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30694,7 +30753,7 @@
       "path": "market/fmr_tract_map_co.json",
       "kind": "json",
       "size_bytes": 103596,
-      "mtime": "2026-07-30T10:58:12.519Z",
+      "mtime": "2026-07-30T15:02:43.309Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30709,7 +30768,7 @@
       "path": "market/food_access_co.json",
       "kind": "json",
       "size_bytes": 442053,
-      "mtime": "2026-07-30T10:58:12.520Z",
+      "mtime": "2026-07-30T15:02:43.310Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30724,7 +30783,7 @@
       "path": "market/freddie-mac-multifamily-outlook.json",
       "kind": "json",
       "size_bytes": 3657,
-      "mtime": "2026-07-30T10:58:12.520Z",
+      "mtime": "2026-07-30T15:02:43.310Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30742,7 +30801,7 @@
       "path": "market/hospitals_co.geojson",
       "kind": "geojson",
       "size_bytes": 76214,
-      "mtime": "2026-07-30T10:58:12.520Z",
+      "mtime": "2026-07-30T15:02:43.310Z",
       "shape": "geojson",
       "feature_count": 121,
       "property_keys": [
@@ -30767,7 +30826,7 @@
       "path": "market/housing_policy_jurisdictions_co.geojson",
       "kind": "geojson",
       "size_bytes": 1223927,
-      "mtime": "2026-07-30T10:58:12.521Z",
+      "mtime": "2026-07-30T15:02:43.311Z",
       "shape": "geojson",
       "feature_count": 336,
       "property_keys": [
@@ -30790,7 +30849,7 @@
       "path": "market/hud_egis_co.geojson",
       "kind": "geojson",
       "size_bytes": 56257,
-      "mtime": "2026-07-30T10:58:12.521Z",
+      "mtime": "2026-07-30T15:02:43.311Z",
       "shape": "geojson",
       "feature_count": 53,
       "property_keys": [
@@ -30815,7 +30874,7 @@
       "path": "market/hud_lihtc_co.geojson",
       "kind": "geojson",
       "size_bytes": 1529920,
-      "mtime": "2026-07-30T10:58:12.524Z",
+      "mtime": "2026-07-30T15:02:43.314Z",
       "shape": "geojson",
       "feature_count": 926,
       "property_keys": [
@@ -30840,7 +30899,7 @@
       "path": "market/hud_zip_tract_crosswalk_co.json",
       "kind": "json",
       "size_bytes": 793484,
-      "mtime": "2026-07-30T10:58:12.526Z",
+      "mtime": "2026-07-30T15:02:43.322Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30864,7 +30923,7 @@
       "path": "market/inclusionary_zoning_co.json",
       "kind": "json",
       "size_bytes": 6912,
-      "mtime": "2026-07-30T10:58:12.527Z",
+      "mtime": "2026-07-30T15:02:43.323Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30891,7 +30950,7 @@
       "path": "market/landuse_zoning_proxy_co.geojson",
       "kind": "geojson",
       "size_bytes": 7185121,
-      "mtime": "2026-07-30T10:58:12.532Z",
+      "mtime": "2026-07-30T15:02:43.328Z",
       "shape": "geojson",
       "feature_count": 28715,
       "property_keys": [
@@ -30910,7 +30969,7 @@
       "path": "market/lihtc-equity-pricing-history.json",
       "kind": "json",
       "size_bytes": 2370,
-      "mtime": "2026-07-30T10:58:12.533Z",
+      "mtime": "2026-07-30T15:02:43.328Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30929,7 +30988,7 @@
       "path": "market/lodes_co.json",
       "kind": "json",
       "size_bytes": 678458,
-      "mtime": "2026-07-30T10:58:12.534Z",
+      "mtime": "2026-07-30T15:02:43.329Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30957,7 +31016,7 @@
       "path": "market/lodes_od_arcs_co.geojson",
       "kind": "geojson",
       "size_bytes": 127193,
-      "mtime": "2026-07-30T10:58:12.537Z",
+      "mtime": "2026-07-30T15:02:43.329Z",
       "shape": "geojson",
       "feature_count": 500,
       "property_keys": [
@@ -30975,7 +31034,7 @@
       "path": "market/lodes_tract_od_co.json",
       "kind": "json",
       "size_bytes": 14776234,
-      "mtime": "2026-07-30T10:58:12.560Z",
+      "mtime": "2026-07-30T15:02:43.351Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -30994,14 +31053,14 @@
       "path": "market/natural_barriers_co.geojson",
       "kind": "geojson",
       "size_bytes": 29087494,
-      "mtime": "2026-07-30T10:58:12.609Z",
+      "mtime": "2026-07-30T15:02:43.387Z",
       "note": "too-large-to-parse"
     },
     {
       "path": "market/nhpd_co.geojson",
       "kind": "geojson",
       "size_bytes": 12489,
-      "mtime": "2026-07-30T10:58:12.609Z",
+      "mtime": "2026-07-30T15:02:43.388Z",
       "shape": "geojson",
       "feature_count": 20,
       "property_keys": [
@@ -31026,7 +31085,7 @@
       "path": "market/novogradac-equity-pricing.json",
       "kind": "json",
       "size_bytes": 5307,
-      "mtime": "2026-07-30T10:58:12.609Z",
+      "mtime": "2026-07-30T15:02:43.388Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31043,7 +31102,7 @@
       "path": "market/opportunity_insights_co.json",
       "kind": "json",
       "size_bytes": 167238,
-      "mtime": "2026-07-30T10:58:12.610Z",
+      "mtime": "2026-07-30T15:02:43.388Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31058,7 +31117,7 @@
       "path": "market/opportunity_zones_co.geojson",
       "kind": "geojson",
       "size_bytes": 10606819,
-      "mtime": "2026-07-30T10:58:12.630Z",
+      "mtime": "2026-07-30T15:02:43.411Z",
       "shape": "geojson",
       "feature_count": 126,
       "property_keys": [
@@ -31076,7 +31135,7 @@
       "path": "market/parcel_aggregates_co.json",
       "kind": "json",
       "size_bytes": 2888,
-      "mtime": "2026-07-30T10:58:12.632Z",
+      "mtime": "2026-07-30T15:02:43.413Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31101,7 +31160,7 @@
       "path": "market/pma_tract_display_geometry.geojson",
       "kind": "geojson",
       "size_bytes": 1078508,
-      "mtime": "2026-07-30T10:58:12.633Z",
+      "mtime": "2026-07-30T15:02:43.414Z",
       "shape": "geojson",
       "feature_count": 1447,
       "property_keys": [
@@ -31116,7 +31175,7 @@
       "path": "market/qct_dda_designations_co.json",
       "kind": "json",
       "size_bytes": 480,
-      "mtime": "2026-07-30T10:58:12.634Z",
+      "mtime": "2026-07-30T15:02:43.414Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31131,7 +31190,7 @@
       "path": "market/qct_dda_designations_co_normalized.json",
       "kind": "json",
       "size_bytes": 698,
-      "mtime": "2026-07-30T10:58:12.634Z",
+      "mtime": "2026-07-30T15:02:43.414Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31147,7 +31206,7 @@
       "path": "market/redfin_place_market_tracker_co.json",
       "kind": "json",
       "size_bytes": 1568714,
-      "mtime": "2026-07-30T10:58:12.635Z",
+      "mtime": "2026-07-30T15:02:43.415Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31162,7 +31221,7 @@
       "path": "market/reference-projects.json",
       "kind": "json",
       "size_bytes": 25321,
-      "mtime": "2026-07-30T10:58:12.635Z",
+      "mtime": "2026-07-30T15:02:43.415Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31190,7 +31249,7 @@
       "path": "market/schools_co.geojson",
       "kind": "geojson",
       "size_bytes": 1243277,
-      "mtime": "2026-07-30T10:58:12.638Z",
+      "mtime": "2026-07-30T15:02:43.419Z",
       "shape": "geojson",
       "feature_count": 1941,
       "property_keys": [
@@ -31214,7 +31273,7 @@
       "path": "market/state-trend-analysis.json",
       "kind": "json",
       "size_bytes": 6995,
-      "mtime": "2026-07-30T10:58:12.638Z",
+      "mtime": "2026-07-30T15:02:43.419Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31229,7 +31288,7 @@
       "path": "market/tax-credit-transfer-pricing.json",
       "kind": "json",
       "size_bytes": 3439,
-      "mtime": "2026-07-30T10:58:12.638Z",
+      "mtime": "2026-07-30T15:02:43.419Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -31258,7 +31317,7 @@
       "path": "market/tract_boundaries_co.geojson",
       "kind": "geojson",
       "size_bytes": 17250210,
-      "mtime": "2026-07-30T10:58:12.674Z",
+      "mtime": "2026-07-30T15:02:43.443Z",
       "shape": "geojson",
       "feature_count": 1447,
       "property_keys": [
@@ -31279,7 +31338,7 @@
       "path": "market/tract_centroids_co.json",
       "kind": "json",
       "size_bytes": 353190,
-      "mtime": "2026-07-30T10:58:12.681Z",
+      "mtime": "2026-07-30T15:02:43.465Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31304,14 +31363,14 @@
       "path": "market/transit_routes_co.geojson",
       "kind": "geojson",
       "size_bytes": 47360222,
-      "mtime": "2026-07-30T10:58:12.750Z",
+      "mtime": "2026-07-30T15:02:43.567Z",
       "note": "too-large-to-parse"
     },
     {
       "path": "market/travel_time_matrix_co.json",
       "kind": "json",
       "size_bytes": 4435192,
-      "mtime": "2026-07-30T10:58:12.762Z",
+      "mtime": "2026-07-30T15:02:43.579Z",
       "shape": "object",
       "keys": [
         "hubs",
@@ -31327,7 +31386,7 @@
       "path": "market/utility_capacity_co.geojson",
       "kind": "geojson",
       "size_bytes": 182611,
-      "mtime": "2026-07-30T10:58:12.763Z",
+      "mtime": "2026-07-30T15:02:43.580Z",
       "shape": "geojson",
       "feature_count": 351,
       "property_keys": [
@@ -31347,7 +31406,7 @@
       "path": "market/walkability_co.geojson",
       "kind": "geojson",
       "size_bytes": 368283,
-      "mtime": "2026-07-30T10:58:12.763Z",
+      "mtime": "2026-07-30T15:02:43.582Z",
       "shape": "geojson",
       "feature_count": 1070,
       "property_keys": [
@@ -31363,7 +31422,7 @@
       "path": "market/walkability_scores_co.json",
       "kind": "json",
       "size_bytes": 346242,
-      "mtime": "2026-07-30T10:58:12.764Z",
+      "mtime": "2026-07-30T15:02:43.583Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31388,7 +31447,7 @@
       "path": "market/yardi-matrix-national-multifamily.json",
       "kind": "json",
       "size_bytes": 3877,
-      "mtime": "2026-07-30T10:58:12.765Z",
+      "mtime": "2026-07-30T15:02:43.583Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31405,7 +31464,7 @@
       "path": "market/zillow_co_metros.json",
       "kind": "json",
       "size_bytes": 107987,
-      "mtime": "2026-07-30T10:58:12.765Z",
+      "mtime": "2026-07-30T15:02:43.583Z",
       "shape": "object",
       "keys": [
         "median_list_price_metro",
@@ -31434,7 +31493,7 @@
       "path": "market/zoning_compat_index_co.json",
       "kind": "json",
       "size_bytes": 3208,
-      "mtime": "2026-07-30T10:58:12.765Z",
+      "mtime": "2026-07-30T15:02:43.583Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31460,7 +31519,7 @@
       "path": "market/zori_rents_co.json",
       "kind": "json",
       "size_bytes": 24712,
-      "mtime": "2026-07-30T10:58:12.765Z",
+      "mtime": "2026-07-30T15:02:43.584Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31477,7 +31536,7 @@
       "path": "metadata/rent_burden_sources.json",
       "kind": "json",
       "size_bytes": 8527,
-      "mtime": "2026-07-30T10:58:12.766Z",
+      "mtime": "2026-07-30T15:02:43.584Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31507,7 +31566,7 @@
       "path": "multifamily-inventory-co.json",
       "kind": "json",
       "size_bytes": 92896,
-      "mtime": "2026-07-30T10:58:12.767Z",
+      "mtime": "2026-07-30T15:02:43.584Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31524,7 +31583,7 @@
       "path": "pipeline/content.json",
       "kind": "json",
       "size_bytes": 34942,
-      "mtime": "2026-07-30T10:58:12.768Z",
+      "mtime": "2026-07-30T15:02:43.584Z",
       "shape": "object",
       "keys": [
         "_meta",
@@ -31557,7 +31616,7 @@
       "path": "policy/chfa-awards-historical.json",
       "kind": "json",
       "size_bytes": 10935,
-      "mtime": "2026-07-30T10:58:12.769Z",
+      "mtime": "2026-07-30T15:02:43.586Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31585,7 +31644,7 @@
       "path": "policy/chfa-watchlist.json",
       "kind": "json",
       "size_bytes": 9777,
-      "mtime": "2026-07-30T10:58:12.769Z",
+      "mtime": "2026-07-30T15:02:43.586Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31613,7 +31672,7 @@
       "path": "policy/county-ownership.json",
       "kind": "json",
       "size_bytes": 6253,
-      "mtime": "2026-07-30T10:58:12.769Z",
+      "mtime": "2026-07-30T15:02:43.586Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31628,7 +31687,7 @@
       "path": "policy/developer-ownership-funding.json",
       "kind": "json",
       "size_bytes": 4576,
-      "mtime": "2026-07-30T10:58:12.769Z",
+      "mtime": "2026-07-30T15:02:43.586Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -31657,7 +31716,7 @@
       "path": "policy/homeownership-programs.json",
       "kind": "json",
       "size_bytes": 16701,
-      "mtime": "2026-07-30T10:58:12.769Z",
+      "mtime": "2026-07-30T15:02:43.586Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -31686,7 +31745,7 @@
       "path": "policy/housing-policy-scorecard.json",
       "kind": "json",
       "size_bytes": 183420,
-      "mtime": "2026-07-30T10:58:12.770Z",
+      "mtime": "2026-07-30T15:02:43.587Z",
       "shape": "object",
       "keys": [
         "metadata",
@@ -31705,7 +31764,7 @@
       "path": "policy/jchs-state-of-nations-housing.json",
       "kind": "json",
       "size_bytes": 3713,
-      "mtime": "2026-07-30T10:58:12.770Z",
+      "mtime": "2026-07-30T15:02:43.587Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31722,7 +31781,7 @@
       "path": "policy/jurisdiction-housing-progress.json",
       "kind": "json",
       "size_bytes": 35179,
-      "mtime": "2026-07-30T10:58:12.770Z",
+      "mtime": "2026-07-30T15:02:43.587Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31737,7 +31796,7 @@
       "path": "policy/lihtc-assumptions.json",
       "kind": "json",
       "size_bytes": 3881,
-      "mtime": "2026-07-30T10:58:12.770Z",
+      "mtime": "2026-07-30T15:02:43.587Z",
       "shape": "object",
       "keys": [
         "version",
@@ -31764,7 +31823,7 @@
       "path": "policy/methodology-version.json",
       "kind": "json",
       "size_bytes": 6455,
-      "mtime": "2026-07-30T10:58:12.770Z",
+      "mtime": "2026-07-30T15:02:43.588Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31779,7 +31838,7 @@
       "path": "policy/pab-allocations.json",
       "kind": "json",
       "size_bytes": 17151,
-      "mtime": "2026-07-30T10:58:12.770Z",
+      "mtime": "2026-07-30T15:02:43.588Z",
       "shape": "object",
       "keys": [
         "metadata",
@@ -31794,7 +31853,7 @@
       "path": "policy/prop123_jurisdictions.json",
       "kind": "json",
       "size_bytes": 72652,
-      "mtime": "2026-07-30T10:58:12.770Z",
+      "mtime": "2026-07-30T15:02:43.588Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -31823,7 +31882,7 @@
       "path": "policy/resale-conventions.json",
       "kind": "json",
       "size_bytes": 3187,
-      "mtime": "2026-07-30T10:58:12.771Z",
+      "mtime": "2026-07-30T15:02:43.589Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -31852,7 +31911,7 @@
       "path": "policy/research-orgs-housing.json",
       "kind": "json",
       "size_bytes": 7859,
-      "mtime": "2026-07-30T10:58:12.771Z",
+      "mtime": "2026-07-30T15:02:43.589Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31876,7 +31935,7 @@
       "path": "policy/soft-funding-status.json",
       "kind": "json",
       "size_bytes": 25351,
-      "mtime": "2026-07-30T10:58:12.771Z",
+      "mtime": "2026-07-30T15:02:43.589Z",
       "shape": "object",
       "keys": [
         "lastUpdated",
@@ -31894,7 +31953,7 @@
       "path": "policy/tax-credit-legislation.json",
       "kind": "json",
       "size_bytes": 11882,
-      "mtime": "2026-07-30T10:58:12.771Z",
+      "mtime": "2026-07-30T15:02:43.589Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -31922,7 +31981,7 @@
       "path": "policy/tool-watch.json",
       "kind": "json",
       "size_bytes": 4840,
-      "mtime": "2026-07-30T10:58:12.772Z",
+      "mtime": "2026-07-30T15:02:43.589Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -31951,7 +32010,7 @@
       "path": "policy_briefs.json",
       "kind": "json",
       "size_bytes": 177074,
-      "mtime": "2026-07-30T10:58:12.772Z",
+      "mtime": "2026-07-30T15:02:43.590Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -31977,7 +32036,7 @@
       "path": "policy_briefs_curated.json",
       "kind": "json",
       "size_bytes": 3781,
-      "mtime": "2026-07-30T10:58:12.772Z",
+      "mtime": "2026-07-30T15:02:43.590Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -32005,7 +32064,7 @@
       "path": "polymarket-data.json",
       "kind": "json",
       "size_bytes": 20092,
-      "mtime": "2026-07-30T10:58:12.772Z",
+      "mtime": "2026-07-30T15:02:43.590Z",
       "shape": "object",
       "keys": [
         "updated",
@@ -32022,7 +32081,7 @@
       "path": "processed/co_county_housing_indicators.geojson",
       "kind": "geojson",
       "size_bytes": 440204,
-      "mtime": "2026-07-30T10:58:12.773Z",
+      "mtime": "2026-07-30T15:02:43.591Z",
       "shape": "geojson",
       "feature_count": 64,
       "property_keys": [
@@ -32047,7 +32106,7 @@
       "path": "processed/rent_burden_crosscheck.json",
       "kind": "json",
       "size_bytes": 665655,
-      "mtime": "2026-07-30T10:58:12.773Z",
+      "mtime": "2026-07-30T15:02:43.592Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -32062,7 +32121,7 @@
       "path": "provenance/deal-calculator.json",
       "kind": "json",
       "size_bytes": 3108,
-      "mtime": "2026-07-30T10:58:12.773Z",
+      "mtime": "2026-07-30T15:02:43.592Z",
       "shape": "object",
       "keys": [
         "_comment",
@@ -32085,7 +32144,7 @@
       "path": "provenance/hna-scenario-builder.json",
       "kind": "json",
       "size_bytes": 3271,
-      "mtime": "2026-07-30T10:58:12.774Z",
+      "mtime": "2026-07-30T15:02:43.592Z",
       "shape": "object",
       "keys": [
         "_comment",
@@ -32111,7 +32170,7 @@
       "path": "provenance/housing-needs-assessment.json",
       "kind": "json",
       "size_bytes": 5898,
-      "mtime": "2026-07-30T10:58:12.774Z",
+      "mtime": "2026-07-30T15:02:43.592Z",
       "shape": "object",
       "keys": [
         "_comment",
@@ -32134,7 +32193,7 @@
       "path": "provenance/market-analysis.json",
       "kind": "json",
       "size_bytes": 2314,
-      "mtime": "2026-07-30T10:58:12.774Z",
+      "mtime": "2026-07-30T15:02:43.592Z",
       "shape": "object",
       "keys": [
         "_comment",
@@ -32157,7 +32216,7 @@
       "path": "qct-colorado.json",
       "kind": "json",
       "size_bytes": 446692,
-      "mtime": "2026-07-30T10:58:12.774Z",
+      "mtime": "2026-07-30T15:02:43.593Z",
       "shape": "object",
       "keys": [
         "type",
@@ -32179,7 +32238,7 @@
       "path": "reports/a11y-baseline.json",
       "kind": "json",
       "size_bytes": 2670,
-      "mtime": "2026-07-30T10:58:12.775Z",
+      "mtime": "2026-07-30T15:02:43.594Z",
       "shape": "object",
       "keys": [
         "generatedAt",
@@ -32201,7 +32260,7 @@
       "path": "reports/data-source-health.json",
       "kind": "json",
       "size_bytes": 7833,
-      "mtime": "2026-07-30T10:58:12.775Z",
+      "mtime": "2026-07-30T15:02:43.594Z",
       "shape": "object",
       "keys": [
         "generated_at",
@@ -32231,7 +32290,7 @@
       "path": "reports/developer-url-health.json",
       "kind": "json",
       "size_bytes": 22258,
-      "mtime": "2026-07-30T10:58:12.775Z",
+      "mtime": "2026-07-30T15:02:43.595Z",
       "shape": "object",
       "keys": [
         "meta",
@@ -32252,7 +32311,7 @@
       "path": "reports/repo-link-audit.json",
       "kind": "json",
       "size_bytes": 2051613,
-      "mtime": "2026-07-30T10:58:12.779Z",
+      "mtime": "2026-07-30T15:02:43.597Z",
       "shape": "object",
       "keys": [
         "generatedAt",
@@ -32274,7 +32333,7 @@
       "path": "resort-workforce-housing-programs.json",
       "kind": "json",
       "size_bytes": 12810,
-      "mtime": "2026-07-30T10:58:12.779Z",
+      "mtime": "2026-07-30T15:02:43.597Z",
       "shape": "object",
       "keys": [
         "metadata",
@@ -32301,7 +32360,7 @@
       "path": "schema/semantic-label-evidence.json",
       "kind": "json",
       "size_bytes": 6123,
-      "mtime": "2026-07-30T10:58:12.779Z",
+      "mtime": "2026-07-30T15:02:43.597Z",
       "shape": "object",
       "keys": [
         "schema",
@@ -32324,7 +32383,7 @@
       "path": "source-registry.json",
       "kind": "json",
       "size_bytes": 6362,
-      "mtime": "2026-07-30T10:58:12.780Z",
+      "mtime": "2026-07-30T15:02:43.597Z",
       "shape": "object",
       "keys": [
         "generated_at",
@@ -32348,7 +32407,7 @@
       "path": "states-10m.json",
       "kind": "json",
       "size_bytes": 114554,
-      "mtime": "2026-07-30T10:58:12.780Z",
+      "mtime": "2026-07-30T15:02:43.598Z",
       "shape": "object",
       "keys": [
         "type",
@@ -32376,7 +32435,7 @@
       "path": "tax-abatement-inventory.json",
       "kind": "json",
       "size_bytes": 21723,
-      "mtime": "2026-07-30T10:58:12.780Z",
+      "mtime": "2026-07-30T15:02:43.598Z",
       "shape": "object",
       "keys": [
         "metadata",
@@ -32395,7 +32454,7 @@
       "path": "url-health.json",
       "kind": "json",
       "size_bytes": 409452,
-      "mtime": "2026-07-30T10:58:12.781Z",
+      "mtime": "2026-07-30T15:02:43.598Z",
       "shape": "object",
       "keys": [
         "lastSweepAt",

--- a/data/jurisdiction-briefs/0822035.json
+++ b/data/jurisdiction-briefs/0822035.json
@@ -1,0 +1,457 @@
+{
+  "geoid": "0822035",
+  "jurisdiction": "City of Durango",
+  "scope": "place",
+  "containing_county_fips": "08067",
+  "last_curated": "2026-07-30",
+  "curator": "claude-draft",
+  "published": false,
+  "summary": "Draft brief for City of Durango (pending curator review). Durango's verified affordable-housing record is anchored by Espero Apartments — a 40-unit permanent supportive-housing development — the City's Innovative Housing Solutions Division and Fair Share fee-offset policy, the 2024 La Plata County lodgers-tax reallocation to workforce housing, and regional capacity through the Regional Housing Alliance of La Plata County and Housing Solutions for the Southwest.",
+  "sections": [
+    {
+      "id": "espero-supportive-housing",
+      "heading": "Espero Apartments",
+      "paragraphs": [
+        {
+          "text": "Espero Apartments, at 1051 Avenida del Sol, is the region's first permanent supportive-housing development, built for individuals and families who have experienced homelessness and live with a disabling condition. All 40 one-bedroom units opened in the fall of 2021, with the first residents moving in during late October 2021.",
+          "cites": [
+            "s-espero-sw",
+            "s-espero-chfa"
+          ]
+        },
+        {
+          "text": "The project was developed by Housing Solutions for the Southwest in partnership with BlueLine Development, financed with federal 9% Low-Income Housing Tax Credits awarded by CHFA plus a Colorado Division of Housing grant, and built on a low-cost, long-term land lease from the City of Durango on the city's downtown social-services campus. Its total development cost was $10,052,873, and AXIS Health System and Manna Soup Kitchen provide services on site.",
+          "cites": [
+            "s-espero-chfa",
+            "s-espero-sw"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "city-housing-policy",
+      "heading": "City housing policy & funding",
+      "paragraphs": [
+        {
+          "text": "The City of Durango's Innovative Housing Solutions Division directs, plans, and coordinates the city's housing program across seven strategic areas: new development, housing preservation, adaptive reuse, policy and code reform, housing programs, land acquisition, and funding sources.",
+          "cites": [
+            "s-durango-ihsd"
+          ]
+        },
+        {
+          "text": "The city's Affordable Housing Fee Offset program, which mirrors its Fair Share Ordinance, waives development fees of up to $15,000 per income-restricted unit in rental developments and up to $18,000 per income-restricted unit in for-sale developments. The division also participates in the Pre-Development Catalyst Fund, a public-private partnership that seeds below-market housing development in the region.",
+          "cites": [
+            "s-durango-ihsd"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "county-lodgers-tax",
+      "heading": "County lodgers-tax reallocation for housing",
+      "paragraphs": [
+        {
+          "text": "In November 2024, La Plata County voters approved Ballot Issue 1A by roughly 69% to 31%, authorizing the county to redirect up to 70% of its lodgers-tax revenue — an estimated $700,000 a year — away from tourism marketing and toward workforce housing and child care.",
+          "cites": [
+            "s-lodgers-herald"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "regional-housing-authority",
+      "heading": "Housing authority & regional context",
+      "paragraphs": [
+        {
+          "text": "The Regional Housing Alliance of La Plata County is a multi-jurisdictional regional housing authority created in 2004 by an intergovernmental agreement among La Plata County, the City of Durango, the Town of Ignacio, and the Town of Bayfield. It is governed by a nine-member board — two representatives from each party plus one at-large member — and its mission is to support the preservation, rehabilitation, and development of affordable and attainable workforce housing across the region.",
+          "cites": [
+            "s-rha"
+          ]
+        },
+        {
+          "text": "Housing Solutions for the Southwest is a nonprofit affordable-housing organization that has served Archuleta, Dolores, La Plata, Montezuma, and San Juan counties since 1981. It creates new construction of affordable housing for seniors, families, and people with disabilities, including rental apartments and single-family homes.",
+          "cites": [
+            "s-sw-solutions"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "metric-digest",
+      "heading": "Metric Digest",
+      "paragraphs": [
+        {
+          "text": "The housing-needs digest ranks the City of Durango #60 statewide with an overall housing-need score of 74.4. It counts a shortfall of 754 units affordable at or below 30% AMI — equal to 60.8% of the 1,240 lowest-income households — and finds 53.3% of renter households cost-burdened, with 1.5% of occupied units overcrowded.",
+          "cites": [
+            "d-rank",
+            "d-score",
+            "d-gap",
+            "d-gaprate",
+            "d-lowinc",
+            "d-burden",
+            "d-overcrowd"
+          ]
+        },
+        {
+          "text": "On the market side, the digest reports a ZHVI home-value estimate of $758,990 and a median gross rent of $1,636. 47% of households rent, and 24.5% of the housing stock is multifamily.",
+          "cites": [
+            "d-zhvi",
+            "d-rent",
+            "d-renters",
+            "d-mf"
+          ]
+        },
+        {
+          "text": "Durango's population is 19,411. LEHD commuting data show 9,551 in-commuters and a 64.6% commute ratio, and the county-context projection points to 713 additional units needed over 20 years, so that projection should be read as county context rather than a place trend.",
+          "cites": [
+            "d-pop",
+            "d-incommute",
+            "d-commuteratio",
+            "d-future"
+          ]
+        },
+        {
+          "text": "Workforce-housing pressure scores 74.7. A worker earning the containing county's estimated wage faces an ownership affordability gap of $130,040 and a rent affordability gap of $10,440. Opportunity and walkability score 63.8 and 42.7. County-context ACS cohorts show median gross rent up 89.4% and median household income up 47.1% from 2009 to 2024, alongside a 39.5% county service-sector employment share; these county-context figures are economic context, not place-level observations.",
+          "cites": [
+            "d-wf",
+            "d-owngap",
+            "d-rentgap",
+            "d-opp",
+            "d-walk",
+            "d-rentchg",
+            "d-incchg",
+            "d-service"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "tenure-strategy-screening",
+      "heading": "Tenure strategy screening",
+      "paragraphs": [
+        {
+          "text": "The Affordable Ownership Need screening module recommends Deep affordability priority for City of Durango. It classifies rental pressure as Very High, ownership pressure as Moderate, and identifies 1,271 moderate-income renter households as the ownership-fit base.",
+          "cites": [
+            "own1",
+            "own2",
+            "own3",
+            "own4"
+          ]
+        },
+        {
+          "text": "The same screening run counts 1,982 renter households and 997 owner households as cost-burdened. This is a screening estimate only; verify local prices, financing assumptions, assistance programs, household size, and local deed-restriction policy before using it for a project decision.",
+          "cites": [
+            "own5",
+            "own6"
+          ]
+        }
+      ]
+    }
+  ],
+  "sources": [
+    {
+      "id": "s-espero-sw",
+      "label": "Espero Apartments — Housing Solutions for the Southwest",
+      "url": "https://swhousingsolutions.com/projects/espero-apartments/",
+      "kind": "primary",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "s-espero-chfa",
+      "label": "Espero Apartments case study — CHFA Colorado Multifamily Affordable Housing Electrification Hub",
+      "url": "https://multifamily-ehub.chfainfo.com/espero-apartments-durango",
+      "kind": "primary",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "s-durango-ihsd",
+      "label": "Innovative Housing Solutions Division — City of Durango",
+      "url": "https://www.durangoco.gov/877/Housing-Innovations",
+      "kind": "primary",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "s-lodgers-herald",
+      "label": "Voters overwhelmingly approve La Plata County lodgers tax reallocation — The Durango Herald",
+      "url": "https://www.durangoherald.com/articles/voters-overwhelmingly-approve-la-plata-county-lodgers-tax-reallocation/",
+      "kind": "press",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "s-rha",
+      "label": "Regional Housing Alliance of La Plata County — official site (La Plata Housing Authority)",
+      "url": "https://laplatahousing.colorado.gov/",
+      "kind": "primary",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "s-sw-solutions",
+      "label": "Housing Solutions for the Southwest — official site",
+      "url": "https://swhousingsolutions.com/",
+      "kind": "primary",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-rank",
+      "label": "Ranking index rank - jurisdiction metrics digest",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "rank",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-score",
+      "label": "Overall housing-need score - jurisdiction metrics digest",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overall_need_score",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-gap",
+      "label": "Deep-affordability housing gap units - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_units",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-gaprate",
+      "label": "Deep-affordability gap rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "housing_gap_rate_lte30",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-lowinc",
+      "label": "Lowest-income households (<=30% AMI) - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "low_income_households_lte30",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-burden",
+      "label": "Renter cost-burden rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_cost_burdened",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-overcrowd",
+      "label": "Occupied-household overcrowding rate - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "overcrowding_rate",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-zhvi",
+      "label": "ZHVI market home-value estimate - jurisdiction metrics digest",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "median_home_value",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-rent",
+      "label": "Median gross rent - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "gross_rent_median",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-renters",
+      "label": "Renter household share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_renters",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-mf",
+      "label": "Multifamily housing-stock share - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "pct_multifamily",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-pop",
+      "label": "Population - jurisdiction metrics digest (ACS 2020-2024 5-year)",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "population",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-incommute",
+      "label": "In-commuters - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "in_commuters",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-commuteratio",
+      "label": "Commute ratio - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "commute_ratio",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-future",
+      "label": "Twenty-year future units needed - jurisdiction metrics digest (DOLA projection cache)",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "future_units_needed_20yr",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-wf",
+      "label": "Workforce housing pressure score - jurisdiction metrics digest",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "workforce_housing_pressure_score",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-owngap",
+      "label": "Ownership wage-affordability gap - jurisdiction metrics digest",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "wage_affordability_ownership_gap_dollars",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-rentgap",
+      "label": "Rent wage-affordability gap - jurisdiction metrics digest",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "wage_affordability_rent_gap_dollars",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-opp",
+      "label": "Opportunity score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "opportunity_score",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-walk",
+      "label": "Walkability score - jurisdiction metrics digest (latest committed opportunity context)",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "walkability_score",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-rentchg",
+      "label": "County rent change, ACS cohort trend - jurisdiction metrics digest (County housing-cost ACS cohorts 2009/2014/2024)",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "county_trend_rent_change_2009_2024_pct",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-incchg",
+      "label": "County income change, ACS cohort trend - jurisdiction metrics digest (County housing-cost ACS cohorts 2009/2014/2024)",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "county_trend_income_change_2009_2024_pct",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "d-service",
+      "label": "County service-sector employment share - jurisdiction metrics digest (LEHD LODES latest committed vintage)",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "county_service_sector_share_pct",
+      "accessed": "2026-07-30"
+    },
+    {
+      "id": "own1",
+      "label": "Affordable Ownership Need recommendation",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "ownership_need_recommendation",
+      "accessed": "2026-07-07"
+    },
+    {
+      "id": "own2",
+      "label": "Affordable Ownership Need rental pressure tier",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "ownership_need_rental_pressure_tier",
+      "accessed": "2026-07-07"
+    },
+    {
+      "id": "own3",
+      "label": "Affordable Ownership Need ownership pressure tier",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "ownership_need_ownership_pressure_tier",
+      "accessed": "2026-07-07"
+    },
+    {
+      "id": "own4",
+      "label": "Affordable Ownership Need moderate-income renter households",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "ownership_need_moderate_income_renter_households",
+      "accessed": "2026-07-07"
+    },
+    {
+      "id": "own5",
+      "label": "Affordable Ownership Need renter cost burdened households",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "ownership_need_renter_cost_burdened",
+      "accessed": "2026-07-07"
+    },
+    {
+      "id": "own6",
+      "label": "Affordable Ownership Need owner cost burdened households",
+      "url": "data/hna/jurisdiction-metrics-digest/0822035.json",
+      "kind": "data",
+      "dataset": "jurisdiction-metrics-digest",
+      "field": "ownership_need_owner_cost_burdened",
+      "accessed": "2026-07-07"
+    }
+  ],
+  "_meta_population_at_draft": 19411
+}

--- a/data/jurisdiction-briefs/_verified/0822035.json
+++ b/data/jurisdiction-briefs/_verified/0822035.json
@@ -1,0 +1,98 @@
+{
+  "brief_geoid": "0822035",
+  "brief_jurisdiction": "City of Durango",
+  "audited_at": "2026-07-30",
+  "audit_method": "direct WebFetch and direct URL fetch, 2026-07-30. Each cited narrative source URL was fetched directly and its article text read; no WebSearch snippets were used to establish verdicts. Two WAF-gated hosts (CHFA multifamily-ehub, laplatahousing.colorado.gov) return 403 to WebFetch/curl and were read by direct browser render of the same URL. All 30 kind:data sources auto-verify against data/hna/jurisdiction-metrics-digest/0822035.json.",
+  "rows": [
+    {
+      "section_id": "espero-supportive-housing",
+      "paragraph_index": 0,
+      "source_id": "s-espero-sw",
+      "source_url": "https://swhousingsolutions.com/projects/espero-apartments/",
+      "verdict": "supported",
+      "supporting_quote": "40 units of Supportive Housing in Durango located on property at 1051 Avenida del Sol … Housing Solutions and BlueLine Development built Espero Apartments, the region's first permanent supportive housing project. Espero opened in the Fall of 2021.",
+      "notes": "Direct browser render of the project page (2026-07-30). 'first residents moved in late October 2021' confirmed by direct WebFetch of the same URL."
+    },
+    {
+      "section_id": "espero-supportive-housing",
+      "paragraph_index": 0,
+      "source_id": "s-espero-chfa",
+      "source_url": "https://multifamily-ehub.chfainfo.com/espero-apartments-durango",
+      "verdict": "supported",
+      "supporting_quote": "All 40 units within the building offer Supportive Housing for individuals and families who have previously experienced homelessness and live with a disabling condition. … Units (#) 40 (all one-bedroom apartments)",
+      "notes": "CHFA case study; direct browser render (WAF blocks curl/WebFetch), 2026-07-30."
+    },
+    {
+      "section_id": "espero-supportive-housing",
+      "paragraph_index": 1,
+      "source_id": "s-espero-chfa",
+      "source_url": "https://multifamily-ehub.chfainfo.com/espero-apartments-durango",
+      "verdict": "supported",
+      "supporting_quote": "BlueLine and Housing Solutions obtained a low-cost, long-term land lease from the City of Durango. The property is situated as part of the city's social services campus, near downtown Durango. … Housing Tax Credit (HTC) Deal Type: Federal 9 percent Housing Tax Credits … Total Development Cost: $10,052,873 (2021)",
+      "notes": "CHFA case study; direct browser render, 2026-07-30."
+    },
+    {
+      "section_id": "espero-supportive-housing",
+      "paragraph_index": 1,
+      "source_id": "s-espero-sw",
+      "source_url": "https://swhousingsolutions.com/projects/espero-apartments/",
+      "verdict": "supported",
+      "supporting_quote": "Housing Solutions for the Southwest is partnering with BlueLine Development to build this project. The capital for this project came through the award of Low-Income Tax Credits from CHFA and grant funding from the Colorado Division of Housing. In addition, AXIS Health System and Manna Soup Kitchen provide services onsite in partnership with the Housing Solutions Team.",
+      "notes": "Direct browser render of the project page, 2026-07-30."
+    },
+    {
+      "section_id": "city-housing-policy",
+      "paragraph_index": 0,
+      "source_id": "s-durango-ihsd",
+      "source_url": "https://www.durangoco.gov/877/Housing-Innovations",
+      "verdict": "supported",
+      "supporting_quote": "The Innovative Housing Solutions Division creates and administers community housing initiatives … Directs, plans, and coordinates the City of Durango's Housing Program … across seven strategic areas: new development, housing preservation, adaptive reuse, policy/code reform, housing programs, land acquisition, and funding sources.",
+      "notes": "Direct WebFetch of the city page, 2026-07-30."
+    },
+    {
+      "section_id": "city-housing-policy",
+      "paragraph_index": 1,
+      "source_id": "s-durango-ihsd",
+      "source_url": "https://www.durangoco.gov/877/Housing-Innovations",
+      "verdict": "supported",
+      "supporting_quote": "Affordable Housing Fee Offset: up to $15,000 per set aside unit(s) constructed in rental development or $18,000 per set aside unit(s) constructed in for-sale developments … mirrors the Fair Share Ordinance for fee refunds and waivers … Pre-Development Catalyst Fund, a public-private partnership to create seed funding to support below-market housing development in La Plata County.",
+      "notes": "Direct WebFetch of the city page, 2026-07-30."
+    },
+    {
+      "section_id": "county-lodgers-tax",
+      "paragraph_index": 0,
+      "source_id": "s-lodgers-herald",
+      "source_url": "https://www.durangoherald.com/articles/voters-overwhelmingly-approve-la-plata-county-lodgers-tax-reallocation/",
+      "verdict": "supported",
+      "supporting_quote": "With 81% of ballots counted, approximately 69% of voters approved Ballot Issue 1A … the county has broad discretion to use an estimated $700,000 in any number of ways related to workforce housing and child care.",
+      "notes": "Direct WebFetch of the Durango Herald article (2024 election), 2026-07-30."
+    },
+    {
+      "section_id": "regional-housing-authority",
+      "paragraph_index": 0,
+      "source_id": "s-rha",
+      "source_url": "https://laplatahousing.colorado.gov/",
+      "verdict": "supported",
+      "supporting_quote": "The Regional Housing Alliance of La Plata County is a Multi-Jurisdictional Regional Housing Authority (RHA) created in 2004 by an Intergovernmental Agreement (IGA) between La Plata County, City of Durango, Town of Ignacio, and Town of Bayfield. The RHA is governed by a 9-member Board of Directors with two representatives from each of the parties to the IGA and one at large member appointed by the Board.",
+      "notes": "RHA official site; direct browser render (WAF blocks WebFetch), 2026-07-30."
+    },
+    {
+      "section_id": "regional-housing-authority",
+      "paragraph_index": 1,
+      "source_id": "s-sw-solutions",
+      "source_url": "https://swhousingsolutions.com/",
+      "verdict": "supported",
+      "supporting_quote": "Serving Archuleta, Dolores, La Plata, Montezuma, and San Juan Counties Since 1981. … Housing Solutions works to create new construction of affordable housing for seniors, families, and persons with disabilities including rental apartments and single-family homes.",
+      "notes": "Direct browser render of the homepage, 2026-07-30."
+    }
+  ],
+  "dropped_rows": [],
+  "summary": {
+    "total_rows": 9,
+    "supported": 9,
+    "partial": 0,
+    "unsupported": 0,
+    "inaccessible": 0
+  },
+  "strip_summary": "Brief authored 2026-07-30 with verified primary/press sources only (no kind:search placeholders). Held at published:false pending owner review."
+}

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/paulglasgow1/Documents/GitHub/Housing-Analytics/node_modules


### PR DESCRIPTION
Drafts the missing City of Durango jurisdictional housing brief requested in #1360.

**Held at `published:false`** — it stays hidden from the public renderer until you flip the flag after review.

## What's in it
Scaffolded via `scripts/draft-jurisdiction-brief.py`, then every `kind:search` placeholder replaced with a **directly-fetched** primary/press source:

- **Espero Apartments** — the region's first permanent supportive housing (40 one-bedroom units, formerly-homeless residents with a disabling condition), federal 9% LIHTC from CHFA + CO Division of Housing grant, low-cost long-term city land lease, $10,052,873 TDC. _(Housing Solutions for the Southwest, CHFA case study)_
- **City housing policy & funding** — Innovative Housing Solutions Division; Affordable Housing Fee Offset ($15k rental / $18k for-sale) mirroring the Fair Share Ordinance; Pre-Development Catalyst Fund. _(durangoco.gov)_
- **County lodgers-tax reallocation** — 2024 Ballot Issue 1A, up to 70% (~$700k) redirected to workforce housing + child care. _(Durango Herald)_
- **Housing authority & regional context** — Regional Housing Alliance of La Plata County (2004 IGA, 9-member board) + Housing Solutions for the Southwest. _(laplatahousing.colorado.gov, swhousingsolutions.com)_
- **Metric Digest + Tenure screening** — pulled from `jurisdiction-metrics-digest/0822035.json` (auto-verified by the validator). Durango ranks **#60** statewide, need score **74.4**, a **754-unit** gap at ≤30% AMI, ZHVI **$758,990**.

## Verification
- `python3 scripts/validate-jurisdiction-briefs.py` → **14/14** pass.
- `_verified/0822035.json` carries verbatim supporting quotes for all 9 narrative citations; `audit_method` declares direct-fetch (WebFetch, plus browser render for the WAF-gated CHFA + RHA pages).
- **Dry-run of the publish gate passes** — flipping `published:true` validates cleanly, so publishing is a one-line change after your review.

## To publish after review
Set `"published": true` in `data/jurisdiction-briefs/0822035.json` and re-run `npm run test:briefs` (spot-check the `_verified` quotes first).

Closes #1360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)