### PR TITLE
fix(nav): add ownership and for-sale front door

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -93,6 +93,7 @@
     {
       label: "Insights",
       items: [
+        { label: "Help for Homebuyers",     href: "help-for-homebuyers.html",       desc: "Assistance programs for buyers" },
         { label: "Housing News",           href: "policy-briefs.html",             desc: "Auto-generated summaries — always check the linked source" },
         { label: "Market Insights",       href: "insights.html",                  desc: "Analysis & commentary" },
         { label: "Market Intelligence",   href: "market-intelligence.html",       desc: "Statewide demand & supply data" },

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -5,10 +5,14 @@
  *
  * Information Architecture:
  * ─────────────────────────────────────────────────────────────────────────
- * SCOPING A PROJECT (primary workflow):
+ * SCOPING A RENTAL PROJECT (primary workflow):
  *   LIHTC Guide (start here) → Opportunity Finder (find a market) →
  *   Select Jurisdiction → HNA → Market Analysis → Scenario Builder →
  *   Deal Calculator
+ *
+ * SCOPING A FOR-SALE PROJECT (entry points):
+ *   Ownership Need, For-Sale Market Study, Deal Calculator,
+ *   Land Value & Negotiation
  *
  * EXPLORE (comparative & context):
  *   Compare Jurisdictions, Colorado Deep Dive, CHFA Portfolio,
@@ -25,7 +29,7 @@
 (function () {
   const GROUPS = [
     {
-      label: "Scoping a Project",
+      label: "Scoping a Rental Project",
       items: [
         { label: "The Affordable Housing Pipeline",  href: "pipeline.html", desc: "From housing need to housing built — our 8-step public methodology", isNew: true },
         { label: "LIHTC Guide",             href: "lihtc-guide-for-stakeholders.html", desc: "Start here — LIHTC basics for all audiences" },
@@ -35,6 +39,15 @@
         { label: "Market Analysis",         href: "market-analysis.html",           desc: "Step 4: Site screening & PMA scoring" },
         { label: "Scenario Builder",        href: "hna-scenario-builder.html",      desc: "Step 5: 20-year demographic projections" },
         { label: "Deal Calculator",         href: "deal-calculator.html",           desc: "Step 6: LIHTC pro forma & capital stack" },
+      ]
+    },
+    {
+      label: "Scoping a For-Sale Project",
+      items: [
+        { label: "Ownership Need",           href: "housing-needs-assessment.html#affordable-ownership-need-section", desc: "Who can afford to buy, and what is missing" },
+        { label: "For-Sale Market Study",    href: "for-sale-market-study.html", desc: "Demand, capture, absorption, land disposition" },
+        { label: "Deal Calculator",          href: "deal-calculator.html", desc: "For-sale feasibility and buyer cash requirements" },
+        { label: "Land Value & Negotiation", href: "land-value.html", desc: "Site economics — shared with the rental track" },
       ]
     },
     {


### PR DESCRIPTION
## Summary

Gives the ownership and for-sale tools a clear front door in the shared site navigation.

- Renames `Scoping a Project` to `Scoping a Rental Project`, making the existing eight-step LIHTC sequence explicit.
- Adds `Scoping a For-Sale Project` immediately after it, with unnumbered entry points for Ownership Need, the For-Sale Market Study, the Deal Calculator, and Land Value & Negotiation.
- Adds Help for Homebuyers to Insights, keeping the household-facing resource separate from practitioner project-scoping workflows.
- Retains Deal Calculator and Land Value & Negotiation in their existing locations because both serve the rental and ownership tracks.

## Why

The prior group name promised general project scoping but contained only the rental LIHTC workflow. Ownership tools existed, yet the shared header offered no ownership-oriented path to them. This change fixes the information architecture without changing any tool, data, or scoring behavior.

## Validation

- `npm test` — passed.
- `npm run test:navigation-paths` — passed.
- `npm run test:orphan-nav-cleanup` — passed.
- `npm run test:phantom-alias-no-orphans` — passed.
- `node scripts/compute-inventory.mjs` — inventory current and unchanged.
- Confirmed `housing-needs-assessment.html#affordable-ownership-need-section` still exists.
- Rendered `index.html`, `housing-needs-assessment.html`, and `for-sale-market-study.html` locally: both scoping groups and the Homebuyer entry appeared on every page, and all three pages reported no console errors.

## Scope

One file changed: `js/navigation.js`. No application-tool logic, data, scoring, or inventory changes.
