### PR TITLE
fix(nav): collapse scoping groups, constrain dropdown height

### DIFF
--- a/css/navigation.css
+++ b/css/navigation.css
@@ -164,6 +164,13 @@ main {
   top: 100%;
   left: 0;
   min-width: 220px;
+  /* The "Scoping a Project" menu carries both the 8-step rental sequence and
+     the for-sale entry points, so it can exceed the viewport on shorter
+     screens. Without these two lines the lower section is rendered but
+     unreachable — no scroll, just clipped off the bottom of the page. */
+  max-height: calc(100vh - 96px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: 8px;

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -29,25 +29,22 @@
 (function () {
   const GROUPS = [
     {
-      label: "Scoping a Rental Project",
+      label: "Scoping a Project",
       items: [
         { label: "The Affordable Housing Pipeline",  href: "pipeline.html", desc: "From housing need to housing built — our 8-step public methodology", isNew: true },
         { label: "LIHTC Guide",             href: "lihtc-guide-for-stakeholders.html", desc: "Start here — LIHTC basics for all audiences" },
+        { label: "— Rental (LIHTC) —", isHeader: true },
         { label: "Opportunity Finder",      href: "lihtc-opportunity-finder.html",  desc: "Step 1: Rank CO jurisdictions for 4% bond + 9% competitive LIHTC", isNew: true },
         { label: "Select Jurisdiction",     href: "select-jurisdiction.html",       desc: "Step 2: Pick your target county / city" },
         { label: "Housing Needs Assessment",href: "housing-needs-assessment.html",  desc: "Step 3: Community need evidence" },
         { label: "Market Analysis",         href: "market-analysis.html",           desc: "Step 4: Site screening & PMA scoring" },
         { label: "Scenario Builder",        href: "hna-scenario-builder.html",      desc: "Step 5: 20-year demographic projections" },
         { label: "Deal Calculator",         href: "deal-calculator.html",           desc: "Step 6: LIHTC pro forma & capital stack" },
-      ]
-    },
-    {
-      label: "Scoping a For-Sale Project",
-      items: [
+        { label: "— For-Sale / Ownership —", isHeader: true },
         { label: "Ownership Need",           href: "housing-needs-assessment.html#affordable-ownership-need-section", desc: "Who can afford to buy, and what is missing" },
-        { label: "For-Sale Market Study",    href: "for-sale-market-study.html", desc: "Demand, capture, absorption, land disposition" },
-        { label: "Deal Calculator",          href: "deal-calculator.html", desc: "For-sale feasibility and buyer cash requirements" },
-        { label: "Land Value & Negotiation", href: "land-value.html", desc: "Site economics — shared with the rental track" },
+        { label: "For-Sale Market Study",    href: "for-sale-market-study.html",     desc: "Demand, capture, absorption, land disposition" },
+        { label: "For-Sale Feasibility",     href: "deal-calculator.html",           desc: "Buyer cash requirements in the Deal Calculator" },
+        { label: "Land Value & Negotiation", href: "land-value.html",                desc: "Site economics — serves both tracks" },
       ]
     },
     {


### PR DESCRIPTION
Fixes the clunky header introduced by #1445.

## What went wrong

#1445 added a **fifth** top-level nav group *and* lengthened an existing label, so the header carried two long, near-identical buttons side by side:

`Scoping a Rental Project` | `Scoping a For-Sale Project` | Explore | Data | Insights

That crowded the bar and made the choice ambiguous — which "Scoping" do you want?

## Fix, part one — back to four buttons

Collapsed to a single `Scoping a Project` button, splitting the two tracks *inside* the dropdown with the existing **`isHeader` separator pattern (F177)** — already implemented in the renderer at `js/navigation.js:229` but never used by any group:

```
Scoping a Project ▾
  The Affordable Housing Pipeline
  LIHTC Guide
  — RENTAL (LIHTC) —
  Opportunity Finder … Deal Calculator      (the 8-step sequence)
  — FOR-SALE / OWNERSHIP —
  Ownership Need, For-Sale Market Study,
  For-Sale Feasibility, Land Value
```

## Fix, part two — the bug that created

Collapsing alone made things **worse**. Measured in a real browser rather than assumed:

| | height | bottom edge | overflows 800px viewport | scrollable |
|---|---|---|---|---|
| before | 1059px | 1106px | **yes** | **no** |
| after | 704px | 751px | no | yes |

With `overflow-y: visible` and `max-height: none`, the For-Sale section was in the DOM but **unreachable** — clipped off the bottom with no way to scroll to it. That defeats the entire purpose of the change.

Added `max-height: calc(100vh - 96px)` + `overflow-y: auto` + `overscroll-behavior: contain` to `.nav-dropdown`.

## Verification
- Rendered at 1280×800, opened the menu, scrolled to the end, confirmed `Land Value & Negotiation` sits fully inside the dropdown bounds
- Both section headers render: `Rental (LIHTC)`, `For-Sale / Ownership`
- `for-sale-market-study.html`, `help-for-homebuyers.html` and the HNA ownership anchor all still in nav
- `test:navigation-paths`, `test:orphan-nav-cleanup`, `test:phantom-alias-no-orphans` pass
- Full `npm test` exit 0

The dropdown constraint benefits every menu, not just this one — it was a latent bug that the longer menu exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)