### PR TITLE
fix(data): rebuild manifest after byte drift in _manifest.json

### DIFF
--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,10 +1,10 @@
 {
-  "generated": "2026-08-18T07:39:08.254222Z",
+  "generated": "2026-08-18T10:00:54.166314Z",
   "files": {
     "data/_manifest.json": {
       "featureCount": 0,
       "placeholder": false,
-      "bytes": 779733
+      "bytes": 779735
     },
     "data/_qa-status.json": {
       "featureCount": 0,


### PR DESCRIPTION
## Summary

- Rebuilds `data/manifest.json` from a clean disposable worktree.
- Corrects the recorded size of `data/_manifest.json` from 779,733 bytes to 779,735 bytes.
- Keeps the manifest at exactly 1,607 entries.

## Scope

This is the requested symptom-only repair. The PR changes only `data/manifest.json`. It does not modify `data-refresh.yml`, either manifest-producing script, or any application behavior. The source of the one-off intervening write remains unknown and is not guessed at here.

## Before and after

| State | Recorded bytes | Actual committed bytes |
|---|---:|---:|
| `origin/main` before repair | 779,733 | 779,735 |
| This commit | 779,735 | 779,735 |

The post-commit comparison was performed against the Git objects in `HEAD`, not the working tree.

## Validation

- Clean disposable-worktree rebuild: 1,607 entries
- `node scripts/validate-schemas.js` — 85/85 passed
- `node test/file-manifest.test.js` — passed before and after the full suite
- Full `npm test` — passed
- Post-suite generated data drift removed and the exact rebuilt manifest restored
- Final commit changes one file only: `data/manifest.json`
