### PR TITLE
fix(ci): rebase before workflow pushes

### DIFF
--- a/.github/workflows/backfill_housing_brief.yml
+++ b/.github/workflows/backfill_housing_brief.yml
@@ -49,5 +49,9 @@ jobs:
             echo "No changes to commit."
           else
             git commit -m "chore: GDELT backfill ${{ inputs.weeks }} weeks $(date -u '+%Y-%m-%d')"
+            if [ "${{ github.ref_name }}" = "main" ]; then
+              git fetch origin main
+              git rebase --autostash origin/main
+            fi
             git push
           fi

--- a/.github/workflows/cleanup-stale-branches.yml
+++ b/.github/workflows/cleanup-stale-branches.yml
@@ -87,6 +87,10 @@ jobs:
             fi
 
             if [ "$DRY_RUN" = "false" ]; then
+              if [ "${{ github.ref_name }}" = "main" ]; then
+                git fetch origin main
+                git rebase --autostash origin/main
+              fi
               git push origin --delete "$branch" 2>&1 \
                 && echo "    ✓ deleted $branch" \
                 || echo "    ✗ failed to delete $branch"

--- a/.github/workflows/data-source-monitoring.yml
+++ b/.github/workflows/data-source-monitoring.yml
@@ -276,6 +276,10 @@ jobs:
             echo "pushed=false" >> "$GITHUB_OUTPUT"
           else
             git commit -m "chore: update data discovery report [skip ci]"
+            if [ "${{ github.ref_name }}" = "main" ]; then
+              git fetch origin main
+              git rebase --autostash origin/main
+            fi
             git push
             echo "pushed=true" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/discover-local-resources-weekly.yml
+++ b/.github/workflows/discover-local-resources-weekly.yml
@@ -63,6 +63,10 @@ jobs:
             python3 scripts/rebuild_manifest.py
             git add data/hna/local-resources-candidates.json data/manifest.json
             git commit -m "chore(local-resources): weekly discovery $(date -u +%Y-%m-%d)"
+            if [ "${{ github.ref_name }}" = "main" ]; then
+              git fetch origin main
+              git rebase --autostash origin/main
+            fi
             git push
           fi
 

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -53,6 +53,10 @@ jobs:
           git checkout -b "$BRANCH"
           git add docs/
           git commit -m "docs: regenerate inventory and refresh deprecated-doc banners [$(date +%Y-%m-%d)]"
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            git fetch origin main
+            git rebase --autostash origin/main
+          fi
           git push origin "$BRANCH"
 
           gh pr create \

--- a/.github/workflows/fetch-chfa-lihtc.yml
+++ b/.github/workflows/fetch-chfa-lihtc.yml
@@ -147,4 +147,8 @@ jobs:
           git --no-pager diff --stat HEAD~1 HEAD || true
 
           echo "── Pushing changes ──"
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            git fetch origin main
+            git rebase --autostash origin/main
+          fi
           git push origin HEAD:main

--- a/.github/workflows/fetch-polymarket-data.yml
+++ b/.github/workflows/fetch-polymarket-data.yml
@@ -109,6 +109,10 @@ jobs:
             exit 0
           fi
           git commit -m "chore: update cached Polymarket prediction market data"
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            git fetch origin main
+            git rebase --autostash origin/main
+          fi
           git push
           echo "pushed=true" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/market_data_build.yml
+++ b/.github/workflows/market_data_build.yml
@@ -300,6 +300,10 @@ jobs:
           git fetch origin "$BRANCH" || true
           git checkout -B "$BRANCH"
           git commit -m "chore(data): rebuild market data artifacts [skip ci]"
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            git fetch origin main
+            git rebase --autostash origin/main
+          fi
           git push --force --set-upstream origin "$BRANCH"
 
           # Only create a PR when one isn't already open for this branch.

--- a/.github/workflows/pab-allocations-annual.yml
+++ b/.github/workflows/pab-allocations-annual.yml
@@ -60,6 +60,10 @@ jobs:
             python3 scripts/rebuild_manifest.py
             git add data/policy/pab-allocations.json data/manifest.json
             git commit -m "chore(pab): annual volume-cap refresh $(date -u +%Y-%m-%d)"
+            if [ "${{ github.ref_name }}" = "main" ]; then
+              git fetch origin main
+              git rebase --autostash origin/main
+            fi
             git push
           fi
 

--- a/.github/workflows/rebuild-bps-permits.yml
+++ b/.github/workflows/rebuild-bps-permits.yml
@@ -179,6 +179,10 @@ jobs:
           } > "$msg"
           git commit -F "$msg"
           rm -f "$msg"
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            git fetch origin main
+            git rebase --autostash origin/main
+          fi
           git push
           echo "pushed=true" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/rebuild-place-od-flows.yml
+++ b/.github/workflows/rebuild-place-od-flows.yml
@@ -96,6 +96,10 @@ jobs:
           } > "$msg"
           git commit -F "$msg"
           rm -f "$msg"
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            git fetch origin main
+            git rebase --autostash origin/main
+          fi
           git push
           echo "pushed=true" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/sync-data-mtimes.yml
+++ b/.github/workflows/sync-data-mtimes.yml
@@ -80,6 +80,10 @@ jobs:
           } > "$msg"
           git commit -F "$msg"
           rm -f "$msg"
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            git fetch origin main
+            git rebase --autostash origin/main
+          fi
           git push
           echo "pushed=true" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/url-health-weekly.yml
+++ b/.github/workflows/url-health-weekly.yml
@@ -72,6 +72,10 @@ jobs:
             python3 scripts/rebuild_manifest.py
             git add data/url-health.json data/manifest.json
             git commit -m "chore(url-health): weekly sweep $(date -u +%Y-%m-%d)"
+            if [ "${{ github.ref_name }}" = "main" ]; then
+              git fetch origin main
+              git rebase --autostash origin/main
+            fi
             git push
           fi
 


### PR DESCRIPTION
## Summary

Adds the proven fetch-and-rebase push guard to all 13 workflows that previously issued a bare `git push`. The three `push: main` workflows were handled first because their trigger structurally exposes them to follow-on commits; the remaining cron/dispatch workflows receive the same mechanical safety guard.

Each workflow now fetches `origin/main` and runs `git rebase --autostash origin/main` when operating from `main`, then pushes normally. `--autostash` preserves the F122 protection for build steps that leave unstaged drift.

This preserves the F119 conflict-safety rule: there is no `ours`/`theirs` strategy, conflict checkout, ignored rebase failure, or broad conflict swallow. A genuine conflict still fails loudly. The specialized `build-hna-data` manifest-conflict recovery was not copied because these jobs are short and do not need that narrowly bounded recovery path.

## Before / after

| Workflow | Trigger priority | Before | After |
| --- | --- | --- | --- |
| `rebuild-place-od-flows.yml` | push-triggered | bare push | fetch main + rebase with autostash before push |
| `rebuild-bps-permits.yml` | push-triggered | bare push | fetch main + rebase with autostash before push |
| `sync-data-mtimes.yml` | push-triggered | bare push | fetch main + rebase with autostash before push |
| `backfill_housing_brief.yml` | cron/dispatch | bare push | fetch main + rebase with autostash before push |
| `cleanup-stale-branches.yml` | cron/dispatch | bare push | fetch main + rebase with autostash before push |
| `data-source-monitoring.yml` | cron/dispatch | bare push | fetch main + rebase with autostash before push |
| `discover-local-resources-weekly.yml` | cron/dispatch | bare push | fetch main + rebase with autostash before push |
| `docs-sync.yml` | cron/dispatch | bare push | fetch main + rebase with autostash before push |
| `fetch-chfa-lihtc.yml` | cron/dispatch | bare push | fetch main + rebase with autostash before push |
| `fetch-polymarket-data.yml` | cron/dispatch | bare push | fetch main + rebase with autostash before push |
| `market_data_build.yml` | cron/dispatch | bare push | fetch main + rebase with autostash before push |
| `pab-allocations-annual.yml` | cron/dispatch | bare push | fetch main + rebase with autostash before push |
| `url-health-weekly.yml` | cron/dispatch | bare push | fetch main + rebase with autostash before push |

Result: **13 bare-push workflows before; 0 after.**

## Validation

- Full `npm test`: passed.
- Parsed every `.github/workflows/*.yml` file with PyYAML: passed.
- Required zero-bare-push audit: no output.
- `git diff --check origin/main...HEAD`: passed.
- Scope is limited to 13 files under `.github/workflows/`.

