### PR TITLE
fix(ci): add workflow timeout ceilings

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -23,6 +23,7 @@ jobs:
   contrast-check:
     name: WCAG AA Contrast Token Check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/archive-audit-post-merge.yml
+++ b/.github/workflows/archive-audit-post-merge.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   audit-and-docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/audit-endpoints.yml
+++ b/.github/workflows/audit-endpoints.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7

--- a/.github/workflows/backfill-hna-extended-acs-cache.yml
+++ b/.github/workflows/backfill-hna-extended-acs-cache.yml
@@ -33,6 +33,7 @@ concurrency:
 jobs:
   backfill:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/backfill-hna-household-occupation.yml
+++ b/.github/workflows/backfill-hna-household-occupation.yml
@@ -41,6 +41,7 @@ concurrency:
 jobs:
   backfill:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/backfill-hna-value-brackets.yml
+++ b/.github/workflows/backfill-hna-value-brackets.yml
@@ -34,6 +34,7 @@ concurrency:
 jobs:
   backfill:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/backfill_housing_brief.yml
+++ b/.github/workflows/backfill_housing_brief.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   backfill:
     runs-on: ubuntu-latest
+    timeout-minutes: 300
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-hna-data.yml
+++ b/.github/workflows/build-hna-data.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   build-hna:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7

--- a/.github/workflows/build-rent-burden-crosscheck.yml
+++ b/.github/workflows/build-rent-burden-crosscheck.yml
@@ -35,6 +35,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/cache-hud-gis-data.yml
+++ b/.github/workflows/cache-hud-gis-data.yml
@@ -35,6 +35,7 @@ concurrency:
 jobs:
   cache-hud-gis:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/car-data-update.yml
+++ b/.github/workflows/car-data-update.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   update:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   ci-checks:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/cleanup-stale-branches.yml
+++ b/.github/workflows/cleanup-stale-branches.yml
@@ -29,6 +29,7 @@ permissions:
 jobs:
   prune:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,7 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       security-events: write
       packages: read

--- a/.github/workflows/configure-alerts-feeds.yml
+++ b/.github/workflows/configure-alerts-feeds.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   fetch-alerts-and-generate-briefs:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/console-error-audit.yml
+++ b/.github/workflows/console-error-audit.yml
@@ -13,6 +13,7 @@ jobs:
   console-error-audit:
     name: Audit Console Errors Across All Pages
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       # ── Setup ──────────────────────────────────────────────────────────────

--- a/.github/workflows/contrast-audit.yml
+++ b/.github/workflows/contrast-audit.yml
@@ -26,6 +26,7 @@ permissions:
 jobs:
   contrast-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/coverage-audit-nightly.yml
+++ b/.github/workflows/coverage-audit-nightly.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   coverage-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/create-phase3-sub-issues.yml
+++ b/.github/workflows/create-phase3-sub-issues.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   create-sub-issues:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/daily-audit-system.yml
+++ b/.github/workflows/daily-audit-system.yml
@@ -9,6 +9,7 @@ jobs:
   audit:
     name: Full Diagnostic Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
 

--- a/.github/workflows/data-quality-check.yml
+++ b/.github/workflows/data-quality-check.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   validate-data:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   refresh:
     runs-on: ubuntu-latest
+    timeout-minutes: 75
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7

--- a/.github/workflows/data-source-monitoring.yml
+++ b/.github/workflows/data-source-monitoring.yml
@@ -19,6 +19,7 @@ jobs:
   discover:
     name: Discover & Monitor Data Sources
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       # ── Setup ───────────────────────────────────────────────────────────────

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:

--- a/.github/workflows/developer-url-health.yml
+++ b/.github/workflows/developer-url-health.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/discover-agenda-urls.yml
+++ b/.github/workflows/discover-agenda-urls.yml
@@ -35,6 +35,7 @@ concurrency:
 jobs:
   discover:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/discover-local-resources-weekly.yml
+++ b/.github/workflows/discover-local-resources-weekly.yml
@@ -35,6 +35,7 @@ jobs:
   discover:
     name: Probe + write candidates + file issue
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   sync-docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/external-references-check.yml
+++ b/.github/workflows/external-references-check.yml
@@ -34,6 +34,7 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/fetch-cdphe-boundaries.yml
+++ b/.github/workflows/fetch-cdphe-boundaries.yml
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   fetch:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/fetch-census-acs.yml
+++ b/.github/workflows/fetch-census-acs.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   fetch-census:
     runs-on: ubuntu-latest
+    timeout-minutes: 75
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7

--- a/.github/workflows/fetch-chas-data.yml
+++ b/.github/workflows/fetch-chas-data.yml
@@ -28,6 +28,7 @@ concurrency:
 jobs:
   fetch-chas:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/fetch-chfa-lihtc.yml
+++ b/.github/workflows/fetch-chfa-lihtc.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   fetch-chfa-lihtc:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/fetch-county-data.yml
+++ b/.github/workflows/fetch-county-data.yml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   fetch-county-data:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/fetch-fmr-data.yml
+++ b/.github/workflows/fetch-fmr-data.yml
@@ -40,6 +40,7 @@ concurrency:
 jobs:
   fetch-fmr:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/fetch-fred-data.yml
+++ b/.github/workflows/fetch-fred-data.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   fetch-data:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7

--- a/.github/workflows/fetch-hmda-data.yml
+++ b/.github/workflows/fetch-hmda-data.yml
@@ -27,6 +27,7 @@ concurrency:
 jobs:
   fetch-hmda:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/fetch-kalshi.yml
+++ b/.github/workflows/fetch-kalshi.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   fetch-kalshi:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/fetch-parcel-zoning-data.yml
+++ b/.github/workflows/fetch-parcel-zoning-data.yml
@@ -44,6 +44,7 @@ concurrency:
 jobs:
   fetch-parcel-zoning:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/fetch-polymarket-data.yml
+++ b/.github/workflows/fetch-polymarket-data.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   fetch-data:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7

--- a/.github/workflows/jurisdiction-briefs-monthly.yml
+++ b/.github/workflows/jurisdiction-briefs-monthly.yml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   surface-needs:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout main
         uses: actions/checkout@v7

--- a/.github/workflows/market_data_build.yml
+++ b/.github/workflows/market_data_build.yml
@@ -34,6 +34,7 @@ jobs:
   health-check:
     name: Health Check — validate data source availability
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     outputs:
       tigerweb_ok: ${{ steps.check.outputs.tigerweb_ok }}
@@ -83,6 +84,7 @@ jobs:
   build:
     name: Fetch and build market data artifacts
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: health-check
 
     steps:
@@ -159,6 +161,7 @@ jobs:
   bbox-fix:
     name: Fix missing bbox fields in GeoJSON artifacts
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: build
 
     steps:
@@ -327,6 +330,7 @@ jobs:
   notify-failure:
     name: Notify on build failure
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [health-check, build, bbox-fix]
     if: failure()
 

--- a/.github/workflows/pab-allocations-annual.yml
+++ b/.github/workflows/pab-allocations-annual.yml
@@ -27,6 +27,7 @@ jobs:
   refresh:
     name: Fetch + reconcile + commit
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/qa-status.yml
+++ b/.github/workflows/qa-status.yml
@@ -45,6 +45,7 @@ concurrency:
 jobs:
   qa-status:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/redeploy-zip.yml
+++ b/.github/workflows/redeploy-zip.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   validate-and-zip:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/refresh-state-trend-analysis.yml
+++ b/.github/workflows/refresh-state-trend-analysis.yml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   refresh:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/run-all-workflows.yml
+++ b/.github/workflows/run-all-workflows.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   run-data-workflows:
     runs-on: ubuntu-latest
+    timeout-minutes: 180
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/scrape-agenda-items.yml
+++ b/.github/workflows/scrape-agenda-items.yml
@@ -31,6 +31,7 @@ concurrency:
 jobs:
   scrape:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/site-audit.yml
+++ b/.github/workflows/site-audit.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   site-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/source-liveness-weekly.yml
+++ b/.github/workflows/source-liveness-weekly.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   source-liveness:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout main
         uses: actions/checkout@v7

--- a/.github/workflows/test-sentinel-normalization.yml
+++ b/.github/workflows/test-sentinel-normalization.yml
@@ -26,6 +26,7 @@ jobs:
   sentinel-unit-tests:
     name: Sentinel normalization unit tests (Python)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository
@@ -45,6 +46,7 @@ jobs:
   sentinel-production-scan:
     name: Production JSON sentinel scan
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository
@@ -61,6 +63,7 @@ jobs:
   hna-static-smoke:
     name: HNA page static smoke tests (Node.js)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/triage-open-issues.yml
+++ b/.github/workflows/triage-open-issues.yml
@@ -17,6 +17,7 @@ jobs:
   triage:
     name: Triage Open Issues
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO: pggLLC/Housing-Analytics

--- a/.github/workflows/upstream-vintage-watch.yml
+++ b/.github/workflows/upstream-vintage-watch.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   watch:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/url-health-weekly.yml
+++ b/.github/workflows/url-health-weekly.yml
@@ -30,6 +30,7 @@ jobs:
   sweep:
     name: Sweep + diff + report
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout

--- a/.github/workflows/weekly_housing_brief.yml
+++ b/.github/workflows/weekly_housing_brief.yml
@@ -36,6 +36,7 @@ concurrency:
 jobs:
   refresh-policy-briefs:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/workflow-comment-trigger.yml
+++ b/.github/workflows/workflow-comment-trigger.yml
@@ -57,6 +57,7 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Acknowledge trigger
         if: github.event_name == 'issue_comment'
@@ -110,6 +111,7 @@ jobs:
       (github.event.workflow_run.conclusion == 'cancelled' ||
        github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/.github/workflows/zillow-data-sync.yml
+++ b/.github/workflows/zillow-data-sync.yml
@@ -15,6 +15,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────────
   zillow-research:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
 
@@ -118,6 +119,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────────
   bridge-public-data:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
 


### PR DESCRIPTION
## Summary

- adds job-level `timeout-minutes` ceilings to every workflow job that lacked one
- uses measured maxima from the last 10 runs, with readable headroom rather than a blanket value
- preserves all cron schedules, concurrency settings, and rebase-before-push safety blocks

## Runtime basis and ceilings

| Workflow | Observed max / basis | Ceiling (min) |
|---|---:|---:|
| accessibility | <1m; audit/check | 30 |
| archive-audit-post-merge | 1m; audit | 30 |
| audit-endpoints | <1m; audit | 30 |
| backfill-hna-extended-acs-cache | 2m | 15 |
| backfill-hna-household-occupation | 1m | 15 |
| backfill-hna-value-brackets | 2m | 15 |
| backfill_housing_brief | 267m successful run; 365m apparent default-limit hang | 300 |
| build-hna-data | 64m, including end rebase | 120 |
| build-rent-burden-crosscheck | <1m | 15 |
| cache-hud-gis-data | <1m | 15 |
| car-data-update | <1m | 15 |
| ci-checks | 4m; checks | 30 |
| cleanup-stale-branches | 4m | 15 |
| codeql | 3m; audit/check | 30 |
| configure-alerts-feeds | 1m | 15 |
| console-error-audit | 3m; audit | 30 |
| contrast-audit | 360m apparent default-limit hang; audit ceiling | 30 |
| coverage-audit-nightly | <1m; audit | 30 |
| create-phase3-sub-issues | no run history | 30 |
| daily-audit-system | <1m; audit | 30 |
| data-quality-check | <1m; check | 30 |
| data-refresh | 37m | 75 |
| data-source-monitoring | <1m | 15 |
| deploy | 1m | 15 |
| developer-url-health | 1m; audit | 30 |
| discover-agenda-urls | <1m | 15 |
| discover-local-resources-weekly | 1m | 15 |
| docs-sync | 1m | 15 |
| external-references-check | <1m; check | 30 |
| fetch-cdphe-boundaries | <1m | 15 |
| fetch-census-acs | 33m | 75 |
| fetch-chas-data | 11m | 30 |
| fetch-chfa-lihtc | 1m | 15 |
| fetch-county-data | 1m | 15 |
| fetch-fmr-data | <1m | 15 |
| fetch-fred-data | 3m | 15 |
| fetch-hmda-data | 8m | 20 |
| fetch-kalshi | <1m | 15 |
| fetch-parcel-zoning-data | 14m | 30 |
| fetch-polymarket-data | <1m | 15 |
| jurisdiction-briefs-monthly | <1m | 15 |
| market_data_build | 10m supplied basis; all four jobs | 30 |
| pab-allocations-annual | no run history | 30 |
| qa-status | 3m; checks | 30 |
| redeploy-zip | <1m; check/deploy | 30 |
| refresh-state-trend-analysis | no run history | 30 |
| run-all-workflows | 177m; fan-out orchestrator | 180 |
| scrape-agenda-items | <1m | 15 |
| site-audit | 4m; audit | 30 |
| source-liveness-weekly | 4m; audit | 30 |
| test-sentinel-normalization | <1m; all three jobs are checks | 30 |
| triage-open-issues | no run history | 30 |
| upstream-vintage-watch | <1m | 15 |
| url-health-weekly | 3m; audit | 30 |
| weekly_housing_brief | 1m | 15 |
| workflow-comment-trigger | <1m; both jobs | 15 |
| zillow-data-sync | <1m; both jobs | 15 |

## Verification

- full `npm test` — passed
- all `.github/workflows/*.yml` parsed with PyYAML
- job-by-job YAML inspection — every job has `timeout-minutes`
- workflow-level missing-ceiling sweep — zero missing
- `data-commits` concurrency membership — 29 (unchanged)
- `git diff --check` — passed
- scope — 57 workflow files, 64 additions, no application/data/script changes

The two 6-hour observations are evidence of the unbounded-hang problem, not useful normal runtimes. Their new ceilings intentionally terminate them well before GitHub's default.
