### PR TITLE
fix(ci): fail qa-status when the manifest records files it will not commit

### DIFF
--- a/.github/workflows/qa-status.yml
+++ b/.github/workflows/qa-status.yml
@@ -92,6 +92,31 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           python3 scripts/rebuild_manifest.py
+          # Guard: rebuild_manifest.py walks the WHOLE tree and records
+          # os.path.getsize() for every data file, but the commit below stages
+          # only two of them. So any data file left modified on disk by an
+          # earlier step -- even transiently, even one this job has no business
+          # touching -- gets its size baked into the manifest while the file
+          # itself is never committed. The manifest and the tree then disagree
+          # permanently, and test:file-manifest fails on every subsequent PR.
+          #
+          # That happened on 2026-08-19: data/fred-data.json was recorded at
+          # 2,519,410 bytes (a pretty-printed size) while committed at
+          # 1,312,907, and main sat red for hours because data crons suppress
+          # CI on their own commits so nothing flagged it. See issue #1470.
+          #
+          # Fail loudly instead. The message names the offending file, which is
+          # the diagnostic that was missing last time -- the mutator was never
+          # identified.
+          unexpected="$(git status --porcelain -- data/ \
+            | grep -v ' data/_qa-status\.json$' \
+            | grep -v ' data/manifest\.json$' || true)"
+          if [ -n "$unexpected" ]; then
+            echo "::error::Unexpected modifications under data/ after rebuilding the manifest."
+            echo "::error::The manifest now records sizes for files this job will not commit."
+            echo "$unexpected"
+            exit 1
+          fi
           git add data/_qa-status.json data/manifest.json
           if git diff --cached --quiet; then
             echo "No changes to qa-status snapshot."


### PR DESCRIPTION
Closes #1470. Lands before the next `15 12 * * *` cron.

## The defect

`rebuild_manifest.py` walks the **whole tree** and records `os.path.getsize()` for every data file. The commit stages **two**:

```
python3 scripts/rebuild_manifest.py
git add data/_qa-status.json data/manifest.json
```

So any data file left modified on disk by an earlier step — even transiently, even one the job has no business touching — has its size baked into the manifest while the file itself is never committed. Manifest and tree disagree from then on, and `test:file-manifest` fails on every later PR.

On 2026-08-19 that put `data/fred-data.json` in the manifest at **2,519,410** bytes (a pretty-printed size) against **1,312,907** as committed. `main` sat red for hours with no failing run to show for it, because the data crons suppress CI on their own commits.

## What this does — and doesn't

It **does not prevent** the mutation. It makes it loud: the job fails and **names the offending file**.

That naming is the point. The mutator was never identified, and the obvious candidates are all ruled out:

- nothing invokes `scripts/fix_fred_oct_gap.py`, the repo's only `indent=2` writer of that file
- there are no npm `postinstall`/`prepare` hooks
- `fred-data.json` has **never** been ~2.5 MB in git history (steady ~1.31 MB, growing 300–600 bytes/day), so no rebase window explains the value
- `rebuild_manifest.py` itself is fine — `os.path.getsize` on real files

The next occurrence will say which file. That is what turns this from a recurring mystery into a one-line fix.

## Why not the real fix now

Staging what was measured, or scoping the rebuild to one path, are both better end states. Both are structural changes to a data-committing workflow, and making one while the trigger is unknown is how a worse incident gets created. Deliberately deferred.

## Verification

Guard logic tested against seven shapes:

| scenario | result |
|---|---|
| the two expected files alone | allows |
| **the 08-19 incident shape** | **blocks, names `fred-data.json`** |
| clean tree | allows |
| untracked file under `data/` | blocks |
| a `place-chas.json` rewrite | blocks |
| staged-and-modified (`MM`) manifest | allows |
| `manifest.json.bak` decoy | blocks — no over-matching |

YAML validates.

## Tradeoff

If the trigger recurs, the cron now **fails** instead of silently corrupting. That is the intended exchange — an alert beats a broken `main` that blocks every open PR. Say so if you would rather it warn than fail, and I will make it non-blocking while still naming the file.