### PR TITLE
fix(data): correct stale fred-data.json byte count in manifest (main is red)

### DIFF
--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-19T13:10:42.301575Z",
+  "generated": "2026-08-19T17:06:40.320365Z",
   "files": {
     "data/_manifest.json": {
       "featureCount": 0,
@@ -329,7 +329,7 @@
     "data/fred-data.json": {
       "featureCount": 0,
       "placeholder": false,
-      "bytes": 2519410
+      "bytes": 1312907
     },
     "data/glossary.json": {
       "featureCount": 0,


### PR DESCRIPTION
`main` has been failing `test:file-manifest` since **13:10 UTC today**. Every open PR fails `ci-checks` on it, including #1468 and #1458.

## No data was lost

All **62** FRED series present, **zero** series lost observations, and the file has grown normally (1,311,915 → 1,312,907 since 08-16). Only the manifest entry was wrong.

## What happened

| | bytes |
|---|---|
| `fred-data.json` as committed (minified) | 1,312,907 |
| manifest recorded | 2,519,410 |
| same file re-serialized `indent=2` | 2,518,467 |

The recorded number is the **pretty-printed** size. The fetch writes `json.dump(output, f)` with no indent, so the committed form is minified. The manifest was therefore built from a tree where `fred-data.json` had been rewritten pretty-printed — and that rewrite was never committed.

## Where it came from

`83d743879` — *"chore: refresh QA status snapshot 2026-08-19"*, from `qa-status.yml`. The manifest entry was correct through `0efc88ec6` (08:07) and wrong immediately after.

The structural defect: `qa-status.yml:94` runs a **full-tree** `rebuild_manifest.py`, then `:95` commits **only** `data/_qa-status.json` and `data/manifest.json`. Any transient mutation of any data file during that job is baked into the manifest permanently, without the file that would justify it. `rebuild_manifest.py` itself is fine — it uses `os.path.getsize` on the real file.

Filed separately as the root-cause fix; **this PR only repairs the value** so main goes green.

## Why nobody noticed

Data crons commit with `[skip ci]`, so **no `ci-checks` run has executed on main since the breaking commit**. It surfaced only because #1468 happened to trigger a full run.

## Verification

Rebuilt on a clean non-iCloud tree — **1,607 entries** (not the iCloud-inflated 3,573), exactly **one** value changed:

```
-      "bytes": 2519410
+      "bytes": 1312907
```

`node test/file-manifest.test.js` → PASS · `node scripts/validate-schemas.js` → all passed