### PR TITLE
feat(hna): add projection calculation trace

### DIFF
--- a/housing-needs-assessment.html
+++ b/housing-needs-assessment.html
@@ -1079,8 +1079,16 @@
               <p style="margin:10px 0 0;color:var(--muted);font-size:.9rem">
                 Transparent HNA math: projected households = population × headship; total units required = households ÷ (1 − vacancy).
                 The summary's net-new units subtract the current requirement and are not income-targeted affordable deficits.
-                For municipalities/CDPs, projections scale from the containing county using current population share and recent relative growth.
+                For covered municipalities/CDPs, the headline uses the stored place projection built from county need and local ACS household/BPS permit shares; the trace labels any fallback method.
               </p>
+              <details id="projectionCalculationTrace" style="margin-top:12px">
+                <summary style="cursor:pointer;font-weight:700;min-height:44px;display:flex;align-items:center">Show projection calculation trace</summary>
+                <p id="projectionCalculationMethod" style="margin:10px 0 0;color:var(--muted);font-size:.9rem">County housing units needed over the 20-year horizon: SDO components-of-change population forecast × constant base-year headship rate, divided by (1 − target vacancy). Covered place and CDP selections use the county projection downscaled by a 50/50 blend of ACS household share and 2020-2024 Census BPS permit share.</p>
+                <p id="projectionCalculationSources" style="margin:6px 0 0;color:var(--muted);font-size:.9rem">County source series: SDO components-change-county.csv. Place source series: data/hna/projections/places.json, built from county projections, ACS DP02 household counts, and data/hna/permits.json. Cross-county municipalities use combined-county denominators before applying the blended share. Verified 2026-07-04 against SDO's official vintage-2023 county forecast (Oct 2024): median difference −1.4% at 2030 across all 64 counties.</p>
+                <div id="projectionCalculationTraceBody" style="margin-top:10px;color:var(--muted);font-size:.9rem" aria-live="polite" aria-atomic="true">
+                  Select a geography to inspect the calculation.
+                </div>
+              </details>
             </div>
 
             <p id="needNote" style="margin-top:10px;color:var(--muted)">—</p>

--- a/js/hna/hna-controller.js
+++ b/js/hna/hna-controller.js
@@ -2397,6 +2397,9 @@
       if (window.HNAState.els.statBaseUnitsSrc) window.HNAState.els.statBaseUnitsSrc.textContent = unavailable;
       if (window.HNAState.els.statUnitsNeed) window.HNAState.els.statUnitsNeed.textContent = 'Not available';
       if (window.HNAState.els.statNetMig) window.HNAState.els.statNetMig.textContent = 'Not available';
+      if (window.HNARenderers.renderProjectionCalculationTrace) {
+        window.HNARenderers.renderProjectionCalculationTrace({ available: false, message: unavailable });
+      }
       return;
     }
 
@@ -2560,12 +2563,54 @@
       net20 = (net20!==null) ? (net20 * share0) : null;
     }
 
+    const endYear = (i>=0 && years[i]) ? years[i] : (years.length ? years[years.length-1] : '');
+
     // Update cards
     window.HNAState.els.statBaseUnits.textContent = baseUnits !== null ? window.HNAUtils.fmtNum(baseUnits) : '—';
     window.HNAState.els.statBaseUnitsSrc.textContent = baseYear ? 'Current total housing units (DP04)' : 'Current housing stock';
     window.HNAState.els.statTargetVac.textContent = window.HNAUtils.fmtPct(targetVac * 100);
     const incUnitsDisplay = formatIncrementalUnitsDisplay(incUnits);
     window.HNAState.els.statUnitsNeed.textContent = incUnitsDisplay;
+    if (window.HNARenderers.renderProjectionCalculationTrace) {
+      if (usedPlaceProjection) {
+        const placeShares = placeProjectionRec.shares || {};
+        window.HNARenderers.renderProjectionCalculationTrace({
+          available: incUnits !== null,
+          mode: 'place',
+          endYear,
+          incrementalUnits: incUnits,
+          householdShare: placeShares.household,
+          permitShare: placeShares.permit,
+          blendedShare: placeShares.blended,
+          permitWindow: placeShares.permit_window || '2020-2024',
+          crossCounty: placeProjectionRec.cross_county === true,
+        });
+      } else {
+        window.HNARenderers.renderProjectionCalculationTrace({
+          available: incUnits !== null,
+          mode: 'direct',
+          endYear,
+          provenance: selection && selection.geoType !== 'county' && selection.geoType !== 'state'
+            ? 'Containing-county DOLA/SDO forecast scaled to the selected place/CDP'
+            : (selection && selection.geoType === 'state'
+              ? 'Direct statewide DOLA/SDO projection'
+              : 'Direct county DOLA/SDO components-of-change projection'),
+          provenanceNote: selection && selection.geoType !== 'county' && selection.geoType !== 'state'
+            ? 'Fallback path uses current population share and recent relative growth; covered places use the stored place-projection path shown separately.'
+            : 'County source: SDO components-change-county.csv.',
+          projectedPopulation: popH,
+          headshipRate: hsH,
+          headshipModeLabel: headshipMode === 'trend'
+            ? 'Trend headship assumption used by the calculation.'
+            : 'Constant base-year headship rate used by the calculation.',
+          projectedHouseholds: hhH,
+          targetVacancy: targetVac,
+          totalUnitsRequired: needUnits,
+          existingHousingUnits: baseUnits,
+          incrementalUnits: incUnits,
+        });
+      }
+    }
     if (window.HNARenderers.updateDecisionStrip) {
       window.HNARenderers.updateDecisionStrip({
         production: {
@@ -2579,7 +2624,6 @@
     }
     window.HNAState.els.statNetMig.textContent = net20 !== null ? window.HNAUtils.fmtNum(Math.round(net20)) : '—';
 
-    const endYear = (i>=0 && years[i]) ? years[i] : (years.length ? years[years.length-1] : '');
     let countyDolaReconciliationNote = '';
     if (selection && selection.geoType !== 'place' && selection.geoType !== 'cdp' && !_isMultiJurisdictionSelection(selection)) {
       const dolaSeries = proj?.housing_need?.incremental_units_needed_dola;

--- a/js/hna/hna-renderers.js
+++ b/js/hna/hna-renderers.js
@@ -3558,6 +3558,68 @@
     return { horizon, targetVac, headshipMode };
   }
 
+  /**
+   * renderProjectionCalculationTrace — display the exact inputs already used
+   * by the projection result. Formatting only; no projection math lives here.
+   */
+  function renderProjectionCalculationTrace(trace) {
+    const el = document.getElementById('projectionCalculationTraceBody');
+    if (!el) return;
+    if (!trace || trace.available === false) {
+      el.textContent = trace && trace.message ? trace.message : 'Calculation trace is not available.';
+      return;
+    }
+    const num = function (v, digits) {
+      if (v == null || !Number.isFinite(Number(v))) return 'not available';
+      return Number(v).toLocaleString(undefined, {
+        minimumFractionDigits: digits || 0,
+        maximumFractionDigits: digits || 0,
+      });
+    };
+    const pct = function (v, digits) {
+      if (v == null || !Number.isFinite(Number(v))) return 'not available';
+      return num(Number(v) * 100, digits == null ? 1 : digits) + '%';
+    };
+    const row = function (label, value, note) {
+      return '<li><strong>' + escHtml(label) + ':</strong> ' + escHtml(value) +
+        (note ? '<br><span>' + escHtml(note) + '</span>' : '') + '</li>';
+    };
+    let rows = '';
+    if (trace.mode === 'place') {
+      rows += row('Result used by the headline', num(trace.incrementalUnits),
+        'Read directly from data/hna/projections/places.json for ' + trace.endYear + '.');
+      rows += row('ACS household share', pct(trace.householdShare, 3), 'ACS DP02 household counts.');
+      if (trace.permitShare == null) {
+        rows += row('Census BPS permit share', 'not available',
+          'The place result uses household share only; no 50/50 blend is applied.');
+      } else {
+        rows += row('Census BPS permit share', pct(trace.permitShare, 3), trace.permitWindow + ' permit series.');
+        rows += row('Allocation blend', '50% ACS household share + 50% BPS permit share',
+          'Stored blended share used: ' + pct(trace.blendedShare, 3) + '.');
+      }
+      rows += row('County projection provenance', trace.crossCounty
+        ? 'Combined-county denominators before the place share was applied'
+        : 'Containing-county DOLA/SDO projection before the place share was applied',
+        'Source result and shares are read from the same place-projection record used by the headline.');
+    } else {
+      rows += row('Projection provenance', trace.provenance, trace.provenanceNote);
+      rows += row('Projected population', num(trace.projectedPopulation),
+        'DOLA/SDO components-of-change forecast for ' + trace.endYear + '.');
+      rows += row('Headship rate', pct(trace.headshipRate, 3), trace.headshipModeLabel);
+      rows += row('Projected households', num(trace.projectedHouseholds, 1),
+        'Projected population × headship rate.');
+      rows += row('Target vacancy', pct(trace.targetVacancy, 3), 'Screening assumption selected above.');
+      rows += row('Total housing units required', num(trace.totalUnitsRequired, 1),
+        'Projected households ÷ (1 − target vacancy).');
+      rows += row('Existing housing stock', num(trace.existingHousingUnits), 'ACS DP04 value used by the calculation.');
+      rows += row('Incremental units used by the headline', num(trace.incrementalUnits),
+        'Total housing units required − existing housing stock.');
+    }
+    el.innerHTML = '<p style="margin:0 0 8px"><strong>Screening-grade estimate.</strong> ' +
+      'This trace documents the current public-data calculation; it is not a commissioned market study.</p>' +
+      '<ol style="margin:0;padding-left:22px">' + rows + '</ol>';
+  }
+
   // ---------------------------------------------------------------------------
   // Projections: data-quality indicator
   // ---------------------------------------------------------------------------
@@ -8455,6 +8517,7 @@
     // Assumptions
     getAssumptions,
     // Projections
+    renderProjectionCalculationTrace,
     renderScenarioDataQuality,
     clearProjectionsForStateLevel,
     renderProjectionChart,

--- a/test/hna-projection-integrity.test.js
+++ b/test/hna-projection-integrity.test.js
@@ -7,6 +7,7 @@ const { JSDOM } = require('jsdom');
 
 const ROOT = path.resolve(__dirname, '..');
 const PLACES_PATH = path.join(ROOT, 'data/hna/projections/places.json');
+const HNA_HTML = fs.readFileSync(path.join(ROOT, 'housing-needs-assessment.html'), 'utf8');
 
 function freshRequire(relPath) {
   const abs = path.join(ROOT, relPath);
@@ -19,6 +20,11 @@ function closeEnough(actual, expected, label) {
 }
 
 function assertProjectionData() {
+  assert(HNA_HTML.includes('id="projectionCalculationTrace"'), 'HNA includes expandable projection trace');
+  assert(HNA_HTML.includes('id="projectionCalculationTraceBody"'), 'HNA includes projection trace output region');
+  assert(HNA_HTML.includes('County housing units needed over the 20-year horizon: SDO components-of-change population forecast × constant base-year headship rate, divided by (1 − target vacancy).'), 'HNA quotes the documented projection method');
+  assert(HNA_HTML.includes('County source series: SDO components-change-county.csv. Place source series: data/hna/projections/places.json'), 'HNA quotes the documented county and place sources');
+  assert(HNA_HTML.includes('Cross-county municipalities use combined-county denominators before applying the blended share.'), 'HNA quotes cross-county place provenance');
   const data = JSON.parse(fs.readFileSync(PLACES_PATH, 'utf8'));
   const places = data.places || {};
   const leadville = places['0844320'];
@@ -61,6 +67,9 @@ function makeHtml() {
         <div id="statUnitsNeed"></div>
         <div id="statNetMig"></div>
         <div id="needNote"></div>
+        <details id="projectionCalculationTrace"><summary>Show projection calculation trace</summary>
+          <div id="projectionCalculationTraceBody"></div>
+        </details>
       </body>
     </html>`;
 }
@@ -138,6 +147,15 @@ async function assertCountyReconciliationNote() {
   const note = document.getElementById('needNote').textContent;
   assert(note.includes("DOLA's county forecast projects about 12,727 additional units by 2044"), 'County note should include DOLA reconciliation figure');
   assert(note.includes('the figure above is modeled from your selected horizon and target-vacancy assumptions and may differ'), 'County note should explain why the figures may differ');
+  const trace = document.getElementById('projectionCalculationTraceBody').textContent;
+  assert(trace.includes('190,000'), 'County trace shows the exact projected population used');
+  assert(trace.includes('Direct county DOLA/SDO components-of-change projection'), 'County trace labels direct county provenance');
+  assert(trace.includes('40.625%'), 'County trace shows the base-year headship rate used to three decimals');
+  assert(trace.includes('77,187.5'), 'County trace shows projected households used');
+  assert(trace.includes('81,250.0'), 'County trace shows vacancy-adjusted housing units used');
+  assert(trace.includes('70,000'), 'County trace shows existing stock used');
+  assert(trace.includes('11,250'), 'County trace reconciles to the headline incremental units');
+  assert(trace.includes('Screening-grade estimate'), 'County trace carries screening-grade framing');
 }
 
 async function assertHouseholdOnlyPlaceNote() {
@@ -171,13 +189,75 @@ async function assertHouseholdOnlyPlaceNote() {
   const note = document.getElementById('needNote').textContent;
   assert(note.includes('Place-level projection uses ACS household share only (39.8%); Census BPS permit data unavailable for this place.'), 'Place note should use household-only wording when permit share is null');
   assert(!note.includes('50/50 blend'), 'Household-only place note should not mention a 50/50 blend');
+  const trace = document.getElementById('projectionCalculationTraceBody').textContent;
+  assert(trace.includes('224'), 'Place trace uses the same stored result as the headline');
+  assert(trace.includes('39.768%'), 'Place trace shows the stored ACS household share to three decimals');
+  assert(trace.includes('no 50/50 blend is applied'), 'Household-only place trace labels the fallback method');
+}
+
+async function assertBlendedPlaceTrace() {
+  const placeDoc = { places: { '0850480': {
+    years: [2044], incremental_units_needed: [246], cross_county: true,
+    shares: { household: 0.024246, permit: 0.014352, blended: 0.019299, permit_window: '2020-2024' },
+  } } };
+  const dom = new JSDOM(makeHtml(), { url: 'about:blank' });
+  installBrowserStubs(dom, placeDoc);
+  loadHnaModules();
+  const selection = { geoType: 'place', geoid: '0850480', label: 'Milliken', contextCounty: '08123',
+    profile: { DP02_0001E: 3000, DP04_0001E: 3200, DP05_0001E: 8000 } };
+  window.HNAState.state.currentSelection = selection;
+  await window.HNAController.applyAssumptions(projectionFixture(), selection);
+  const trace = document.getElementById('projectionCalculationTraceBody').textContent;
+  assert(trace.includes('246'), 'Blended place trace uses the exact stored headline result');
+  assert(trace.includes('2.425%') && trace.includes('1.435%'), 'Blended place trace shows both stored shares to three decimals');
+  assert(trace.includes('50% ACS household share + 50% BPS permit share'), 'Blended place trace labels the 50/50 allocation');
+  assert(trace.includes('Combined-county denominators'), 'Cross-county place trace discloses combined-county provenance');
+}
+
+async function assertRealDataReconciliation() {
+  const countyProjection = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/hna/projections/08077.json'), 'utf8'));
+  const millikenCountyProjection = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/hna/projections/08123.json'), 'utf8'));
+  const placeDoc = JSON.parse(fs.readFileSync(PLACES_PATH, 'utf8'));
+
+  let dom = new JSDOM(makeHtml(), { url: 'about:blank' });
+  installBrowserStubs(dom, placeDoc);
+  loadHnaModules();
+  let selection = { geoType: 'county', geoid: '08077', label: 'Mesa County' };
+  window.HNAState.state.currentSelection = selection;
+  await window.HNAController.applyAssumptions(countyProjection, selection);
+  const countyHeadline = document.getElementById('statUnitsNeed').textContent;
+  const countyTrace = document.getElementById('projectionCalculationTraceBody').textContent;
+  assert(countyTrace.includes(countyHeadline), 'Real county trace reconciles to the displayed headline');
+  assert(countyTrace.includes('190,165'), 'Real county trace pins the projected population used');
+  assert(countyTrace.includes('41.738%'), 'Real county trace pins the base-year headship rate used to reproducible precision');
+  assert(countyTrace.includes('79,371.1'), 'Real county trace pins the projected households used');
+  assert(countyTrace.includes('5.000%'), 'Real county trace pins the target vacancy used to three decimals');
+  assert(countyTrace.includes('83,548.5'), 'Real county trace pins the vacancy-adjusted units used');
+  assert(countyTrace.includes('71,829'), 'Real county trace pins the existing housing stock used');
+
+  dom = new JSDOM(makeHtml(), { url: 'about:blank' });
+  installBrowserStubs(dom, placeDoc);
+  loadHnaModules();
+  selection = { geoType: 'place', geoid: '0850480', label: 'Milliken', contextCounty: '08123',
+    profile: { DP02_0001E: 3000, DP04_0001E: 3200, DP05_0001E: 8000 } };
+  window.HNAState.state.currentSelection = selection;
+  await window.HNAController.applyAssumptions(millikenCountyProjection, selection);
+  const placeHeadline = document.getElementById('statUnitsNeed').textContent;
+  const placeTrace = document.getElementById('projectionCalculationTraceBody').textContent;
+  assert(placeTrace.includes(placeHeadline), 'Real place trace reconciles to the displayed headline');
+  assert(placeTrace.includes('2.425%') && placeTrace.includes('1.435%'), 'Real place trace displays both stored allocation shares to three decimals');
+  assert(placeTrace.includes('50% ACS household share + 50% BPS permit share'), 'Real place trace labels the 50/50 allocation');
+  assert(placeTrace.includes('Stored blended share used: 1.930%'), 'Real place trace displays the stored blended share to three decimals');
+  return { countyHeadline, placeHeadline };
 }
 
 (async function main() {
   assertProjectionData();
   await assertCountyReconciliationNote();
   await assertHouseholdOnlyPlaceNote();
-  console.log('HNA projection integrity tests passed');
+  await assertBlendedPlaceTrace();
+  const reconciled = await assertRealDataReconciliation();
+  console.log(`HNA projection integrity tests passed (Mesa County ${reconciled.countyHeadline}; Milliken ${reconciled.placeHeadline})`);
 })().catch((err) => {
   console.error(err);
   process.exit(1);


### PR DESCRIPTION
## Summary

- adds an expandable projection calculation trace beside the HNA projection assumptions
- displays the exact values already used by the headline; the renderer formats only and performs no projection calculation
- distinguishes direct county/state projections, fallback place scaling, and stored covered-place projections
- labels the 50/50 ACS household-share / Census BPS permit-share blend and combined-county provenance where applicable
- frames the trace as a screening-grade public-data estimate, not a commissioned market study
- uses option (a) from QA: every displayed trace rate is shown to three decimal places so users can reproduce the arithmetic without a hidden rounding gap

## Calculation paths

County results show the live chain used by the controller:

1. DOLA/SDO components-of-change projected population
2. × the selected headship assumption
3. = projected households
4. ÷ `(1 − target vacancy)`
5. − existing ACS DP04 housing stock
6. = the incremental-units headline

Covered place/CDP results intentionally do not recompute that chain in the page. They show the exact `incremental_units_needed` value read from `data/hna/projections/places.json`, alongside the household, permit, and stored blended shares from that same record. Cross-county rows disclose that combined-county denominators were applied upstream.

## Rendered reconciliation

Using the real controller, renderer, and committed projection files:

### Mesa County (county path)

| Step | Value displayed from the calculation |
|---|---:|
| SDO components-of-change projected population, 2044 | 190,165 |
| Constant base-year headship rate | 41.738% |
| Projected households | 79,371.1 |
| Target vacancy | 5.000% |
| Total housing units required | 83,548.5 |
| Existing ACS DP04 housing stock | 71,829 |
| Incremental-units headline and trace | 11,720 |

### Milliken (stored covered-place path)

| Step | Value displayed from the stored place record |
|---|---:|
| ACS DP02 household share | 2.425% |
| 2020-2024 Census BPS permit share | 1.435% |
| Stored 50/50 blended share | 1.930% |
| 2044 incremental-units headline and trace | 996 |

The place trace identifies the containing-county projection provenance and explicitly labels the allocation as `50% ACS household share + 50% BPS permit share`. The test also covers household-only fallback and combined-county provenance.

The local server was booted successfully with `python3 -m http.server 8765 --bind 127.0.0.1`. The in-app browser could not reach that task-local network namespace, so rendered-DOM verification used JSDOM with the real HNA modules and committed data rather than a mocked calculation.

## Verification

- `node test/hna-projection-integrity.test.js` — passed, including the pinned real Mesa County and Milliken reconciliations
- JS syntax checks for controller and renderer — passed
- `git diff --check` — passed
- full `npm test` — passed after a temporary uncommitted manifest rebuild

## Upstream main issue

The unmodified `origin/main` manifest currently records `data/fred-data.json` as 2,518,167 bytes while the committed file is 1,312,234 bytes. An untouched full suite therefore fails at `test/file-manifest.test.js`. I temporarily rebuilt the manifest only to exercise the remaining suite, then restored `data/` to HEAD. This PR contains no data or manifest change.
