### PR TITLE
fix(data): re-sync manifest byte count for _liveness.json

### DIFF
--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-16T18:34:23.184462Z",
+  "generated": "2026-08-16T21:01:51.560531Z",
   "files": {
     "data/_manifest.json": {
       "featureCount": 0,
@@ -7379,7 +7379,7 @@
     "data/jurisdiction-briefs/_liveness.json": {
       "featureCount": 0,
       "placeholder": false,
-      "bytes": 222713
+      "bytes": 241251
     },
     "data/jurisdiction-briefs/_schema.json": {
       "featureCount": 0,


### PR DESCRIPTION
## What

Single byte-count correction in `data/manifest.json`:

```
data/jurisdiction-briefs/_liveness.json:  222713 -> 241251
```

## Why `main` is red

`ci-checks` has failed on `main` since the #1423 merge commit (`13adb614`):

```
AssertionError: data/manifest.json byte counts are stale
  data/jurisdiction-briefs/_liveness.json: manifest=222713 disk=241251
```

A merge race. #1418 landed its weekly source-liveness snapshot **after** #1423 had already computed the manifest, so the manifest kept the pre-snapshot size. Both PRs were individually green.

This is the byte-accuracy gate added in #1423 catching a real drift on its first live merge race — the gate working, not a regression in it.

## Rebuild hygiene — worth reading before the next manifest rebuild

`scripts/rebuild_manifest.py` walks the **filesystem**, not git. This repo lives under an iCloud-synced directory that has left **~1,966 untracked duplicate files** (`08001 2.json`, `08001 3.json`, ...) in `data/hna/jurisdiction-metrics-digest/`.

Rebuilding in a normal working copy indexes every one of them:

| | entries |
|---|---|
| committed manifest | 1,607 |
| rebuilt in the synced worktree | **3,573** |
| rebuilt in a clean worktree (this PR) | 1,607 |

The bad rebuild produces a 10,917-line diff that reads as a legitimate data update in review, then fails CI on a fresh clone with ~1,966 files "missing" from disk.

**A clean `git status` does not rule this out** — the duplicates are untracked, so the tree looks pristine. This PR was rebuilt in a throwaway worktree under `/private/tmp` with zero duplicates present, which is why the diff is 2 lines.

## Verification

- `node test/file-manifest.test.js` -> `file-manifest automation: PASS`
- Diff confirmed to touch only the `_liveness.json` byte count and the `generated` timestamp
- Entry count unchanged at 1,607

🤖 Generated with [Claude Code](https://claude.com/claude-code)