### PR TITLE
fix(ci): drop --with-deps from the five Playwright audit workflows

### DIFF
--- a/.github/workflows/a11y-audit.yml
+++ b/.github/workflows/a11y-audit.yml
@@ -45,7 +45,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: Run axe-core audit
         id: audit

--- a/.github/workflows/chart-audit.yml
+++ b/.github/workflows/chart-audit.yml
@@ -69,7 +69,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright Chromium
-        run: npx playwright install chromium --with-deps
+        run: npx playwright install chromium
 
       - name: Start local HTTP server
         run: npx http-server . -p 8080 --silent &

--- a/.github/workflows/console-error-audit.yml
+++ b/.github/workflows/console-error-audit.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright browsers
-        run: npx playwright install chromium --with-deps
+        run: npx playwright install chromium
 
       # ── Start static server ─────────────────────────────────────────────────
       - name: Start static server

--- a/.github/workflows/contrast-audit.yml
+++ b/.github/workflows/contrast-audit.yml
@@ -56,7 +56,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright browsers
-        run: npx playwright install chromium --with-deps
+        run: npx playwright install chromium
 
       - name: Install Puppeteer-bundled Chromium
         # F159 — The runtime DOM scanner (added below) uses puppeteer,

--- a/.github/workflows/site-audit.yml
+++ b/.github/workflows/site-audit.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Run core rendered smoke
         run: |
-          npx playwright install chromium --with-deps
+          npx playwright install chromium
           node scripts/audit/core-rendered-smoke.mjs
         env:
           AUDIT_BASE_URL: http://127.0.0.1:8080


### PR DESCRIPTION
`apt-get`, not the Playwright CDN, was hanging these jobs.

## Evidence — concurrent control, not a timing artifact

| branch | install | started | outcome |
|---|---|---|---|
| `fix/chart-audit-timeout` | `--with-deps` | 05:23 | **wedged at 232 min** |
| `test/playwright-install-probe` (#1467) | no `--with-deps` | 09:06 | **passed, normal runtime** |

The variant passed while the control was still hung. Same window, so this is not the fleet recovering on its own. Separately, the CDN answers in ~0.25s from outside CI and serves `chromium-linux.zip` normally — a degraded browser download was never the problem.

## The probe was not a vacuous pass

It launched Chromium and rendered real charts:

```
/housing-needs-assessment.html?geoType=county&geoid=08001 … 11/11 OK
/housing-needs-assessment.html?geoType=place&geoid=0857300 … 4/4 OK
/hna-scenario-builder.html … 1/1 OK
/colorado-deep-dive.html … 4/4 OK
```

Twenty charts across four pages. `ubuntu-latest` already ships Chromium's shared libraries.

## Why it generalizes to all five

All five are `runs-on: ubuntu-latest` with **zero** `container:` directives, and all five install **chromium only** — no firefox or webkit, which have different library requirements. All four non-chart audits do the same class of work (page load + DOM inspection); none generate PDFs or use video codecs.

## Verification plan

Three run automatically on this PR: **a11y-audit**, **chart-audit** (path filters include `.github/workflows`), and **site-audit** (no path filters).

Two do **not** and will be dispatched manually before merge:
- **contrast-audit** — path filters are `css/**`, `**/*.html`, `js/**`; workflow files don't match
- **console-error-audit** — has no `pull_request` trigger at all (schedule + dispatch only)

Not merging until all five are confirmed green.

## Two things this outage exposed

1. **A hung step is recorded as `cancelled`, not `failure`** — it shows grey, not a red X. Anyone scanning the checks list misses it. This is why it went unnoticed for hours.
2. **The wedged job blew past its own 30-minute `timeout-minutes`** and was still `in_progress` at 232 minutes. That backstop cannot be relied on.

## Supersedes / related

- **#1465** (raise chart-audit timeout 10 → 30) — wrong fix; it only chooses how long to wait for a step that never finishes. Should be closed.
- **#1466** (cache Playwright browsers) — still worth doing for speed, but its outage rationale is wrong and needs correcting. Caches the download, which was never the broken half.
- **#1467** — the throwaway probe. Close once this merges.
- Unblocks **#1458**.