### PR TITLE
fix(data): remove personal emails from public resources

### DIFF
--- a/data/hna/local-resources.json
+++ b/data/hna/local-resources.json
@@ -889,7 +889,6 @@
       },
       {
         "name": "Housing Authority for the Town of Cheyenne Wells",
-        "contact": "cwha5964@gmail.com",
         "totalUnits": 25
       }
     ],
@@ -2283,7 +2282,6 @@
       },
       {
         "name": "Housing Authority of the Town of Aguilar",
-        "contact": "aguilarhousing@gmail.com",
         "totalUnits": 18
       },
       {
@@ -2320,7 +2318,6 @@
       },
       {
         "name": "Housing Authority of the Town of Limon",
-        "contact": "lhauthority1001@gmail.com",
         "totalUnits": 40
       }
     ],
@@ -2558,17 +2555,14 @@
       },
       {
         "name": "La Junta Housing Authority",
-        "contact": "ljhous@yahoo.com",
         "totalUnits": 86
       },
       {
         "name": "Otero County Housing Authority",
-        "contact": "ljhous@yahoo.com",
         "totalUnits": 46
       },
       {
         "name": "Rocky Ford Housing Authority",
-        "contact": "tracylovato@yahoo.com",
         "totalUnits": 53
       }
     ],
@@ -2652,7 +2646,6 @@
       },
       {
         "name": "Holyoke Housing Authority",
-        "contact": "holyokehousing@outlook.com",
         "totalUnits": 30
       }
     ],
@@ -3016,7 +3009,6 @@
       },
       {
         "name": "Center Housing Authority",
-        "contact": "centerhousinga@gmail.com",
         "totalUnits": 30
       }
     ],
@@ -3319,7 +3311,6 @@
       },
       {
         "name": "Housing Authority of the Town of Keenesburg",
-        "contact": "keenehousing@aol.com",
         "totalUnits": 20
       }
     ],
@@ -3426,7 +3417,6 @@
       },
       {
         "name": "Housing Authority of the Town of Yuma",
-        "contact": "yumahousingauthority@gmail.com",
         "totalUnits": 50
       }
     ],

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-18T13:09:39.776905Z",
+  "generated": "2026-08-18T22:36:26.304687Z",
   "files": {
     "data/_manifest.json": {
       "featureCount": 0,
@@ -329,7 +329,7 @@
     "data/fred-data.json": {
       "featureCount": 0,
       "placeholder": false,
-      "bytes": 2518167
+      "bytes": 1312234
     },
     "data/glossary.json": {
       "featureCount": 0,
@@ -4109,7 +4109,7 @@
     "data/hna/local-resources.json": {
       "featureCount": 0,
       "placeholder": false,
-      "bytes": 179361
+      "bytes": 178911
     },
     "data/hna/ownership-need.json": {
       "featureCount": 0,


### PR DESCRIPTION
## Summary

- removes 10 public personal-domain email occurrences (9 unique addresses) from `data/hna/local-resources.json`
- retains each housing authority's name and unit count
- preserves at least one institutional, office, or durable lookup route for every affected county
- rebuilds `data/manifest.json` from a clean disposable worktree

No replacement addresses were invented. Where no verified institutional inbox was already published in the dataset, the personal-domain `contact` field was removed and the jurisdiction's existing lookup path was retained.

Binary matches under `data/co-housing-costs/*.parquet` were left untouched as confirmed false positives. Git-history purging remains out of scope.

## Affected jurisdictions

- Cheyenne County
- Las Animas County
- Lincoln County
- Otero County
- Phillips County
- Saguache County
- Weld County
- Yuma County

## Verification

- personal-domain grep: 0 matches
- affected-jurisdiction route assertion: all 8 retain at least one lookup path
- manifest: 1,607 entries; `local-resources.json` byte count matches disk
- `node scripts/validate-schemas.js`: 85 passed, 0 failed
- `node test/file-manifest.test.js`: passed
- full `npm test`: passed

Resolves #1453.
