### PR TITLE
fix(hna): correct AMI definition in place-page template (483 pages)

### DIFF
--- a/places/0800320.html
+++ b/places/0800320.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0800620.html
+++ b/places/0800620.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0800760.html
+++ b/places/0800760.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0800870.html
+++ b/places/0800870.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0800925.html
+++ b/places/0800925.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0801090.html
+++ b/places/0801090.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0801145.html
+++ b/places/0801145.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0801420.html
+++ b/places/0801420.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0801530.html
+++ b/places/0801530.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0801640.html
+++ b/places/0801640.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0801740.html
+++ b/places/0801740.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0801915.html
+++ b/places/0801915.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0802355.html
+++ b/places/0802355.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0802575.html
+++ b/places/0802575.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0802850.html
+++ b/places/0802850.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0802905.html
+++ b/places/0802905.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0803015.html
+++ b/places/0803015.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0803235.html
+++ b/places/0803235.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0803455.html
+++ b/places/0803455.html
@@ -327,7 +327,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0803620.html
+++ b/places/0803620.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0803730.html
+++ b/places/0803730.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0803840.html
+++ b/places/0803840.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0803950.html
+++ b/places/0803950.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0804000.html
+++ b/places/0804000.html
@@ -332,7 +332,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0804110.html
+++ b/places/0804110.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0804165.html
+++ b/places/0804165.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0804620.html
+++ b/places/0804620.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0804935.html
+++ b/places/0804935.html
@@ -327,7 +327,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0805120.html
+++ b/places/0805120.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0805265.html
+++ b/places/0805265.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0806090.html
+++ b/places/0806090.html
@@ -327,7 +327,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0806172.html
+++ b/places/0806172.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0806255.html
+++ b/places/0806255.html
@@ -327,7 +327,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0806530.html
+++ b/places/0806530.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0806602.html
+++ b/places/0806602.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0806970.html
+++ b/places/0806970.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0807025.html
+++ b/places/0807025.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0807190.html
+++ b/places/0807190.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0807245.html
+++ b/places/0807245.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0807410.html
+++ b/places/0807410.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0807420.html
+++ b/places/0807420.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0807455.html
+++ b/places/0807455.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0807571.html
+++ b/places/0807571.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0807580.html
+++ b/places/0807580.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0807795.html
+++ b/places/0807795.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0807850.html
+++ b/places/0807850.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0808070.html
+++ b/places/0808070.html
@@ -327,7 +327,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0808290.html
+++ b/places/0808290.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0808345.html
+++ b/places/0808345.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0808400.html
+++ b/places/0808400.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0808530.html
+++ b/places/0808530.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0808620.html
+++ b/places/0808620.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0808675.html
+++ b/places/0808675.html
@@ -327,7 +327,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0808950.html
+++ b/places/0808950.html
@@ -243,7 +243,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0809115.html
+++ b/places/0809115.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0809280.html
+++ b/places/0809280.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0809555.html
+++ b/places/0809555.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0810105.html
+++ b/places/0810105.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0810600.html
+++ b/places/0810600.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0810985.html
+++ b/places/0810985.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0811260.html
+++ b/places/0811260.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0811645.html
+++ b/places/0811645.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0811810.html
+++ b/places/0811810.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0811975.html
+++ b/places/0811975.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0812030.html
+++ b/places/0812030.html
@@ -219,7 +219,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0812045.html
+++ b/places/0812045.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0812325.html
+++ b/places/0812325.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0812387.html
+++ b/places/0812387.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0812393.html
+++ b/places/0812393.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0812415.html
+++ b/places/0812415.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0812450.html
+++ b/places/0812450.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0812460.html
+++ b/places/0812460.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0812470.html
+++ b/places/0812470.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0812635.html
+++ b/places/0812635.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0812815.html
+++ b/places/0812815.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0812855.html
+++ b/places/0812855.html
@@ -327,7 +327,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0812900.html
+++ b/places/0812900.html
@@ -327,7 +327,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0812945.html
+++ b/places/0812945.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0813460.html
+++ b/places/0813460.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0813590.html
+++ b/places/0813590.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0813845.html
+++ b/places/0813845.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0814175.html
+++ b/places/0814175.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0814587.html
+++ b/places/0814587.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0814765.html
+++ b/places/0814765.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0815165.html
+++ b/places/0815165.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0815302.html
+++ b/places/0815302.html
@@ -248,7 +248,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0815330.html
+++ b/places/0815330.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0815440.html
+++ b/places/0815440.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0815550.html
+++ b/places/0815550.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0815605.html
+++ b/places/0815605.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0815825.html
+++ b/places/0815825.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0815935.html
+++ b/places/0815935.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0816000.html
+++ b/places/0816000.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0816110.html
+++ b/places/0816110.html
@@ -243,7 +243,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0816385.html
+++ b/places/0816385.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0816465.html
+++ b/places/0816465.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0816495.html
+++ b/places/0816495.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0816715.html
+++ b/places/0816715.html
@@ -219,7 +219,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0817100.html
+++ b/places/0817100.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0817150.html
+++ b/places/0817150.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0817375.html
+++ b/places/0817375.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0817485.html
+++ b/places/0817485.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0817760.html
+++ b/places/0817760.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0817925.html
+++ b/places/0817925.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0818310.html
+++ b/places/0818310.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0818420.html
+++ b/places/0818420.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0818530.html
+++ b/places/0818530.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0818585.html
+++ b/places/0818585.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0818640.html
+++ b/places/0818640.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0818750.html
+++ b/places/0818750.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0819080.html
+++ b/places/0819080.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0819150.html
+++ b/places/0819150.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0819355.html
+++ b/places/0819355.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0819630.html
+++ b/places/0819630.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0819795.html
+++ b/places/0819795.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0819850.html
+++ b/places/0819850.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0820000.html
+++ b/places/0820000.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0820275.html
+++ b/places/0820275.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0820440.html
+++ b/places/0820440.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0820495.html
+++ b/places/0820495.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0820605.html
+++ b/places/0820605.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0820770.html
+++ b/places/0820770.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0821155.html
+++ b/places/0821155.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0821265.html
+++ b/places/0821265.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0821330.html
+++ b/places/0821330.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0821390.html
+++ b/places/0821390.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0822035.html
+++ b/places/0822035.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0822145.html
+++ b/places/0822145.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0822200.html
+++ b/places/0822200.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0822575.html
+++ b/places/0822575.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0822860.html
+++ b/places/0822860.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0822882.html
+++ b/places/0822882.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0823025.html
+++ b/places/0823025.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0823135.html
+++ b/places/0823135.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0823300.html
+++ b/places/0823300.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0823520.html
+++ b/places/0823520.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0823575.html
+++ b/places/0823575.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0823630.html
+++ b/places/0823630.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0823740.html
+++ b/places/0823740.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0823795.html
+++ b/places/0823795.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0824235.html
+++ b/places/0824235.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0824290.html
+++ b/places/0824290.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0824620.html
+++ b/places/0824620.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0824785.html
+++ b/places/0824785.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0824950.html
+++ b/places/0824950.html
@@ -327,7 +327,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0825115.html
+++ b/places/0825115.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0825280.html
+++ b/places/0825280.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0825390.html
+++ b/places/0825390.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0825550.html
+++ b/places/0825550.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0825610.html
+++ b/places/0825610.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0826270.html
+++ b/places/0826270.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0826600.html
+++ b/places/0826600.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0826765.html
+++ b/places/0826765.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0826875.html
+++ b/places/0826875.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0827040.html
+++ b/places/0827040.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0827095.html
+++ b/places/0827095.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0827175.html
+++ b/places/0827175.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0827370.html
+++ b/places/0827370.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0827425.html
+++ b/places/0827425.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0827535.html
+++ b/places/0827535.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0827700.html
+++ b/places/0827700.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0827810.html
+++ b/places/0827810.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0827865.html
+++ b/places/0827865.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0827950.html
+++ b/places/0827950.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0827975.html
+++ b/places/0827975.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0828105.html
+++ b/places/0828105.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0828250.html
+++ b/places/0828250.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0828305.html
+++ b/places/0828305.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0828360.html
+++ b/places/0828360.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0828690.html
+++ b/places/0828690.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0828745.html
+++ b/places/0828745.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0828800.html
+++ b/places/0828800.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0828830.html
+++ b/places/0828830.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0829185.html
+++ b/places/0829185.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0829240.html
+++ b/places/0829240.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0829295.html
+++ b/places/0829295.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0829625.html
+++ b/places/0829625.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0829680.html
+++ b/places/0829680.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0829735.html
+++ b/places/0829735.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0829845.html
+++ b/places/0829845.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0829955.html
+++ b/places/0829955.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0830340.html
+++ b/places/0830340.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0830350.html
+++ b/places/0830350.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0830420.html
+++ b/places/0830420.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0830780.html
+++ b/places/0830780.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0830835.html
+++ b/places/0830835.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0830890.html
+++ b/places/0830890.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0830945.html
+++ b/places/0830945.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0831550.html
+++ b/places/0831550.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0831605.html
+++ b/places/0831605.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0831660.html
+++ b/places/0831660.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0831715.html
+++ b/places/0831715.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0831935.html
+++ b/places/0831935.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0832155.html
+++ b/places/0832155.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0832650.html
+++ b/places/0832650.html
@@ -243,7 +243,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0833035.html
+++ b/places/0833035.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0833310.html
+++ b/places/0833310.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0833420.html
+++ b/places/0833420.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0833502.html
+++ b/places/0833502.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0833640.html
+++ b/places/0833640.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0833695.html
+++ b/places/0833695.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0834520.html
+++ b/places/0834520.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0834630.html
+++ b/places/0834630.html
@@ -219,7 +219,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0834685.html
+++ b/places/0834685.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0834740.html
+++ b/places/0834740.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0834960.html
+++ b/places/0834960.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0835070.html
+++ b/places/0835070.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0835400.html
+++ b/places/0835400.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0835860.html
+++ b/places/0835860.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0836410.html
+++ b/places/0836410.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0836610.html
+++ b/places/0836610.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0836940.html
+++ b/places/0836940.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0837215.html
+++ b/places/0837215.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0837220.html
+++ b/places/0837220.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0837270.html
+++ b/places/0837270.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0837380.html
+++ b/places/0837380.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0837545.html
+++ b/places/0837545.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0837600.html
+++ b/places/0837600.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0837655.html
+++ b/places/0837655.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0837820.html
+++ b/places/0837820.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0837875.html
+++ b/places/0837875.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0838370.html
+++ b/places/0838370.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0838425.html
+++ b/places/0838425.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0838480.html
+++ b/places/0838480.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0838535.html
+++ b/places/0838535.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0838590.html
+++ b/places/0838590.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0838810.html
+++ b/places/0838810.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0838910.html
+++ b/places/0838910.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0839160.html
+++ b/places/0839160.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0839195.html
+++ b/places/0839195.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0839250.html
+++ b/places/0839250.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0839745.html
+++ b/places/0839745.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0839800.html
+++ b/places/0839800.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0839855.html
+++ b/places/0839855.html
@@ -327,7 +327,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0839965.html
+++ b/places/0839965.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0840185.html
+++ b/places/0840185.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0840377.html
+++ b/places/0840377.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0840515.html
+++ b/places/0840515.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0840550.html
+++ b/places/0840550.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0840570.html
+++ b/places/0840570.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0840790.html
+++ b/places/0840790.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0840900.html
+++ b/places/0840900.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0841010.html
+++ b/places/0841010.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0841065.html
+++ b/places/0841065.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0841560.html
+++ b/places/0841560.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0841835.html
+++ b/places/0841835.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0842000.html
+++ b/places/0842000.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0842055.html
+++ b/places/0842055.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0842110.html
+++ b/places/0842110.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0842165.html
+++ b/places/0842165.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0842330.html
+++ b/places/0842330.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0842495.html
+++ b/places/0842495.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0843000.html
+++ b/places/0843000.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0843110.html
+++ b/places/0843110.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0843220.html
+++ b/places/0843220.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0843550.html
+++ b/places/0843550.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0843605.html
+++ b/places/0843605.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0843660.html
+++ b/places/0843660.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0844100.html
+++ b/places/0844100.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0844265.html
+++ b/places/0844265.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0844270.html
+++ b/places/0844270.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0844320.html
+++ b/places/0844320.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0844375.html
+++ b/places/0844375.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0844595.html
+++ b/places/0844595.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0844695.html
+++ b/places/0844695.html
@@ -219,7 +219,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0844980.html
+++ b/places/0844980.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0845145.html
+++ b/places/0845145.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0845255.html
+++ b/places/0845255.html
@@ -332,7 +332,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0845530.html
+++ b/places/0845530.html
@@ -327,7 +327,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0845680.html
+++ b/places/0845680.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0845695.html
+++ b/places/0845695.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0845750.html
+++ b/places/0845750.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0845955.html
+++ b/places/0845955.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0845970.html
+++ b/places/0845970.html
@@ -327,7 +327,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0846355.html
+++ b/places/0846355.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0846410.html
+++ b/places/0846410.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0846465.html
+++ b/places/0846465.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0847015.html
+++ b/places/0847015.html
@@ -219,7 +219,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0847070.html
+++ b/places/0847070.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0847235.html
+++ b/places/0847235.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0847345.html
+++ b/places/0847345.html
@@ -219,7 +219,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0848060.html
+++ b/places/0848060.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0848115.html
+++ b/places/0848115.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0848445.html
+++ b/places/0848445.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0848500.html
+++ b/places/0848500.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0848555.html
+++ b/places/0848555.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0848940.html
+++ b/places/0848940.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0849215.html
+++ b/places/0849215.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0849325.html
+++ b/places/0849325.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0849490.html
+++ b/places/0849490.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0849600.html
+++ b/places/0849600.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0849875.html
+++ b/places/0849875.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0850012.html
+++ b/places/0850012.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0850026.html
+++ b/places/0850026.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0850040.html
+++ b/places/0850040.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0850380.html
+++ b/places/0850380.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0850480.html
+++ b/places/0850480.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0850920.html
+++ b/places/0850920.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0851250.html
+++ b/places/0851250.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0851635.html
+++ b/places/0851635.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0851690.html
+++ b/places/0851690.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0851745.html
+++ b/places/0851745.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0851800.html
+++ b/places/0851800.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0851975.html
+++ b/places/0851975.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0852075.html
+++ b/places/0852075.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0852210.html
+++ b/places/0852210.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0852350.html
+++ b/places/0852350.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0852550.html
+++ b/places/0852550.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0852570.html
+++ b/places/0852570.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0852820.html
+++ b/places/0852820.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0853010.html
+++ b/places/0853010.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0853120.html
+++ b/places/0853120.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0853175.html
+++ b/places/0853175.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0853395.html
+++ b/places/0853395.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0853780.html
+++ b/places/0853780.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0853875.html
+++ b/places/0853875.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0853945.html
+++ b/places/0853945.html
@@ -219,7 +219,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0854330.html
+++ b/places/0854330.html
@@ -327,7 +327,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0854495.html
+++ b/places/0854495.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0854750.html
+++ b/places/0854750.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0854880.html
+++ b/places/0854880.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0854935.html
+++ b/places/0854935.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0855045.html
+++ b/places/0855045.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0855155.html
+++ b/places/0855155.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0855540.html
+++ b/places/0855540.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0855705.html
+++ b/places/0855705.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0855870.html
+++ b/places/0855870.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0855925.html
+++ b/places/0855925.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0855980.html
+++ b/places/0855980.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0856035.html
+++ b/places/0856035.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0856145.html
+++ b/places/0856145.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0856365.html
+++ b/places/0856365.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0856420.html
+++ b/places/0856420.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0856475.html
+++ b/places/0856475.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0856695.html
+++ b/places/0856695.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0856860.html
+++ b/places/0856860.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0856970.html
+++ b/places/0856970.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0857025.html
+++ b/places/0857025.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0857245.html
+++ b/places/0857245.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0857300.html
+++ b/places/0857300.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0857400.html
+++ b/places/0857400.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0857445.html
+++ b/places/0857445.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0857465.html
+++ b/places/0857465.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0857630.html
+++ b/places/0857630.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0857850.html
+++ b/places/0857850.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0858235.html
+++ b/places/0858235.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0858400.html
+++ b/places/0858400.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0858510.html
+++ b/places/0858510.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0858592.html
+++ b/places/0858592.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0858675.html
+++ b/places/0858675.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0858785.html
+++ b/places/0858785.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0858960.html
+++ b/places/0858960.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0859005.html
+++ b/places/0859005.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0859240.html
+++ b/places/0859240.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0859520.html
+++ b/places/0859520.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0859830.html
+++ b/places/0859830.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0859885.html
+++ b/places/0859885.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0860160.html
+++ b/places/0860160.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0860600.html
+++ b/places/0860600.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0860655.html
+++ b/places/0860655.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0860765.html
+++ b/places/0860765.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0861315.html
+++ b/places/0861315.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0862000.html
+++ b/places/0862000.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0862220.html
+++ b/places/0862220.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0862660.html
+++ b/places/0862660.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0862880.html
+++ b/places/0862880.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0863045.html
+++ b/places/0863045.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0863265.html
+++ b/places/0863265.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0863320.html
+++ b/places/0863320.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0863375.html
+++ b/places/0863375.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0863650.html
+++ b/places/0863650.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0863705.html
+++ b/places/0863705.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0864090.html
+++ b/places/0864090.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0864200.html
+++ b/places/0864200.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0864255.html
+++ b/places/0864255.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0864870.html
+++ b/places/0864870.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0864970.html
+++ b/places/0864970.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0865190.html
+++ b/places/0865190.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0865685.html
+++ b/places/0865685.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0865740.html
+++ b/places/0865740.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0866197.html
+++ b/places/0866197.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0866895.html
+++ b/places/0866895.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0866995.html
+++ b/places/0866995.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0867005.html
+++ b/places/0867005.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0867040.html
+++ b/places/0867040.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0867142.html
+++ b/places/0867142.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0867280.html
+++ b/places/0867280.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0867445.html
+++ b/places/0867445.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0867500.html
+++ b/places/0867500.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0867830.html
+++ b/places/0867830.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0868105.html
+++ b/places/0868105.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0868655.html
+++ b/places/0868655.html
@@ -307,7 +307,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0868847.html
+++ b/places/0868847.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0868875.html
+++ b/places/0868875.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0868930.html
+++ b/places/0868930.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0868985.html
+++ b/places/0868985.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0869040.html
+++ b/places/0869040.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0869110.html
+++ b/places/0869110.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0869150.html
+++ b/places/0869150.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0869480.html
+++ b/places/0869480.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0869645.html
+++ b/places/0869645.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0869700.html
+++ b/places/0869700.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0869810.html
+++ b/places/0869810.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0870112.html
+++ b/places/0870112.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0870195.html
+++ b/places/0870195.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0870250.html
+++ b/places/0870250.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0870360.html
+++ b/places/0870360.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0870525.html
+++ b/places/0870525.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0870580.html
+++ b/places/0870580.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0870635.html
+++ b/places/0870635.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0871625.html
+++ b/places/0871625.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0871755.html
+++ b/places/0871755.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0871790.html
+++ b/places/0871790.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0871845.html
+++ b/places/0871845.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0872320.html
+++ b/places/0872320.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0872395.html
+++ b/places/0872395.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0873330.html
+++ b/places/0873330.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0873715.html
+++ b/places/0873715.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0873825.html
+++ b/places/0873825.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0873925.html
+++ b/places/0873925.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0873935.html
+++ b/places/0873935.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0873943.html
+++ b/places/0873943.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0874080.html
+++ b/places/0874080.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0874275.html
+++ b/places/0874275.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0874375.html
+++ b/places/0874375.html
@@ -243,7 +243,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0874430.html
+++ b/places/0874430.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0874485.html
+++ b/places/0874485.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0874815.html
+++ b/places/0874815.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0874980.html
+++ b/places/0874980.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0875585.html
+++ b/places/0875585.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0875640.html
+++ b/places/0875640.html
@@ -327,7 +327,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0875970.html
+++ b/places/0875970.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0876190.html
+++ b/places/0876190.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0876325.html
+++ b/places/0876325.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0876795.html
+++ b/places/0876795.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0877235.html
+++ b/places/0877235.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0877290.html
+++ b/places/0877290.html
@@ -327,7 +327,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0877510.html
+++ b/places/0877510.html
@@ -327,7 +327,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0877757.html
+++ b/places/0877757.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0878280.html
+++ b/places/0878280.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0878335.html
+++ b/places/0878335.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0878345.html
+++ b/places/0878345.html
@@ -225,7 +225,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0878610.html
+++ b/places/0878610.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0879100.html
+++ b/places/0879100.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0879105.html
+++ b/places/0879105.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0879270.html
+++ b/places/0879270.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0879785.html
+++ b/places/0879785.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0879800.html
+++ b/places/0879800.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0880040.html
+++ b/places/0880040.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0880095.html
+++ b/places/0880095.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0880370.html
+++ b/places/0880370.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0880755.html
+++ b/places/0880755.html
@@ -219,7 +219,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0880865.html
+++ b/places/0880865.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0881030.html
+++ b/places/0881030.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0881305.html
+++ b/places/0881305.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0881690.html
+++ b/places/0881690.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0882130.html
+++ b/places/0882130.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0882350.html
+++ b/places/0882350.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0882460.html
+++ b/places/0882460.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0882735.html
+++ b/places/0882735.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0882900.html
+++ b/places/0882900.html
@@ -241,7 +241,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0883120.html
+++ b/places/0883120.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0883175.html
+++ b/places/0883175.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0883230.html
+++ b/places/0883230.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0883450.html
+++ b/places/0883450.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0883500.html
+++ b/places/0883500.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0883835.html
+++ b/places/0883835.html
@@ -327,7 +327,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0884000.html
+++ b/places/0884000.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0884042.html
+++ b/places/0884042.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0884440.html
+++ b/places/0884440.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0884770.html
+++ b/places/0884770.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0885045.html
+++ b/places/0885045.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0885155.html
+++ b/places/0885155.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0885485.html
+++ b/places/0885485.html
@@ -327,7 +327,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0885705.html
+++ b/places/0885705.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0885760.html
+++ b/places/0885760.html
@@ -219,7 +219,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0886090.html
+++ b/places/0886090.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0886117.html
+++ b/places/0886117.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0886200.html
+++ b/places/0886200.html
@@ -223,7 +223,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0886310.html
+++ b/places/0886310.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0886475.html
+++ b/places/0886475.html
@@ -227,7 +227,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/0886750.html
+++ b/places/0886750.html
@@ -311,7 +311,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/places/_template.html
+++ b/places/_template.html
@@ -87,7 +87,7 @@
         <div class="place-stat"><span class="label">&gt;100% AMI</span><span class="value" id="psTier100p">—</span></div>
         <details class="place-explain">
           <summary>What do these AMI tiers mean?</summary>
-          <p><strong>AMI = Area Median Income</strong> — HUD's annual median household income for the area. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
+          <p><strong>AMI = Area Median Income</strong> — HUD program AMI is based on area median family income and HUD's income-limit methodology; it is not the municipality's ACS median household income. Affordable-housing programs set eligibility as a share of AMI, so renter households are grouped into income bands:</p>
           <ul>
             <li><strong>≤30% AMI</strong> — extremely low income</li>
             <li><strong>31-50% AMI</strong> — very low income</li>

--- a/test/place-pages.test.js
+++ b/test/place-pages.test.js
@@ -33,6 +33,9 @@ function readRel(rel) {
 
 console.log('\n[test] Generator script + template');
 const generator = readRel('scripts/hna/build_place_pages.py');
+const template = readRel('places/_template.html');
+assert(template.includes("HUD program AMI is based on area median family income and HUD's income-limit methodology"), 'template defines HUD AMI from family income and income-limit methodology');
+assert(!template.includes("HUD's annual median household income for the area"), 'template does not equate HUD AMI with median household income');
 assert(/def generate_page/.test(generator),
   'generator has generate_page() function');
 assert(/def build_index/.test(generator),


### PR DESCRIPTION
## Phase 2 — HUD AMI definition

- Corrects the shared place-page template: HUD program AMI is based on area median family income and HUD’s income-limit methodology, not municipal ACS median household income.
- Regenerates all 482 place pages from the template; no generated page was hand-edited.
- Adds template regression assertions for the correct definition and banned old wording.

## Validation

- `python3 scripts/hna/build_place_pages.py` — 482 pages generated
- Old definition under `places/` — 0 files
- Correct definition under `places/` — 483 files (482 pages + template)
- `npm test` — pass (exit 0)
- `test:place-pages-fresh` — pass within the full suite
- `git diff --cached --check` — pass

Do not merge until Claude/human review.