### PR TITLE
docs: Phase 3.1 + Phase 5 Codex handoffs (screening flag; Tier-1 ownership strategy)

### DIFF
--- a/docs/audits/CODEX-HANDOFF-PHASE31-SCREENING-APPLY-FLAG.md
+++ b/docs/audits/CODEX-HANDOFF-PHASE31-SCREENING-APPLY-FLAG.md
@@ -1,0 +1,37 @@
+# Codex Handoff — Phase 3.1 (micro): `screening_apply` Flag for the Deal Calculator Ownership Stack
+
+**For:** Codex (implementer) · **QA:** Claude Code (independent recompute + sabotage, as PRs #1390/#1392/#1394)
+**Date:** 2026-08-04 · **Size:** deliberately small — one flag, one gate change, labels, tests.
+**Depends on:** #1394 merged.
+**Why:** #1394's commitment gate correctly flipped `apply_to_gap` to false on WMRHC/CHFA-DPA (availability ≠ money), but that left the Deal Calculator's **screening** stack vacuous — it now applies $0 and answers nothing. The owner has approved restoring screening-level display via a **separate flag with a distinct meaning**: `screening_apply` marks a source that may be *shown as potential* in the screening stack, explicitly labeled **"potential — not committed"**, while the hard commitment gate (`apply_to_gap` ⇒ `awarded|committed`) remains untouched for anything counted as real funding.
+
+## Exact changes
+
+### 1. Data — `data/policy/developer-ownership-funding.json`
+- Add `"screening_apply": true` to **exactly two** entries — `wmrhc-good-deeds-buydown` and `chfa-dpa-layering` (restores the pre-#1394 screening behavior, no more). All other entries get `"screening_apply": false` explicitly (schema completeness).
+- Add to `meta.methodology`: one sentence distinguishing the two flags — `screening_apply` = may appear as a potential source in screening displays, never counted as committed funding; `apply_to_gap` = counts toward closing a gap and requires `awarded|committed`.
+- **Rule:** `screening_apply: true` requires a non-null amount term (`max_amount` or `max_percent` + `amount_type`) AND a dated `source_url`/`last_verified` — you can't screen with an unverified number.
+
+### 2. JS — `js/deal-calculator.js` (minimal, two spots)
+- `_developerFundingAmountPerUnit` gate (line ~245): `if (!program || (program.apply_to_gap !== true && program.screening_apply !== true)) return null;`
+- Labels: in `computeDeveloperOwnershipFundingStack`, each applied source object gains `screeningOnly: program.apply_to_gap !== true`; in `renderDeveloperOwnershipFundingStack`, screening-only sources render with the suffix **" (potential — not committed)"** and the residual line keeps its existing "no unverified amount is counted" framing. Do not touch any other function; do not touch `ownership-decision-chain.js`.
+
+### 3. Tests
+- New `test/deal-calc-screening-apply.test.js` (jsdom, conventions of `deal-calc-for-sale-feasibility.test.js`): with the **real** funding doc, the stack applies **> 0** per unit again; every screening-only applied source carries the "potential — not committed" label in the rendered output; a fixture with `screening_apply: true` but null amounts is NOT applied; a fixture with `apply_to_gap: true` + status `available` still fails the schema validator (gate intact).
+- Extend `test/ownership-funding-schema.test.js` **additively** (it's the Phase-3 file — add assertions, change none): `screening_apply` present on every entry as a boolean; true ⇒ amount + dated source; true does NOT satisfy or bypass the commitment gate.
+- No pre-Phase-3 test file may change.
+
+### 4. Wiring / hygiene
+- `package.json`: `test:deal-calc-screening-apply`, inserted into `test:ci` after `test:deal-calc-for-sale-feasibility`.
+- Run `npm run audit:file-manifest`; commit `data/_manifest.json` **if** it diffs (modified data file). README inventory unchanged (no new `js/` file).
+
+## File allowlist
+`data/policy/developer-ownership-funding.json` · `js/deal-calculator.js` (the two spots) · `test/deal-calc-screening-apply.test.js` (new) · `test/ownership-funding-schema.test.js` (additive) · `package.json` · `data/_manifest.json` (if diffing) · nothing else.
+
+## Acceptance criteria (Claude QA)
+1. With the real doc: WMRHC applies 30% × per-unit cost basis and CHFA DPA applies $25,000 (capped at the gap), matching QA's independent recompute; both labeled "potential — not committed" in rendered output.
+2. Commitment gate unbroken: QA re-injects `available`+`apply_to_gap:true` — validator must fail; `screening_apply` cannot be used to count committed funding anywhere.
+3. Sabotage: remove the "potential — not committed" label; set `screening_apply: true` on a null-amount entry; flip the gate change to ignore `apply_to_gap` — each must fail the suites.
+4. `test:deal-calc-for-sale-feasibility`, `test:ownership-decision-chain`, `test:ownership-funding-schema`, `validate`, `test:file-manifest` all green; no pre-Phase-3 test modified.
+
+Pre-open: `npm run test:deal-calc-screening-apply && npm run test:ownership-funding-schema && npm run test:deal-calc-for-sale-feasibility && npm run test:ownership-decision-chain && npm run test:file-manifest && npm run validate`. **Do not merge — stop after opening the PR for Claude QA.**

--- a/docs/audits/CODEX-HANDOFF-PHASE5-TIER1-OWNERSHIP-STRATEGY.md
+++ b/docs/audits/CODEX-HANDOFF-PHASE5-TIER1-OWNERSHIP-STRATEGY.md
@@ -1,0 +1,68 @@
+# Codex Handoff — Phase 5: Tier-1 Jurisdictional Ownership-Strategy Interface
+
+**For:** Codex (implementer) · **QA:** Claude Code (place-scoping audit, model-guardrail checks, degradation-state checks, sabotage — the usual gauntlet).
+**Date:** 2026-08-04
+**Depends on:** Phases 1–3 merged (#1388/#1390/#1392/#1394). Phase 3.1 (screening flag) is independent — no ordering constraint, but avoid touching `deal-calculator.js` in this PR to prevent merge conflicts.
+**Spec of record:** `docs/audits/SCOPING-FRUITA-COMMONS-REVISION-2-2026-08.md` §2 (Tier-1 definition), §4 (Phase 5 row); refinement §16 (the jurisdictional output list); `docs/audits/STATEWIDE-READINESS-AND-GAP-REVIEW-2026-08.md` (coverage + degradation duties, G2/G4/G10/G11); reference docs for authority structures, local contributions, rural-urban competitiveness.
+**This is the statewide deliverable** — every supported county and place gets an ownership-strategy read. It is a *screening* product and must say so; it is **not** a market study.
+
+---
+
+## What you are building
+
+A new **"Ownership Strategy"** subsection inside the existing Affordable Ownership Need section of `housing-needs-assessment.html`, rendered by a **new** module `js/hna/hna-ownership-strategy.js` (keep `hna-renderers.js` churn to a wiring call). For the selected jurisdiction it composes, from data already on the page or in Phase-3 datasets:
+
+1. **AMI / income ladder + affordable-price ladder** — per AMI tier (60–120%), income and max affordable price via `OwnershipFinance` with the **model registry**: default `conservative_screening`, a user-selectable model dropdown, and the model's `implications` panel. The comparator's risk-disclosure contract applies: a more permissive model's results always render the buyer-risk note. Household-size selector (default 4) using the engine's factors.
+2. **Local price anchor + per-tier shortfall** — the jurisdiction's own price (the same place-scoped home-value cascade value the section already uses — **never county-masked for a place**; provenance pill required). Show per-tier **shortfall $** (price − tier max price) and which tiers clear the median (boolean). **Do NOT render a "% of households priced out" figure** — the income distribution tops out at 100% AMI (readiness G2); a code comment must say why it's absent.
+3. **Income required to buy** — `incomeNeededForHomeValue(local price)` under the selected model, with AMI-ratio context.
+4. **Attainable supply + potential buyer pool** — reuse the existing `ownerValueSupply` bands and `priceBandScreen` outputs (render, don't recompute; the "potential buyer pool … not committed demand" label is protected).
+5. **Programs & funding** — from Phase-3 datasets: developer/project sources and buyer-assistance for this geography, each showing `commitment_status` with the standing rule rendered: *available is context, never money*. Screening-only application labeling per Phase 3.1 if present.
+6. **Stewardship & authority capacity** — the jurisdiction's `housingAuthority` structure/capacity fields and `stewardship_providers`; where none: render the canonical flag string from `stewardship-providers.json` meta (`no_stewardship_flag`) verbatim.
+7. **Public land** — count + list from `county-ownership.json` for the containing county (labeled county-scope).
+8. **Funding-competitiveness checklist** — current-HNA status + Prop 123 status (`jurisdiction-housing-progress.json` where covered, else "not tracked"), rural/urban designation **only where derivable** (else "VERIFY"), and the §3 checklist items rendered done/gap/unknown. No fabricated designations.
+9. **Preliminary strategy** — **reuse** the existing `tenureMixRecommendation` + detail from `computeOwnershipNeed` (render, never re-derive or re-weight).
+10. **Disclosure block** — "screening estimate; not a completed project market study"; the methods-exposure principle (each figure's source/model/classification visible via the existing pill/badge patterns); and the **verification flag** naming the parties (developer discussions, lender, appraiser, broker, program administrator, local jurisdiction) required before decision-grade use.
+
+### Degradation duties (readiness review — first-class, not afterthoughts)
+- Any missing input renders a labeled "data not available for this jurisdiction" state — never zero, never blank, never a county value silently standing in for a place.
+- **Zero/negative-gap jurisdictions** (price ≤ tier max): render the affirmative "market-attainable at this tier" state; do not force a subsidy narrative.
+- Funding/progress data covers ~33 jurisdictions; providers cover 64 counties + ~70 places — everything else shows the not-tracked state.
+
+## Hard rules
+1. **Place-vs-county masking is the repo's recurring bug** — every data element carries the existing provenance-pill pattern; a place selection must never show county data unlabeled. QA spot-checks Fruita (0828745) and Erie (0824950) against raw JSON.
+2. **Banned language** (this is `js/hna/` — the strict lane): no `forecast`, `capture rate`, `absorption`, `time-phasing`, `qualified buyer`, `mortgage-ready`; the existing banned-phrase tests must stay green. Strategy copy stays screening-framed.
+3. **Model guardrail:** default is the registry default; switching to a permissive model renders `riskDisclosure`; no auto-selection of the most permissive; selections do not persist as statewide defaults.
+4. **Additive only:** no changes to existing HNA calculations, scores, rankings, exports, or the existing ownership cards; no `deal-calculator.js`; no `data/` content changes (render what Phase 3 shipped).
+5. House UI rules: `chart-card` markup, CSS variables only (`test:phantom-css-vars`), WCAG pills (`test:pill-contrast`), counts lead / tiers secondary, mobile containment, no hover-only content.
+
+## File allowlist
+- `js/hna/hna-ownership-strategy.js` (new — pure render module, data passed in, mirroring `hna-ownership-need.js` conventions; jsdom-testable)
+- `housing-needs-assessment.html` (subsection mount + script tag + fetches for the two new policy datasets if not already loaded)
+- `js/hna/hna-controller.js` and/or `js/hna/hna-renderers.js` — **wiring only** (fetch + one render call)
+- `test/hna-ownership-strategy.test.js` (new)
+- `package.json` (script + `test:ci` insertion after `test:hna-ownership-need`)
+- `README.md` inventory (+1 js file — run `node scripts/compute-inventory.mjs`)
+- `data/_manifest.json` only if a data file's bytes change (they shouldn't)
+- Nothing else. **No new datasets, no Python, no workflows, no exports.**
+
+## Tests required (jsdom + vm, house conventions)
+- **Ladder correctness:** per-tier prices equal `OwnershipFinance.maxAffordablePrice(ami, tier, modelId)` exactly for two pinned jurisdiction fixtures (recomputed by QA); household-size selector changes results per engine factors; default model = registry default.
+- **Risk disclosure:** rendering with `conventional_dti` selected shows the buyer-risk note; sabotage-able (removing the note must fail).
+- **Place-scoping:** Fruita fixture renders place price ($ from the cascade `places` map) with a place pill; a place lacking place data renders the labeled county-fallback pill, not a silent county number.
+- **No priced-out %:** rendered output contains no `% of households` / `priced out` percentage claim (regex test) — the G2 guard.
+- **Commitment rule:** an `available` program renders with its status and never in an "applied/counted" position; the no-steward flag string renders verbatim for a no-provider fixture.
+- **Degradation:** missing funding/progress/provider data → "not tracked/available" states (assert exact strings); zero-gap fixture → market-attainable state, no subsidy language.
+- **Strategy reuse:** the recommendation string equals `computeOwnershipNeed(...).tenureMixRecommendation` for the fixture (no re-derivation).
+- **Copy scan:** banned phrases absent from the new module; "screening estimate" and "not a completed project market study" present; verification-parties list present.
+- **Regression:** `test:hna-ownership-need`, `test:hna`, `test:metric-truth-crosssurface`, `test:pill-contrast`, `test:phantom-css-vars`, `test:mobile-overflow-containment`, `validate` all green by exit code.
+
+## Delivery
+One branch, one PR, squash. PR description: screenshot/DOM snippet of the section for a data-rich place (Fruita), a thin place (degradation states visible), and a county; statement of which datasets are fetched and when; known limitations. **Do not merge — stop after opening the PR for Claude QA.**
+
+## Acceptance criteria (Claude QA)
+1. Ladder values match QA's independent engine calls for both pinned fixtures; model switch + disclosure behavior verified live in jsdom.
+2. Place-scoping audit passes on Fruita + Erie (raw-JSON cross-check); no silent county masking anywhere in the section.
+3. All degradation states render as specified against QA-constructed thin fixtures; zero-gap jurisdiction renders without subsidy framing.
+4. No priced-out % anywhere; banned-language and screening-disclosure scans clean; existing HNA outputs byte-identical for a control fixture.
+5. Sabotage: break a ladder tier constant; remove the risk disclosure; remove the place pill; render a % priced-out — each must fail the suite.
+6. Allowlist respected; README inventory bumped once; full `test:ci` green.


### PR DESCRIPTION
Two implementation handoffs, following the QA'd pattern of #1390/#1392/#1394:

**Phase 3.1 (micro)** — `screening_apply` flag: restores the Deal Calculator's screening stack (currently applying $0 after the #1394 commitment-gate flip) via a separate flag with a distinct meaning — sources render as **potential — not committed**, while the hard gate (`apply_to_gap` ⇒ awarded|committed) stays intact. Exactly two data entries restored; two-spot JS change; gate-preservation sabotage checks.

**Phase 5** — Tier-1 jurisdictional ownership-strategy subsection (the statewide deliverable): model-selectable AMI/price ladder with mandatory risk disclosures, per-tier shortfalls (no priced-out % — readiness G2 guard), Phase-3 programs/stewardship/authority-capacity rendering with the availability-is-never-money rule, competitiveness checklist, canonical no-steward flag, and first-class degradation states for thin jurisdictions. Additive only; place-vs-county provenance pills mandatory; the tenure recommendation is reused, never re-derived.

The two are independent (disjoint file surfaces) and can run as parallel Codex sessions. Merge to put both specs on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)