### PR TITLE
fix(hna): make ownership AMI ceiling load-bearing

### DIFF
--- a/js/hna/hna-ownership-need.js
+++ b/js/hna/hna-ownership-need.js
@@ -11,6 +11,7 @@
   var BANDS = ['lte30', '31to50', '51to80', '81to100', '100plus'];
   var MODERATE_BANDS = ['51to80', '81to100'];
   var PRICE_BAND_SCREEN_LABEL = 'potential buyer pool (moderate-income renter households) - not committed demand';
+  var CHAS_TOP_BAND_LIMIT = 'Not derivable from CHAS — the top band (100plus) is unbounded above 100% AMI.';
   var OWNER_VALUE_BINS = [
     ['B25075_002E', 0, 9999],
     ['B25075_003E', 10000, 14999],
@@ -393,7 +394,8 @@
         demandBands: [],
       },
     ].map(function (row) {
-      var potentialBuyerPoolHouseholds = renterDemand(row.demandBands);
+      var hasDemandBands = row.demandBands.length > 0;
+      var potentialBuyerPoolHouseholds = hasDemandBands ? renterDemand(row.demandBands) : null;
       var ownerValueSupplyUnits = supplyUnitsInPriceRange(ownerValueSupply, row.lowerPriceExclusive, row.upperPrice);
       return Object.assign({}, row, {
         priceRange: {
@@ -403,7 +405,8 @@
         maxAffordablePrice: row.upperPrice,
         potentialBuyerPoolHouseholds: potentialBuyerPoolHouseholds,
         ownerValueSupplyUnits: ownerValueSupplyUnits,
-        currentGapHouseholds: potentialBuyerPoolHouseholds == null || ownerValueSupplyUnits == null ? null : Math.max(0, round(potentialBuyerPoolHouseholds - ownerValueSupplyUnits, 1)),
+        currentGapHouseholds: !hasDemandBands || potentialBuyerPoolHouseholds == null || ownerValueSupplyUnits == null ? null : Math.max(0, round(potentialBuyerPoolHouseholds - ownerValueSupplyUnits, 1)),
+        demandUnavailableReason: hasDemandBands ? null : CHAS_TOP_BAND_LIMIT,
         demandSourceBands: row.demandBands.slice(),
       });
     });
@@ -602,6 +605,7 @@
     ownerValueSupplySeries: ownerValueSupplySeries,
     priceBandDemandScreen: priceBandDemandScreen,
     PRICE_BAND_SCREEN_LABEL: PRICE_BAND_SCREEN_LABEL,
+    CHAS_TOP_BAND_LIMIT: CHAS_TOP_BAND_LIMIT,
     OWNER_VALUE_BINS: OWNER_VALUE_BINS,
     CONSTANTS: CONSTANTS,
   };

--- a/js/hna/hna-ownership-strategy.js
+++ b/js/hna/hna-ownership-strategy.js
@@ -11,7 +11,9 @@
 }(typeof window !== 'undefined' ? window : this, function () {
   'use strict';
 
-  var TIERS = [0.60, 0.80, 1.00, 1.20];
+  var BASE_TIERS = [0.60, 0.80, 1.00];
+  var DEFAULT_AMI_CEILING_PCT = 1.20;
+  var CEILING_OPTIONS = [0.80, 1.00, 1.10, 1.20, 1.30, 1.40, 1.50, 1.60];
   var MISSING = 'data not available for this jurisdiction';
   var NOT_TRACKED = 'not tracked for this jurisdiction';
   var VERIFY_PARTIES = 'Verify with developer discussions, lender, appraiser, broker, program administrator, and local jurisdiction before decision-grade use.';
@@ -26,6 +28,26 @@
     return '<span class="hna-own-strategy-pill" data-scope="' + esc(scope) + '" style="display:inline-flex;align-items:center;min-height:22px;padding:2px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card);color:var(--text);font-size:.72rem;font-weight:800;">' + esc(label) + '</span>';
   }
   function keyForGeo(geo) { return (geo.type === 'county' ? 'county:' : geo.type === 'cdp' ? 'cdp:' : 'place:') + geo.geoid; }
+
+  function amiCeilingModel(registry) {
+    return registry && registry.models && registry.models.find(function (row) {
+      return row && row.id === 'prop123_dpa_eligibility';
+    });
+  }
+
+  function defaultAmiCeilingPct(registry) {
+    var model = amiCeilingModel(registry);
+    var value = Number(model && model.params && model.params.amiCeilingPct);
+    return Number.isFinite(value) && value > 0 ? value : DEFAULT_AMI_CEILING_PCT;
+  }
+
+  function priceTiers(amiCeilingPct) {
+    var ceiling = Number(amiCeilingPct);
+    if (!Number.isFinite(ceiling) || ceiling <= 0) ceiling = DEFAULT_AMI_CEILING_PCT;
+    var tiers = BASE_TIERS.filter(function (tier) { return tier < ceiling; });
+    tiers.push(ceiling);
+    return tiers.filter(function (tier, index) { return tiers.indexOf(tier) === index; });
+  }
 
   function resolvePrice(geo, cascade) {
     if (!geo || !cascade) return null;
@@ -75,10 +97,14 @@
     var price = input.price || resolvePrice(geo, input.homeValueCascade);
     var target = price && Number.isFinite(price.value) ? price.value : null;
     var selectedModel = engine.getModel(modelId);
+    var registryCeiling = defaultAmiCeilingPct(registry);
+    var ceilingModel = amiCeilingModel(registry);
+    var enteredCeiling = Number(input.amiCeilingPct);
+    var amiCeilingPct = Number.isFinite(enteredCeiling) && enteredCeiling > 0 ? enteredCeiling : registryCeiling;
     var comparison = Number.isFinite(ami) && ami > 0
       ? engine.compareModels(ami, 1, [modelId], { overrides: { householdSize: householdSize }, targetPrice: target })[0]
       : null;
-    var ladder = TIERS.map(function (tier) {
+    var ladder = priceTiers(amiCeilingPct).map(function (tier) {
       var maxPrice = Number.isFinite(ami) && ami > 0
         ? engine.maxAffordablePrice(ami, tier, { modelId: modelId, householdSize: householdSize }) : null;
       var shortfall = target != null && maxPrice != null ? target - maxPrice : null;
@@ -104,6 +130,9 @@
       registry: registry,
       modelId: modelId,
       model: selectedModel,
+      amiCeilingPct: amiCeilingPct,
+      amiCeilingSource: Number.isFinite(enteredCeiling) && enteredCeiling > 0 ? 'user' : 'registry',
+      amiCeilingCaveat: ceilingModel && ceilingModel.implications && ceilingModel.implications.when_not_to_use || '',
       comparison: comparison,
       price: price,
       ladder: ladder,
@@ -130,6 +159,10 @@
     var pricePill = vm.price ? pill(vm.price.label, vm.price.scope) : pill('Place value unavailable', 'unavailable');
     var models = vm.registry && vm.registry.models || [];
     var options = models.map(function (model) { return '<option value="' + esc(model.id) + '"' + (model.id === vm.modelId ? ' selected' : '') + '>' + esc(model.label) + '</option>'; }).join('');
+    var ceilingValues = CEILING_OPTIONS.concat([vm.amiCeilingPct]).sort(function (a, b) { return a - b; }).filter(function (value, index, values) { return values.indexOf(value) === index; });
+    var ceilingOptions = ceilingValues.map(function (value) {
+      return '<option value="' + value + '"' + (value === vm.amiCeilingPct ? ' selected' : '') + '>' + Math.round(value * 100) + '% AMI</option>';
+    }).join('');
     var ladderRows = vm.ladder.map(function (row) {
       var state = row.clearsMedian === true ? 'market-attainable at this tier' : row.clearsMedian === false ? 'shortfall ' + money(row.shortfall) : MISSING;
       return '<tr><td>' + Math.round(row.tier * 100) + '% AMI</td><td>' + money(row.income) + '</td><td>' + money(row.maxPrice) + '</td><td>' + esc(state) + '</td><td>' + (row.clearsMedian == null ? 'Unavailable' : row.clearsMedian ? 'Yes' : 'No') + '</td></tr>';
@@ -143,7 +176,12 @@
     var pool = vm.ownership.priceBandScreen && vm.ownership.priceBandScreen.rows || [];
     var supplyBody = bands.length
       ? '<p><strong>' + number(bands.reduce(function (sum, band) { return sum + (Number(band.ownerOccupiedUnits) || 0); }, 0)) + '</strong> owner units across existing value bands. ' + pill('Jurisdiction owner stock', vm.geo.type) + '</p>' : '<p>' + MISSING + '</p>';
-    supplyBody += pool.length ? '<ul>' + pool.map(function (row) { return '<li>' + esc(row.label || row.priceBand || 'Price band') + ': potential buyer pool ' + number(row.potentialBuyerPoolHouseholds) + ' households; ' + number(row.ownerValueSupplyUnits) + ' owner units. Potential buyer pool — not committed demand.</li>'; }).join('') + '</ul>' : '<p>Potential buyer pool: ' + MISSING + '</p>';
+    supplyBody += pool.length ? '<ul>' + pool.map(function (row) {
+      var demand = row.demandUnavailableReason
+        ? esc(row.demandUnavailableReason)
+        : 'potential buyer pool ' + number(row.potentialBuyerPoolHouseholds) + ' households';
+      return '<li>' + esc(row.label || row.priceBand || 'Price band') + ': ' + demand + '; ' + number(row.ownerValueSupplyUnits) + ' owner units. Potential buyer pool — not committed demand.</li>';
+    }).join('') + '</ul>' : '<p>Potential buyer pool: ' + MISSING + '</p>';
     var funding = vm.developerPrograms.concat(vm.buyerPrograms);
     var fundingBody = funding.length ? '<p><strong>Available is context, never money.</strong></p><ul>' + funding.map(function (program) {
       var potential = program.screening_apply === true ? ' — potential — not committed' : '';
@@ -160,7 +198,9 @@
     return '<div class="hna-ownership-strategy" style="overflow-wrap:anywhere;min-width:0;">' +
       '<div style="display:flex;justify-content:space-between;gap:.6rem;flex-wrap:wrap;align-items:center;"><h3 style="margin:0;font-size:1.05rem;">Ownership Strategy</h3>' + geoPill + '</div>' +
       '<p style="color:var(--muted);line-height:1.45;">Tier-1 jurisdictional screening interface — screening estimate; not a completed project market study.</p>' +
-      '<div style="display:flex;gap:.75rem;flex-wrap:wrap;align-items:end;"><label>Model<select data-own-strategy-model style="display:block;max-width:100%;background:var(--card);color:var(--text);border:1px solid var(--border);">' + options + '</select></label><label>Household size<select data-own-strategy-household style="display:block;background:var(--card);color:var(--text);border:1px solid var(--border);">' + [1,2,3,4,5,6,7,8].map(function (size) { return '<option' + (size === vm.householdSize ? ' selected' : '') + '>' + size + '</option>'; }).join('') + '</select></label></div>' +
+      '<div style="display:flex;gap:.75rem;flex-wrap:wrap;align-items:end;"><label>Model<select data-own-strategy-model style="display:block;max-width:100%;background:var(--card);color:var(--text);border:1px solid var(--border);">' + options + '</select></label><label>Household size<select data-own-strategy-household style="display:block;background:var(--card);color:var(--text);border:1px solid var(--border);">' + [1,2,3,4,5,6,7,8].map(function (size) { return '<option' + (size === vm.householdSize ? ' selected' : '') + '>' + size + '</option>'; }).join('') + '</select></label><label>AMI price ceiling<select data-own-strategy-ami-ceiling style="display:block;min-height:44px;background:var(--card);color:var(--text);border:1px solid var(--border);">' + ceilingOptions + '</select></label></div>' +
+      '<p data-own-strategy-ami-ceiling-note style="margin:.45rem 0;color:var(--muted);font-size:.8rem;line-height:1.45;"><strong>Price-only control.</strong> This changes modeled affordable-price thresholds; it does not create household-demand counts above 100% AMI because CHAS\'s 100plus band is unbounded. The statutory default is 120% AMI under SB26-040 (effective July 1, 2026). Rural resort communities may petition DOLA under HB23-1304 for a different percentage.</p>' +
+      (vm.amiCeilingCaveat ? '<details style="margin:.35rem 0 .65rem;"><summary style="cursor:pointer;font-size:.8rem;font-weight:700;">Documented AMI-ceiling exception path</summary><p style="color:var(--muted);font-size:.78rem;line-height:1.45;">' + esc(vm.amiCeilingCaveat) + '</p></details>' : '') +
       '<p><strong>Model implications:</strong> ' + esc(implications.who_it_fits || MISSING) + ' ' + pill('Modeled', 'modeled') + '</p>' + risk +
       section('AMI and affordable-price ladder', '<div style="overflow-x:auto;"><table style="width:100%;border-collapse:collapse;"><thead><tr><th>Tier</th><th>Income</th><th>Maximum price</th><th>Shortfall state</th><th>Clears local median</th></tr></thead><tbody>' + ladderRows + '</tbody></table></div>') +
       section('Local price and income required', '<p>Local price: <strong>' + money(vm.price && vm.price.value) + '</strong> ' + pricePill + '</p><p>Income required to buy: <strong>' + money(vm.requiredIncome) + '</strong>' + (vm.requiredIncomeAmiRatio != null ? ' (' + vm.requiredIncomeAmiRatio.toFixed(2) + ' × 4-person AMI)' : '') + '. ' + pill('Modeled', 'modeled') + '</p>') +
@@ -179,12 +219,14 @@
       mount.innerHTML = renderHtml(vm);
       var model = mount.querySelector('[data-own-strategy-model]');
       var household = mount.querySelector('[data-own-strategy-household]');
+      var amiCeiling = mount.querySelector('[data-own-strategy-ami-ceiling]');
       if (model) model.addEventListener('change', function () { current.modelId = model.value; paint(); });
       if (household) household.addEventListener('change', function () { current.householdSize = Number(household.value); paint(); });
+      if (amiCeiling) amiCeiling.addEventListener('change', function () { current.amiCeilingPct = Number(amiCeiling.value); paint(); });
       return vm;
     }
     return paint();
   }
 
-  return { TIERS: TIERS.slice(), MISSING: MISSING, NOT_TRACKED: NOT_TRACKED, resolvePrice: resolvePrice, buildViewModel: buildViewModel, renderHtml: renderHtml, render: render };
+  return { TIERS: BASE_TIERS.concat([DEFAULT_AMI_CEILING_PCT]), MISSING: MISSING, NOT_TRACKED: NOT_TRACKED, defaultAmiCeilingPct: defaultAmiCeilingPct, priceTiers: priceTiers, resolvePrice: resolvePrice, buildViewModel: buildViewModel, renderHtml: renderHtml, render: render };
 }));

--- a/js/hna/ownership-decision-chain.js
+++ b/js/hna/ownership-decision-chain.js
@@ -127,9 +127,11 @@
       '<p>' + esc(priceBand && priceBand.label || 'potential buyer pool (moderate-income renter households) - not committed demand') + '</p>' +
       '<table><thead><tr><th>Band</th><th>Max price</th><th>Pool</th><th>Supply</th><th>Current gap</th></tr></thead><tbody>' +
       bandRows.map(function (row) {
+        var demandLabel = row.demandUnavailableReason || fmtNumber(row.potentialBuyerPoolHouseholds);
+        var gapLabel = row.demandUnavailableReason || fmtNumber(row.currentGapHouseholds);
         return '<tr><td>' + esc(row.label) + '</td><td>' + esc(fmtMoney(row.maxAffordablePrice)) + '</td><td>' +
-          esc(fmtNumber(row.potentialBuyerPoolHouseholds)) + '</td><td>' + esc(fmtNumber(row.ownerValueSupplyUnits)) + '</td><td>' +
-          esc(fmtNumber(row.currentGapHouseholds)) + '</td></tr>';
+          esc(demandLabel) + '</td><td>' + esc(fmtNumber(row.ownerValueSupplyUnits)) + '</td><td>' +
+          esc(gapLabel) + '</td></tr>';
       }).join('') +
       '</tbody></table>'));
 

--- a/test/hna-ownership-need.test.js
+++ b/test/hna-ownership-need.test.js
@@ -335,6 +335,10 @@ test('price-band screen binds AMI ceiling labels to maxAffordablePrice helper', 
       row.key + ' maxAffordablePrice follows its displayed AMI ceiling'
     );
   });
+  const upper = out.priceBandScreen.rows.find((row) => row.key === '101to120');
+  assert.equal(upper.potentialBuyerPoolHouseholds, null, '101-120% potential buyer pool is not fabricated from CHAS');
+  assert.equal(upper.currentGapHouseholds, null, '101-120% current gap is not fabricated from CHAS');
+  assert.equal(upper.demandUnavailableReason, Ownership.CHAS_TOP_BAND_LIMIT, 'unmeasurable row carries the specific CHAS top-band reason');
 });
 
 test('deep affordability recommendation requires rate, count, and total-household share', () => {

--- a/test/hna-ownership-strategy.test.js
+++ b/test/hna-ownership-strategy.test.js
@@ -34,7 +34,10 @@ const ownership = {
   tenureMixRecommendation: 'Mixed tenure strategy',
   recommendationDetail: 'Retain the existing computed recommendation.',
   ownerValueSupply: realOwnerValueSupply,
-  priceBandScreen: { rows: [{ label: '$250k–$350k', potentialBuyerPoolHouseholds: 90, ownerValueSupplyUnits: 42 }] },
+  priceBandScreen: { rows: [
+    { label: '$250k–$350k', potentialBuyerPoolHouseholds: 90, ownerValueSupplyUnits: 42 },
+    { label: '101-120% AMI middle-income price', potentialBuyerPoolHouseholds: null, currentGapHouseholds: null, ownerValueSupplyUnits: 12, demandUnavailableReason: HNAOwnershipNeed.CHAS_TOP_BAND_LIMIT },
+  ] },
 };
 function input(geo, ami) {
   return { geo, ami4Person: ami, ownershipNeedResult: ownership, engine: Finance, homeValueCascade: cascade, datasets };
@@ -51,12 +54,26 @@ assert.equal(fruita.price.value, cascade.places['0828745'].value);
 assert.equal(erie.price.value, cascade.places['0824950'].value);
 assert.equal(fruita.price.scope, 'place');
 assert.equal(erie.price.scope, 'place');
+const prop123Model = models.models.find((model) => model.id === 'prop123_dpa_eligibility');
+assert.equal(fruita.amiCeilingPct, prop123Model.params.amiCeilingPct, 'registry amiCeilingPct drives the default price bound');
+assert.equal(fruita.amiCeilingSource, 'registry');
+const changedRegistry = JSON.parse(JSON.stringify(models));
+changedRegistry.models.find((model) => model.id === 'prop123_dpa_eligibility').params.amiCeilingPct = 1.35;
+assert.equal(Strategy.defaultAmiCeilingPct(changedRegistry), 1.35, 'changing the registry parameter changes the resolved default');
 fruita.ladder.forEach((row) => assert.equal(row.maxPrice, Finance.maxAffordablePrice(100000, row.tier, { modelId: defaultModel.id, householdSize: 4 })));
 erie.ladder.forEach((row) => assert.equal(row.maxPrice, Finance.maxAffordablePrice(125000, row.tier, { modelId: defaultModel.id, householdSize: 4 })));
 
 const hh2 = Strategy.buildViewModel(Object.assign(input(fruitaGeo, 100000), { householdSize: 2 }));
 assert.notEqual(hh2.ladder[1].maxPrice, fruita.ladder[1].maxPrice);
 assert.equal(hh2.ladder[1].maxPrice, Finance.maxAffordablePrice(100000, 0.80, { modelId: defaultModel.id, householdSize: 2 }));
+
+const ceiling140 = Strategy.buildViewModel(Object.assign(input(fruitaGeo, 100000), { amiCeilingPct: 1.40 }));
+assert.equal(ceiling140.amiCeilingSource, 'user');
+assert.equal(ceiling140.ladder.at(-1).tier, 1.40, 'user ceiling becomes the top price tier');
+assert.equal(ceiling140.ladder.at(-1).maxPrice, Finance.maxAffordablePrice(100000, 1.40, { modelId: defaultModel.id, householdSize: 4 }));
+assert.notEqual(ceiling140.ladder.at(-1).maxPrice, fruita.ladder.at(-1).maxPrice, 'changed ceiling moves the modeled price threshold');
+assert.equal(ceiling140.ownership.priceBandScreen.rows[1].potentialBuyerPoolHouseholds, null, 'changed ceiling does not fabricate upper-band demand');
+assert.equal(ceiling140.ownership.priceBandScreen.rows[1].currentGapHouseholds, null, 'changed ceiling does not fabricate an upper-band gap');
 
 const permissive = Strategy.buildViewModel(Object.assign(input(fruitaGeo, 100000), { modelId: 'conventional_dti' }));
 assert.equal(permissive.comparison.riskDisclosureRequired, true);
@@ -96,6 +113,12 @@ assert(!/subsid/i.test(zeroHtml));
 assert(fruitaHtml.includes(ownership.tenureMixRecommendation));
 assert(fruitaHtml.includes(ownership.recommendationDetail));
 assert(fruitaHtml.includes('Potential buyer pool — not committed demand.'));
+assert(fruitaHtml.includes(HNAOwnershipNeed.CHAS_TOP_BAND_LIMIT));
+assert(fruitaHtml.includes('Price-only control.'));
+assert(fruitaHtml.includes('does not create household-demand counts above 100% AMI'));
+assert(fruitaHtml.includes('SB26-040 (effective July 1, 2026)'));
+assert(fruitaHtml.includes('Rural resort communities may petition DOLA under HB23-1304'));
+assert(fruitaHtml.includes(prop123Model.implications.when_not_to_use), 'registry exception caveat is surfaced verbatim');
 assert(fruitaHtml.includes('screening estimate; not a completed project market study'));
 ['developer discussions', 'lender', 'appraiser', 'broker', 'program administrator', 'local jurisdiction'].forEach((party) => assert(fruitaHtml.includes(party)));
 
@@ -114,5 +137,10 @@ const select = mount.querySelector('[data-own-strategy-model]');
 select.value = 'conventional_dti';
 select.dispatchEvent(new dom.window.Event('change'));
 assert(mount.textContent.includes('Buyer-risk note:'));
+const ceilingSelect = mount.querySelector('[data-own-strategy-ami-ceiling]');
+ceilingSelect.value = '1.4';
+ceilingSelect.dispatchEvent(new dom.window.Event('change'));
+assert(mount.textContent.includes('140% AMI'), 'ceiling control repaints the price ladder at the selected bound');
+assert(mount.textContent.includes(HNAOwnershipNeed.CHAS_TOP_BAND_LIMIT), 'ceiling control leaves the CHAS demand limitation visible');
 
 console.log('hna-ownership-strategy: PASS');

--- a/test/ownership-decision-chain.test.js
+++ b/test/ownership-decision-chain.test.js
@@ -99,6 +99,7 @@ const text = mount.textContent;
 ].forEach((needle) => {
   assert(text.includes(needle), 'rendered chain includes "' + needle + '"');
 });
+assert(text.includes(window.HNAOwnershipNeed.CHAS_TOP_BAND_LIMIT), 'decision chain explains why 101-120% demand is not derivable from CHAS');
 
 const stageEls = Array.from(document.querySelectorAll('[data-own-chain-stage]'));
 assert.equal(stageEls.length, 5, 'rendered DOM has one stage per decision step');


### PR DESCRIPTION
## Summary
- return null—not a fabricated zero—for the 101–120% AMI buyer pool and current gap because CHAS 100plus is unbounded above 100% AMI
- show that reason explicitly in both Ownership Strategy and Ownership Decision Chain render paths
- read the default AMI price ceiling from the Prop 123 DPA model registry and expose it through the existing ownership controls
- keep the ceiling price-only: changing it moves modeled affordable-price thresholds but never creates household demand above 100% AMI
- surface the 120% SB26-040 default, July 1, 2026 effective date, and the documented HB23-1304 rural-resort petition exception

## Boundary
The AMI ceiling controls only the price ladder. CHAS cannot isolate households from 101–120% AMI because its top band is 100plus and unbounded, so those demand and gap fields remain deliberately unavailable at every selected ceiling.

## Verification
- `npm run test:hna-ownership-need`
- `npm run test:hna-ownership-strategy`
- `npm run test:ownership-decision-chain`
- `npm test`
- `node scripts/audit/source-url-sweep.mjs --quiet --diff-added --base-ref origin/main` — 0 hard failures

No data files changed, so no manifest or schema rebuild was required.

Resolves #1462