### PR TITLE
fix(ownership-resale): null market value rendered as $0 and negative equity

### DIFF
--- a/js/deal-calculator.js
+++ b/js/deal-calculator.js
@@ -383,6 +383,7 @@
 
     if (window.OwnershipResale && screen.comparison && typeof window.OwnershipResale.renderComparisonHtml === 'function') {
       mount.innerHTML = window.OwnershipResale.renderComparisonHtml(screen.comparison);
+      mount.insertBefore(title, mount.firstChild);
       window.OwnershipResale.bindComparisonControls(mount, function (change) {
         if (change.subsidyType) _resaleSelection.subsidyType = change.subsidyType;
         if (change.selectedConventionId) _resaleSelection.selectedConventionId = change.selectedConventionId;

--- a/js/hna/ownership-resale.js
+++ b/js/hna/ownership-resale.js
@@ -15,6 +15,7 @@
   ];
 
   function num(value) {
+    if (value == null) return null;
     var n = Number(value);
     return Number.isFinite(n) ? n : null;
   }

--- a/test/ownership-resale.test.js
+++ b/test/ownership-resale.test.js
@@ -145,6 +145,11 @@ const screen = Resale.evaluateAll(data, {
 });
 assert.equal(screen.length, 4, 'evaluateAll returns every convention');
 assert.equal(screen[0].conventionId, 'fixed_simple', 'default convention remains first');
+// recapture without unrestrictedMarketValue → maxResalePrice and equity must be null, not a misleading number
+const noMarketRecapture = screen.find((row) => row.conventionId === 'recapture');
+assert.equal(noMarketRecapture.maxResalePrice, null, 'evaluateAll recapture row yields null price when market value is absent');
+assert.equal(noMarketRecapture.ownerGrossEquity, null, 'evaluateAll recapture row yields null equity when market value is absent');
+assert.equal(noMarketRecapture.publicSubsidyRecaptured, 0, 'evaluateAll recapture row yields 0 recovered when market value is absent');
 
 const comparisonInput = {
   purchasePrice: 400000,
@@ -166,6 +171,28 @@ const highPrices = comparison.rows.map((row) => row.outcomes[0].maxResalePrice);
 assert.equal(new Set(highPrices).size, 4, 'all four mechanisms produce distinct next-buyer prices under the same 6% scenario');
 assert.deepEqual(highPrices, [520000, 480000, 499085, 716339], 'same-scenario comparison pins each mechanism without ranking');
 assert.equal(comparison.rows.find((row) => row.conventionId === 'recapture').outcomes[0].publicSubsidyRecaptured, 90000, 'recapture returns the fixed screening amount when net proceeds permit');
+
+// Recapture net-proceeds cap: downturn drives market value below principal+costs+recaptureAmount
+// purchasePrice=400000, years=10, rate=-0.02 → marketValue=326829
+// net proceeds = 326829 - 250000 - 20000 = 56829 < 90000 → recaptured is capped at net proceeds
+const downComparison = Resale.compareConventions(data, Object.assign({}, comparisonInput, {
+  scenarios: [{ id: 'downturn', label: 'Downturn (-2% annually)', appreciationRateAnnual: -0.02 }],
+}));
+const downRecaptureRow = downComparison.rows.find((row) => row.conventionId === 'recapture').outcomes[0];
+assert.equal(downRecaptureRow.publicSubsidyRecaptured, 56829, 'recapture is capped at net proceeds when net proceeds < screening amount');
+assert.equal(downRecaptureRow.ownerGrossEquity, 0, 'owner equity is zero when all net proceeds are recovered');
+
+// Underwater guard: large remaining principal leaves no net proceeds → recaptured must be 0, not negative
+// marketValue=326829, remainingPrincipal=316829, sellingCosts=20000 → net proceeds = -10000 → recaptured=0
+const underwaterConvention = Resale.evaluateConvention(byId('recapture'), {
+  purchasePrice: 400000,
+  holdingPeriodYears: 10,
+  unrestrictedMarketValue: 326829,
+  remainingPrincipal: 316829,
+  sellingCosts: 20000,
+  recaptureAmount: 90000,
+});
+assert.equal(underwaterConvention.publicSubsidyRecaptured, 0, 'Math.max(0) guard: no recapture from underwater property');
 
 const homeDevelopment = Resale.compareConventions(data, Object.assign({}, comparisonInput, {
   subsidyType: 'home_development_subsidy',


### PR DESCRIPTION
`main` can currently display a resale price of **$0** and owner equity of **−$320,000** for any jurisdiction missing market-value data.

## The bug

`Number(null) === 0`, and `0` is finite — so `num()` returned `0` rather than `null` for a genuinely absent value:

```
unrestrictedMarketValue = null
  maxResalePrice   = 0
  ownerGrossEquity = -320000
```

That is fabricated certainty presented as fact, which is exactly what this series of PRs exists to prevent.

The flaw was latent in `num()` long before now. The recapture branch added in #1475 is the first caller to assign `resaleCap = num(input)` directly, which made it reachable and user-visible.

## Attribution

**Found by the Copilot coding agent on #1477**, which also wrote the null-path coverage — a case my review of #1475 missed, because all three of my scenario tests supplied a market value.

#1477 itself is not mergeable: it was cut from the pre-merge head of #1475, and diffed against current `main` it **reverts five commits**, including the `AGENTS.md` correction from #1476. So the two useful lines and their 27 lines of tests are transplanted here onto a clean base, and #1477 is closed unmerged.

## The change

```js
+    if (value == null) return null;                // js/hna/ownership-resale.js
+      mount.insertBefore(title, mount.firstChild); // js/deal-calculator.js
```

29 insertions, **zero deletions**, three files.

## Verification

| check | result |
|---|---|
| null market value | `maxResalePrice: null`, `ownerGrossEquity: null` |
| high-growth regression | `recaptured: 90000`, `equity: 226195` — unchanged |
| `num()` call sites in the module | 24, all suites green |
| **non-vacuousness** | reverting the guard makes the new test **fail** |

Suites: `test:ownership-resale`, `test:hna-ownership-strategy`, `test:shared-equity-lifecycle`, `test:deal-calc-for-sale-feasibility` — all pass.