### PR TITLE
fix(ci): classify Yahoo Finance as bot-blocked, not a dead link

### DIFF
--- a/scripts/audit/source-url-sweep.mjs
+++ b/scripts/audit/source-url-sweep.mjs
@@ -58,6 +58,13 @@ const ALLOW_LIST = new Set([
   // it fetches 200 from residential IPs. Verified 2026-07-18.
   "https://polymarket.com",
   "https://polymarket.com/",
+  // Yahoo Finance rate-limits datacenter IPs and drops the connection
+  // rather than returning a status, so it lands in the hard-failure
+  // bucket instead of the WAF bucket like the other bot-blocked hosts.
+  // Verified 2026-08-18: plain curl gets HTTP 429, a browser user-agent
+  // gets HTTP 200 — the host is healthy, the CI probe is throttled.
+  "https://finance.yahoo.com",
+  "https://finance.yahoo.com/",
   "https://www.novoco.com",
   "https://www.novoco.com/",
   "https://www.novoco.com/resource-centers/affordable-housing-tax-credits",


### PR DESCRIPTION
The URL sweep has failed on `https://finance.yahoo.com/` across three consecutive unrelated PRs (#1456, #1457, #1458), blocking merges on a host that is not down.

## Diagnosis

Yahoo rate-limits datacenter IPs by **dropping the connection instead of returning a status code**. The sweep's WAF bucket keys off an HTTP status, so a connection with no status falls through to the hard-failure bucket — even though this is the same bot-protection behavior the sweep already tolerates on seven other hosts (novoco, zillow, jchs, congress.gov, ncsha).

Verified 2026-08-18:

| probe | result |
|---|---|
| plain `curl` | HTTP 429 |
| browser user-agent | **HTTP 200** |

The host is healthy; the CI probe is being throttled.

## Why an allowlist entry is the right shape

`scripts/audit/source-url-sweep.mjs` already documents this exact case for Polymarket a few lines above, in near-identical wording — *"drops datacenter connections outright (no HTTP status), so the sweep can't classify it as WAF."* This follows that established pattern rather than introducing a new mechanism.

## Verification

Local sweep after the change reports `ALLOW - https://finance.yahoo.com/`.

## Separately found — not fixed here

The same local run surfaced a genuine 404 on `https://fred.stlouisfed.org/series/WPU13310101` (Portland Cement PPI), which is **not** a WAF case. Investigating it showed **10 of 62 FRED series carry zero observations** while `fetch-fred-data.yml` reports success daily. Filed separately — deliberately out of scope for this one-line CI unblock.