### PR TITLE
fix(ci): give chart-audit the same timeout as its Playwright siblings

### DIFF
--- a/.github/workflows/chart-audit.yml
+++ b/.github/workflows/chart-audit.yml
@@ -54,7 +54,7 @@ permissions:
 jobs:
   chart-audit:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
chart-audit has been cancelled **three consecutive times** on #1458, every time at `Install Playwright Chromium` — never at an assertion.

## Diagnosis

Five workflows run the identical `playwright install chromium --with-deps` command, but their job timeouts diverge sharply:

| workflow | timeout | outcome on #1458 |
|---|---|---|
| **chart-audit** | **10 min** | **cancelled 3/3** |
| a11y-audit | 15 min | passed on rerun |
| console-error-audit | 30 min | — |
| site-audit | 30 min | passed |
| contrast-audit | 30 min | passed on rerun |

When the Playwright CDN is slow, chart-audit is the only one killed. Its usual 2m20s runtime makes 10 minutes look generous, but that budget has to absorb install variance the other four already tolerate — and on 2026-08-19 the install alone exceeded 10 minutes fleet-wide (contrast-audit hung 30m20s at its own scanner step in the same window).

## Change

Raised to 30, matching the three siblings running the same install. This loosens a backstop, not a real time budget — a genuinely hung job still gets killed, just on the same schedule as its peers.

## Not a recent regression

The 10-minute value dates to #826 (May 2026). #1455, which added timeouts across 56 workflows, did not touch this file.