### PR TITLE
fix(hna): summarize expected ACS1 no-content responses

### DIFF
--- a/scripts/hna/build_hna_data.py
+++ b/scripts/hna/build_hna_data.py
@@ -70,6 +70,19 @@ OUT = {
 # ============================================================================
 
 
+_HTTP_NO_CONTENT_COUNT = 0
+
+
+def _is_expected_acs1_no_content(url: str, status: int) -> bool:
+    """Return whether Census ACS1 reported its normal no-row response."""
+    parsed = urllib.parse.urlparse(url)
+    return (
+        status == 204
+        and parsed.hostname == 'api.census.gov'
+        and '/acs/acs1' in parsed.path
+    )
+
+
 def utc_now_z() -> str:
     """Return ISO 8601 UTC timestamp string ending with 'Z'."""
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
@@ -107,7 +120,15 @@ def http_get_text(url: str, timeout: int = 30, retries: int = 3, backoff: float 
                 body = r.read().decode('utf-8', errors='replace')
                 status = r.status
             elapsed = time.monotonic() - t0
-            print(f"← {status} OK  {len(body):,} bytes  {elapsed:.1f}s", file=sys.stderr)
+            if _is_expected_acs1_no_content(url, status):
+                # Census ACS1 returns 204 for geographies outside its
+                # publication universe. Callers deliberately retry ACS5, so
+                # keep one build-level count instead of emitting thousands of
+                # warnings for this expected no-row response.
+                global _HTTP_NO_CONTENT_COUNT
+                _HTTP_NO_CONTENT_COUNT += 1
+            else:
+                print(f"← {status} OK  {len(body):,} bytes  {elapsed:.1f}s", file=sys.stderr)
             return (status, body)
         except urllib.error.HTTPError as e:
             elapsed = time.monotonic() - t0
@@ -141,6 +162,8 @@ def http_get_text(url: str, timeout: int = 30, retries: int = 3, backoff: float 
 def http_get_json(url: str, timeout: int = 30) -> dict | list | None:
     """Fetch URL and parse as JSON. Returns None on error."""
     status, text = http_get_text(url, timeout=timeout, retries=1)
+    if _is_expected_acs1_no_content(url, status):
+        return None
     if status != 200:
         print(f"⚠ Failed to fetch JSON from external source: HTTP {status}", file=sys.stderr)
         print(f"  Response preview: {redact(text)[:500]}", file=sys.stderr)
@@ -2679,6 +2702,10 @@ def _print_summary() -> None:
     key = census_key()
     key_status = f'set ({len(key)} chars)' if key else 'NOT SET — Census API calls will be unauthenticated'
     print(f"  ℹ CENSUS_API_KEY: {key_status}")
+    print(
+        f"  ℹ Expected ACS1 HTTP 204 no-content responses: {_HTTP_NO_CONTENT_COUNT} "
+        "(handled as no data so caller fallbacks can run)"
+    )
     print(f"── Done [{utc_now_z()}] ──\n")
 
 

--- a/tests/test_build_hna_data_http_204.py
+++ b/tests/test_build_hna_data_http_204.py
@@ -1,0 +1,87 @@
+"""Regression coverage for expected ACS1 HTTP 204 responses."""
+
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+import sys
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "hna"))
+
+import build_hna_data as hna  # noqa: E402
+
+
+class _NoContentResponse:
+    status = 204
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    @staticmethod
+    def read():
+        return b""
+
+
+def test_http_204_returns_none_without_per_request_warning():
+    hna._HTTP_NO_CONTENT_COUNT = 0
+    stderr = StringIO()
+    acs1_url = "https:" + "//api.census.gov/data/2024/acs/acs1/subject"
+
+    with mock.patch.object(hna.urllib.request, "urlopen", return_value=_NoContentResponse()):
+        with redirect_stderr(stderr):
+            result = hna.http_get_json(acs1_url)
+
+    assert result is None
+    assert hna._HTTP_NO_CONTENT_COUNT == 1
+    assert "HTTP 204" not in stderr.getvalue()
+    assert "Failed to fetch JSON" not in stderr.getvalue()
+
+
+def test_non_acs1_http_204_still_warns():
+    hna._HTTP_NO_CONTENT_COUNT = 0
+    stderr = StringIO()
+    other_url = "https:" + "//example.invalid/unexpected-empty"
+
+    with mock.patch.object(hna.urllib.request, "urlopen", return_value=_NoContentResponse()):
+        with redirect_stderr(stderr):
+            result = hna.http_get_json(other_url)
+
+    assert result is None
+    assert hna._HTTP_NO_CONTENT_COUNT == 0
+    assert "HTTP 204" in stderr.getvalue()
+    assert "Failed to fetch JSON" in stderr.getvalue()
+
+
+def test_s0801_204_none_falls_back_to_acs5_values():
+    acs5_result = [
+        ["S0801_C01_001E", "S0801_C01_046E", "NAME"],
+        ["6300", "20.5", "Fruita city, Colorado"],
+    ]
+
+    with mock.patch.object(hna, "http_get_json", side_effect=[None, acs5_result]) as fetch:
+        result = hna.fetch_acs_s0801("place", "0828745")
+
+    assert fetch.call_count == 2
+    assert "/acs/acs1/subject?" in fetch.call_args_list[0].args[0]
+    assert "/acs/acs5/subject?" in fetch.call_args_list[1].args[0]
+    assert result["S0801_C01_001E"] == "6300"
+    assert result["S0801_C01_046E"] == "20.5"
+    assert result["_acsSeries"] == "acs5"
+    assert result["_acsYear"] == 2024
+
+
+def test_build_summary_reports_one_aggregate_204_count():
+    hna._HTTP_NO_CONTENT_COUNT = 3084
+    stdout = StringIO()
+
+    with redirect_stdout(stdout):
+        hna._print_summary()
+
+    rendered = stdout.getvalue()
+    assert rendered.count("Expected ACS1 HTTP 204 no-content responses:") == 1
+    assert "Expected ACS1 HTTP 204 no-content responses: 3084" in rendered


### PR DESCRIPTION
## Investigation result

Determination: **(a) genuinely empty upstream ACS1 responses for small geographies.** This is expected Census publication behavior, not a malformed query and not a key failure.

### Endpoint and cardinality

The 204s come from the 2024 Census ACS **1-year** endpoints when the HNA builder probes geographies that have no ACS1 row:

- four batched calls to `/acs/acs1/profile` (profile batches A–D);
- one call to `/acs/acs1/subject` (S0801); and
- one call to `/acs/acs1` (B08301).

Run `32006041670` contains exactly 3,084 HTTP 204s and 514 logged S0801 fallbacks to ACS5. The call graph explains the count exactly:

`514 geographies × 6 ACS1 probes = 3,084 HTTP 204 responses`

The build processes 546 geographies, so 32 resolve directly through ACS1 and 514 follow the documented ACS5 path. This stable arithmetic also explains why the same count recurred across green builds.

### One fully traced `None`: Fruita

For Fruita (`place:0828745`), the ACS1 S0801 request returns 204. `http_get_json()` converts that response to `None`; `fetch_acs_s0801()` then immediately calls the 2024 ACS5 subject endpoint. The committed `data/hna/summary/0828745.json` records that ACS5 subject endpoint and contains:

- workers age 16+: `6,300`;
- mean travel time: `20.5` minutes.

The same ACS1-to-ACS5 sequence populates the profile and B08301 sections. The current Fruita artifact contains population `13,691`, median household income `$87,184`, total housing units `5,455`, and B08301 total workers `6,300`.

For this traced `None`, the destination is **populated from ACS5**—not null, not absent, and not a cached stale value. The existing merge-preserve guard remains unchanged and continues protecting unrelated backfill-owned or transiently lost fields.

## Change

- Treat only `204` responses from `api.census.gov` ACS1 paths as expected no-row responses.
- Return `None` so the existing ACS5 caller fallback continues unchanged.
- Replace thousands of per-request failure warnings with one end-of-build aggregate count.
- Continue warning for HTTP 204 from every non-ACS1 endpoint; the finding is not globally silenced.
- Add regression coverage for expected ACS1 handling, unexpected non-ACS1 204 warnings, the Fruita S0801 ACS5 fallback, and the single aggregate summary.

No URLs were unredacted. `build-hna-data.yml`, application rendering, and `data/` are untouched. No user-facing figures change.

## Validation

- `npm test` — passed.
- New focused suite — 4 passed.
- Full Python suite — 522 passed; one local sandbox-only `py_compile` cache-permission failure. The failing test passed when rerun with `PYTHONPYCACHEPREFIX=/tmp/hna-fetch-204-pycache`, confirming valid syntax rather than a repository failure.
- `python3 -m py_compile scripts/hna/build_hna_data.py` with the same temporary cache prefix — passed.
- `git diff --check` — passed.
