### PR TITLE
feat(policy): add Prop 123 DPA eligibility model

### DIFF
--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-17T22:25:16.187220Z",
+  "generated": "2026-08-18T04:11:11.610463Z",
   "files": {
     "data/_manifest.json": {
       "featureCount": 0,
@@ -7834,7 +7834,7 @@
     "data/policy/affordability-models.json": {
       "featureCount": 0,
       "placeholder": false,
-      "bytes": 8737
+      "bytes": 11211
     },
     "data/policy/buyer-assistance-programs.json": {
       "featureCount": 0,

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-18T04:11:11.610463Z",
+  "generated": "2026-08-18T05:04:41.786264Z",
   "files": {
     "data/_manifest.json": {
       "featureCount": 0,
@@ -7834,7 +7834,7 @@
     "data/policy/affordability-models.json": {
       "featureCount": 0,
       "placeholder": false,
-      "bytes": 11211
+      "bytes": 11210
     },
     "data/policy/buyer-assistance-programs.json": {
       "featureCount": 0,

--- a/data/policy/affordability-models.json
+++ b/data/policy/affordability-models.json
@@ -165,6 +165,40 @@
       "verify": true
     },
     {
+      "id": "prop123_dpa_eligibility",
+      "label": "Prop 123 DPA eligibility gate (not an affordability finding)",
+      "default": false,
+      "params": {
+        "rateAnnual": 0.065,
+        "rate_as_of": "shared HNA AFFORD assumption",
+        "termYears": 30,
+        "downPaymentPct": 0.1,
+        "housingRatioType": "front",
+        "housingRatio": 0.38,
+        "propertyTaxRate": 0.0065,
+        "insuranceRate": 0.0035,
+        "pmiRate": 0.005,
+        "pmiLtvGate": false,
+        "hoaMonthly": 0,
+        "groundRentMonthly": 0,
+        "borrowerMonthlyDebt": 0,
+        "amiCeilingPct": 1.2,
+        "household_size_default": 4
+      },
+      "implications": {
+        "who_it_fits": "Prop 123 down-payment-assistance eligibility screening for households at or below 120% of either statewide or local AMI. This is an assistance-eligibility screen, not a burden or affordability test.",
+        "gap_direction": "Compare with conservative_screening (30% front-end) to see the eligibility-versus-affordability gap. The difference between the two is the useful output, not either number alone.",
+        "buyer_risk": "The 38% front-end gate exceeds conventional (28%), USDA (29%), and FHA (31%) standards, so a household passing this gate may still fail underwriting for the underlying mortgage.",
+        "lender_appraisal_acceptance": "SB26-040 raised the prior 35% threshold to 38% effective 2026-07-01. This program rule does not determine what a lender will write.",
+        "when_not_to_use": "Do not use as an affordability finding or mortgage-qualification result. The Division of Housing may modify the percentage by waiver where substantial housing need exists and a unit was marketed for at least 6 months without a purchaser, so 38% is a default with a documented exception path rather than a hard constant."
+      },
+      "source": "https://leg.colorado.gov/bills/SB26-040",
+      "source_note": "The enacted bill summary documents the 38% monthly-housing-cost gate, the statewide-or-local 120% AMI test, and the waiver path. The front-end characterization and 35%-to-38% change are also stated in the sponsor summary at https://www.senatedems.co/newsroom/legislation-to-create-more-affordable-home-ownership-opportunities-signed-into-law. The enacted-text PDF was not retrievable during research and was not represented as directly reviewed.",
+      "last_verified": null,
+      "classification": "modeled",
+      "verify": true
+    },
+    {
       "id": "custom",
       "label": "Custom (user sets all parameters)",
       "params": {

--- a/data/policy/affordability-models.json
+++ b/data/policy/affordability-models.json
@@ -193,7 +193,7 @@
         "when_not_to_use": "Do not use as an affordability finding or mortgage-qualification result. The Division of Housing may modify the percentage by waiver where substantial housing need exists and a unit was marketed for at least 6 months without a purchaser, so 38% is a default with a documented exception path rather than a hard constant."
       },
       "source": "https://leg.colorado.gov/bills/SB26-040",
-      "source_note": "The enacted bill summary documents the 38% monthly-housing-cost gate, the statewide-or-local 120% AMI test, and the waiver path. The front-end characterization and 35%-to-38% change are also stated in the sponsor summary at https://www.senatedems.co/newsroom/legislation-to-create-more-affordable-home-ownership-opportunities-signed-into-law. The enacted-text PDF was not retrievable during research and was not represented as directly reviewed.",
+      "source_note": "The enacted bill summary documents the 38% monthly-housing-cost gate, the statewide-or-local 120% AMI test, and the waiver path. The front-end characterization and 35%-to-38% change are also stated in the sponsor summary at https://www.senatedems.co/newsroom/legislation-to-create-more-affordable-home-ownership-opportunities-signed-into-law The enacted-text PDF was not retrievable during research and was not represented as directly reviewed.",
       "last_verified": null,
       "classification": "modeled",
       "verify": true


### PR DESCRIPTION
## Summary

- Adds `prop123_dpa_eligibility` as the seventh affordability-model registry entry, labeled “Prop 123 DPA eligibility gate (not an affordability finding).”
- Mirrors `conservative_screening` assumptions except for the statutory 38% front-end housing-cost share and the new `amiCeilingPct: 1.20` eligibility field.
- Keeps `conservative_screening` as the sole default and leaves all JavaScript constants, computation, ranking, and scoring unchanged.
- Rebuilds `data/manifest.json` from a clean disposable worktree (1,607 entries).

## Interpretation and safeguards

This is an assistance-eligibility screen, not an affordability or mortgage-qualification finding. The 38% front-end gate is above conventional 28%, USDA 29%, and FHA 31% reference standards, so passing this screen does not establish that the underlying loan is affordable or underwritable. The model directs users to compare it with `conservative_screening` to expose the eligibility-versus-affordability gap.

The entry records the statutory ceiling as at or below 120% of either local-jurisdiction AMI or statewide AMI by household size. It also records the prior 35%-to-38% change effective July 1, 2026 and the Division of Housing waiver path where substantial need exists and a unit has been marketed for at least six months without a purchaser.

`amiCeilingPct` fit the existing registry structure and validation contract without weakening or changing a schema.

## Provenance caveat

The official enacted-bill summary was reviewed for the 38% housing-cost gate, the local-or-statewide 120% AMI test, and the waiver path. The sponsor statement is cited for the front-end characterization and the 35%-to-38% change. The enacted-text PDF was not retrievable during research and is not claimed as directly reviewed.

## Validation

- `npm run test:ownership-funding-schema`
- `node scripts/validate-schemas.js` — 85/85
- `node test/file-manifest.test.js`
- `npm test`
- Registry assertions: 7 models, sole default unchanged, and exact parameter mirror/deltas
