### PR TITLE
fix(pma): correct help-modal to the tract-based workflow

### DIFF
--- a/market-analysis.html
+++ b/market-analysis.html
@@ -1504,8 +1504,8 @@
     title: 'How to Use the Market Analysis Tool',
     description: 'This tool performs a Primary Market Area (PMA) analysis for LIHTC site selection. It scores your proposed development site across demand, competition, rent, and supply factors using free public data.',
     steps: [
-      { label: 'Enter a location', desc: 'Type an address, city, or county in the search box. The tool geocodes your input and defines a PMA radius around the site.' },
-      { label: 'Review the PMA boundary', desc: 'The map shows your Primary Market Area. You can adjust the radius if the auto-delineated area doesn\'t match the competitive landscape.' },
+      { label: 'Enter a location', desc: 'Type an address, city, or county in the search box. The tool geocodes your input and pre-selects whole census tracts within an approximately 4-mile ring as a starting set.' },
+      { label: 'Review the PMA boundary', desc: 'Add or remove individual tracts, then justify the boundary using natural barriers, school districts, jurisdictional lines, or commute sheds. The 4-mile ring is an auto-selection aid, not an adjustable PMA radius.' },
       { label: 'Run the analysis', desc: 'Click "Run Analysis" to score the site. The tool pulls Census, HUD, and FRED data to calculate demand, capture rate, rent pressure, and supply scores.' },
       { label: 'Interpret the scorecard', desc: 'The radar chart and score cards show how your site performs across all PMA dimensions. Scores above 70 are generally favorable for LIHTC.' },
       { label: 'Review comparable projects', desc: 'The competitive set section lists nearby LIHTC developments with occupancy benchmarks and rent comparables.' },

--- a/test/pma-methodology-language.test.js
+++ b/test/pma-methodology-language.test.js
@@ -33,6 +33,12 @@ assert(!tabs.some((tab) => tab.method !== 'tract' && /^Tract-based\b/i.test(tab.
 assert(!html.includes('(CHFA submittal)'), 'Tract picker should not carry an uncaveated CHFA submittal badge');
 assert.match(byMethod.tract || '', /whole-tract/i, 'Tract picker still names the whole-tract shape');
 assert.match(byMethod.tract || '', /screening/i, 'Tract picker badge should remain caveated as screening');
+assert.match(html, /pre-selects whole census tracts within an approximately 4-mile ring as a starting set/, 'help modal explains the tract auto-selection ring');
+assert.match(html, /Add or remove individual tracts/, 'help modal explains tract curation');
+assert.match(html, /natural barriers, school districts, jurisdictional lines, or commute sheds/, 'help modal names boundary evidence');
+assert.match(html, /not an adjustable PMA radius/, 'help modal distinguishes the ring from an adjustable PMA radius');
+assert(!html.includes('defines a PMA radius around the site'), 'help modal no longer claims geocoding defines a PMA radius');
+assert(!html.includes('You can adjust the radius'), 'help modal no longer claims the PMA radius is adjustable');
 
 const radius = doc.querySelector('#pmaBufferSelect');
 assert(radius, 'buffer radius select exists');


### PR DESCRIPTION
## Phase 3 — PMA help-modal workflow

- Replaces the false adjustable-radius instructions with the actual whole-tract workflow.
- Describes the approximately 4-mile auto-selection ring as a starting aid.
- Directs users to add/remove tracts and justify the boundary with natural barriers, school districts, jurisdictional lines, or commute sheds.
- Preserves the existing 4-mile ring language and calculation behavior.
- Adds regression assertions for the correct help copy and removal of both radius claims.

## Validation

- `npm run test:pma-methodology-language` — pass
- `git diff --check` — pass

Do not merge until Claude/human review.