### PR TITLE
Format for-sale capture schedules and annual figures

### DIFF
--- a/js/project-market-study/market-study-page.js
+++ b/js/project-market-study/market-study-page.js
@@ -200,14 +200,11 @@
   }
 
   function figure(value, kind) {
-    return `<span class="ms-figure">${display(value.value, kind)} <span class="ms-denominator">denominator: ${display(value.denominator.value)} — ${value.denominator.basis}</span></span>`;
+    return `<span class="ms-figure">${display(value.value, kind)} <span class="ms-denominator">denominator: ${value.denominator.value === NOT_AVAILABLE ? display(value.denominator.value) : value.denominator.value.toLocaleString('en-US', { maximumFractionDigits: 2 })} — ${value.denominator.basis}</span></span>`;
   }
   function renderCapture(model) {
     var scenarioRows = model.capture.scenarios.map(function (item) {
-      var annual = Array.isArray(item.annualCaptureRate)
-        ? item.annualCaptureRate.map(function (rate) { return figure(rate, 'rate'); }).join('<br>')
-        : display(item.annualCaptureRate);
-      return `<tr><td>${item.scenarioLabel}</td><td>${display(item.monthlyClosings)}</td><td>${display(item.annualClosings)}</td><td>${annual}</td><td>${figure(item.totalProjectPenetration, 'rate')}</td><td>${figure(item.grossContractsNeeded)}</td><td>${String(item.poolDepletionModeled)}</td></tr>`;
+      return `<tr><td>${item.scenarioLabel}</td><td>${MarketStudyReport.formatSchedule(item.monthlyClosings, model.scenario.program.total_units.value)}</td><td>${MarketStudyReport.formatAnnualClosings(item.annualClosings)}</td><td>${MarketStudyReport.formatAnnualCapture(item.annualCaptureRate)}</td><td>${figure(item.totalProjectPenetration, 'rate')}</td><td>${figure(item.grossContractsNeeded)}</td><td>${String(item.poolDepletionModeled)}</td></tr>`;
     });
     var amiRows = Object.keys(model.capture.captureByAmiBand).map(function (key) {
       var item = model.capture.captureByAmiBand[key];

--- a/js/project-market-study/market-study-report.js
+++ b/js/project-market-study/market-study-report.js
@@ -36,6 +36,31 @@
     if (kind === 'rate') return value.toLocaleString('en-US', { style: 'percent', maximumFractionDigits: 2 });
     return value.toLocaleString('en-US', { maximumFractionDigits: 3 });
   }
+  function rounded(value, digits) {
+    if (unavailable(value)) return 'not_available — owner input required';
+    return Number(value).toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: digits });
+  }
+  function formatSchedule(values, total) {
+    if (!Array.isArray(values)) return display(values);
+    var even = values.length > 0 && values.every(function (value) {
+      return rounded(value, 2) === rounded(values[0], 2);
+    });
+    if (even) return '≈' + rounded(values[0], 2) + ' / month × ' + values.length + ' months (total ' + rounded(total, 2) + ')';
+    return 'total ' + rounded(total, 2) + ' — ' + values.map(function (value) { return rounded(value, 2); }).join(' · ');
+  }
+  function formatAnnualClosings(values) {
+    if (!Array.isArray(values)) return display(values);
+    return values.map(function (value) { return rounded(value, 2); }).join(' · ');
+  }
+  function formatDenominator(figure, kind) {
+    return display(figure.value, kind) + '<small>denominator: ' + rounded(figure.denominator.value, 2) + ' — ' + escape(figure.denominator.basis) + '</small>';
+  }
+  function formatAnnualCapture(values) {
+    if (!Array.isArray(values)) return display(values);
+    return values.map(function (entry, index) {
+      return 'Year ' + (index + 1) + ': ' + (unavailable(entry.value) ? display(entry.value) : entry.value.toLocaleString('en-US', { style: 'percent', minimumFractionDigits: 1, maximumFractionDigits: 1 })) + ' — pool ' + rounded(entry.denominator.value, 2);
+    }).join('<br>');
+  }
   function badge(value) { return '<span class="classification">' + escape(value) + '</span>'; }
   function table(headers, rows) {
     return '<div class="table-wrap"><table><thead><tr>' + headers.map(function (item) {
@@ -47,10 +72,6 @@
       if (html.indexOf(entry) === -1) throw new Error('MarketStudyReport: required caveat missing: ' + entry);
     });
   }
-  function denominator(figure, kind) {
-    return display(figure.value, kind) + '<small>denominator: ' + display(figure.denominator.value) + ' — ' + escape(figure.denominator.basis) + '</small>';
-  }
-
   function buildReport(model, meta) {
     if (!model || !model.scenario || !model.derived || !model.funnel || !model.capture) {
       throw new Error('MarketStudyReport: a complete Phase-8 buildModel object is required');
@@ -109,12 +130,11 @@
     var demand = '<section><h2>6. Demand (screening)</h2><p><strong>Unresolved stages:</strong> ' + escape(model.funnel.unresolvedStages.length ? model.funnel.unresolvedStages.join(', ') : 'none') + '</p>' + table(['Stage', 'Share', 'Output', 'Protected label', 'Evidence basis', 'Classification'], funnelRows) + '<p><strong>' + BUYER_POOL + '</strong></p><p class="warning">' + G2 + '</p></section>';
 
     var captureRows = model.capture.scenarios.map(function (item) {
-      var annual = Array.isArray(item.annualCaptureRate) ? item.annualCaptureRate.map(function (entry) { return denominator(entry, 'rate'); }).join('<br>') : display(item.annualCaptureRate);
-      return '<tr><td>' + escape(item.scenarioLabel) + '</td><td>' + display(item.monthlyClosings) + '</td><td>' + display(item.annualClosings) + '</td><td>' + annual + '</td><td>' + denominator(item.totalProjectPenetration, 'rate') + '</td><td>' + denominator(item.grossContractsNeeded) + '</td><td>' + display(item.poolDepletionModeled) + '</td></tr>';
+      return '<tr><td>' + escape(item.scenarioLabel) + '</td><td>' + formatSchedule(item.monthlyClosings, model.scenario.program.total_units.value) + '</td><td>' + formatAnnualClosings(item.annualClosings) + '</td><td>' + formatAnnualCapture(item.annualCaptureRate) + '</td><td>' + formatDenominator(item.totalProjectPenetration, 'rate') + '</td><td>' + formatDenominator(item.grossContractsNeeded) + '</td><td>' + display(item.poolDepletionModeled) + '</td></tr>';
     });
     var captureBands = Object.keys(model.capture.captureByAmiBand).map(function (key) {
       var item = model.capture.captureByAmiBand[key];
-      return '<tr><td>' + escape(key) + '</td><td>' + display(item.numerator) + '</td><td>' + denominator(item, 'rate') + '</td><td>' + escape(item.reason || '') + '</td></tr>';
+      return '<tr><td>' + escape(key) + '</td><td>' + display(item.numerator) + '</td><td>' + formatDenominator(item, 'rate') + '</td><td>' + escape(item.reason || '') + '</td></tr>';
     });
     var capture = '<section><h2>7. Capture scenarios (screening)</h2>' + table(['Pace', 'Monthly closings', 'Annual closings', 'Annual capture and denominator', 'Project penetration and denominator', 'Gross contracts and denominator', 'Pool depletion modeled'], captureRows) + table(['AMI band', 'Scenario units', 'Capture and denominator', 'Data limitation'], captureBands) + '<p class="warning">' + escape(model.capture.competitiveSupplyNote) + '</p><p class="warning">' + escape(model.capture.captureHumilityCaveat) + '</p></section>';
 
@@ -136,5 +156,14 @@
     return '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>' + escape(report.title) + '</title><style>body{font:16px/1.5 system-ui,sans-serif;color:#172033;max-width:1100px;margin:auto;padding:28px}h1,h2,h3{line-height:1.2}section{border-top:1px solid #bac4d0;padding-top:18px;margin-top:24px}.banner,.warning{border:2px solid #8b4b00;background:#fff5df;padding:12px}.table-wrap{overflow-x:auto}table{border-collapse:collapse;width:100%}th,td{border:1px solid #bac4d0;padding:7px;text-align:left;vertical-align:top}th{background:#eef2f6}.classification,.verify{display:inline-block;border:1px solid #52616f;border-radius:999px;padding:1px 7px;font-size:.8em}small{display:block}footer{border-top:3px solid #172033;margin-top:30px;padding-top:16px}@media print{body{max-width:none}.table-wrap{overflow:visible}}</style></head><body>' + content + '</body></html>';
   }
 
-  return { REQUIRED_CAVEATS: REQUIRED_CAVEATS, buildReport: buildReport, renderReportPreview: renderReportPreview, renderReportHtml: renderReportHtml };
+  return {
+    REQUIRED_CAVEATS: REQUIRED_CAVEATS,
+    formatSchedule: formatSchedule,
+    formatAnnualClosings: formatAnnualClosings,
+    formatAnnualCapture: formatAnnualCapture,
+    formatDenominator: formatDenominator,
+    buildReport: buildReport,
+    renderReportPreview: renderReportPreview,
+    renderReportHtml: renderReportHtml
+  };
 }));

--- a/test/market-study-page.test.js
+++ b/test/market-study-page.test.js
@@ -14,6 +14,7 @@ const Lifecycle = require('../js/project-market-study/shared-equity-lifecycle.js
 const Waterfall = require('../js/project-market-study/resale-waterfall.js');
 const EffectiveDemand = require('../js/project-market-study/effective-demand.js');
 const ForsaleCapture = require('../js/project-market-study/forsale-capture.js');
+const Report = require('../js/project-market-study/market-study-report.js');
 const conventions = require('../data/policy/resale-conventions.json');
 const landDataset = require('../data/policy/land-disposition-models.json');
 
@@ -187,9 +188,19 @@ assert.strictEqual(typeof directResolved.funnel.effectiveDemand, 'number');
 assert(text(interactive.mount.querySelector('#ms-s5')).includes(directResolved.funnel.effectiveDemand.toLocaleString('en-US', { maximumFractionDigits: 3 })));
 const directThirty = directResolved.capture.scenarios.find((item) => item.selloutMonths === 30);
 assert(text(interactive.mount.querySelector('#ms-s6')).includes(
-  directThirty.totalProjectPenetration.denominator.value.toLocaleString('en-US', { maximumFractionDigits: 3 })
+  directThirty.totalProjectPenetration.denominator.value.toLocaleString('en-US', { maximumFractionDigits: 2 })
 ));
 assert(interactive.mount.querySelectorAll('#ms-s6 .ms-denominator').length > 0);
+const s6Html = interactive.mount.querySelector('#ms-s6').innerHTML;
+const evenSchedule = '≈2.08 / month × 24 months (total 50)';
+assert.strictEqual(Report.formatSchedule(directResolved.capture.scenarios.find((item) => item.selloutMonths === 24).monthlyClosings, 50), evenSchedule);
+assert.strictEqual(Report.formatSchedule([1, 1.2345, 47.7655], 50), 'total 50 — 1 · 1.23 · 47.77');
+assert(s6Html.includes(evenSchedule));
+assert(s6Html.includes('25 · 25'));
+assert.strictEqual(Report.formatAnnualCapture([{ value: 0.849, denominator: { value: 29.46 } }]), 'Year 1: 84.9% — pool 29.46');
+assert(s6Html.includes('Year 1:'));
+assert(s6Html.includes('Year 2:'));
+assert(!/\d\.\d{4,}/.test(s6Html), 'S6 must not expose floating-point noise');
 
 // A fresh render is session-clean: no assumption survives and no persistence API exists.
 const fresh = dom();

--- a/test/market-study-report.test.js
+++ b/test/market-study-report.test.js
@@ -83,9 +83,24 @@ EffectiveDemand.STAGE_IDS.forEach((id) => { shares[id] = id === 'contract_fallou
 const resolved = Page.buildModel(data, { assumptions: shares });
 const resolvedReport = Report.buildReport(resolved, meta);
 const thirty = resolved.capture.scenarios.find((item) => item.selloutMonths === 30);
-const denominator = thirty.totalProjectPenetration.denominator.value.toLocaleString('en-US', { maximumFractionDigits: 3 });
+const denominator = thirty.totalProjectPenetration.denominator.value.toLocaleString('en-US', { maximumFractionDigits: 2 });
 assert(Report.renderReportPreview(resolvedReport).includes(denominator));
 assert(Report.renderReportHtml(resolvedReport).includes(denominator));
+const resolvedPreview = Report.renderReportPreview(resolvedReport);
+const resolvedDom = new JSDOM(resolvedPreview);
+const captureSection = Array.from(resolvedDom.window.document.querySelectorAll('section')).find((section) => section.querySelector('h2') && section.querySelector('h2').textContent.startsWith('7. Capture scenarios'));
+const evenSchedule = '≈2.08 / month × 24 months (total 50)';
+assert.strictEqual(Report.formatSchedule(resolved.capture.scenarios.find((item) => item.selloutMonths === 24).monthlyClosings, 50), evenSchedule);
+assert(captureSection.innerHTML.includes(evenSchedule));
+assert(captureSection.innerHTML.includes('25 · 25'));
+assert(captureSection.innerHTML.includes('Year 1:'));
+assert(captureSection.innerHTML.includes('Year 2:'));
+assert(!/\d\.\d{4,}/.test(captureSection.innerHTML), 'report capture section must not expose floating-point noise');
+const pageDom = new JSDOM('<main><div id="mount"></div></main>');
+Page.render(pageDom.window.document.getElementById('mount'), resolved, data);
+const pageSchedule = pageDom.window.document.querySelector('#ms-s6 tbody tr td:nth-child(2)').textContent;
+const reportSchedule = captureSection.querySelector('tbody tr td:nth-child(2)').textContent;
+assert.strictEqual(pageSchedule, reportSchedule, 'page S6 and report §7 must use the identical shared schedule string');
 
 assert.equal(model.funnel.effectiveDemand, 'not_available');
 model.funnel.stages.forEach((stage) => assert(preview.includes(stage.basis)));


### PR DESCRIPTION
## What changed

- Added shared display-only formatters for monthly schedules, annual closings, annual capture lines, and capture-table denominators.
- Section 6 and report §7 now render the 50-unit/24-month even schedule as `≈2.08 / month × 24 months (total 50)`.
- Custom schedules render with a `total N` prefix and two-decimal monthly values separated by ` · `.
- Annual closings render without float noise (`25 · 25`).
- Annual capture is labeled by year on separate lines, for example `Year 1: 84.9% — pool 29.46`; rates above 100% remain unchanged apart from display rounding.
- Capture-table denominator displays are rounded to two decimal places.

## Root cause and impact

The page and report passed engine arrays and binary floating-point values directly through their generic display helpers. Arrays therefore became long comma-separated strings, and annual figures could expose floating-point artifacts or visually run year labels into adjacent values. This PR changes formatting only: engine computations, depleted-pool arithmetic, zero-math protections, session-only assumptions, caveats, and classifications are unchanged.

## Test coverage

- Pins the even 50-unit/24-month schedule string.
- Pins custom schedule and annual-capture formatter output.
- Asserts no `/\d\.\d{4,}/` float noise in resolved page S6 or report §7.
- Asserts `Year N:` labels and clean annual closings.
- Asserts page S6 and report §7 use an identical shared schedule string.

## Verification

- `npm run test:market-study-page` — pass
- `npm run test:market-study-report` — pass
- `npm run test:ci` — pass (exit 0)
- `git diff --check` — pass
- Fresh local browser load confirmed updated assets and no long-decimal strings in the capture surfaces.