### PR TITLE
Fix for-sale funnel share input focus

### DIFF
--- a/js/project-market-study/market-study-page.js
+++ b/js/project-market-study/market-study-page.js
@@ -194,9 +194,9 @@
     var rows = model.funnel.stages.map(function (stage) {
       if (stage.id === 'observed_base') return `<tr><td>${stage.id}</td><td>${display(stage.outputCount)}</td><td>${stage.label}</td><td>${stage.basis}</td><td>${pill(stage.classification)}</td></tr>`;
       var assumption = model.assumptions[stage.id];
-      return `<tr><td>${stage.id}</td><td><input class="ms-share-input" data-stage-id="${stage.id}" type="number" min="0" max="1" step="0.01" value="${assumption.share === null ? '' : assumption.share}" aria-label="${stage.id} share"></td><td>${display(stage.outputCount)}</td><td>${stage.basis}</td><td>${pill(stage.classification)}</td></tr>`;
+      return `<tr><td>${stage.id}</td><td><input class="ms-share-input" data-stage-id="${stage.id}" type="number" min="0" max="1" step="0.01" placeholder="0–1" value="${assumption.share === null ? '' : assumption.share}" aria-label="${stage.id} share"></td><td>${display(stage.outputCount)}</td><td>${stage.basis}</td><td>${pill(stage.classification)}</td></tr>`;
     });
-    return `<section id="ms-s5" class="chart-card ms-section"><h2>5. Effective-demand funnel</h2>${caveat()}<p><strong>Owner inputs pending:</strong> session-only shares; reload clears every entry. No values are stored.</p><p><strong>Unresolved stages:</strong> ${model.funnel.unresolvedStages.length ? model.funnel.unresolvedStages.join(', ') : 'none'}</p>${table(['Stage', 'Share / output', 'Output / protected label', 'Evidence basis', 'Classification'], rows, 'Effective-demand funnel')}</section>`;
+    return `<section id="ms-s5" class="chart-card ms-section"><h2>5. Effective-demand funnel</h2>${caveat()}<p><strong>Owner inputs pending:</strong> session-only shares; reload clears every entry. No values are stored.</p><p><strong>Unresolved stages:</strong> ${model.funnel.unresolvedStages.length ? model.funnel.unresolvedStages.join(', ') : 'none'}</p>${table(['Stage', 'Share / output (decimal share, e.g. 0.8 = 80%)', 'Output / protected label', 'Evidence basis', 'Classification'], rows, 'Effective-demand funnel')}</section>`;
   }
 
   function figure(value, kind) {
@@ -265,7 +265,7 @@
         options.year = Number(event.target.value); paint();
       });
       mount.querySelectorAll('.ms-share-input').forEach(function (input) {
-        input.addEventListener('input', function (event) {
+        input.addEventListener('change', function (event) {
           options.assumptions = options.assumptions || {};
           options.assumptions[event.target.dataset.stageId] = event.target.value === '' ? null : Number(event.target.value);
           paint();

--- a/test/market-study-page.test.js
+++ b/test/market-study-page.test.js
@@ -159,12 +159,28 @@ assert(!text(defaultDom.mount.querySelector('#ms-s6')).includes('not_available: 
 // Entering a complete real assumption set recomputes S5/S6 through the engines.
 const interactive = dom();
 Page.start(interactive.mount, data);
+const typed = interactive.mount.querySelector('[data-stage-id="household_size_compatibility"]');
+typed.focus();
+typed.value = '0';
+typed.dispatchEvent(new interactive.window.Event('input', { bubbles: true }));
+typed.value = '0.8';
+typed.dispatchEvent(new interactive.window.Event('input', { bubbles: true }));
+assert.strictEqual(typed.isConnected, true);
+assert.strictEqual(interactive.window.document.activeElement, typed);
+assert.strictEqual(typed.value, '0.8');
+typed.dispatchEvent(new interactive.window.Event('change', { bubbles: true }));
+assert.strictEqual(interactive.mount.querySelector('[data-stage-id="household_size_compatibility"]').value, '0.8');
+assert.strictEqual(interactive.mount.querySelector('[data-stage-id="household_size_compatibility"]').placeholder, '0–1');
+assert(text(interactive.mount.querySelector('#ms-s5')).includes('(decimal share, e.g. 0.8 = 80%)'));
 const shares = {};
 EffectiveDemand.STAGE_IDS.forEach((id) => { shares[id] = id === 'contract_fallout' ? 0.85 : 0.8; });
 EffectiveDemand.STAGE_IDS.forEach((id) => {
   const input = interactive.mount.querySelector(`[data-stage-id="${id}"]`);
+  input.value = '0';
+  input.dispatchEvent(new interactive.window.Event('input', { bubbles: true }));
   input.value = String(shares[id]);
   input.dispatchEvent(new interactive.window.Event('input', { bubbles: true }));
+  input.dispatchEvent(new interactive.window.Event('change', { bubbles: true }));
 });
 const directResolved = Page.buildModel(data, { assumptions: shares });
 assert.strictEqual(typeof directResolved.funnel.effectiveDemand, 'number');


### PR DESCRIPTION
## What changed

- Commit funnel share assumptions on `change` (blur/Enter) instead of repainting the page on every `input` event.
- Add the visible `0–1` placeholder and the column hint `(decimal share, e.g. 0.8 = 80%)`.
- Replace the masked single-event test path with per-keystroke `input` events (`0`, then `0.8`), assert that the field remains connected and focused, and verify that `change` commits the final `0.8` share.

## Root cause and impact

The `input` listener called `paint()` for every keystroke. That replaced the active input element, so subsequent keystrokes targeted a detached node and were lost. Committing on `change` lets users finish typing while preserving the existing session-only assumptions and zero-math constraints.

## Verification

- `npm run test:market-study-page` — pass
- `npm run test:market-study-report` — pass
- `npm run test:ci` — pass (exit 0)
- `git diff --check` — pass
- Browser verification: typed `0`, then `.8`; the same input remained connected and focused with value `0.8`, blur committed `0.8`, and the console had no warnings/errors.