### PR TITLE
docs(agents): correct current-state block after the 2026-08-16 merges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,11 +45,12 @@ Notes on numbers that look like contradictions but aren't:
 Work that is **DONE — do not redo**:
 - `place-chas.json` schema validation. `node scripts/validate-schemas.js` passes **85/85**; `jsonschema` is installed at `ci-checks.yml:311`. (Older docs describe "482 errors" — that was fixed; the claim is stale.)
 - Remediation Batch 1A (#1367) and Batch 2 geometry simplification (#1370).
+- Security-headers runbook (#1421).
 - Ownership / for-sale build, Phases 0–9 (#1388–#1408).
 - README inventory line + its CI drift check.
 
 Work that is **OPEN**:
-- Remediation Batch 1B — security-headers runbook + relocating internal agent docs. PR #1368 went stale and conflicts; being re-cut against current `main`.
+- Remediation Batch 1B — relocating internal agent docs remains open; the security-headers runbook landed in #1421.
 - Credibility closeout, 6 items: BPS place/county contradiction (`js/hna/hna-renderers.js:6103,6115` contradicts `js/hna/hna-controller.js:2330` and `js/methodology-explainer.js:89`); AMI defined as median *household* income across 483 `places/*.html` (fix the generator, not the outputs); PMA help modal describing an adjustable radius (`market-analysis.html:1507-1508`, contradicting line 395); Independence Village duplicated in `data/affordable-housing/properties.json`; `ranking-index.json` past its 9-day freshness SLA; NHPD data past its 95-day threshold.
 
 Work that is **DEFERRED — do not start without owner sign-off**:


### PR DESCRIPTION
## Phase 0 — current-state correction

- Moves the security-headers runbook (#1421) into the completed work list.
- Narrows the open Batch 1B item to the remaining internal-agent-doc relocation.
- Leaves the CI-enforced inventory line untouched because no file count changed.

## Validation

- `git diff --check` — pass
- Scope: `AGENTS.md` only

This PR is intentionally isolated as the first credibility-closeout phase. Do not merge until Claude/human review.