### PR TITLE
chore(data): refresh NHPD or disclose vintage

### DIFF
--- a/market-analysis.html
+++ b/market-analysis.html
@@ -287,7 +287,7 @@
             { name: 'FEMA Flood Zones', status: 'cached', vintage: '2026 (NFHL current effective)', coverage: 'Colorado', note: 'Polygon SFHA high-risk zones only (A/AE/AO/AH); Zone X/D moderate-low not included' },
             { name: 'EPA EJI (Environmental Justice)', status: 'cached', vintage: '2022', coverage: 'Tract-level', note: 'Used as soil/cleanup proxy, not geotechnical data' },
             { name: 'LEHD LODES Commuting', status: 'primary', vintage: '2023', coverage: 'CO counties', note: 'Workforce sub-score (25% weight)' },
-            { name: 'NHPD Preservation', status: 'stub', vintage: '—', coverage: '—', note: 'Loaded but not yet integrated into scoring' }
+            { name: 'NHPD Preservation', status: 'stub', vintage: '2026-03-13', coverage: 'Colorado stub snapshot', note: 'Registration-gated source; verify current subsidy status. Loaded but not integrated into scoring.' }
           ],
           limitations: 'PMA uses a circular buffer, not a professionally delineated market area. Amenity distances are point-based approximations. Employment detection requires 500+ job clusters (may fail in rural areas). Barrier analysis is heuristic only — the PMA boundary is not spatially modified.'
         });
@@ -977,6 +977,7 @@
           <!-- Subsidy expiry risk table (populated when NHPD data found) -->
           <div id="pmaSubsidyRiskWrap" hidden style="margin-top:.75rem;">
             <p style="font-size:.78em;font-weight:600;margin-bottom:.35rem;">⚠ At-risk subsidy properties near site:</p>
+            <p style="font-size:.74em;margin:0 0 .35rem;color:var(--muted);"><strong>NHPD snapshot vintage: 2026-03-13 (stub).</strong> Access is registration-gated; verify current subsidy status with NHPD.</p>
             <div id="pmaSubsidyRiskList" style="font-size:.78em;"></div>
           </div>
           <!-- Absorption risk card — proposed units vs total competitive set -->

--- a/preservation.html
+++ b/preservation.html
@@ -282,6 +282,7 @@
         Colorado affordable housing properties with active subsidies — flag expiring contracts before units lose affordability.
         Data sourced from the <a href="https://preservationdatabase.org/" target="_blank" rel="noopener">National Housing Preservation Database (NHPD)</a>.
         <span id="presDataTimestamp" aria-live="polite"></span>
+        <strong>NHPD access is registration-gated; this page uses the disclosed 2026-03-13 stub snapshot. Verify current subsidy status with NHPD.</strong>
       </p>
       <small class="data-timestamp" title="Sourced from data/manifest.json — updated each time the data pipeline runs"></small>
     </div>
@@ -418,6 +419,7 @@
       </a>,
       a joint project of the National Low Income Housing Coalition and Public Housing Analytics.
       Rebuild local data with <code>python3 scripts/fetch_nhpd.py</code>.
+      Snapshot vintage: 2026-03-13 (stub); NHPD access is registration-gated, so current subsidy status must be verified with the source.
       Expiry horizon warnings flag subsidies expiring within 3 years. ·
       <a href="compliance-dashboard.html">Prop 123 Compliance →</a> ·
       <a href="chfa-portfolio.html">CHFA Portfolio →</a>

--- a/scripts/audit/data-freshness-check.mjs
+++ b/scripts/audit/data-freshness-check.mjs
@@ -47,7 +47,13 @@ const SLA_CONFIG = [
   // NHPD now requires account registration and the repo currently ships a
   // stub fixture. Keep surfacing age drift in reports, but do not fail CI
   // until we have a reliable automated refresh path again.
-  { file: 'data/market/nhpd_co.geojson',                    slaDays: 95,  cadence: 'quarterly (NHPD export)', warnOnly: true },
+  {
+    file: 'data/market/nhpd_co.geojson',
+    slaDays: 95,
+    cadence: 'quarterly (NHPD export)',
+    warnOnly: true,
+    exception: 'NHPD access is registration-gated; the shipped 2026-03-13 stub vintage is disclosed wherever rendered.',
+  },
   { file: 'data/co_ami_gap_by_county.json',                 slaDays: 95,  cadence: 'quarterly (AMI gap build)' },
   { file: 'data/co_ami_gap_by_place.json',                  slaDays: 95,  cadence: 'quarterly (matches county counterpart; underlying ACS + HUD income limits refresh annually)' },
   { file: 'data/market/cdphe_county_boundaries_co.geojson', slaDays: 400, cadence: 'annual (CDPHE boundary refresh)' },
@@ -191,6 +197,7 @@ async function main() {
         console.log(
           `  [${r.warnOnly ? 'warning' : 'blocking'} · ${r.ageDays}d past SLA of ${r.slaDays}d]  ${r.file}  (cadence: ${r.cadence})`,
         );
+        if (r.exception) console.log(`    exception: ${r.exception}`);
       }
     }
     if (missing.length) {

--- a/test/pipeline-guards-a2.test.js
+++ b/test/pipeline-guards-a2.test.js
@@ -76,6 +76,11 @@ assert(
   'freshness check keeps NHPD in SLA reporting but marks it warnOnly while the source remains registration-gated',
 );
 assert(
+  freshnessSrc.includes("exception: 'NHPD access is registration-gated; the shipped 2026-03-13 stub vintage is disclosed wherever rendered.'") &&
+    freshnessSrc.includes('if (r.exception) console.log(`    exception: ${r.exception}`);'),
+  'freshness check documents and reports the NHPD stale-data exception',
+);
+assert(
   freshnessSrc.includes('const blockingStale = stale.filter(r => !r.warnOnly);') &&
     freshnessSrc.includes('if (blockingStale.length) process.exit(1);'),
   'freshness check only fails CI for blocking stale files',

--- a/test/preservation.test.js
+++ b/test/preservation.test.js
@@ -376,6 +376,16 @@ test('preservation.html: includes required scripts', function () {
   assert(html.includes('js/data-service-portable.js'), 'includes data-service-portable.js');
 });
 
+test('NHPD rendering surfaces disclose the real stub vintage and gated-source limitation', function () {
+  const preservation = fs.readFileSync(path.join(ROOT, 'preservation.html'), 'utf8');
+  const market = fs.readFileSync(path.join(ROOT, 'market-analysis.html'), 'utf8');
+  [preservation, market].forEach(function (surface) {
+    assert(surface.includes('2026-03-13'), 'surface discloses the checked-in NHPD vintage');
+    assert(surface.includes('registration-gated'), 'surface discloses the NHPD access limitation');
+    assert(/verify current subsidy status/i.test(surface), 'surface requires current-source verification');
+  });
+});
+
 test('preservation.html: accessibility — landmarks present', function () {
   const html = fs.readFileSync(path.join(ROOT, 'preservation.html'), 'utf8');
   assert(html.includes('<main'),       '<main> landmark present');


### PR DESCRIPTION
## Summary
- disclose the checked-in NHPD stub vintage (2026-03-13) on both rendering surfaces
- warn users that NHPD access is registration-gated and current subsidy status requires source verification
- document and print the warn-only freshness exception

## Verification
- live legacy API endpoint returned HTTP 404; no refresh date was fabricated
- node test/preservation.test.js
- node test/pipeline-guards-a2.test.js
- node scripts/audit/data-freshness-check.mjs
- node scripts/compute-inventory.mjs
- git diff --check

Issue #1409 is intentionally left for the freshness automation to close.